### PR TITLE
[MSCTFIME][CICERO] Implement CicProfile::GetActiveLanguageProfile

### DIFF
--- a/base/ctf/cicero/cicbase.h
+++ b/base/ctf/cicero/cicbase.h
@@ -2,10 +2,13 @@
  * PROJECT:     ReactOS Cicero
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     Cicero base
- * COPYRIGHT:   Copyright 2023-2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ * COPYRIGHT:   Copyright 2023-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once
+
+#include <assert.h>
+#define cicAssert assert
 
 static inline LPVOID cicMemAlloc(SIZE_T size)
 {

--- a/base/ctf/cicero/ciciface.h
+++ b/base/ctf/cicero/ciciface.h
@@ -1,0 +1,37 @@
+/*
+ * PROJECT:     ReactOS Cicero
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Cicero interface
+ * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#pragma once
+
+#include "cicbase.h"
+
+template <typename T>
+class CicInterface_RefCnt
+{
+protected:
+    T* m_ptr;
+
+public:
+    CicInterface_RefCnt(T* ptr = NULL) : m_ptr(ptr)
+    {
+        if (m_ptr)
+            m_ptr->AddRef();
+    }
+    ~CicInterface_RefCnt()
+    {
+        if (m_ptr)
+            m_ptr->Release();
+    }
+
+    operator T*() { return m_ptr; }
+    T* operator->() { return m_ptr; }
+    T** operator&() { return &m_ptr; }
+
+private:
+    CicInterface_RefCnt(const CicInterface_RefCnt<T>&) = delete;
+    CicInterface_RefCnt<T>&operator=(const CicInterface_RefCnt<T>&) = delete;
+};

--- a/base/ctf/cicero/ciciface.h
+++ b/base/ctf/cicero/ciciface.h
@@ -33,5 +33,5 @@ public:
 
 private:
     CicInterface_RefCnt(const CicInterface_RefCnt<T>&) = delete;
-    CicInterface_RefCnt<T>&operator=(const CicInterface_RefCnt<T>&) = delete;
+    CicInterface_RefCnt<T>& operator=(const CicInterface_RefCnt<T>&) = delete;
 };

--- a/base/ctf/cicero/ciciface.h
+++ b/base/ctf/cicero/ciciface.h
@@ -32,21 +32,15 @@ public:
 
     void Attach(T_IFACE* ptr)
     {
-        if (ptr)
-        {
-            m_ptr = ptr;
-            m_ptr->AddRef();
-        }
+        if (m_ptr)
+            m_ptr->Release();
+        m_ptr = ptr;
     }
 
     T_IFACE* Detach()
     {
         T_IFACE* old_ptr = m_ptr;
-        if (m_ptr)
-        {
-            m_ptr->Release();
-            m_ptr = NULL;
-        }
+        m_ptr = NULL;
         return old_ptr;
     }
 

--- a/base/ctf/cicero/ciciface.h
+++ b/base/ctf/cicero/ciciface.h
@@ -46,7 +46,12 @@ public:
 
     operator T_IFACE*() { return m_ptr; }
     T_IFACE* operator->() { return m_ptr; }
-    T_IFACE** operator&() { return &m_ptr; }
+
+    T_IFACE** operator&()
+    {
+        cicAssert(!m_ptr);
+        return &m_ptr;
+    }
 
 private:
     CicInterface_RefCnt(const CicInterface_RefCnt<T_IFACE>&) = delete;

--- a/base/ctf/cicero/ciciface.h
+++ b/base/ctf/cicero/ciciface.h
@@ -9,29 +9,52 @@
 
 #include "cicbase.h"
 
-template <typename T>
+template <typename T_IFACE>
 class CicInterface_RefCnt
 {
 protected:
-    T* m_ptr;
+    T_IFACE* m_ptr;
 
 public:
-    CicInterface_RefCnt(T* ptr = NULL) : m_ptr(ptr)
+    CicInterface_RefCnt() : m_ptr(NULL) { }
+
+    CicInterface_RefCnt(T_IFACE* ptr) : m_ptr(ptr)
     {
         if (m_ptr)
             m_ptr->AddRef();
     }
+
     ~CicInterface_RefCnt()
     {
         if (m_ptr)
             m_ptr->Release();
     }
 
-    operator T*() { return m_ptr; }
-    T* operator->() { return m_ptr; }
-    T** operator&() { return &m_ptr; }
+    void Attach(T_IFACE* ptr)
+    {
+        if (ptr)
+        {
+            m_ptr = ptr;
+            m_ptr->AddRef();
+        }
+    }
+
+    T_IFACE* Detach()
+    {
+        T_IFACE* old_ptr = m_ptr;
+        if (m_ptr)
+        {
+            m_ptr->Release();
+            m_ptr = NULL;
+        }
+        return old_ptr;
+    }
+
+    operator T_IFACE*() { return m_ptr; }
+    T_IFACE* operator->() { return m_ptr; }
+    T_IFACE** operator&() { return &m_ptr; }
 
 private:
-    CicInterface_RefCnt(const CicInterface_RefCnt<T>&) = delete;
-    CicInterface_RefCnt<T>& operator=(const CicInterface_RefCnt<T>&) = delete;
+    CicInterface_RefCnt(const CicInterface_RefCnt<T_IFACE>&) = delete;
+    CicInterface_RefCnt<T_IFACE>& operator=(const CicInterface_RefCnt<T_IFACE>&) = delete;
 };

--- a/base/ctf/cicero/ciciface.h
+++ b/base/ctf/cicero/ciciface.h
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     ReactOS Cicero
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
- * PURPOSE:     Cicero interface
- * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ * PURPOSE:     Cicero COM interface
+ * COPYRIGHT:   Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once

--- a/base/ctf/msctfime/msctfime.h
+++ b/base/ctf/msctfime/msctfime.h
@@ -28,6 +28,7 @@
 
 #include <cicbase.h>
 #include <cicarray.h>
+#include <ciciface.h>
 #include <cicimc.h>
 #include <cictf.h>
 #include <cicreg.h>

--- a/base/ctf/msctfime/profile.cpp
+++ b/base/ctf/msctfime/profile.cpp
@@ -16,7 +16,7 @@ typedef HRESULT (CALLBACK *FN_LanguageProfilesCallback)(TF_LANGUAGEPROFILE profi
 HRESULT
 CicProfile::LanguageProfilesCallback(
     _In_ TF_LANGUAGEPROFILE profile,
-    _Inout_ LPARAM lParam)
+    _Inout_opt_ LPARAM lParam)
 {
     if (!profile.fActive || !memcmp(&profile.clsid, &GUID_NULL, sizeof(GUID_NULL)))
         return S_FALSE;

--- a/base/ctf/msctfime/profile.cpp
+++ b/base/ctf/msctfime/profile.cpp
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS msctfime.ime
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     Profile of msctfime.ime
- * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ * COPYRIGHT:   Copyright 2024-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include "msctfime.h"
@@ -30,14 +30,14 @@ CicProfile::LanguageProfilesCallback(
 }
 
 template <typename T_IFACE, typename T_DATA>
-class CEnumValue
+class CicEnumValue
 {
     T_IFACE* m_iface;
     FN_LanguageProfilesCallback m_callback;
     LPARAM m_lParam;
 
 public:
-    CEnumValue(T_IFACE* iface, FN_LanguageProfilesCallback callback, LPARAM lParam)
+    CicEnumValue(T_IFACE* iface, FN_LanguageProfilesCallback callback, LPARAM lParam = 0)
         : m_iface(iface)
         , m_callback(callback)
         , m_lParam(lParam)
@@ -231,8 +231,8 @@ CicProfile::GetActiveLanguageProfile(
     LANG_PROF_ENUM_ARG arg;
     arg.catid = catid;
 
-    CEnumValue<IEnumTfLanguageProfiles, TF_LANGUAGEPROFILE>
-        enumValue(pEnum, CicProfile::LanguageProfilesCallback, (LPARAM)&arg);
+    CicEnumValue<IEnumTfLanguageProfiles, TF_LANGUAGEPROFILE>
+        enumValue(pEnum, LanguageProfilesCallback, (LPARAM)&arg);
     DWORD ret = enumValue.DoEnumrate();
     if (ret != ERROR_SUCCESS || !pProfile)
         return S_FALSE;
@@ -248,8 +248,8 @@ HRESULT CicProfile::IsIME(HKL hKL)
     if (FAILED(hr))
         return S_FALSE;
 
-    CEnumValue<IEnumTfLanguageProfiles, TF_LANGUAGEPROFILE>
-        enumValue(pEnum, CicProfile::LanguageProfilesCallback, 0);
+    CicEnumValue<IEnumTfLanguageProfiles, TF_LANGUAGEPROFILE>
+        enumValue(pEnum, LanguageProfilesCallback);
     DWORD ret = enumValue.DoEnumrate();
     return (ret == ERROR_SUCCESS) ? S_OK : S_FALSE;
 }

--- a/base/ctf/msctfime/profile.cpp
+++ b/base/ctf/msctfime/profile.cpp
@@ -9,6 +9,54 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(msctfime);
 
+typedef HRESULT (CALLBACK *FN_LanguageProfilesCallback)(TF_LANGUAGEPROFILE profile, LPARAM lParam);
+
+template <typename T_IFACE, typename T_DATA>
+struct CEnumrateValue
+{
+    FN_LanguageProfilesCallback m_fnCallback;
+    LPARAM m_lParam;
+    T_IFACE* m_iface;
+
+    CEnumrateValue(T_IFACE* iface) : m_iface(iface) { }
+
+    DWORD DoEnumrate()
+    {
+        HRESULT hr;
+        T_DATA data;
+
+        for (;;)
+        {
+            hr = m_iface->Next(1, &data, NULL);
+            if (hr != S_OK)
+                break;
+
+            hr = m_fnCallback(data, m_lParam);
+            if (hr == S_OK)
+                return ERROR_SUCCESS;
+        }
+
+        return ERROR_FILE_NOT_FOUND;
+    }
+};
+
+/// @implemented
+HRESULT
+CicProfile::LanguageProfilesCallback(
+    _In_ TF_LANGUAGEPROFILE profile,
+    _Inout_opt_ LPARAM lParam)
+{
+    if (!profile.fActive || !memcmp(&profile.clsid, &GUID_NULL, sizeof(GUID_NULL)))
+        return S_FALSE;
+    PLANG_PROF_ENUM_ARG pArg = (PLANG_PROF_ENUM_ARG)lParam;
+    if (!pArg)
+        return S_OK;
+    if (memcmp(&profile.catid, &pArg->catid, sizeof(profile.catid)) != 0)
+        return S_FALSE;
+    pArg->profile = profile;
+    return S_OK;
+}
+
 /// @implemented
 CicProfile::CicProfile()
 {
@@ -162,19 +210,41 @@ CicProfile::InitProfileInstance(_Inout_ TLS *pTLS)
     return hr;
 }
 
-/// @unimplemented
+/// @implemented
 HRESULT
 CicProfile::GetActiveLanguageProfile(
     _In_ HKL hKL,
-    _In_ REFGUID rguid,
-    _Out_ TF_LANGUAGEPROFILE *pProfile)
+    _In_ REFGUID catid,
+    _Out_ TF_LANGUAGEPROFILE* pProfile)
 {
-    return E_NOTIMPL;
+    CicInterface_RefCnt<IEnumTfLanguageProfiles> pEnum;
+    HRESULT hr = m_pIPProfiles->EnumLanguageProfiles(LOWORD(hKL), &pEnum);
+    if (FAILED(hr))
+        return S_FALSE;
+
+    LANG_PROF_ENUM_ARG arg = { catid };
+    CEnumrateValue<IEnumTfLanguageProfiles, TF_LANGUAGEPROFILE> profiles(pEnum);
+    profiles.m_fnCallback = CicProfile::LanguageProfilesCallback;
+    profiles.m_lParam = (LPARAM)&arg;
+    DWORD ret = profiles.DoEnumrate();
+    if (ret != ERROR_SUCCESS || !pProfile)
+        return S_FALSE;
+
+    *pProfile = arg.profile;
+    return S_OK;
 }
 
-/// The return value of CicProfile::IsIME is brain-damaged.
-/// @unimplemented
-BOOL CicProfile::IsIME(HKL hKL)
+/// @implemented
+HRESULT CicProfile::IsIME(HKL hKL)
 {
-    return TRUE;
+    CicInterface_RefCnt<IEnumTfLanguageProfiles> pEnum;
+    HRESULT hr = m_pIPProfiles->EnumLanguageProfiles(LOWORD(hKL), &pEnum);
+    if (FAILED(hr))
+        return S_FALSE;
+
+    CEnumrateValue<IEnumTfLanguageProfiles, TF_LANGUAGEPROFILE> profiles(pEnum);
+    profiles.m_fnCallback = CicProfile::LanguageProfilesCallback;
+    profiles.m_lParam = 0;
+    DWORD ret = profiles.DoEnumrate();
+    return (ret == ERROR_SUCCESS) ? S_OK : S_FALSE;
 }

--- a/base/ctf/msctfime/profile.cpp
+++ b/base/ctf/msctfime/profile.cpp
@@ -9,16 +9,39 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(msctfime);
 
+// The callback function type
 typedef HRESULT (CALLBACK *FN_LanguageProfilesCallback)(TF_LANGUAGEPROFILE profile, LPARAM lParam);
 
-template <typename T_IFACE, typename T_DATA>
-struct CEnumrateValue
+/// @implemented
+HRESULT
+CicProfile::LanguageProfilesCallback(
+    _In_ TF_LANGUAGEPROFILE profile,
+    _Inout_ LPARAM lParam)
 {
-    FN_LanguageProfilesCallback m_fnCallback;
-    LPARAM m_lParam;
-    T_IFACE* m_iface;
+    if (!profile.fActive || !memcmp(&profile.clsid, &GUID_NULL, sizeof(GUID_NULL)))
+        return S_FALSE;
+    PLANG_PROF_ENUM_ARG pArg = (PLANG_PROF_ENUM_ARG)lParam;
+    if (!pArg)
+        return S_OK;
+    if (memcmp(&profile.catid, &pArg->catid, sizeof(profile.catid)) != 0)
+        return S_FALSE;
+    pArg->profile = profile;
+    return S_OK;
+}
 
-    CEnumrateValue(T_IFACE* iface) : m_iface(iface) { }
+template <typename T_IFACE, typename T_DATA>
+class CEnumValue
+{
+    T_IFACE* m_iface;
+    FN_LanguageProfilesCallback m_callback;
+    LPARAM m_lParam;
+
+public:
+    CEnumValue(T_IFACE* iface, FN_LanguageProfilesCallback callback, LPARAM lParam)
+        : m_iface(iface)
+        , m_callback(callback)
+        , m_lParam(lParam)
+    { }
 
     DWORD DoEnumrate()
     {
@@ -31,7 +54,7 @@ struct CEnumrateValue
             if (hr != S_OK)
                 break;
 
-            hr = m_fnCallback(data, m_lParam);
+            hr = m_callback(data, m_lParam);
             if (hr == S_OK)
                 return ERROR_SUCCESS;
         }
@@ -39,23 +62,6 @@ struct CEnumrateValue
         return ERROR_FILE_NOT_FOUND;
     }
 };
-
-/// @implemented
-HRESULT
-CicProfile::LanguageProfilesCallback(
-    _In_ TF_LANGUAGEPROFILE profile,
-    _Inout_opt_ LPARAM lParam)
-{
-    if (!profile.fActive || !memcmp(&profile.clsid, &GUID_NULL, sizeof(GUID_NULL)))
-        return S_FALSE;
-    PLANG_PROF_ENUM_ARG pArg = (PLANG_PROF_ENUM_ARG)lParam;
-    if (!pArg)
-        return S_OK;
-    if (memcmp(&profile.catid, &pArg->catid, sizeof(profile.catid)) != 0)
-        return S_FALSE;
-    pArg->profile = profile;
-    return S_OK;
-}
 
 /// @implemented
 CicProfile::CicProfile()
@@ -222,14 +228,14 @@ CicProfile::GetActiveLanguageProfile(
     if (FAILED(hr))
         return S_FALSE;
 
-    LANG_PROF_ENUM_ARG arg = { catid };
-    CEnumrateValue<IEnumTfLanguageProfiles, TF_LANGUAGEPROFILE> profiles(pEnum);
-    profiles.m_fnCallback = CicProfile::LanguageProfilesCallback;
-    profiles.m_lParam = (LPARAM)&arg;
-    DWORD ret = profiles.DoEnumrate();
+    LANG_PROF_ENUM_ARG arg;
+    arg.catid = catid;
+
+    CEnumValue<IEnumTfLanguageProfiles, TF_LANGUAGEPROFILE>
+        enumValue(pEnum, CicProfile::LanguageProfilesCallback, (LPARAM)&arg);
+    DWORD ret = enumValue.DoEnumrate();
     if (ret != ERROR_SUCCESS || !pProfile)
         return S_FALSE;
-
     *pProfile = arg.profile;
     return S_OK;
 }
@@ -242,9 +248,8 @@ HRESULT CicProfile::IsIME(HKL hKL)
     if (FAILED(hr))
         return S_FALSE;
 
-    CEnumrateValue<IEnumTfLanguageProfiles, TF_LANGUAGEPROFILE> profiles(pEnum);
-    profiles.m_fnCallback = CicProfile::LanguageProfilesCallback;
-    profiles.m_lParam = 0;
-    DWORD ret = profiles.DoEnumrate();
+    CEnumValue<IEnumTfLanguageProfiles, TF_LANGUAGEPROFILE>
+        enumValue(pEnum, CicProfile::LanguageProfilesCallback, 0);
+    DWORD ret = enumValue.DoEnumrate();
     return (ret == ERROR_SUCCESS) ? S_OK : S_FALSE;
 }

--- a/base/ctf/msctfime/profile.cpp
+++ b/base/ctf/msctfime/profile.cpp
@@ -43,7 +43,7 @@ public:
         , m_lParam(lParam)
     { }
 
-    DWORD DoEnumrate()
+    DWORD DoEnum()
     {
         HRESULT hr;
         T_DATA data;
@@ -233,7 +233,7 @@ CicProfile::GetActiveLanguageProfile(
 
     CicEnumValue<IEnumTfLanguageProfiles, TF_LANGUAGEPROFILE>
         enumValue(pEnum, LanguageProfilesCallback, (LPARAM)&arg);
-    DWORD ret = enumValue.DoEnumrate();
+    DWORD ret = enumValue.DoEnum();
     if (ret != ERROR_SUCCESS || !pProfile)
         return S_FALSE;
     *pProfile = arg.profile;
@@ -250,6 +250,6 @@ HRESULT CicProfile::IsIME(HKL hKL)
 
     CicEnumValue<IEnumTfLanguageProfiles, TF_LANGUAGEPROFILE>
         enumValue(pEnum, LanguageProfilesCallback);
-    DWORD ret = enumValue.DoEnumrate();
+    DWORD ret = enumValue.DoEnum();
     return (ret == ERROR_SUCCESS) ? S_OK : S_FALSE;
 }

--- a/base/ctf/msctfime/profile.h
+++ b/base/ctf/msctfime/profile.h
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS msctfime.ime
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     Profile of msctfime.ime
- * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ * COPYRIGHT:   Copyright 2024-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once

--- a/base/ctf/msctfime/profile.h
+++ b/base/ctf/msctfime/profile.h
@@ -9,15 +9,15 @@
 
 #include "sinks.h"
 
-typedef struct tagLANG_PROF_ENUM_ARG
-{
-    GUID catid;
-    TF_LANGUAGEPROFILE profile;
-} LANG_PROF_ENUM_ARG, *PLANG_PROF_ENUM_ARG;
-
 class CicProfile : public IUnknown
 {
 protected:
+    typedef struct tagLANG_PROF_ENUM_ARG
+    {
+        GUID catid;
+        TF_LANGUAGEPROFILE profile;
+    } LANG_PROF_ENUM_ARG, *PLANG_PROF_ENUM_ARG;
+
     ITfInputProcessorProfiles *m_pIPProfiles;
     CActiveLanguageProfileNotifySink *m_pActiveLanguageProfileNotifySink;
     LANGID  m_LangID1;

--- a/base/ctf/msctfime/profile.h
+++ b/base/ctf/msctfime/profile.h
@@ -9,6 +9,12 @@
 
 #include "sinks.h"
 
+typedef struct tagLANG_PROF_ENUM_ARG
+{
+    GUID catid;
+    TF_LANGUAGEPROFILE profile;
+} LANG_PROF_ENUM_ARG, *PLANG_PROF_ENUM_ARG;
+
 class CicProfile : public IUnknown
 {
 protected:
@@ -42,12 +48,16 @@ public:
     HRESULT
     GetActiveLanguageProfile(
         _In_ HKL hKL,
-        _In_ REFGUID rguid,
-        _Out_ TF_LANGUAGEPROFILE *pProfile);
+        _In_ REFGUID catid,
+        _Out_ TF_LANGUAGEPROFILE* pProfile);
     HRESULT GetLangId(_Out_ LANGID *pLangID);
     HRESULT GetCodePageA(_Out_ UINT *puCodePage);
 
     HRESULT InitProfileInstance(_Inout_ TLS *pTLS);
+    HRESULT IsIME(HKL hKL);
 
-    BOOL IsIME(HKL hKL);
+    static HRESULT CALLBACK
+    LanguageProfilesCallback(
+        _In_ TF_LANGUAGEPROFILE profile,
+        _Inout_opt_ LPARAM lParam);
 };


### PR DESCRIPTION
## Purpose
Supporting CTF IMEs.
JIRA issue: [CORE-19360](https://jira.reactos.org/browse/CORE-19360)

## Proposed changes

- Add `base/ctf/cicero/ciciface.h` to add `CicInterface_RefCnt` template class.
- Add `CicProfile::LanguageProfilesCallback` callback function.
- Implement `CicProfile::GetActiveLanguageProfile` and `CicProfile::IsIME` functions.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: