### PR TITLE
[SHELL32] Fix E_OUTOFMEMORY not being returned on allocation failure

### DIFF
--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -425,7 +425,7 @@ HRESULT STDMETHODCALLTYPE CQueryAssociations::GetString(
                 }
                 else
                 {
-                    hr = HRESULT_FROM_WIN32(ret);
+                    hr = E_OUTOFMEMORY;
                 }
             }
             else


### PR DESCRIPTION
…in ASSOCSTR_DEFAULTICON

## Purpose

Fix `ASSOCSTR_DEFAULTICON` in `CQueryAssociations::GetString` incorrectly returning **S_OK** instead of **E_OUTOFMEMORY** when HeapAlloc fails.

JIRA issue: None

## Proposed changes

- In `ASSOCSTR_DEFAULTICON` case, when HeapAlloc returns **NULL**, the error branch was doing hr = HRESULT_FROM_WIN32(ret) where ret still held **ERROR_SUCCESS** from the before successful `RegGetValueW` call. This caused the function to silently return **S_OK** on allocation failure.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: