### PR TITLE
[FREELDR] Fix NTFS bootsector USA fixup indexing

### DIFF
--- a/boot/freeldr/bootsect/ntfs.S
+++ b/boot/freeldr/bootsect/ntfs.S
@@ -676,8 +676,10 @@ ApplyFixups:
         sub   di, 2
         cmp   ax, word ptr es:[di]     // Check fixup value
         jnz   PrintFileSystemError     // Fixup is corrupted, so print error
+        mov   ax, cx                   // Compute USA offset for k-th sector = 2*cx bytes
+        shl   ax, 1
+        add   si, ax                   // si -> USA word for current sector (USAoff + 2*cx)
         inc   cx
-        add   si, cx
         mov   ax, word ptr es:[si]     // Apply fixup
         mov   word ptr es:[di], ax
 


### PR DESCRIPTION
## Purpose

The NTFS bootsector fixup loop was advancing into the Update Sequence Array by cx bytes instead of cx*sizeof(USHORT).

This only worked for the first sector and selected the wrong fixup entry for later sectors in multi-sector FILE / INDX records.

the fix is tested on amd64/GCC, while exercising booting freeldr from img with ntfs formatted partition.

for reference, see:
freeldr/freeldr/lib/fs/ntfs.c:590-591-599
USA is a USHORT *, so each USA++ advances by sizeof(USHORT)

[CORE-18524](https://jira.reactos.org/browse/CORE-18524)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: