### PR TITLE
[CHKDSK][VFATLIB] Chkdsk improve code

### DIFF
--- a/sdk/lib/fslib/vfatlib/check/io.c
+++ b/sdk/lib/fslib/vfatlib/check/io.c
@@ -372,10 +372,10 @@ void fs_write(off_t pos, int size, void *data)
 
             /* Patch data in memory */
             memcpy((char *)scratch + seek_delta, data, size);
-        }
 
-        /* Seek back to the beginning of our read/write */ 
-        if (lseek(fd, seekpos_aligned, 0) != seekpos_aligned) pdie("Seek to %lld",seekpos_aligned);
+            /* Seek back to the beginning of our read */ 
+            if (lseek(fd, seekpos_aligned, 0) != seekpos_aligned) pdie("Seek to %lld",seekpos_aligned);
+        }
 
         /* Write it back */
         if ((did = write(fd, scratch, readsize_aligned)) == (int)readsize_aligned)


### PR DESCRIPTION
CORE-20546

## Purpose

_Avoid unnecessary lseek if not needed._
_This is a refinement of PR #8840._

JIRA issue: [CORE-20546](https://jira.reactos.org/browse/CORE-20546)

## Proposed changes

_Make second lseek dependent upon having "use_read" and needing to do read alignment._

## Testbot runs (Filled in by Devs)

Nothing to test here. Only runs when requested by the user.

This may be easier to understand what I have done by looking at this in a side-by-side comparison here:

<img width="1596" height="320" alt="chkdsk-improve-code-01" src="https://github.com/user-attachments/assets/95477f93-d369-4ec3-a456-2d52c2bfc976" />
