### PR TITLE
[SHELL32] Copy CMINVOKECOMMANDINFO before mutating lpVerb

### DIFF
--- a/dll/win32/shell32/CDefViewBckgrndMenu.cpp
+++ b/dll/win32/shell32/CDefViewBckgrndMenu.cpp
@@ -247,8 +247,9 @@ CDefViewBckgrndMenu::InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi)
     case FCIDM_SHVIEW_INSERTLINK:
         if (m_folderCM)
         {
-            lpcmi->lpVerb = MAKEINTRESOURCEA(idCmd);
-            return m_folderCM->InvokeCommand(lpcmi);
+            CMINVOKECOMMANDINFO cmi = *lpcmi;
+            cmi.lpVerb = MAKEINTRESOURCEA(idCmd);
+            return m_folderCM->InvokeCommand(&cmi);
         }
         WARN("m_folderCM is NULL!\n");
         return E_NOTIMPL;


### PR DESCRIPTION
## Purpose

Fix undefined behavior in `CDefViewBckgrndMenu::InvokeCommand` where `lpVerb` was
being mutated through a `const` pointer (`LPCMINVOKECOMMANDINFO`).

JIRA issue: None

## Proposed changes
- Copy `CMINVOKECOMMANDINFO` to a local struct before mutating `lpVerb` in the
  `FCIDM_SHVIEW_INSERT` / `FCIDM_SHVIEW_INSERTLINK` cases of `InvokeCommand`

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: