### PR TITLE
[SHELL32][SDK] Implement CDefFolderMenu_MergeMenu

### DIFF
--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -136,19 +136,6 @@ SHGetSetFolderCustomSettingsA(LPSHFOLDERCUSTOMSETTINGSA pfcs,
 /*
  * Unimplemented
  */
-EXTERN_C VOID
-WINAPI
-CDefFolderMenu_MergeMenu(HINSTANCE hInstance,
-                         UINT uMainMerge,
-                         UINT uPopupMerge,
-                         LPQCMINFO lpQcmInfo)
-{
-    FIXME("CDefFolderMenu_MergeMenu() stub\n");
-}
-
-/*
- * Unimplemented
- */
 EXTERN_C HRESULT
 WINAPI
 CDefFolderMenu_Create(LPITEMIDLIST pidlFolder,

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -34,8 +34,10 @@ static PCWSTR StrEndNW(_In_ PCWSTR psz, _In_ INT_PTR cch)
 
 static INT _SHMergePopupMenus(HMENU hMenu, HMENU hPopupMenu, UINT uIDAdjust, UINT uIDAdjustMax)
 {
-    UINT maxID = uIDAdjust;
-    const UINT itemCount = GetMenuItemCount(hPopupMenu);
+    INT maxID = uIDAdjust;
+    const INT itemCount = GetMenuItemCount(hPopupMenu);
+    if (itemCount == -1)
+        return maxID;
 
     MENUITEMINFOW mii = { sizeof(mii), MIIM_ID | MIIM_SUBMENU };
     for (INT i = itemCount - 1; i >= 0; --i)
@@ -44,9 +46,12 @@ static INT _SHMergePopupMenus(HMENU hMenu, HMENU hPopupMenu, UINT uIDAdjust, UIN
             continue;
 
         HMENU hTargetSubMenu = SHGetMenuFromID(hMenu, mii.wID);
-        UINT currentMax = Shell_MergeMenus(hTargetSubMenu, mii.hSubMenu, 0,
-                                           uIDAdjust, uIDAdjustMax,
-                                           MM_ADDSEPARATOR | MM_SUBMENUSHAVEIDS);
+        if (!hTargetSubMenu)
+            continue;
+
+        INT currentMax = Shell_MergeMenus(hTargetSubMenu, mii.hSubMenu, 0,
+                                          uIDAdjust, uIDAdjustMax,
+                                          MM_ADDSEPARATOR | MM_SUBMENUSHAVEIDS);
         maxID = max(maxID, currentMax);
     }
 

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -32,6 +32,83 @@ static PCWSTR StrEndNW(_In_ PCWSTR psz, _In_ INT_PTR cch)
     return pch;
 }
 
+static INT _SHMergePopupMenus(HMENU hMenu, HMENU hPopupMenu, UINT uIDAdjust, UINT uIDAdjustMax)
+{
+    UINT maxID = uIDAdjust;
+    const UINT itemCount = GetMenuItemCount(hPopupMenu);
+
+    MENUITEMINFOW mii = { sizeof(mii), MIIM_ID | MIIM_SUBMENU };
+    for (INT i = itemCount - 1; i >= 0; --i)
+    {
+        if (!GetMenuItemInfoW(hPopupMenu, i, TRUE, &mii))
+            continue;
+
+        HMENU hTargetSubMenu = SHGetMenuFromID(hMenu, mii.wID);
+        UINT currentMax = Shell_MergeMenus(hTargetSubMenu, mii.hSubMenu, 0,
+                                           uIDAdjust, uIDAdjustMax,
+                                           MM_ADDSEPARATOR | MM_SUBMENUSHAVEIDS);
+        maxID = max(maxID, currentMax);
+    }
+
+    return maxID;
+}
+
+static HMENU SHLoadPopupMenu(HINSTANCE hInstance, UINT uMenuId)
+{
+    HMENU hMenu = LoadMenuW(hInstance, MAKEINTRESOURCEW(uMenuId));
+    if (!hMenu)
+        return NULL;
+    HMENU hSubMenu = GetSubMenu(hMenu, 0);
+    RemoveMenu(hMenu, 0, MF_BYPOSITION);
+    DestroyMenu(hMenu);
+    return hSubMenu;
+}
+
+/*************************************************************************
+ * CDefFolderMenu_MergeMenu [SHELL32.702]
+ */
+EXTERN_C
+VOID WINAPI
+CDefFolderMenu_MergeMenu(
+    _In_ HINSTANCE hInstance,
+    _In_ UINT uMainMerge,
+    _In_ UINT uPopupMerge,
+    _Inout_ LPQCMINFO lpQcmInfo)
+{
+    UINT idCmdFirst = lpQcmInfo->idCmdFirst;
+    HMENU hPopupMenu;
+
+    if (uMainMerge)
+    {
+        hPopupMenu = SHLoadPopupMenu(hInstance, uMainMerge);
+        if (hPopupMenu)
+        {
+            enum { uFlags = MM_ADDSEPARATOR | MM_SUBMENUSHAVEIDS | MM_DONTREMOVESEPS };
+            idCmdFirst = Shell_MergeMenus(lpQcmInfo->hmenu,
+                                          hPopupMenu,
+                                          lpQcmInfo->indexMenu,
+                                          lpQcmInfo->idCmdFirst,
+                                          lpQcmInfo->idCmdLast,
+                                          uFlags);
+            DestroyMenu(hPopupMenu);
+        }
+    }
+
+    if (uPopupMerge)
+    {
+        hPopupMenu = LoadMenuW(hInstance, MAKEINTRESOURCEW(uPopupMerge));
+        if (hPopupMenu)
+        {
+            UINT id = _SHMergePopupMenus(lpQcmInfo->hmenu, hPopupMenu,
+                                         lpQcmInfo->idCmdFirst, lpQcmInfo->idCmdLast);
+            idCmdFirst = max(idCmdFirst, id);
+            DestroyMenu(hPopupMenu);
+        }
+    }
+
+    lpQcmInfo->idCmdFirst = idCmdFirst;
+}
+
 /*************************************************************************
  *  StrRStrA [SHELL32.389]
  */

--- a/dll/win32/shell32/wine/shlmenu.c
+++ b/dll/win32/shell32/wine/shlmenu.c
@@ -27,7 +27,6 @@
 #include <shlobj.h>
 #include <undocshell.h>
 #include <shlwapi.h>
-#include <shlwapi_undoc.h>
 #include <wine/debug.h>
 #include <wine/unicode.h>
 
@@ -995,86 +994,4 @@ UINT WINAPI Shell_MergeMenus (HMENU hmDst, HMENU hmSrc, UINT uInsert, UINT uIDAd
 	  }
 	}
 	return(uIDMax);
-}
-
-static INT _SHMergePopupMenus(HMENU hMenu, HMENU hPopupMenu, UINT uIDAdjust, UINT uIDAdjustMax)
-{
-    INT maxID = uIDAdjust;
-    const INT itemCount = GetMenuItemCount(hPopupMenu);
-
-    MENUITEMINFOW mii = { sizeof(mii), MIIM_ID | MIIM_SUBMENU };
-    for (INT i = itemCount - 1; i >= 0; --i)
-    {
-        if (!GetMenuItemInfoW(hPopupMenu, i, TRUE, &mii))
-            continue;
-
-        HMENU hTargetSubMenu = SHGetMenuFromID(hMenu, mii.wID);
-        INT currentMax = Shell_MergeMenus(
-            hTargetSubMenu, 
-            mii.hSubMenu, 
-            0, 
-            uIDAdjust, 
-            uIDAdjustMax, 
-            MM_ADDSEPARATOR | MM_SUBMENUSHAVEIDS);
-
-        maxID = max(maxID, currentMax);
-    }
-
-    return maxID;
-}
-
-static HMENU SHLoadPopupMenu(HINSTANCE hInstance, UINT uMenuId)
-{
-    HMENU hMenu = LoadMenuW(hInstance, MAKEINTRESOURCEW(uMenuId));
-    if (!hMenu)
-        return NULL;
-    HMENU hSubMenu = GetSubMenu(hMenu, 0);
-    RemoveMenu(hMenu, 0, MF_BYPOSITION);
-    DestroyMenu(hMenu);
-    return hSubMenu;
-}
-
-/*************************************************************************
- * CDefFolderMenu_MergeMenu         [SHELL32.702]
- */
-VOID WINAPI
-CDefFolderMenu_MergeMenu(
-    _In_ HINSTANCE hInstance,
-    _In_ UINT uMainMerge,
-    _In_ UINT uPopupMerge,
-    _Inout_ LPQCMINFO lpQcmInfo)
-{
-	TRACE("(%p, %u, %u, %p)\n", hInstance, uMainMerge, uPopupMerge, lpQcmInfo);
-
-    UINT idCmdFirst = lpQcmInfo->idCmdFirst;
-
-    if (uMainMerge)
-    {
-        HMENU hMenu = SHLoadPopupMenu(hInstance, uMainMerge);
-        if (hMenu)
-        {
-            const UINT uFlags = MM_ADDSEPARATOR | MM_SUBMENUSHAVEIDS | MM_DONTREMOVESEPS;
-            idCmdFirst = Shell_MergeMenus(lpQcmInfo->hmenu,
-                                          hMenu,
-                                          lpQcmInfo->indexMenu,
-                                          lpQcmInfo->idCmdFirst,
-                                          lpQcmInfo->idCmdLast,
-                                          uFlags);
-            DestroyMenu(hMenu);
-        }
-    }
-
-    if (uPopupMerge)
-    {
-        HMENU hMenu = LoadMenuW(hInstance, MAKEINTRESOURCEW(uPopupMerge));
-        if (hMenu)
-        {
-            INT id = _SHMergePopupMenus(lpQcmInfo->hmenu, hMenu,
-                                       lpQcmInfo->idCmdFirst, lpQcmInfo->idCmdLast);
-            idCmdFirst = max(idCmdFirst, id);
-            DestroyMenu(hMenu);
-        }
-    }
-
-    lpQcmInfo->idCmdFirst = idCmdFirst;
 }

--- a/dll/win32/shell32/wine/shlmenu.c
+++ b/dll/win32/shell32/wine/shlmenu.c
@@ -27,6 +27,7 @@
 #include <shlobj.h>
 #include <undocshell.h>
 #include <shlwapi.h>
+#include <shlwapi_undoc.h>
 #include <wine/debug.h>
 #include <wine/unicode.h>
 
@@ -994,4 +995,86 @@ UINT WINAPI Shell_MergeMenus (HMENU hmDst, HMENU hmSrc, UINT uInsert, UINT uIDAd
 	  }
 	}
 	return(uIDMax);
+}
+
+static INT _SHMergePopupMenus(HMENU hMenu, HMENU hPopupMenu, UINT uIDAdjust, UINT uIDAdjustMax)
+{
+    INT maxID = uIDAdjust;
+    const INT itemCount = GetMenuItemCount(hPopupMenu);
+
+    MENUITEMINFOW mii = { sizeof(mii), MIIM_ID | MIIM_SUBMENU };
+    for (INT i = itemCount - 1; i >= 0; --i)
+    {
+        if (!GetMenuItemInfoW(hPopupMenu, i, TRUE, &mii))
+            continue;
+
+        HMENU hTargetSubMenu = SHGetMenuFromID(hMenu, mii.wID);
+        INT currentMax = Shell_MergeMenus(
+            hTargetSubMenu, 
+            mii.hSubMenu, 
+            0, 
+            uIDAdjust, 
+            uIDAdjustMax, 
+            MM_ADDSEPARATOR | MM_SUBMENUSHAVEIDS);
+
+        maxID = max(maxID, currentMax);
+    }
+
+    return maxID;
+}
+
+static HMENU SHLoadPopupMenu(HINSTANCE hInstance, UINT uMenuId)
+{
+    HMENU hMenu = LoadMenuW(hInstance, MAKEINTRESOURCEW(uMenuId));
+    if (!hMenu)
+        return NULL;
+    HMENU hSubMenu = GetSubMenu(hMenu, 0);
+    RemoveMenu(hMenu, 0, MF_BYPOSITION);
+    DestroyMenu(hMenu);
+    return hSubMenu;
+}
+
+/*************************************************************************
+ * CDefFolderMenu_MergeMenu         [SHELL32.702]
+ */
+VOID WINAPI
+CDefFolderMenu_MergeMenu(
+    _In_ HINSTANCE hInstance,
+    _In_ UINT uMainMerge,
+    _In_ UINT uPopupMerge,
+    _Inout_ LPQCMINFO lpQcmInfo)
+{
+	TRACE("(%p, %u, %u, %p)\n", hInstance, uMainMerge, uPopupMerge, lpQcmInfo);
+
+    UINT idCmdFirst = lpQcmInfo->idCmdFirst;
+
+    if (uMainMerge)
+    {
+        HMENU hMenu = SHLoadPopupMenu(hInstance, uMainMerge);
+        if (hMenu)
+        {
+            const UINT uFlags = MM_ADDSEPARATOR | MM_SUBMENUSHAVEIDS | MM_DONTREMOVESEPS;
+            idCmdFirst = Shell_MergeMenus(lpQcmInfo->hmenu,
+                                          hMenu,
+                                          lpQcmInfo->indexMenu,
+                                          lpQcmInfo->idCmdFirst,
+                                          lpQcmInfo->idCmdLast,
+                                          uFlags);
+            DestroyMenu(hMenu);
+        }
+    }
+
+    if (uPopupMerge)
+    {
+        HMENU hMenu = LoadMenuW(hInstance, MAKEINTRESOURCEW(uPopupMerge));
+        if (hMenu)
+        {
+            INT id = _SHMergePopupMenus(lpQcmInfo->hmenu, hMenu,
+                                       lpQcmInfo->idCmdFirst, lpQcmInfo->idCmdLast);
+            idCmdFirst = max(idCmdFirst, id);
+            DestroyMenu(hMenu);
+        }
+    }
+
+    lpQcmInfo->idCmdFirst = idCmdFirst;
 }

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -139,6 +139,17 @@ BOOL WINAPI StrRetToStrNA(LPSTR,DWORD,LPSTRRET,const ITEMIDLIST*);
 BOOL WINAPI StrRetToStrNW(LPWSTR,DWORD,LPSTRRET,const ITEMIDLIST*);
 
 /****************************************************************************
+ * Folder Menu
+ */
+
+VOID WINAPI
+CDefFolderMenu_MergeMenu(
+    _In_ HINSTANCE hInstance,
+    _In_ UINT uMainMerge,
+    _In_ UINT uPopupMerge,
+    _Inout_ LPQCMINFO lpQcmInfo);
+
+/****************************************************************************
  * SHChangeNotifyRegister API
  */
 #define SHCNRF_InterruptLevel       0x0001

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -139,7 +139,7 @@ BOOL WINAPI StrRetToStrNA(LPSTR,DWORD,LPSTRRET,const ITEMIDLIST*);
 BOOL WINAPI StrRetToStrNW(LPWSTR,DWORD,LPSTRRET,const ITEMIDLIST*);
 
 /****************************************************************************
- * Folder Menu
+ * Misc.
  */
 
 VOID WINAPI


### PR DESCRIPTION
## Purpose
Implementing missing functions...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Add `_SHMergePopupMenus` and `SHLoadPopupMenu` helper functions.
- Implement `CDefFolderMenu_MergeMenu` function in `utils.cpp`.
- Add function prototype into `<undocshell.h>`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: