### PR TITLE
[WINSRV] Introduce FakeDrag* functions and remove shell32 import

### DIFF
--- a/win32ss/user/winsrv/consrv.cmake
+++ b/win32ss/user/winsrv/consrv.cmake
@@ -30,6 +30,7 @@ list(APPEND CONSRV_SOURCE
     consrv/frontends/terminal.c
     consrv/frontends/wcwidth.c
     consrv/frontends/gui/conwnd.c
+    consrv/frontends/gui/fakedrag.c
     consrv/frontends/gui/fullscreen.c
     consrv/frontends/gui/guiterm.c
     consrv/frontends/gui/guisettings.c
@@ -58,6 +59,6 @@ add_dependencies(consrv psdk)
 add_pch(consrv consrv/consrv.h CONSRV_SOURCE)
 #add_object_library(consrv ${CONSRV_SOURCE})
 #list(APPEND CONSRV_IMPORT_LIBS)
-list(APPEND CONSRV_DELAY_IMPORT_LIBS shell32 ole32 psapi)
+list(APPEND CONSRV_DELAY_IMPORT_LIBS ole32 psapi)
 list(APPEND CONSRV_TARGET_LINK_LIBS concfg uuid)
 set_module_type(consrv module UNICODE)

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -22,6 +22,7 @@
 
 #include "concfg/font.h"
 #include "guiterm.h"
+#include "fakedrag.h"
 #include "resource.h"
 
 /* GLOBALS ********************************************************************/
@@ -36,7 +37,6 @@
 #define CONGUI_UPDATE_TIMER   1
 
 #define CURSOR_BLINK_TIME 500
-
 
 /**************************************************************\
 \** Define the Console Leader Process for the console window **/
@@ -714,7 +714,7 @@ OnNcCreate(HWND hWnd, LPCREATESTRUCTW Create)
     NtSetEvent(GuiData->hGuiInitEvent, NULL);
 
     /* We accept dropped files */
-    DragAcceptFiles(GuiData->hWindow, TRUE);
+    FakeDragAcceptFiles(GuiData->hWindow, TRUE);
 
     return (BOOL)DefWindowProcW(GuiData->hWindow, WM_NCCREATE, 0, (LPARAM)Create);
 }
@@ -2216,8 +2216,8 @@ OnDropFiles(PCONSRV_CONSOLE Console, HDROP hDrop)
 
     szPath[0] = L'"';
 
-    DragQueryFileW(hDrop, 0, &szPath[1], ARRAYSIZE(szPath) - 1);
-    DragFinish(hDrop);
+    FakeDragQueryFileW(hDrop, 0, &szPath[1], ARRAYSIZE(szPath) - 1);
+    FakeDragFinish(hDrop);
 
     if (wcschr(&szPath[1], L' ') != NULL)
     {

--- a/win32ss/user/winsrv/consrv/frontends/gui/fakedrag.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/fakedrag.c
@@ -1,0 +1,135 @@
+/*
+ * PROJECT:     ReactOS User API Server DLL
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Defining FakeDrag* functions and removing shell32 import
+ * COPYRIGHT:   Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <consrv.h>
+#include <shellapi.h>
+#include <shlobj.h>
+#include "fakedrag.h"
+
+#define NDEBUG
+#include <debug.h>
+
+/* FakeDrag functions *********************************************************/
+
+UINT FakeDragQueryFileA(HDROP hDrop, UINT lFile, LPSTR lpszFile, UINT lLength)
+{
+    LPSTR lpDrop;
+    UINT i = 0;
+    DROPFILES *lpDropFileStruct = GlobalLock(hDrop);
+
+    if (!lpDropFileStruct)
+        goto end;
+
+    lpDrop = (LPSTR)lpDropFileStruct + lpDropFileStruct->pFiles;
+
+    if (lpDropFileStruct->fWide)
+    {
+        LPWSTR lpszFileW = NULL;
+        if (lpszFile && lFile != 0xFFFFFFFF)
+        {
+            lpszFileW = HeapAlloc(GetProcessHeap(), 0, lLength*sizeof(WCHAR));
+            if (!lpszFileW)
+                goto end;
+        }
+
+        i = FakeDragQueryFileW(hDrop, lFile, lpszFileW, lLength);
+
+        if (lpszFileW)
+        {
+            WideCharToMultiByte(CP_ACP, 0, lpszFileW, -1, lpszFile, lLength, 0, NULL);
+            HeapFree(GetProcessHeap(), 0, lpszFileW);
+        }
+        goto end;
+    }
+
+    while (i++ < lFile)
+    {
+        while (*lpDrop++); /* skip filename */
+
+        if (!*lpDrop)
+        {
+            i = (lFile == 0xFFFFFFFF) ? i : 0;
+            goto end;
+        }
+    }
+
+    i = lstrlenA(lpDrop);
+    if (!lpszFile)
+        goto end;
+    lstrcpynA(lpszFile, lpDrop, lLength);
+end:
+    GlobalUnlock(hDrop);
+    return i;
+}
+
+UINT FakeDragQueryFileW(HDROP hDrop, UINT lFile, LPWSTR lpszwFile, UINT lLength)
+{
+    LPWSTR lpwDrop;
+    UINT i = 0;
+    DROPFILES *lpDropFileStruct = GlobalLock(hDrop);
+
+    if (!lpDropFileStruct)
+        goto end;
+
+    lpwDrop = (LPWSTR)((LPSTR)lpDropFileStruct + lpDropFileStruct->pFiles);
+
+    if (!lpDropFileStruct->fWide)
+    {
+        LPSTR lpszFileA = NULL;
+
+        if (lpszwFile && lFile != 0xFFFFFFFF)
+        {
+            lpszFileA = HeapAlloc(GetProcessHeap(), 0, lLength);
+            if (!lpszFileA)
+                goto end;
+        }
+
+        i = FakeDragQueryFileA(hDrop, lFile, lpszFileA, lLength);
+
+        if (lpszFileA)
+        {
+            MultiByteToWideChar(CP_ACP, 0, lpszFileA, -1, lpszwFile, lLength);
+            HeapFree(GetProcessHeap(), 0, lpszFileA);
+        }
+        goto end;
+    }
+
+    i = 0;
+    while (i++ < lFile)
+    {
+        while (*lpwDrop++); /* skip filename */
+
+        if (!*lpwDrop)
+        {
+            i = (lFile == 0xFFFFFFFF) ? i : 0;
+            goto end;
+        }
+    }
+
+    i = lstrlenW(lpwDrop);
+    if (!lpszwFile)
+        goto end;
+    lstrcpynW(lpszwFile, lpwDrop, lLength);
+
+end:
+    GlobalUnlock(hDrop);
+    return i;
+}
+
+VOID FakeDragAcceptFiles(HWND hWnd, BOOL fAccept)
+{
+    if (!IsWindow(hWnd))
+        return;
+
+    LONG_PTR exstyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
+    if (fAccept)
+        exstyle |= WS_EX_ACCEPTFILES;
+    else
+        exstyle &= ~WS_EX_ACCEPTFILES;
+
+    SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exstyle);
+}

--- a/win32ss/user/winsrv/consrv/frontends/gui/fakedrag.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/fakedrag.c
@@ -13,8 +13,6 @@
 #define NDEBUG
 #include <debug.h>
 
-/* FakeDrag functions *********************************************************/
-
 UINT FakeDragQueryFileA(HDROP hDrop, UINT lFile, LPSTR lpszFile, UINT lLength)
 {
     LPSTR lpDrop;

--- a/win32ss/user/winsrv/consrv/frontends/gui/fakedrag.h
+++ b/win32ss/user/winsrv/consrv/frontends/gui/fakedrag.h
@@ -1,0 +1,14 @@
+/*
+ * PROJECT:     ReactOS User API Server DLL
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Defining FakeDrag* functions and removing shell32 import
+ * COPYRIGHT:   Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#pragma once
+
+UINT FakeDragQueryFileA(HDROP hDrop, UINT lFile, LPSTR lpszFile, UINT lLength);
+UINT FakeDragQueryFileW(HDROP hDrop, UINT lFile, LPWSTR lpszFile, UINT lLength);
+VOID FakeDragAcceptFiles(HWND hWnd, BOOL fAccept);
+
+#define FakeDragFinish(hDrop) GlobalFree(hDrop)


### PR DESCRIPTION
## Purpose

Reduce memory usage by removing `shell32` import.
JIRA issue: N/A

## Proposed changes

- Add `consrv/frontends/gui/fakedrag.c`.
- Define `FakeDragQueryFileA/W`, `FakeDragAcceptFiles`, and `FakeDragFinish` functions and use them.
- Remove `shell32` delay import.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: