### PR TITLE
[FREELDR] Add UEFI F9 firmware setup reboot

### DIFF
--- a/boot/freeldr/freeldr/arch/uefi/uefireboot.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefireboot.c
@@ -8,7 +8,7 @@
 #include <uefildr.h>
 
 #include <debug.h>
-DBG_DEFAULT_CHANNEL(WARNING);
+DBG_DEFAULT_CHANNEL(HWDETECT);
 
 extern EFI_SYSTEM_TABLE *GlobalSystemTable;
 
@@ -21,7 +21,7 @@ extern EFI_SYSTEM_TABLE *GlobalSystemTable;
 
 static EFI_GUID EfiGlobalVariableGuid = EFI_GLOBAL_VARIABLE;
 
-static BOOLEAN
+BOOLEAN
 UefiFirmwareSetupSupported(VOID)
 {
     EFI_STATUS Status;
@@ -36,15 +36,15 @@ UefiFirmwareSetupSupported(VOID)
         &OsIndicationsSupported);
     if (Status != EFI_SUCCESS)
     {
-        WARN("Failed to query firmware setup support, status 0x%lx\n",
-             (ULONG)Status);
+        WARN("Failed to query firmware setup support, status 0x%Ix\n",
+             Status);
         return FALSE;
     }
 
     if (Size != sizeof(OsIndicationsSupported))
     {
-        WARN("Firmware setup support variable has unexpected size %lu\n",
-             (ULONG)Size);
+        WARN("Firmware setup support variable has unexpected size %Iu\n",
+             Size);
         return FALSE;
     }
 
@@ -72,15 +72,15 @@ UefiSetFirmwareSetupBoot(VOID)
     {
         if (Status != EFI_SUCCESS)
         {
-            WARN("Failed to query firmware setup request variable, status 0x%lx\n",
-                 (ULONG)Status);
+            WARN("Failed to query firmware setup request variable, status 0x%Ix\n",
+                 Status);
             return Status;
         }
 
         if (Size != sizeof(OsIndications))
         {
-            WARN("Firmware setup request variable has unexpected size %lu\n",
-                 (ULONG)Size);
+            WARN("Firmware setup request variable has unexpected size %Iu\n",
+                 Size);
             return EFI_INVALID_PARAMETER;
         }
     }
@@ -109,8 +109,8 @@ UefiBootToFirmware(VOID)
     Status = UefiSetFirmwareSetupBoot();
     if (Status != EFI_SUCCESS)
     {
-        WARN("Failed to request firmware setup, status 0x%lx\n",
-             (ULONG)Status);
+        WARN("Failed to request firmware setup, status 0x%Ix\n",
+             Status);
         UiMessageBox("Unable to request firmware setup.");
         return;
     }

--- a/boot/freeldr/freeldr/arch/uefi/uefireboot.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefireboot.c
@@ -1,0 +1,122 @@
+/*
+ * PROJECT:     FreeLoader UEFI Support
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Request firmware setup menu on next boot
+ * COPYRIGHT:   Copyright 2026 Ahmed Arif <arif.img@outlook.com>
+ */
+
+#include <uefildr.h>
+
+#include <debug.h>
+DBG_DEFAULT_CHANNEL(WARNING);
+
+extern EFI_SYSTEM_TABLE *GlobalSystemTable;
+
+#define EFI_OS_INDICATIONS_BOOT_TO_FW_UI    0x0000000000000001ULL
+
+#define EFI_OS_INDICATIONS_ATTRIBUTES       \
+    (EFI_VARIABLE_NON_VOLATILE |            \
+     EFI_VARIABLE_BOOTSERVICE_ACCESS |      \
+     EFI_VARIABLE_RUNTIME_ACCESS)
+
+static EFI_GUID EfiGlobalVariableGuid = EFI_GLOBAL_VARIABLE;
+
+static BOOLEAN
+UefiFirmwareSetupSupported(VOID)
+{
+    EFI_STATUS Status;
+    UINT64 OsIndicationsSupported = 0;
+    UINTN Size = sizeof(OsIndicationsSupported);
+
+    Status = GlobalSystemTable->RuntimeServices->GetVariable(
+        EFI_OS_INDICATIONS_SUPPORT_VARIABLE_NAME,
+        &EfiGlobalVariableGuid,
+        NULL,
+        &Size,
+        &OsIndicationsSupported);
+    if (Status != EFI_SUCCESS)
+    {
+        WARN("Failed to query firmware setup support, status 0x%lx\n",
+             (ULONG)Status);
+        return FALSE;
+    }
+
+    if (Size != sizeof(OsIndicationsSupported))
+    {
+        WARN("Firmware setup support variable has unexpected size %lu\n",
+             (ULONG)Size);
+        return FALSE;
+    }
+
+    return !!(OsIndicationsSupported & EFI_OS_INDICATIONS_BOOT_TO_FW_UI);
+}
+
+static EFI_STATUS
+UefiSetFirmwareSetupBoot(VOID)
+{
+    EFI_STATUS Status;
+    UINT64 OsIndications = 0;
+    UINTN Size = sizeof(OsIndications);
+
+    Status = GlobalSystemTable->RuntimeServices->GetVariable(
+        EFI_OS_INDICATIONS_VARIABLE_NAME,
+        &EfiGlobalVariableGuid,
+        NULL,
+        &Size,
+        &OsIndications);
+    if (Status == EFI_NOT_FOUND)
+    {
+        OsIndications = 0;
+    }
+    else
+    {
+        if (Status != EFI_SUCCESS)
+        {
+            WARN("Failed to query firmware setup request variable, status 0x%lx\n",
+                 (ULONG)Status);
+            return Status;
+        }
+
+        if (Size != sizeof(OsIndications))
+        {
+            WARN("Firmware setup request variable has unexpected size %lu\n",
+                 (ULONG)Size);
+            return EFI_INVALID_PARAMETER;
+        }
+    }
+
+    OsIndications |= EFI_OS_INDICATIONS_BOOT_TO_FW_UI;
+
+    return GlobalSystemTable->RuntimeServices->SetVariable(
+        EFI_OS_INDICATIONS_VARIABLE_NAME,
+        &EfiGlobalVariableGuid,
+        EFI_OS_INDICATIONS_ATTRIBUTES,
+        sizeof(OsIndications),
+        &OsIndications);
+}
+
+VOID
+UefiBootToFirmware(VOID)
+{
+    EFI_STATUS Status;
+
+    if (!UefiFirmwareSetupSupported())
+    {
+        UiMessageBox("Firmware setup is not supported by this system.");
+        return;
+    }
+
+    Status = UefiSetFirmwareSetupBoot();
+    if (Status != EFI_SUCCESS)
+    {
+        WARN("Failed to request firmware setup, status 0x%lx\n",
+             (ULONG)Status);
+        UiMessageBox("Unable to request firmware setup.");
+        return;
+    }
+
+    GlobalSystemTable->RuntimeServices->ResetSystem(
+        EfiResetCold, EFI_SUCCESS, 0, NULL);
+
+    UiMessageBox("Unable to reboot into firmware setup.");
+}

--- a/boot/freeldr/freeldr/bootmgr.c
+++ b/boot/freeldr/freeldr/bootmgr.c
@@ -21,6 +21,18 @@
 
 #include <freeldr.h>
 
+#ifdef UEFIBOOT
+VOID
+UefiBootToFirmware(VOID);
+
+#define MAIN_BOOT_MENU_KEY_HINT \
+    "F8: Advanced   F9: Firmware Setup   F2: FreeLdr SETUP"
+#else
+#define MAIN_BOOT_MENU_KEY_HINT \
+    "Press F8 for troubleshooting and advanced startup options." \
+    "     F2: FreeLdr SETUP"
+#endif
+
 #include <debug.h>
 DBG_DEFAULT_CHANNEL(WARNING);
 
@@ -377,6 +389,12 @@ MainBootMenuKeyPressFilter(
         return TRUE;
 #endif
 
+#ifdef UEFIBOOT
+    case KEY_F9:
+        UefiBootToFirmware();
+        return TRUE;
+#endif
+
     default:
         /* We didn't handle the key */
         return FALSE;
@@ -451,8 +469,7 @@ VOID RunLoader(VOID)
         /* Show the operating system list menu */
         if (!UiDisplayMenu("Please select the operating system to start:",
                            /* The string is 80 characters long; don't make it longer! */
-                           "Press F8 for troubleshooting and advanced startup options."
-                           "     F2: FreeLdr SETUP",
+                           MAIN_BOOT_MENU_KEY_HINT,
                            OperatingSystemDisplayNames,
                            OperatingSystemCount,
                            SelectedOperatingSystem,

--- a/boot/freeldr/freeldr/bootmgr.c
+++ b/boot/freeldr/freeldr/bootmgr.c
@@ -21,17 +21,9 @@
 
 #include <freeldr.h>
 
-#ifdef UEFIBOOT
-VOID
-UefiBootToFirmware(VOID);
-
-#define MAIN_BOOT_MENU_KEY_HINT \
-    "F8: Advanced   F9: Firmware Setup   F2: FreeLdr SETUP"
-#else
 #define MAIN_BOOT_MENU_KEY_HINT \
     "Press F8 for troubleshooting and advanced startup options." \
     "     F2: FreeLdr SETUP"
-#endif
 
 #include <debug.h>
 DBG_DEFAULT_CHANNEL(WARNING);
@@ -386,12 +378,6 @@ MainBootMenuKeyPressFilter(
     /* Boot entry editor */
     case KEY_F10:
         EditOperatingSystemEntry(OperatingSystem);
-        return TRUE;
-#endif
-
-#ifdef UEFIBOOT
-    case KEY_F9:
-        UefiBootToFirmware();
         return TRUE;
 #endif
 

--- a/boot/freeldr/freeldr/include/arch/uefi/machuefi.h
+++ b/boot/freeldr/freeldr/include/arch/uefi/machuefi.h
@@ -112,3 +112,6 @@ UefiHwIdle(VOID);
 VOID
 UefiInitializeFileSystemSupport(_In_ EFI_HANDLE ImageHandle,
                                 _In_ EFI_SYSTEM_TABLE *SystemTable);
+
+VOID
+UefiBootToFirmware(VOID);

--- a/boot/freeldr/freeldr/include/arch/uefi/machuefi.h
+++ b/boot/freeldr/freeldr/include/arch/uefi/machuefi.h
@@ -112,6 +112,3 @@ UefiHwIdle(VOID);
 VOID
 UefiInitializeFileSystemSupport(_In_ EFI_HANDLE ImageHandle,
                                 _In_ EFI_SYSTEM_TABLE *SystemTable);
-
-VOID
-UefiBootToFirmware(VOID);

--- a/boot/freeldr/freeldr/include/machine.h
+++ b/boot/freeldr/freeldr/include/machine.h
@@ -142,4 +142,9 @@ VOID MachGetExtendedBIOSData(PULONG ExtendedBIOSDataArea, PULONG ExtendedBIOSDat
 VOID MachVideoGetFontsFromFirmware(PULONG RomFontPointers);
 ULONG MachGetBootSectorLoadAddress(IN UCHAR DriveNumber);
 
+#ifdef UEFIBOOT
+BOOLEAN UefiFirmwareSetupSupported(VOID);
+VOID UefiBootToFirmware(VOID);
+#endif
+
 /* EOF */

--- a/boot/freeldr/freeldr/options.c
+++ b/boot/freeldr/freeldr/options.c
@@ -14,22 +14,15 @@
 
 /* GLOBALS ********************************************************************/
 
-static PCSTR OptionsMenuList[] =
+typedef enum _FREELDR_SETUP_ACTION
 {
-    "FreeLdr debugging",
-
-    NULL,
-
-#ifdef HAS_OPTION_MENU_EDIT_CMDLINE
-    "Edit Boot Command Line (F10)",
-#endif
-#ifdef HAS_OPTION_MENU_CUSTOM_BOOT
-    "Custom Boot",
-#endif
-#ifdef HAS_OPTION_MENU_REBOOT
-    "Reboot",
-#endif
-};
+    FreeldrSetupActionDebug,
+    FreeldrSetupActionSeparator,
+    FreeldrSetupActionEditCmdLine,
+    FreeldrSetupActionCustomBoot,
+    FreeldrSetupActionReboot,
+    FreeldrSetupActionFirmwareSetup,
+} FREELDR_SETUP_ACTION;
 
 static PCSTR FrldrDbgMsg =
     "Enable FreeLdr debug channels\n"
@@ -53,16 +46,53 @@ VOID
 FreeLdrSetupMenu(
     _In_opt_ OperatingSystemItem* OperatingSystem)
 {
+    PCSTR OptionsMenuList[6];
+    FREELDR_SETUP_ACTION OptionsMenuActions[RTL_NUMBER_OF(OptionsMenuList)];
     ULONG SelectedMenuItem = 0;
+    ULONG MenuItemCount;
 
 doMenu:
+    MenuItemCount = 0;
+
+    OptionsMenuList[MenuItemCount] = "FreeLdr debugging";
+    OptionsMenuActions[MenuItemCount++] = FreeldrSetupActionDebug;
+
+    OptionsMenuList[MenuItemCount] = NULL;
+    OptionsMenuActions[MenuItemCount++] = FreeldrSetupActionSeparator;
+
+#ifdef HAS_OPTION_MENU_EDIT_CMDLINE
+    OptionsMenuList[MenuItemCount] = "Edit Boot Command Line (F10)";
+    OptionsMenuActions[MenuItemCount++] = FreeldrSetupActionEditCmdLine;
+#endif
+#ifdef HAS_OPTION_MENU_CUSTOM_BOOT
+    OptionsMenuList[MenuItemCount] = "Custom Boot";
+    OptionsMenuActions[MenuItemCount++] = FreeldrSetupActionCustomBoot;
+#endif
+#ifdef HAS_OPTION_MENU_REBOOT
+    OptionsMenuList[MenuItemCount] = "Reboot";
+    OptionsMenuActions[MenuItemCount++] = FreeldrSetupActionReboot;
+#endif
+#ifdef UEFIBOOT
+    if (UefiFirmwareSetupSupported())
+    {
+        OptionsMenuList[MenuItemCount] = "Reboot to Firmware Setup";
+        OptionsMenuActions[MenuItemCount++] = FreeldrSetupActionFirmwareSetup;
+    }
+#endif
+
+    if ((SelectedMenuItem >= MenuItemCount) ||
+        (OptionsMenuList[SelectedMenuItem] == NULL))
+    {
+        SelectedMenuItem = 0;
+    }
+
     /* Clear the backdrop */
     UiDrawBackdrop(UiGetScreenHeight());
 
     if (!UiDisplayMenu(VERSION " Setup and Configuration",
                        OperatingSystem ? NULL : "Press ESC to reboot.",
                        OptionsMenuList,
-                       RTL_NUMBER_OF(OptionsMenuList),
+                       MenuItemCount,
                        SelectedMenuItem, -1,
                        &SelectedMenuItem,
                        TRUE,
@@ -72,9 +102,9 @@ doMenu:
         return;
     }
 
-    switch (SelectedMenuItem)
+    switch (OptionsMenuActions[SelectedMenuItem])
     {
-        case 0: // FreeLdr debugging
+        case FreeldrSetupActionDebug:
         {
             CHAR DebugChannelString[100] = "";
             // DebugChannelString[0] = ANSI_NULL;
@@ -86,24 +116,24 @@ doMenu:
             }
             break;
         }
-        // case 1: // Separator
-        //     break;
-#ifdef HAS_OPTION_MENU_EDIT_CMDLINE
-        case 2: // Edit command line
+        case FreeldrSetupActionEditCmdLine:
             if (OperatingSystem)
                 EditOperatingSystemEntry(OperatingSystem);
             break;
-#endif
-#ifdef HAS_OPTION_MENU_CUSTOM_BOOT
-        case 3: // Custom Boot
+        case FreeldrSetupActionCustomBoot:
             OptionMenuCustomBoot();
             break;
-#endif
-#ifdef HAS_OPTION_MENU_REBOOT
-        case 4: // Reboot
+        case FreeldrSetupActionReboot:
             OptionMenuReboot();
             break;
+#ifdef UEFIBOOT
+        case FreeldrSetupActionFirmwareSetup:
+            UefiBootToFirmware();
+            break;
 #endif
+        case FreeldrSetupActionSeparator:
+        default:
+            break;
     }
     goto doMenu;
 }

--- a/boot/freeldr/freeldr/uefi.cmake
+++ b/boot/freeldr/freeldr/uefi.cmake
@@ -18,6 +18,7 @@ list(APPEND UEFILDR_ARC_SOURCE
     arch/uefi/uefidisk.c
     arch/uefi/uefihw.c
     arch/uefi/uefimem.c
+    arch/uefi/uefireboot.c
     arch/uefi/uefisetup.c
     arch/uefi/uefiutil.c
     arch/uefi/uefivid.c


### PR DESCRIPTION
## Purpose

- Add `F9` handling in the FreeLdr boot menu when built as UEFI.
- Request firmware setup through the UEFI `OsIndications` variable.
- Check `OsIndicationsSupported` before rebooting.
- Preserve existing `OsIndications` bits and only set `BootToFirmwareUI`.
- Return to the boot menu with an error message if firmware setup is unsupported or the request fails.


## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: