### PR TITLE
[HALPC98] Improve TSC calibration routine

### DIFF
--- a/hal/halx86/pc98/delay.S
+++ b/hal/halx86/pc98/delay.S
@@ -97,6 +97,8 @@ _KeStallExecutionProcessor@4:
      * Force the in-order execution of the RDTSC instruction.
      * HAL will overwrite this with a no-op instruction on older processors.
      */
+PUBLIC _HalpStallExecutionStart
+_HalpStallExecutionStart:
     xor eax, eax
     cpuid
 

--- a/hal/halx86/pc98/delay.S
+++ b/hal/halx86/pc98/delay.S
@@ -97,8 +97,8 @@ _KeStallExecutionProcessor@4:
      * Force the in-order execution of the RDTSC instruction.
      * HAL will overwrite this with a no-op instruction on older processors.
      */
-PUBLIC _HalpStallExecutionStart
-_HalpStallExecutionStart:
+PUBLIC _HalpStallExecutionSerialize
+_HalpStallExecutionSerialize:
     xor eax, eax
     cpuid
 

--- a/hal/halx86/pc98/delay.c
+++ b/hal/halx86/pc98/delay.c
@@ -25,6 +25,7 @@ HalpTscCalibrationISR(VOID);
 
 extern volatile ULONG TscCalibrationPhase;
 extern ULONG64 TscCalibrationArray[NUM_SAMPLES];
+extern UCHAR HalpStallExecutionStart;
 
 /* FUNCTIONS *****************************************************************/
 
@@ -33,7 +34,7 @@ CODE_SEG("INIT")
 VOID
 HalpPrepareStallExecution(VOID)
 {
-    PUCHAR Instruction = (PUCHAR)((ULONG_PTR)KeStallExecutionProcessor + 1);
+    PUCHAR Instruction = &HalpStallExecutionStart;
     PKPRCB Prcb = KeGetCurrentPrcb();
 
     /* xor eax, eax; cpuid */

--- a/hal/halx86/pc98/delay.c
+++ b/hal/halx86/pc98/delay.c
@@ -25,7 +25,7 @@ HalpTscCalibrationISR(VOID);
 
 extern volatile ULONG TscCalibrationPhase;
 extern ULONG64 TscCalibrationArray[NUM_SAMPLES];
-extern UCHAR HalpStallExecutionStart;
+extern UCHAR HalpStallExecutionSerialize;
 
 /* FUNCTIONS *****************************************************************/
 
@@ -34,7 +34,7 @@ CODE_SEG("INIT")
 VOID
 HalpPrepareStallExecution(VOID)
 {
-    PUCHAR Instruction = &HalpStallExecutionStart;
+    PUCHAR Instruction = &HalpStallExecutionSerialize;
     PKPRCB Prcb = KeGetCurrentPrcb();
 
     /* xor eax, eax; cpuid */
@@ -49,7 +49,7 @@ HalpPrepareStallExecution(VOID)
      * Intel "Using the RDTSC Instruction for Performance Monitoring".
      *
      * Patch the KeStallExecutionProcessor function to remove the serializing instruction
-     * for the Pentium and Pentium MMX processors.
+     * for the Pentium and Pentium MMX processors because the CPUID instruction is slow.
      */
     if ((Prcb->CpuType < 6) && !strcmp(Prcb->VendorString, "GenuineIntel"))
     {


### PR DESCRIPTION
## Purpose

Do not rely on a hardcoded ASM instruction offset.

Addendum to commit 45e6d49a29dcc76ffad0cc11a5ea0526d1da09cf

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: