### PR TITLE
[CICERO] Add CicFirstInFirstOut (cicfifo.h)

### DIFF
--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -76,7 +76,9 @@ public:
 protected:
     BOOL GrowBuffer(INT_PTR nGrow)
     {
-        if (nGrow <= 0)
+        if (nGrow < 0)
+            return FALSE;
+        if (nGrow == 0)
             return TRUE;
 
         if (!m_pItems)

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -15,15 +15,15 @@ class CicFirstInFirstOut
 protected:
     T_ITEM* m_pItems;
     size_t m_cItems;
-    size_t m_iLastItem;
     size_t m_iFirstItem;
+    size_t m_iLastItem;
 
 public:
     CicFirstInFirstOut()
         : m_pItems(NULL)
         , m_cItems(0)
-        , m_iLastItem(0)
         , m_iFirstItem(0)
+        , m_iLastItem(0)
     {
     }
 
@@ -34,21 +34,21 @@ public:
 
     size_t GetSize() const
     {
-        if (m_iLastItem == m_iFirstItem)
+        if (m_iFirstItem == m_iLastItem)
             return 0;
-        if (m_iLastItem < m_iFirstItem)
-            return m_iLastItem + m_cItems - m_iFirstItem;
-        return m_iLastItem - m_iFirstItem;
+        if (m_iFirstItem < m_iLastItem)
+            return m_iFirstItem + m_cItems - m_iLastItem;
+        return m_iFirstItem - m_iLastItem;
     }
 
     BOOL GetData(T_ITEM* pItem)
     {
-        if (m_iFirstItem == m_iLastItem)
+        if (m_iLastItem == m_iFirstItem)
             return FALSE;
-        *pItem = m_pItems[m_iFirstItem];
-        ZeroMemory(&m_pItems[m_iFirstItem], sizeof(T_ITEM));
-        if (++m_iFirstItem == m_cItems)
-            m_iFirstItem = 0;
+        *pItem = m_pItems[m_iLastItem];
+        ZeroMemory(&m_pItems[m_iLastItem], sizeof(T_ITEM));
+        if (++m_iLastItem == m_cItems)
+            m_iLastItem = 0;
         return TRUE;
     }
 
@@ -70,14 +70,14 @@ public:
         if (!pNewItems)
             return FALSE;
 
-        if (m_iLastItem < m_iFirstItem)
+        if (m_iFirstItem < m_iLastItem)
         {
-            size_t cTail = m_cItems - m_iFirstItem;
-            CopyMemory(pNewItems, &m_pItems[m_iFirstItem], cTail * sizeof(T_ITEM));
-            CopyMemory(&pNewItems[cTail], m_pItems, m_iLastItem * sizeof(T_ITEM));
-            size_t cUsed = cTail + m_iLastItem;
-            m_iFirstItem = 0;
-            m_iLastItem = cUsed;
+            size_t cTail = m_cItems - m_iLastItem;
+            CopyMemory(pNewItems, &m_pItems[m_iLastItem], cTail * sizeof(T_ITEM));
+            CopyMemory(&pNewItems[cTail], m_pItems, m_iFirstItem * sizeof(T_ITEM));
+            size_t cUsed = cTail + m_iFirstItem;
+            m_iLastItem = 0;
+            m_iFirstItem = cUsed;
         }
         else
         {
@@ -98,10 +98,10 @@ public:
                 return FALSE;
         }
 
-        m_pItems[m_iLastItem] = *pItem;
+        m_pItems[m_iFirstItem] = *pItem;
 
-        if (++m_iLastItem == m_cItems)
-            m_iLastItem = 0;
+        if (++m_iFirstItem == m_cItems)
+            m_iFirstItem = 0;
 
         return TRUE;
     }

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -15,13 +15,13 @@ class CicFirstInFirstOut
 {
 protected:
     T_ITEM* m_pItems;
-    INT_PTR m_cItems;
-    INT_PTR m_iBack;
-    INT_PTR m_iFront;
+    size_t m_cItems;
+    size_t m_iBack;
+    size_t m_iFront;
     //static_assert(std::is_trivially_copyable<T_ITEM>::value, ""); // FIXME
 
 public:
-    CicFirstInFirstOut(INT_PTR cInitial = 0)
+    CicFirstInFirstOut(size_t cInitial = 0)
         : m_pItems(NULL)
         , m_cItems(0)
         , m_iBack(0)
@@ -36,7 +36,7 @@ public:
         cicMemFree(m_pItems);
     }
 
-    INT_PTR GetSize() const
+    size_t GetSize() const
     {
         if (m_iBack == m_iFront)
             return 0;
@@ -74,10 +74,8 @@ public:
     }
 
 protected:
-    BOOL GrowBuffer(INT_PTR nGrow)
+    BOOL GrowBuffer(size_t nGrow)
     {
-        if (nGrow < 0)
-            return FALSE;
         if (nGrow == 0)
             return TRUE;
 
@@ -89,21 +87,24 @@ protected:
             return !!m_pItems;
         }
 
-        INT_PTR cNewItems = m_cItems + nGrow;
+        size_t cNewItems = m_cItems + nGrow;
+        if (cNewItems < m_cItems || cNewItems >= ~(size_t)0 / sizeof(T_ITEM))
+            return FALSE;
+
         T_ITEM* pNewItems = (T_ITEM*)cicMemAlloc(cNewItems * sizeof(T_ITEM));
         if (!pNewItems)
             return FALSE;
 
         if (m_iBack < m_iFront)
         {
-            INT_PTR cTail = m_cItems - m_iFront;
+            size_t cTail = m_cItems - m_iFront;
             CopyMemory(pNewItems, &m_pItems[m_iFront], cTail * sizeof(T_ITEM));
             CopyMemory(&pNewItems[cTail], m_pItems, m_iBack * sizeof(T_ITEM));
             m_iBack = cTail + m_iBack;
         }
         else
         {
-            INT_PTR nCount = m_iBack - m_iFront;
+            size_t nCount = m_iBack - m_iFront;
             CopyMemory(pNewItems, &m_pItems[m_iFront], nCount * sizeof(T_ITEM));
             m_iBack = nCount;
         }

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -21,12 +21,14 @@ protected:
     //static_assert(std::is_trivially_copyable<T_ITEM>::value, ""); // FIXME
 
 public:
-    CicFirstInFirstOut()
+    CicFirstInFirstOut(INT_PTR cInitial = 0)
         : m_pItems(NULL)
         , m_cItems(0)
         , m_iBack(0)
         , m_iFront(0)
     {
+        if (cInitial)
+            GrowBuffer(cInitial);
     }
 
     ~CicFirstInFirstOut()

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -71,6 +71,7 @@ public:
         return TRUE;
     }
 
+protected:
     BOOL GrowBuffer(INT_PTR nGrow)
     {
         if (nGrow <= 0)

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -12,6 +12,7 @@
 template <typename T_ITEM>
 class CicFirstInFirstOut
 {
+public:
     T_ITEM* m_pItems;
     INT_PTR m_cItems;
     INT_PTR m_iFirstItem;
@@ -49,20 +50,20 @@ class CicFirstInFirstOut
         return TRUE;
     }
 
-    void GrowBuffer(INT_PTR nGrow)
+    BOOL GrowBuffer(INT_PTR nGrow)
     {
         if (!m_pItems)
         {
             m_pItems = (T_ITEM*)cicMemAllocClear(nGrow * sizeof(T_ITEM));
             if (m_pItems)
                 m_cItems = nGrow;
-            return;
+            return !!m_pItems;
         }
 
         INT_PTR cNewItems = m_cItems + nGrow;
         T_ITEM* pNewItems = cicMemAlloc(cNewItems * sizeof(T_ITEM));
         if (!pNewItems)
-            return;
+            return FALSE;
 
         CopyMemory(pNewItems, m_pItems, m_cItems * sizeof(T_ITEM));
         ZeroMemory(&pNewItems[m_cItems], nGrow * sizeof(T_ITEM));
@@ -77,18 +78,23 @@ class CicFirstInFirstOut
         cicMemFree(m_pItems);
         m_pItems = pNewItems;
         m_cItems = cNewItems;
+        return TRUE;
     }
 
-    INT_PTR SetData(T_ITEM* pItem)
+    BOOL SetData(T_ITEM* pItem)
     {
         if (!m_cItems || GetSize() + 1 >= m_cItems)
-            GrowBuffer(3);
+        {
+            if (!GrowBuffer(3))
+                return FALSE;
+        }
 
         m_pItems[m_iFirstItem] = *pItem;
 
         INT_PTR iItem = ++m_iFirstItem;
         if (iItem == m_cItems)
             m_iFirstItem = 0;
-        return iItem;
+
+        return TRUE;
     }
 };

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -58,7 +58,7 @@ public:
         return TRUE;
     }
 
-    // Like pop and pop_front
+    // Like front and pop_front
     BOOL GetData(T_ITEM* pItem)
     {
         if (m_iFront == m_iBack)

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -65,11 +65,12 @@ class CicFirstInFirstOut
             return;
 
         CopyMemory(pNewItems, m_pItems, m_cItems * sizeof(T_ITEM));
-        if (m_iLastItem > m_iFirstItem)
+        ZeroMemory(&pNewItems[m_cItems], nGrow * sizeof(T_ITEM));
+
+        if (m_iFirstItem < m_iLastItem)
         {
             size_t cbCopy = (m_cItems - m_iLastItem) * sizeof(T_ITEM);
-            CopyMemory(&pNewItems[nGrow + m_iLastItem], &m_pItems[m_iLastItem], cbCopy);
-            ZeroMemory(&pNewItems[m_cItems], nGrow * sizeof(T_ITEM));
+            CopyMemory(&pNewItems[m_iLastItem + nGrow], &m_pItems[m_iLastItem], cbCopy);
             m_iLastItem += nGrow;
         }
 

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -14,16 +14,16 @@ class CicFirstInFirstOut
 {
 protected:
     T_ITEM* m_pItems;
-    size_t m_cItems;
-    size_t m_iFirstItem;
-    size_t m_iLastItem;
+    INT_PTR m_cItems;
+    INT_PTR m_iBack;
+    INT_PTR m_iFront;
 
 public:
     CicFirstInFirstOut()
         : m_pItems(NULL)
         , m_cItems(0)
-        , m_iFirstItem(0)
-        , m_iLastItem(0)
+        , m_iBack(0)
+        , m_iFront(0)
     {
     }
 
@@ -32,16 +32,16 @@ public:
         cicMemFree(m_pItems);
     }
 
-    size_t GetSize() const
+    INT_PTR GetSize() const
     {
-        if (m_iFirstItem == m_iLastItem)
+        if (m_iBack == m_iFront)
             return 0;
-        if (m_iFirstItem < m_iLastItem)
-            return m_iFirstItem + (m_cItems - m_iLastItem);
-        return m_iFirstItem - m_iLastItem;
+        if (m_iBack < m_iFront)
+            return m_iBack + (m_cItems - m_iFront);
+        return m_iBack - m_iFront;
     }
 
-    // First-In
+    // Like push_back
     BOOL SetData(const T_ITEM* pItem)
     {
         if (!m_cItems || GetSize() + 1 >= m_cItems) /* "+1" is for marking */
@@ -50,29 +50,29 @@ public:
                 return FALSE;
         }
 
-        m_pItems[m_iFirstItem] = *pItem;
+        m_pItems[m_iBack] = *pItem;
 
-        if (++m_iFirstItem == m_cItems)
-            m_iFirstItem = 0;
+        if (++m_iBack == m_cItems)
+            m_iBack = 0;
 
         return TRUE;
     }
 
-    // First-Out
+    // Like pop and pop_front
     BOOL GetData(T_ITEM* pItem)
     {
-        if (m_iLastItem == m_iFirstItem)
+        if (m_iFront == m_iBack)
             return FALSE;
-        *pItem = m_pItems[m_iLastItem];
-        ZeroMemory(&m_pItems[m_iLastItem], sizeof(T_ITEM));
-        if (++m_iLastItem == m_cItems)
-            m_iLastItem = 0;
+        *pItem = m_pItems[m_iFront];
+        ZeroMemory(&m_pItems[m_iFront], sizeof(T_ITEM));
+        if (++m_iFront == m_cItems)
+            m_iFront = 0;
         return TRUE;
     }
 
-    BOOL GrowBuffer(size_t nGrow)
+    BOOL GrowBuffer(INT_PTR nGrow)
     {
-        if (!nGrow)
+        if (nGrow <= 0)
             return TRUE;
 
         if (!m_pItems)
@@ -83,19 +83,19 @@ public:
             return !!m_pItems;
         }
 
-        size_t cNewItems = m_cItems + nGrow;
+        INT_PTR cNewItems = m_cItems + nGrow;
         T_ITEM* pNewItems = (T_ITEM*)cicMemAllocClear(cNewItems * sizeof(T_ITEM));
         if (!pNewItems)
             return FALSE;
 
-        if (m_iFirstItem < m_iLastItem)
+        if (m_iBack < m_iFront)
         {
-            size_t cTail = m_cItems - m_iLastItem;
-            CopyMemory(pNewItems, &m_pItems[m_iLastItem], cTail * sizeof(T_ITEM));
-            CopyMemory(&pNewItems[cTail], m_pItems, m_iFirstItem * sizeof(T_ITEM));
-            size_t cUsed = cTail + m_iFirstItem;
-            m_iLastItem = 0;
-            m_iFirstItem = cUsed;
+            INT_PTR cTail = m_cItems - m_iFront;
+            CopyMemory(pNewItems, &m_pItems[m_iFront], cTail * sizeof(T_ITEM));
+            CopyMemory(&pNewItems[cTail], m_pItems, m_iBack * sizeof(T_ITEM));
+            INT_PTR cUsed = cTail + m_iBack;
+            m_iFront = 0;
+            m_iBack = cUsed;
         }
         else
         {

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -46,9 +46,7 @@ public:
         if (m_iFirstItem == m_iLastItem)
             return FALSE;
         *pItem = m_pItems[m_iFirstItem];
-#ifndef NDEBUG
         ZeroMemory(&m_pItems[m_iFirstItem], sizeof(T_ITEM));
-#endif
         if (++m_iFirstItem == m_cItems)
             m_iFirstItem = 0;
         return TRUE;
@@ -61,18 +59,14 @@ public:
 
         if (!m_pItems)
         {
-#ifndef NDEBUG
             m_pItems = (T_ITEM*)cicMemAllocClear(nGrow * sizeof(T_ITEM));
-#else
-            m_pItems = (T_ITEM*)cicMemAlloc(nGrow * sizeof(T_ITEM));
-#endif
             if (m_pItems)
                 m_cItems = nGrow;
             return !!m_pItems;
         }
 
         size_t cNewItems = m_cItems + nGrow;
-        T_ITEM* pNewItems = (T_ITEM*)cicMemAlloc(cNewItems * sizeof(T_ITEM));
+        T_ITEM* pNewItems = (T_ITEM*)cicMemAllocClear(cNewItems * sizeof(T_ITEM));
         if (!pNewItems)
             return FALSE;
 
@@ -82,18 +76,12 @@ public:
             CopyMemory(pNewItems, &m_pItems[m_iFirstItem], cTail * sizeof(T_ITEM));
             CopyMemory(&pNewItems[cTail], m_pItems, m_iLastItem * sizeof(T_ITEM));
             size_t cUsed = cTail + m_iLastItem;
-#ifndef NDEBUG
-            ZeroMemory(&pNewItems[cUsed], (cNewItems - cUsed) * sizeof(T_ITEM));
-#endif
             m_iFirstItem = 0;
             m_iLastItem = cUsed;
         }
         else
         {
             CopyMemory(pNewItems, m_pItems, m_cItems * sizeof(T_ITEM));
-#ifndef NDEBUG
-            ZeroMemory(&pNewItems[m_cItems], nGrow * sizeof(T_ITEM));
-#endif
         }
 
         cicMemFree(m_pItems);

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -95,8 +95,7 @@ protected:
             INT_PTR cTail = m_cItems - m_iFront;
             CopyMemory(pNewItems, &m_pItems[m_iFront], cTail * sizeof(T_ITEM));
             CopyMemory(&pNewItems[cTail], m_pItems, m_iBack * sizeof(T_ITEM));
-            INT_PTR cUsed = cTail + m_iBack;
-            m_iBack = cUsed;
+            m_iBack = cTail + m_iBack;
         }
         else
         {

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -88,7 +88,7 @@ protected:
         }
 
         size_t cNewItems = m_cItems + nGrow;
-        if (cNewItems < m_cItems || cNewItems >= ~(size_t)0 / sizeof(T_ITEM))
+        if (cNewItems < m_cItems || cNewItems > ~(size_t)0 / sizeof(T_ITEM))
             return FALSE;
 
         T_ITEM* pNewItems = (T_ITEM*)cicMemAlloc(cNewItems * sizeof(T_ITEM));

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -9,6 +9,7 @@
 
 #include "cicbase.h"
 
+// FIFO (First-In-First-Out) ring buffer
 template <typename T_ITEM>
 class CicFirstInFirstOut
 {

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -79,7 +79,7 @@ class CicFirstInFirstOut
 
     INT_PTR SetData(T_ITEM* pItem)
     {
-        if (!m_cItems || GetSize() >= m_cItems - 1)
+        if (!m_cItems || GetSize() + 1 >= m_cItems)
             GrowBuffer(3);
 
         m_pItems[m_iFirstItem] = *pItem;

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -1,0 +1,92 @@
+/*
+ * PROJECT:     ReactOS Cicero
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Cicero FIFO (First-In-First-Out)
+ * COPYRIGHT:   Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#pragma once
+
+#include "cicbase.h"
+
+template <typename T_ITEM>
+class CicFirstInFirstOut
+{
+    T_ITEM* m_pItems;
+    INT m_cItems;
+    INT m_iFirstItem;
+    INT m_iLastItem;
+
+    CicFirstInFirstOut()
+        : m_pItems(NULL)
+        , m_cItems(0)
+        , m_iFirstItem(0)
+        , m_iLastItem(0)
+    {
+    }
+
+    ~CicFirstInFirstOut()
+    {
+        cicMemFree(m_pItems);
+    }
+
+    INT GetSize() const
+    {
+        if (m_iFirstItem == m_iLastItem)
+            return 0;
+        if (m_iFirstItem <= m_iLastItem)
+            return m_iFirstItem + m_cItems - m_iLastItem;
+        return m_iFirstItem - m_iLastItem;
+    }
+
+    BOOL GetData(T_ITEM* pItem)
+    {
+        if (m_iLastItem == m_iFirstItem)
+            return FALSE;
+        *pItem = m_pItems[m_iLastItem];
+        if (++m_iLastItem == m_cItems)
+            m_iLastItem = 0;
+        return TRUE;
+    }
+
+    void GrowBuffer(INT nGrow)
+    {
+        if (!m_pItems)
+        {
+            m_pItems = (T_ITEM*)cicMemAllocClear(nGrow * sizeof(T_ITEM));
+            if (m_pItems)
+                m_cItems = nGrow;
+            return;
+        }
+
+        INT cNewItems = m_cItems + nGrow;
+        T_ITEM* pNewItems = cicMemAllocClear(cNewItems * sizeof(T_ITEM));
+        if (!pNewItems)
+            return;
+
+        CopyMemory(pNewItems, m_pItems, m_cItems * sizeof(T_ITEM));
+        if (m_iLastItem > m_iFirstItem)
+        {
+            size_t cbCopy = (m_cItems - m_iLastItem) * sizeof(T_ITEM);
+            CopyMemory(&pNewItems[nGrow + m_iLastItem], &m_pItems[m_iLastItem], cbCopy);
+            m_iLastItem += nGrow;
+        }
+
+        cicMemFree(m_pItems);
+        m_pItems = pNewItems;
+        m_cItems = cNewItems;
+    }
+
+    INT SetData(T_ITEM* pItem)
+    {
+        if (!m_cItems || GetSize() >= m_cItems - 1)
+            GrowBuffer(3);
+
+        m_pItems[m_iFirstItem] = *pItem;
+
+        INT iItem = ++m_iFirstItem;
+        if (iItem == m_cItems)
+            m_iFirstItem = 0;
+        return iItem;
+    }
+};

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -12,17 +12,18 @@
 template <typename T_ITEM>
 class CicFirstInFirstOut
 {
-public:
+protected:
     T_ITEM* m_pItems;
-    INT_PTR m_cItems;
-    INT_PTR m_iFirstItem;
-    INT_PTR m_iLastItem;
+    size_t m_cItems;
+    size_t m_iLastItem;
+    size_t m_iFirstItem;
 
+public:
     CicFirstInFirstOut()
         : m_pItems(NULL)
         , m_cItems(0)
-        , m_iFirstItem(0)
         , m_iLastItem(0)
+        , m_iFirstItem(0)
     {
     }
 
@@ -31,27 +32,30 @@ public:
         cicMemFree(m_pItems);
     }
 
-    INT_PTR GetSize() const
+    size_t GetSize() const
     {
-        if (m_iFirstItem == m_iLastItem)
+        if (m_iLastItem == m_iFirstItem)
             return 0;
-        if (m_iFirstItem <= m_iLastItem)
-            return m_iFirstItem + m_cItems - m_iLastItem;
-        return m_iFirstItem - m_iLastItem;
+        if (m_iLastItem < m_iFirstItem)
+            return m_iLastItem + m_cItems - m_iFirstItem;
+        return m_iLastItem - m_iFirstItem;
     }
 
     BOOL GetData(T_ITEM* pItem)
     {
-        if (m_iLastItem == m_iFirstItem)
+        if (m_iFirstItem == m_iLastItem)
             return FALSE;
-        *pItem = m_pItems[m_iLastItem];
-        if (++m_iLastItem == m_cItems)
-            m_iLastItem = 0;
+        *pItem = m_pItems[m_iFirstItem];
+        if (++m_iFirstItem == m_cItems)
+            m_iFirstItem = 0;
         return TRUE;
     }
 
-    BOOL GrowBuffer(INT_PTR nGrow)
+    BOOL GrowBuffer(size_t nGrow)
     {
+        if (!nGrow)
+            return TRUE;
+
         if (!m_pItems)
         {
             m_pItems = (T_ITEM*)cicMemAllocClear(nGrow * sizeof(T_ITEM));
@@ -60,19 +64,25 @@ public:
             return !!m_pItems;
         }
 
-        INT_PTR cNewItems = m_cItems + nGrow;
-        T_ITEM* pNewItems = cicMemAlloc(cNewItems * sizeof(T_ITEM));
+        size_t cNewItems = m_cItems + nGrow;
+        T_ITEM* pNewItems = (T_ITEM*)cicMemAlloc(cNewItems * sizeof(T_ITEM));
         if (!pNewItems)
             return FALSE;
 
-        CopyMemory(pNewItems, m_pItems, m_cItems * sizeof(T_ITEM));
-        ZeroMemory(&pNewItems[m_cItems], nGrow * sizeof(T_ITEM));
-
-        if (m_iFirstItem < m_iLastItem)
+        if (m_iLastItem < m_iFirstItem)
         {
-            size_t cbCopy = (m_cItems - m_iLastItem) * sizeof(T_ITEM);
-            CopyMemory(&pNewItems[m_iLastItem + nGrow], &m_pItems[m_iLastItem], cbCopy);
-            m_iLastItem += nGrow;
+            size_t cTail = m_cItems - m_iFirstItem;
+            CopyMemory(pNewItems, &m_pItems[m_iFirstItem], cTail * sizeof(T_ITEM));
+            CopyMemory(&pNewItems[cTail], m_pItems, m_iLastItem * sizeof(T_ITEM));
+            size_t cUsed = cTail + m_iLastItem;
+            ZeroMemory(&pNewItems[cUsed], (cNewItems - cUsed) * sizeof(T_ITEM));
+            m_iFirstItem = 0;
+            m_iLastItem = cUsed;
+        }
+        else
+        {
+            CopyMemory(pNewItems, m_pItems, m_cItems * sizeof(T_ITEM));
+            ZeroMemory(&pNewItems[m_cItems], nGrow * sizeof(T_ITEM));
         }
 
         cicMemFree(m_pItems);
@@ -81,20 +91,23 @@ public:
         return TRUE;
     }
 
-    BOOL SetData(T_ITEM* pItem)
+    BOOL SetData(const T_ITEM* pItem)
     {
-        if (!m_cItems || GetSize() + 1 >= m_cItems)
+        if (!m_cItems || GetSize() + 1 >= m_cItems) /* "+1" is for marking */
         {
-            if (!GrowBuffer(3))
+            if (!GrowBuffer(!m_cItems ? 8 : (2 * m_cItems)))
                 return FALSE;
         }
 
-        m_pItems[m_iFirstItem] = *pItem;
+        m_pItems[m_iLastItem] = *pItem;
 
-        INT_PTR iItem = ++m_iFirstItem;
-        if (iItem == m_cItems)
-            m_iFirstItem = 0;
+        if (++m_iLastItem == m_cItems)
+            m_iLastItem = 0;
 
         return TRUE;
     }
+
+private:
+    CicFirstInFirstOut(const CicFirstInFirstOut&) = delete;
+    CicFirstInFirstOut& operator=(const CicFirstInFirstOut&) = delete;
 };

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -13,9 +13,9 @@ template <typename T_ITEM>
 class CicFirstInFirstOut
 {
     T_ITEM* m_pItems;
-    INT m_cItems;
-    INT m_iFirstItem;
-    INT m_iLastItem;
+    INT_PTR m_cItems;
+    INT_PTR m_iFirstItem;
+    INT_PTR m_iLastItem;
 
     CicFirstInFirstOut()
         : m_pItems(NULL)
@@ -30,7 +30,7 @@ class CicFirstInFirstOut
         cicMemFree(m_pItems);
     }
 
-    INT GetSize() const
+    INT_PTR GetSize() const
     {
         if (m_iFirstItem == m_iLastItem)
             return 0;
@@ -49,7 +49,7 @@ class CicFirstInFirstOut
         return TRUE;
     }
 
-    void GrowBuffer(INT nGrow)
+    void GrowBuffer(INT_PTR nGrow)
     {
         if (!m_pItems)
         {
@@ -59,7 +59,7 @@ class CicFirstInFirstOut
             return;
         }
 
-        INT cNewItems = m_cItems + nGrow;
+        INT_PTR cNewItems = m_cItems + nGrow;
         T_ITEM* pNewItems = cicMemAllocClear(cNewItems * sizeof(T_ITEM));
         if (!pNewItems)
             return;
@@ -77,14 +77,14 @@ class CicFirstInFirstOut
         m_cItems = cNewItems;
     }
 
-    INT SetData(T_ITEM* pItem)
+    INT_PTR SetData(T_ITEM* pItem)
     {
         if (!m_cItems || GetSize() >= m_cItems - 1)
             GrowBuffer(3);
 
         m_pItems[m_iFirstItem] = *pItem;
 
-        INT iItem = ++m_iFirstItem;
+        INT_PTR iItem = ++m_iFirstItem;
         if (iItem == m_cItems)
             m_iFirstItem = 0;
         return iItem;

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -18,6 +18,7 @@ protected:
     INT_PTR m_cItems;
     INT_PTR m_iBack;
     INT_PTR m_iFront;
+    //static_assert(std::is_trivially_copyable<T_ITEM>::value, ""); // FIXME
 
 public:
     CicFirstInFirstOut()
@@ -47,7 +48,7 @@ public:
     {
         if (!m_cItems || GetSize() + 1 >= m_cItems) /* "+1" is for marking */
         {
-            if (!GrowBuffer(!m_cItems ? 8 : (2 * m_cItems)))
+            if (!GrowBuffer(!m_cItems ? 8 : m_cItems))
                 return FALSE;
         }
 
@@ -65,7 +66,6 @@ public:
         if (m_iFront == m_iBack)
             return FALSE;
         *pItem = m_pItems[m_iFront];
-        ZeroMemory(&m_pItems[m_iFront], sizeof(T_ITEM));
         if (++m_iFront == m_cItems)
             m_iFront = 0;
         return TRUE;
@@ -78,14 +78,14 @@ public:
 
         if (!m_pItems)
         {
-            m_pItems = (T_ITEM*)cicMemAllocClear(nGrow * sizeof(T_ITEM));
+            m_pItems = (T_ITEM*)cicMemAlloc(nGrow * sizeof(T_ITEM));
             if (m_pItems)
                 m_cItems = nGrow;
             return !!m_pItems;
         }
 
         INT_PTR cNewItems = m_cItems + nGrow;
-        T_ITEM* pNewItems = (T_ITEM*)cicMemAllocClear(cNewItems * sizeof(T_ITEM));
+        T_ITEM* pNewItems = (T_ITEM*)cicMemAlloc(cNewItems * sizeof(T_ITEM));
         if (!pNewItems)
             return FALSE;
 
@@ -100,7 +100,10 @@ public:
         }
         else
         {
-            CopyMemory(pNewItems, m_pItems, m_cItems * sizeof(T_ITEM));
+            INT_PTR nCount = m_iBack - m_iFront;
+            CopyMemory(pNewItems, &m_pItems[m_iFront], nCount * sizeof(T_ITEM));
+            m_iFront = 0;
+            m_iBack = nCount;
         }
 
         cicMemFree(m_pItems);

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -41,6 +41,24 @@ public:
         return m_iFirstItem - m_iLastItem;
     }
 
+    // First-In
+    BOOL SetData(const T_ITEM* pItem)
+    {
+        if (!m_cItems || GetSize() + 1 >= m_cItems) /* "+1" is for marking */
+        {
+            if (!GrowBuffer(!m_cItems ? 8 : (2 * m_cItems)))
+                return FALSE;
+        }
+
+        m_pItems[m_iFirstItem] = *pItem;
+
+        if (++m_iFirstItem == m_cItems)
+            m_iFirstItem = 0;
+
+        return TRUE;
+    }
+
+    // First-Out
     BOOL GetData(T_ITEM* pItem)
     {
         if (m_iLastItem == m_iFirstItem)
@@ -87,22 +105,6 @@ public:
         cicMemFree(m_pItems);
         m_pItems = pNewItems;
         m_cItems = cNewItems;
-        return TRUE;
-    }
-
-    BOOL SetData(const T_ITEM* pItem)
-    {
-        if (!m_cItems || GetSize() + 1 >= m_cItems) /* "+1" is for marking */
-        {
-            if (!GrowBuffer(!m_cItems ? 8 : (2 * m_cItems)))
-                return FALSE;
-        }
-
-        m_pItems[m_iFirstItem] = *pItem;
-
-        if (++m_iFirstItem == m_cItems)
-            m_iFirstItem = 0;
-
         return TRUE;
     }
 

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -96,16 +96,15 @@ protected:
             CopyMemory(pNewItems, &m_pItems[m_iFront], cTail * sizeof(T_ITEM));
             CopyMemory(&pNewItems[cTail], m_pItems, m_iBack * sizeof(T_ITEM));
             INT_PTR cUsed = cTail + m_iBack;
-            m_iFront = 0;
             m_iBack = cUsed;
         }
         else
         {
             INT_PTR nCount = m_iBack - m_iFront;
             CopyMemory(pNewItems, &m_pItems[m_iFront], nCount * sizeof(T_ITEM));
-            m_iFront = 0;
             m_iBack = nCount;
         }
+        m_iFront = 0;
 
         cicMemFree(m_pItems);
         m_pItems = pNewItems;

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -60,7 +60,7 @@ class CicFirstInFirstOut
         }
 
         INT_PTR cNewItems = m_cItems + nGrow;
-        T_ITEM* pNewItems = cicMemAllocClear(cNewItems * sizeof(T_ITEM));
+        T_ITEM* pNewItems = cicMemAlloc(cNewItems * sizeof(T_ITEM));
         if (!pNewItems)
             return;
 
@@ -69,6 +69,7 @@ class CicFirstInFirstOut
         {
             size_t cbCopy = (m_cItems - m_iLastItem) * sizeof(T_ITEM);
             CopyMemory(&pNewItems[nGrow + m_iLastItem], &m_pItems[m_iLastItem], cbCopy);
+            ZeroMemory(&pNewItems[m_cItems], nGrow * sizeof(T_ITEM));
             m_iLastItem += nGrow;
         }
 

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -37,7 +37,7 @@ public:
         if (m_iFirstItem == m_iLastItem)
             return 0;
         if (m_iFirstItem < m_iLastItem)
-            return m_iFirstItem + m_cItems - m_iLastItem;
+            return m_iFirstItem + (m_cItems - m_iLastItem);
         return m_iFirstItem - m_iLastItem;
     }
 

--- a/base/ctf/cicero/cicfifo.h
+++ b/base/ctf/cicero/cicfifo.h
@@ -46,6 +46,9 @@ public:
         if (m_iFirstItem == m_iLastItem)
             return FALSE;
         *pItem = m_pItems[m_iFirstItem];
+#ifndef NDEBUG
+        ZeroMemory(&m_pItems[m_iFirstItem], sizeof(T_ITEM));
+#endif
         if (++m_iFirstItem == m_cItems)
             m_iFirstItem = 0;
         return TRUE;
@@ -58,7 +61,11 @@ public:
 
         if (!m_pItems)
         {
+#ifndef NDEBUG
             m_pItems = (T_ITEM*)cicMemAllocClear(nGrow * sizeof(T_ITEM));
+#else
+            m_pItems = (T_ITEM*)cicMemAlloc(nGrow * sizeof(T_ITEM));
+#endif
             if (m_pItems)
                 m_cItems = nGrow;
             return !!m_pItems;
@@ -75,14 +82,18 @@ public:
             CopyMemory(pNewItems, &m_pItems[m_iFirstItem], cTail * sizeof(T_ITEM));
             CopyMemory(&pNewItems[cTail], m_pItems, m_iLastItem * sizeof(T_ITEM));
             size_t cUsed = cTail + m_iLastItem;
+#ifndef NDEBUG
             ZeroMemory(&pNewItems[cUsed], (cNewItems - cUsed) * sizeof(T_ITEM));
+#endif
             m_iFirstItem = 0;
             m_iLastItem = cUsed;
         }
         else
         {
             CopyMemory(pNewItems, m_pItems, m_cItems * sizeof(T_ITEM));
+#ifndef NDEBUG
             ZeroMemory(&pNewItems[m_cItems], nGrow * sizeof(T_ITEM));
+#endif
         }
 
         cicMemFree(m_pItems);


### PR DESCRIPTION
## Purpose

Supporting CTF IMEs. This FIFO will be used in `TRANSMSG` handling.
JIRA issue: [CORE-19360](https://jira.reactos.org/browse/CORE-19360)

## Proposed changes

- Add `base/ctf/cicero/cicfifo.h`.
- Implement `CicFirstInFirstOut` template class.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: