### PR TITLE
[WINSRV] ConioWriteConsole: Modify UpdateRect for CJK

### DIFF
--- a/win32ss/user/winsrv/consrv/frontends/terminal.c
+++ b/win32ss/user/winsrv/consrv/frontends/terminal.c
@@ -556,6 +556,8 @@ ConioWriteConsole(PFRONTEND FrontEnd,
             /* --- BS --- */
             else if (Buffer[i] == L'\b')
             {
+                INT OldX = Buff->CursorPosition.X;
+
                 /* Only handle BS if we are not on the first position of the first line */
                 if (Buff->CursorPosition.X == 0 && Buff->CursorPosition.Y == 0)
                     continue;
@@ -622,8 +624,8 @@ ConioWriteConsole(PFRONTEND FrontEnd,
                     Ptr->Attributes = Buff->ScreenDefaultAttrib;
                 Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
 
-                UpdateRect.Left  = min(UpdateRect.Left , Buff->CursorPosition.X);
-                UpdateRect.Right = max(UpdateRect.Right, Buff->CursorPosition.X);
+                UpdateRect.Left  = min(min(UpdateRect.Left , Buff->CursorPosition.X), OldX);
+                UpdateRect.Right = max(max(UpdateRect.Right, Buff->CursorPosition.X), OldX);
                 continue;
             }
             /* --- TAB --- */
@@ -778,6 +780,8 @@ ConioWriteConsole(PFRONTEND FrontEnd,
                 Ptr->Attributes = Buff->ScreenDefaultAttrib;
             Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
             Ptr->Attributes |= COMMON_LVB_TRAILING_BYTE;
+
+            UpdateRect.Right++;
         }
         else
         {


### PR DESCRIPTION
## Purpose

Correctly displaying Asian characters on Asian Console.
JIRA issue: [CORE-18972](https://jira.reactos.org/browse/CORE-18972)

## Proposed changes

- Modify the update rectangle for Chinese, Japanese, and Korean.

## Screenshots

BEFORE (with ReactOS JPN Package):
<img width="800" height="600" alt="before" src="https://github.com/user-attachments/assets/593f5a0e-a443-4eaf-b10e-3c33b61008f9" />

AFTER (with ReactOS JPN Package):
<img width="800" height="600" alt="after" src="https://github.com/user-attachments/assets/25cbde62-6751-449a-aff1-0ddd28d3674c" />

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: