### PR TITLE
[SHLWAPI][SDK] Implement ZoneCheck* functions

### DIFF
--- a/dll/win32/shlwapi/CMakeLists.txt
+++ b/dll/win32/shlwapi/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND PCH_SKIP_SOURCE
     propbag.cpp
     utils.cpp
     wsprintf.c
+    zonechk.c
     ${CMAKE_CURRENT_BINARY_DIR}/shlwapi_stubs.c)
 
 add_library(shlwapi MODULE

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5534,6 +5534,7 @@ INT WINAPI SHFormatDateTimeA(const FILETIME UNALIGNED *fileTime, DWORD *flags,
     return retval;
 }
 
+#ifndef __REACTOS__ /* See zonechk.c */
 /***********************************************************************
  *             ZoneCheckUrlExW [SHLWAPI.231]
  *
@@ -5558,6 +5559,7 @@ INT WINAPI ZoneCheckUrlExW(LPWSTR szURL, PVOID pUnknown, DWORD dwUnknown2,
 
     return 0;
 }
+#endif
 
 /***********************************************************************
  *             SHVerbExistsNA [SHLWAPI.196]

--- a/dll/win32/shlwapi/precomp.h
+++ b/dll/win32/shlwapi/precomp.h
@@ -29,6 +29,7 @@
 
 #ifdef __REACTOS__
 EXTERN_C HRESULT VariantChangeTypeForRead(_Inout_ VARIANTARG *pvarg, _In_ VARTYPE vt);
+EXTERN_C VOID SHLWAPI_DeleteCachedZonesManager(VOID);
 #endif
 
 #include "resource.h"

--- a/dll/win32/shlwapi/precomp.h
+++ b/dll/win32/shlwapi/precomp.h
@@ -29,7 +29,6 @@
 
 #ifdef __REACTOS__
 EXTERN_C HRESULT VariantChangeTypeForRead(_Inout_ VARIANTARG *pvarg, _In_ VARTYPE vt);
-EXTERN_C VOID SHLWAPI_DeleteCachedZonesManager(VOID);
 #endif
 
 #include "resource.h"

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -230,7 +230,7 @@
 230 stdcall -noname ZoneCheckUrlExA(str ptr long ptr long long long ptr)
 231 stdcall -noname ZoneCheckUrlExW(wstr ptr long ptr long long long ptr)
 232 stdcall -noname ZoneCheckUrlExCacheA(str ptr long ptr long long long ptr ptr)
-233 stdcall -noname ZoneCheckUrlExCacheW(ptr wstr ptr long ptr long long long ptr ptr)
+233 stdcall -noname ZoneCheckUrlExCacheW(wstr ptr long ptr long long long ptr ptr)
 234 stub -noname ZoneCheckHost
 235 stub -noname ZoneCheckHostEx
 236 stdcall -noname SHPinDllOfCLSID(ptr)

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -223,14 +223,14 @@
 223 stdcall -noname SHGlobalCounterGetValue(long)
 224 stdcall -noname SHGlobalCounterIncrement(long)
 225 stdcall -noname SHStripMneumonicW(wstr)
-226 stub -noname ZoneCheckPathA
-227 stub -noname ZoneCheckPathW
-228 stub -noname ZoneCheckUrlA
-229 stub -noname ZoneCheckUrlW
-230 stub -noname ZoneCheckUrlExA
-231 stdcall -noname ZoneCheckUrlExW(wstr ptr long long long long long long)
-232 stub -noname ZoneCheckUrlExCacheA
-233 stub -noname ZoneCheckUrlExCacheW
+226 stdcall -noname ZoneCheckPathA(str long long ptr)
+227 stdcall -noname ZoneCheckPathW(wstr long long ptr)
+228 stdcall -noname ZoneCheckUrlA(str long long ptr)
+229 stdcall -noname ZoneCheckUrlW(wstr long long ptr)
+230 stdcall -noname ZoneCheckUrlExA(str ptr long ptr long long long ptr)
+231 stdcall -noname ZoneCheckUrlExW(wstr ptr long ptr long long long ptr)
+232 stdcall -noname ZoneCheckUrlExCacheA(str ptr long ptr long long long ptr ptr)
+233 stdcall -noname ZoneCheckUrlExCacheW(ptr wstr ptr long ptr long long long ptr ptr)
 234 stub -noname ZoneCheckHost
 235 stub -noname ZoneCheckHostEx
 236 stdcall -noname SHPinDllOfCLSID(ptr)

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -231,8 +231,8 @@
 231 stdcall -noname ZoneCheckUrlExW(wstr ptr long ptr long long long ptr)
 232 stdcall -noname ZoneCheckUrlExCacheA(str ptr long ptr long long long ptr ptr)
 233 stdcall -noname ZoneCheckUrlExCacheW(wstr ptr long ptr long long long ptr ptr)
-234 stub -noname ZoneCheckHost
-235 stub -noname ZoneCheckHostEx
+234 stdcall -noname ZoneCheckHost(ptr wstr long)
+235 stdcall -noname ZoneCheckHostEx(ptr ptr long ptr long wstr long)
 236 stdcall -noname SHPinDllOfCLSID(ptr)
 237 stdcall -noname SHRegisterClassW(ptr)
 238 stdcall -noname SHUnregisterClassesA(ptr ptr long)

--- a/dll/win32/shlwapi/shlwapi_main.c
+++ b/dll/win32/shlwapi/shlwapi_main.c
@@ -77,6 +77,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID fImpLoad)
             if (fImpLoad) break;
 #ifdef __REACTOS__
 	    FreeViewStatePropertyBagCache();
+	    SHLWAPI_DeleteCachedZonesManager();
 	    DeleteCriticalSection(&g_csBagCacheLock);
 	    DeleteCriticalSection(&g_csZoneMgrLock);
 #endif

--- a/dll/win32/shlwapi/shlwapi_main.c
+++ b/dll/win32/shlwapi/shlwapi_main.c
@@ -34,6 +34,7 @@ DECLSPEC_HIDDEN HINSTANCE shlwapi_hInstance = 0;
 DECLSPEC_HIDDEN DWORD SHLWAPI_ThreadRef_index = TLS_OUT_OF_INDEXES;
 
 #ifdef __REACTOS__
+extern CRITICAL_SECTION g_csZoneMgrLock;
 extern CRITICAL_SECTION g_csBagCacheLock;
 VOID FreeViewStatePropertyBagCache(VOID);
 #endif
@@ -68,6 +69,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID fImpLoad)
 	    shlwapi_hInstance = hinstDLL;
 	    SHLWAPI_ThreadRef_index = TlsAlloc();
 #ifdef __REACTOS__
+	    InitializeCriticalSection(&g_csZoneMgrLock);
 	    InitializeCriticalSection(&g_csBagCacheLock);
 #endif
 	    break;
@@ -76,6 +78,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID fImpLoad)
 #ifdef __REACTOS__
 	    FreeViewStatePropertyBagCache();
 	    DeleteCriticalSection(&g_csBagCacheLock);
+	    DeleteCriticalSection(&g_csZoneMgrLock);
 #endif
 	    if (SHLWAPI_ThreadRef_index != TLS_OUT_OF_INDEXES) TlsFree(SHLWAPI_ThreadRef_index);
 	    break;

--- a/dll/win32/shlwapi/shlwapi_main.c
+++ b/dll/win32/shlwapi/shlwapi_main.c
@@ -37,7 +37,7 @@ DECLSPEC_HIDDEN DWORD SHLWAPI_ThreadRef_index = TLS_OUT_OF_INDEXES;
 extern CRITICAL_SECTION g_csZoneMgrLock;
 extern CRITICAL_SECTION g_csBagCacheLock;
 VOID FreeViewStatePropertyBagCache(VOID);
-EXTERN_C VOID SHLWAPI_DeleteCachedZonesManager(VOID);
+VOID SHLWAPI_DeleteCachedZonesManager(VOID);
 #endif
 
 /*************************************************************************

--- a/dll/win32/shlwapi/shlwapi_main.c
+++ b/dll/win32/shlwapi/shlwapi_main.c
@@ -37,6 +37,7 @@ DECLSPEC_HIDDEN DWORD SHLWAPI_ThreadRef_index = TLS_OUT_OF_INDEXES;
 extern CRITICAL_SECTION g_csZoneMgrLock;
 extern CRITICAL_SECTION g_csBagCacheLock;
 VOID FreeViewStatePropertyBagCache(VOID);
+EXTERN_C VOID SHLWAPI_DeleteCachedZonesManager(VOID);
 #endif
 
 /*************************************************************************

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -6,11 +6,9 @@
  */
 
 #include <windef.h>
-#include <winbase.h>
 #include <urlmon.h>
 #include <shlobj.h>
 #define NO_SHLWAPI_REG
-#include <shlwapi.h>
 #include <shlwapi_undoc.h>
 #include <wine/debug.h>
 

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -30,7 +30,7 @@ static IClassFactory *g_pcf = NULL;
 static HRESULT
 SHLWAPI_GetCachedZonesManager(
     _In_ REFIID riid,
-    _Out_ LPVOID *ppv)
+    _Out_ PVOID *ppv)
 {
     if (g_pcf)
         return g_pcf->lpVtbl->CreateInstance(g_pcf, NULL, riid, ppv);
@@ -39,7 +39,7 @@ SHLWAPI_GetCachedZonesManager(
                      CLSCTX_INPROC_SERVER,
                      NULL,
                      &IID_IClassFactory,
-                     (LPVOID *)&g_pcf);
+                     (PVOID *)&g_pcf);
 
     SHPinDllOfCLSID(&CLSID_InternetSecurityManager);
 
@@ -50,6 +50,29 @@ SHLWAPI_GetCachedZonesManager(
     }
 
     return g_pcf->lpVtbl->CreateInstance(g_pcf, NULL, riid, ppv);
+}
+
+/*************************************************************************
+ * SuperPrivate_ZoneCheckPath
+ *
+ * An internal helper
+ */
+HRESULT SuperPrivate_ZoneCheckPath(PCWSTR pwszUrl, DWORD dwZone)
+{
+    IInternetSecurityManager *pISM;
+    HRESULT hr = SHLWAPI_GetCachedZonesManager(&IID_IInternetSecurityManager, (PVOID *)&pISM);
+    if (FAILED(hr))
+        return E_ACCESSDENIED;
+
+    DWORD dwRealZone = URLZONE_UNTRUSTED;
+    hr = pISM->lpVtbl->MapUrlToZone(pISM, pwszUrl, &dwRealZone, 0);
+    if (SUCCEEDED(hr) && dwRealZone == dwZone)
+        hr = S_OK;
+    else
+        hr = E_ACCESSDENIED;
+
+    pISM->lpVtbl->Release(pISM);
+    return hr;
 }
 
 /*************************************************************************
@@ -101,18 +124,18 @@ ZoneCheckUrlExCacheW(
     if (pISM && pISM->lpVtbl)
     {
         hr = pISM->lpVtbl->QueryInterface(pISM, &IID_IInternetSecurityManager,
-                                          (LPVOID *)&pNewISM);
+                                          (PVOID *)&pNewISM);
     }
     else
     {
         hr = SHLWAPI_GetCachedZonesManager(&IID_IInternetSecurityManager,
-                                           (LPVOID *)&pNewISM);
+                                           (PVOID *)&pNewISM);
         if (FAILED(hr))
             return hr;
 
         if (pISM)
             hr = pISM->lpVtbl->QueryInterface(pISM, &IID_IInternetSecurityManager,
-                                              (LPVOID *)&pNewISM);
+                                              (PVOID *)&pNewISM);
     }
 
     if (FAILED(hr))

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -15,7 +15,7 @@
 WINE_DEFAULT_DEBUG_CHANNEL(zonechk);
 
 static IClassFactory *g_pZoneMgrCF = NULL; /* Internet Zone Manager's Class Factory (cached) */
-CRITICAL_SECTION g_csZoneMgrLock;
+CRITICAL_SECTION g_csZoneMgrLock; /* Guards g_pZoneMgrCF (ReactOS only) */
 
 /*************************************************************************
  * SHLWAPI_GetCachedZonesManagerInner

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -167,16 +167,10 @@ ZoneCheckUrlExCacheW(
         cbPolicyEffect = sizeof(dwPolicyBuf);
     }
 
-    hr = pNewISM->lpVtbl->ProcessUrlAction(
-        pNewISM,
-        pszUrl,
-        dwAction,
-        pbPolicyEffect,
-        cbPolicyEffect,
-        pbContextEffect,
-        cbContext,
-        dwFlags,
-        0);
+    hr = pNewISM->lpVtbl->ProcessUrlAction(pNewISM, pszUrl, dwAction,
+                                           pbPolicyEffect, cbPolicyEffect,
+                                           pbContextEffect, cbContext,
+                                           dwFlags, 0);
 
     if (pSecuritySite)
         pNewISM->lpVtbl->SetSecuritySite(pNewISM, NULL);

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -35,11 +35,8 @@ SHLWAPI_GetCachedZonesManager(
     if (g_pcf)
         return g_pcf->lpVtbl->CreateInstance(g_pcf, NULL, riid, ppv);
 
-    CoGetClassObject(&CLSID_InternetSecurityManager,
-                     CLSCTX_INPROC_SERVER,
-                     NULL,
-                     &IID_IClassFactory,
-                     (PVOID *)&g_pcf);
+    CoGetClassObject(&CLSID_InternetSecurityManager, CLSCTX_INPROC_SERVER, NULL,
+                     &IID_IClassFactory, (PVOID *)&g_pcf);
 
     SHPinDllOfCLSID(&CLSID_InternetSecurityManager);
 

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -63,7 +63,7 @@ SHLWAPI_GetCachedZonesManager(
 /*************************************************************************
  * SuperPrivate_ZoneCheckPath
  *
- * An internal helper
+ * An internal helper, used in SHRegisterValidateTemplate
  */
 HRESULT SuperPrivate_ZoneCheckPath(PCWSTR pwszUrl, DWORD dwZone)
 {

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -1,7 +1,7 @@
 /*
  * PROJECT:     ReactOS Shell
  * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
- * PURPOSE:     Implementing ZoneCheck* functions
+ * PURPOSE:     Implementing ZoneCheck* functions (Internet Zone Manager)
  * COPYRIGHT:   Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
@@ -14,7 +14,7 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(zonechk);
 
-static IClassFactory *g_pcf = NULL;
+static IClassFactory *g_pZoneMgrCF = NULL; /* Internet Zone Manager's Class Factory (cached) */
 
 /*************************************************************************
  * SHLWAPI_GetCachedZonesManager
@@ -27,21 +27,21 @@ SHLWAPI_GetCachedZonesManager(
     _In_ REFIID riid,
     _Out_ PVOID *ppv)
 {
-    if (g_pcf)
-        return g_pcf->lpVtbl->CreateInstance(g_pcf, NULL, riid, ppv);
+    if (g_pZoneMgrCF)
+        return g_pZoneMgrCF->lpVtbl->CreateInstance(g_pZoneMgrCF, NULL, riid, ppv);
 
     CoGetClassObject(&CLSID_InternetSecurityManager, CLSCTX_INPROC_SERVER, NULL,
-                     &IID_IClassFactory, (PVOID *)&g_pcf);
+                     &IID_IClassFactory, (PVOID *)&g_pZoneMgrCF);
 
     SHPinDllOfCLSID(&CLSID_InternetSecurityManager);
 
-    if (!g_pcf)
+    if (!g_pZoneMgrCF)
     {
         *ppv = NULL;
         return E_FAIL;
     }
 
-    return g_pcf->lpVtbl->CreateInstance(g_pcf, NULL, riid, ppv);
+    return g_pZoneMgrCF->lpVtbl->CreateInstance(g_pZoneMgrCF, NULL, riid, ppv);
 }
 
 /*************************************************************************

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -112,8 +112,8 @@ ZoneCheckUrlExCacheW(
 {
     HRESULT hr;
     IInternetSecurityManager *pNewISM;
-    DWORD dwPolicyBuf, dwContextBuf, cbPolicyEffect;
-    PBYTE pbPolicyEffect, pbContextEffect;
+    DWORD dwPolicyBuf, dwContextBuf, cbPolicyUse, cbContextUse;
+    PBYTE pbPolicyUse, pbContextUse;
 
     if (!pszUrl)
         return E_INVALIDARG;
@@ -145,29 +145,28 @@ ZoneCheckUrlExCacheW(
 
     if (pbContext)
     {
-        pbContextEffect = pbContext;
+        pbContextUse = pbContext;
+        cbContextUse = cbContext;
     }
     else
     {
-        pbContextEffect = (PBYTE)&dwContextBuf;
-        cbContext = sizeof(dwContextBuf);
+        pbContextUse = (PBYTE)&dwContextBuf;
+        cbContextUse = sizeof(dwContextBuf);
     }
 
     if (pbPolicy)
     {
-        pbPolicyEffect = pbPolicy;
-        cbPolicyEffect = cbPolicy;
+        pbPolicyUse = pbPolicy;
+        cbPolicyUse = cbPolicy;
     }
     else
     {
-        pbPolicyEffect = (PBYTE)&dwPolicyBuf;
-        cbPolicyEffect = sizeof(dwPolicyBuf);
+        pbPolicyUse = (PBYTE)&dwPolicyBuf;
+        cbPolicyUse = sizeof(dwPolicyBuf);
     }
 
-    hr = pNewISM->lpVtbl->ProcessUrlAction(pNewISM, pszUrl, dwAction,
-                                           pbPolicyEffect, cbPolicyEffect,
-                                           pbContextEffect, cbContext,
-                                           dwFlags, 0);
+    hr = pNewISM->lpVtbl->ProcessUrlAction(pNewISM, pszUrl, dwAction, pbPolicyUse, cbPolicyUse,
+                                           pbContextUse, cbContextUse, dwFlags, 0);
 
     if (pSecuritySite)
         pNewISM->lpVtbl->SetSecuritySite(pNewISM, NULL);
@@ -295,9 +294,8 @@ ZoneCheckHostEx(
     _In_z_                           PCWSTR                     pszUrl,
     _In_                             DWORD                      dwAction)
 {
-    DWORD dwPolicyBuf, dwContextBuf, cbPolicyEff, cbContextEff;
-    PBYTE pbPolicyEffective;
-    PBYTE pbContextEffective;
+    DWORD dwPolicyBuf, dwContextBuf, cbPolicyUse, cbContextUse;
+    PBYTE pbPolicyUse, pbContextUse;
 
     if (!pISM)
         return E_INVALIDARG;
@@ -306,28 +304,26 @@ ZoneCheckHostEx(
 
     if (pbPolicy)
     {
-        pbPolicyEffective = pbPolicy;
-        cbPolicyEff = cbPolicy;
+        pbPolicyUse = pbPolicy;
+        cbPolicyUse = cbPolicy;
     }
     else
     {
-        pbPolicyEffective = (PBYTE)&dwPolicyBuf;
-        cbPolicyEff = sizeof(dwPolicyBuf);
+        pbPolicyUse = (PBYTE)&dwPolicyBuf;
+        cbPolicyUse = sizeof(dwPolicyBuf);
     }
 
     if (pbContext)
     {
-        pbContextEffective = pbContext;
-        cbContextEff = cbContext;
+        pbContextUse = pbContext;
+        cbContextUse = cbContext;
     }
     else
     {
-        pbContextEffective = (PBYTE)&dwContextBuf;
-        cbContextEff = sizeof(dwContextBuf);
+        pbContextUse = (PBYTE)&dwContextBuf;
+        cbContextUse = sizeof(dwContextBuf);
     }
 
-    return pISM->lpVtbl->ProcessUrlAction(pISM, pszUrl, dwAction,
-                                          pbPolicyEffective, cbPolicyEff,
-                                          pbContextEffective, cbContextEff,
-                                          0, 0);
+    return pISM->lpVtbl->ProcessUrlAction(pISM, pszUrl, dwAction, pbPolicyUse, cbPolicyUse,
+                                          pbContextUse, cbContextUse, 0, 0);
 }

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -117,7 +117,7 @@ ZoneCheckUrlExCacheW(
     if (!pszUrl)
         return E_INVALIDARG;
 
-    if (pISM)
+    if (pISM && pISM->lpVtbl)
         hr = pISM->lpVtbl->QueryInterface(pISM, &IID_IInternetSecurityManager, (PVOID *)&pWorkISM);
     else
         hr = SHLWAPI_GetCachedZonesManager(&IID_IInternetSecurityManager, (PVOID *)&pWorkISM);

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -60,12 +60,20 @@ SHLWAPI_GetCachedZonesManager(
     return hr;
 }
 
+EXTERN_C VOID SHLWAPI_DeleteCachedZonesManager(VOID)
+{
+    EnterCriticalSection(&g_csZoneMgrLock);
+    g_pZoneMgrCF->lpVtbl->Release(g_pZoneMgrCF);
+    g_pZoneMgrCF = NULL;
+    LeaveCriticalSection(&g_csZoneMgrLock);
+}
+
 /*************************************************************************
  * SuperPrivate_ZoneCheckPath
  *
  * An internal helper, used in SHRegisterValidateTemplate
  */
-HRESULT SuperPrivate_ZoneCheckPath(PCWSTR pwszUrl, DWORD dwExpectedZone)
+HRESULT SuperPrivate_ZoneCheckPath(PCWSTR pszPath, DWORD dwExpectedZone)
 {
     IInternetSecurityManager *pISM;
     HRESULT hr = SHLWAPI_GetCachedZonesManager(&IID_IInternetSecurityManager, (PVOID *)&pISM);
@@ -73,7 +81,7 @@ HRESULT SuperPrivate_ZoneCheckPath(PCWSTR pwszUrl, DWORD dwExpectedZone)
         return E_ACCESSDENIED;
 
     DWORD dwRealZone = URLZONE_UNTRUSTED;
-    hr = pISM->lpVtbl->MapUrlToZone(pISM, pwszUrl, &dwRealZone, 0);
+    hr = pISM->lpVtbl->MapUrlToZone(pISM, pszPath, &dwRealZone, 0);
     if (SUCCEEDED(hr) && dwRealZone == dwExpectedZone)
         hr = S_OK;
     else
@@ -312,7 +320,7 @@ ZoneCheckHostEx(
 {
     DWORD dwPolicyBuf, dwContextBuf;
 
-    if (!pISM)
+    if (!pISM || !pszUrl)
         return E_INVALIDARG;
 
     if (!pbPolicy)

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -105,17 +105,15 @@ HRESULT SuperPrivate_ZoneCheckPath(PCWSTR pszPath, DWORD dwExpectedZone)
  */
 HRESULT WINAPI
 ZoneCheckUrlExCacheA(
-    _In_         PCSTR                     pszUrl,
-    _Out_writes_bytes_opt_(cbPolicy)
-                 PBYTE                     pbPolicy,
-    _In_         DWORD                     cbPolicy,
-    _In_reads_bytes_opt_(cbContext)
-                 PBYTE                     pbContext,
-    _In_         DWORD                     cbContext,
-    _In_         DWORD                     dwAction,
-    _In_         DWORD                     dwFlags,
-    _In_opt_     IInternetSecurityMgrSite  *pSecuritySite,
-    _In_opt_     IInternetSecurityManager  *pISM)
+    _In_                             PCSTR                     pszUrl,
+    _Out_writes_bytes_opt_(cbPolicy) PBYTE                     pbPolicy,
+    _In_                             DWORD                     cbPolicy,
+    _In_reads_bytes_opt_(cbContext)  PBYTE                     pbContext,
+    _In_                             DWORD                     cbContext,
+    _In_                             DWORD                     dwAction,
+    _In_                             DWORD                     dwFlags,
+    _In_opt_                         IInternetSecurityMgrSite *pSecuritySite,
+    _In_opt_                         IInternetSecurityManager *pISM)
 {
     WCHAR szUrl[2048];
     if (!pszUrl)
@@ -133,17 +131,15 @@ ZoneCheckUrlExCacheA(
  */
 HRESULT WINAPI
 ZoneCheckUrlExCacheW(
-    _In_         PCWSTR                    pszUrl,
-    _Out_writes_bytes_opt_(cbPolicy)
-                 PBYTE                     pbPolicy,
-    _In_         DWORD                     cbPolicy,
-    _In_reads_bytes_opt_(cbContext)
-                 PBYTE                     pbContext,
-    _In_         DWORD                     cbContext,
-    _In_         DWORD                     dwAction,
-    _In_         DWORD                     dwFlags,
-    _In_opt_     IInternetSecurityMgrSite  *pSecuritySite,
-    _In_opt_     IInternetSecurityManager  *pISM)
+    _In_                             PCWSTR                    pszUrl,
+    _Out_writes_bytes_opt_(cbPolicy) PBYTE                     pbPolicy,
+    _In_                             DWORD                     cbPolicy,
+    _In_reads_bytes_opt_(cbContext)  PBYTE                     pbContext,
+    _In_                             DWORD                     cbContext,
+    _In_                             DWORD                     dwAction,
+    _In_                             DWORD                     dwFlags,
+    _In_opt_                         IInternetSecurityMgrSite *pSecuritySite,
+    _In_opt_                         IInternetSecurityManager *pISM)
 {
     HRESULT hr;
     IInternetSecurityManager *pWorkISM;

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -15,33 +15,49 @@
 WINE_DEFAULT_DEBUG_CHANNEL(zonechk);
 
 static IClassFactory *g_pZoneMgrCF = NULL; /* Internet Zone Manager's Class Factory (cached) */
+CRITICAL_SECTION g_csZoneMgrLock;
 
 /*************************************************************************
- * SHLWAPI_GetCachedZonesManager
+ * SHLWAPI_GetCachedZonesManagerInner
  *
  * An internal helper that caches the InternetSecurityManager's IClassFactory and
  * returns an instance of the specified interface.
  */
 static HRESULT
-SHLWAPI_GetCachedZonesManager(
+SHLWAPI_GetCachedZonesManagerInner(
     _In_ REFIID riid,
     _Out_ PVOID *ppv)
 {
+    HRESULT hr;
+    IClassFactory *pCF;
+
     if (g_pZoneMgrCF)
         return g_pZoneMgrCF->lpVtbl->CreateInstance(g_pZoneMgrCF, NULL, riid, ppv);
 
-    CoGetClassObject(&CLSID_InternetSecurityManager, CLSCTX_INPROC_SERVER, NULL,
-                     &IID_IClassFactory, (PVOID *)&g_pZoneMgrCF);
-
-    SHPinDllOfCLSID(&CLSID_InternetSecurityManager);
-
-    if (!g_pZoneMgrCF)
+    hr = CoGetClassObject(&CLSID_InternetSecurityManager, CLSCTX_INPROC_SERVER, NULL,
+                          &IID_IClassFactory, (PVOID *)&pCF);
+    if (FAILED(hr))
     {
         *ppv = NULL;
         return E_FAIL;
     }
 
+    g_pZoneMgrCF = pCF;
+    SHPinDllOfCLSID(&CLSID_InternetSecurityManager);
+
     return g_pZoneMgrCF->lpVtbl->CreateInstance(g_pZoneMgrCF, NULL, riid, ppv);
+}
+
+static HRESULT
+SHLWAPI_GetCachedZonesManager(
+    _In_ REFIID riid,
+    _Out_ PVOID *ppv)
+{
+    HRESULT hr;
+    EnterCriticalSection(&g_csZoneMgrLock);
+    hr = SHLWAPI_GetCachedZonesManagerInner(riid, ppv);
+    LeaveCriticalSection(&g_csZoneMgrLock);
+    return hr;
 }
 
 /*************************************************************************

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -29,8 +29,8 @@ static IClassFactory *g_pcf = NULL;
  */
 static HRESULT
 SHLWAPI_GetCachedZonesManager(
-    _In_  const IID  *riid,
-    _Out_ void      **ppv)
+    _In_ REFIID riid,
+    _Out_ LPVOID *ppv)
 {
     if (g_pcf)
         return g_pcf->lpVtbl->CreateInstance(g_pcf, NULL, riid, ppv);
@@ -67,7 +67,7 @@ ZoneCheckUrlExCacheA(
     _In_opt_     IInternetSecurityMgrSite  *pSecuritySite,
     _In_opt_     IInternetSecurityManager  *pISM)
 {
-    WCHAR szUrl[2084];
+    WCHAR szUrl[2048];
     SHAnsiToUnicode(pszUrl, szUrl, _countof(szUrl));
     return ZoneCheckUrlExCacheW(NULL, szUrl, pbPolicy, cbPolicy, pbContext, cbContext,
                                 dwAction, dwFlags, pSecuritySite, pISM);
@@ -119,8 +119,7 @@ ZoneCheckUrlExCacheW(
     if (FAILED(hr))
         return hr;
 
-    dwPolicyBuf  = 0;
-    dwContextBuf = 0;
+    dwPolicyBuf = dwContextBuf = 0;
 
     if (pSecuritySite)
         pNewISM->lpVtbl->SetSecuritySite(pNewISM, pSecuritySite);
@@ -174,7 +173,7 @@ ZoneCheckPathA(
     _In_     DWORD   dwFlags,
     _In_opt_ IInternetSecurityMgrSite *pSecuritySite)
 {
-    WCHAR szPath[2084];
+    WCHAR szPath[2048];
     SHAnsiToUnicode(pszPath, szPath, _countof(szPath));
     return ZoneCheckPathW(szPath, dwAction, dwFlags, pSecuritySite);
 }
@@ -202,7 +201,7 @@ ZoneCheckUrlA(
     _In_     DWORD   dwFlags,
     _In_opt_ IInternetSecurityMgrSite *pSecuritySite)
 {
-    WCHAR szUrl[2084];
+    WCHAR szUrl[2048];
     SHAnsiToUnicode(pszUrl, szUrl, _countof(szUrl));
     return ZoneCheckUrlW(szUrl, dwAction, dwFlags, pSecuritySite);
 }
@@ -234,7 +233,7 @@ ZoneCheckUrlExA(
     _In_         DWORD   dwFlags,
     _In_opt_     IInternetSecurityMgrSite *pSecuritySite)
 {
-    WCHAR szUrl[2084];
+    WCHAR szUrl[2048];
     SHAnsiToUnicode(pszUrl, szUrl, _countof(szUrl));
     return ZoneCheckUrlExW(szUrl, pbPolicy, cbPolicy, pbContext, cbContext,
                            dwAction, dwFlags, pSecuritySite);

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -115,7 +115,10 @@ ZoneCheckUrlExCacheW(
           pbPolicy, cbPolicy, pbContext, cbContext, dwAction, dwFlags, pSecuritySite, pISM);
 
     if (!pszUrl)
+    {
+        ERR("pszUrl was NULL\n");
         return E_INVALIDARG;
+    }
 
     if (pISM && pISM->lpVtbl)
         hr = pISM->lpVtbl->QueryInterface(pISM, &IID_IInternetSecurityManager, (PVOID *)&pWorkISM);
@@ -123,7 +126,10 @@ ZoneCheckUrlExCacheW(
         hr = SHLWAPI_GetCachedZonesManager(&IID_IInternetSecurityManager, (PVOID *)&pWorkISM);
 
     if (FAILED(hr))
+    {
+        ERR("hr: 0x%lX\n", hr);
         return hr;
+    }
 
     if (pSecuritySite)
         pWorkISM->lpVtbl->SetSecuritySite(pWorkISM, pSecuritySite);

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -63,8 +63,11 @@ SHLWAPI_GetCachedZonesManager(
 EXTERN_C VOID SHLWAPI_DeleteCachedZonesManager(VOID)
 {
     EnterCriticalSection(&g_csZoneMgrLock);
-    g_pZoneMgrCF->lpVtbl->Release(g_pZoneMgrCF);
-    g_pZoneMgrCF = NULL;
+    if (g_pZoneMgrC)
+    {
+        g_pZoneMgrCF->lpVtbl->Release(g_pZoneMgrCF);
+        g_pZoneMgrCF = NULL;
+    }
     LeaveCriticalSection(&g_csZoneMgrLock);
 }
 

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -178,7 +178,7 @@ ZoneCheckUrlExCacheW(
 
     if (!pbPolicy)
     {
-        dwPolicyBuf  = 0;
+        dwPolicyBuf = 0;
         pbPolicy = (PBYTE)&dwPolicyBuf;
         cbPolicy = sizeof(dwPolicyBuf);
     }

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -65,7 +65,7 @@ SHLWAPI_GetCachedZonesManager(
  *
  * An internal helper, used in SHRegisterValidateTemplate
  */
-HRESULT SuperPrivate_ZoneCheckPath(PCWSTR pwszUrl, DWORD dwZone)
+HRESULT SuperPrivate_ZoneCheckPath(PCWSTR pwszUrl, DWORD dwExpectedZone)
 {
     IInternetSecurityManager *pISM;
     HRESULT hr = SHLWAPI_GetCachedZonesManager(&IID_IInternetSecurityManager, (PVOID *)&pISM);
@@ -74,7 +74,7 @@ HRESULT SuperPrivate_ZoneCheckPath(PCWSTR pwszUrl, DWORD dwZone)
 
     DWORD dwRealZone = URLZONE_UNTRUSTED;
     hr = pISM->lpVtbl->MapUrlToZone(pISM, pwszUrl, &dwRealZone, 0);
-    if (SUCCEEDED(hr) && dwRealZone == dwZone)
+    if (SUCCEEDED(hr) && dwRealZone == dwExpectedZone)
         hr = S_OK;
     else
         hr = E_ACCESSDENIED;

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -16,7 +16,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(zonechk);
 
 static IClassFactory *g_pZoneMgrCF = NULL; /* Internet Zone Manager's Class Factory (cached) */
 CRITICAL_SECTION g_csZoneMgrLock; /* Guards g_pZoneMgrCF (ReactOS only) */
-static HINSTANCE g_hinstZoneMgr = NULL;
+static HINSTANCE g_hinstZoneMgr = NULL; /* The module of Zone Manager */
 
 static HRESULT
 SHLWAPI_GetCachedZonesManagerInner(

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -69,7 +69,7 @@ ZoneCheckUrlExCacheA(
 {
     WCHAR szUrl[2048];
     SHAnsiToUnicode(pszUrl, szUrl, _countof(szUrl));
-    return ZoneCheckUrlExCacheW(NULL, szUrl, pbPolicy, cbPolicy, pbContext, cbContext,
+    return ZoneCheckUrlExCacheW(szUrl, pbPolicy, cbPolicy, pbContext, cbContext,
                                 dwAction, dwFlags, pSecuritySite, pISM);
 }
 
@@ -78,7 +78,6 @@ ZoneCheckUrlExCacheA(
  */
 HRESULT WINAPI
 ZoneCheckUrlExCacheW(
-    _Inout_opt_  LPVOID                    pvReserved,
     _In_z_       PCWSTR                    pszUrl,
     _Out_writes_bytes_opt_(cbPolicy)
                  PBYTE                     pbPolicy,
@@ -154,7 +153,7 @@ ZoneCheckUrlExCacheW(
         pbContextEffect,
         cbContext,
         dwFlags,
-        PtrToUlong(pvReserved));
+        0);
 
     if (pSecuritySite)
         pNewISM->lpVtbl->SetSecuritySite(pNewISM, NULL);
@@ -253,6 +252,6 @@ ZoneCheckUrlExW(
     _In_         DWORD   dwFlags,
     _In_opt_     IInternetSecurityMgrSite *pSecuritySite)
 {
-    return ZoneCheckUrlExCacheW(NULL, pszUrl, pbPolicy, cbPolicy, pbContext, cbContext,
+    return ZoneCheckUrlExCacheW(pszUrl, pbPolicy, cbPolicy, pbContext, cbContext,
                                 dwAction, dwFlags, pSecuritySite, NULL);
 }

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -63,7 +63,7 @@ SHLWAPI_GetCachedZonesManager(
 EXTERN_C VOID SHLWAPI_DeleteCachedZonesManager(VOID)
 {
     EnterCriticalSection(&g_csZoneMgrLock);
-    if (g_pZoneMgrC)
+    if (g_pZoneMgrCF)
     {
         g_pZoneMgrCF->lpVtbl->Release(g_pZoneMgrCF);
         g_pZoneMgrCF = NULL;

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -17,12 +17,6 @@ WINE_DEFAULT_DEBUG_CHANNEL(zonechk);
 static IClassFactory *g_pZoneMgrCF = NULL; /* Internet Zone Manager's Class Factory (cached) */
 CRITICAL_SECTION g_csZoneMgrLock; /* Guards g_pZoneMgrCF (ReactOS only) */
 
-/*************************************************************************
- * SHLWAPI_GetCachedZonesManagerInner
- *
- * An internal helper that caches the InternetSecurityManager's IClassFactory and
- * returns an instance of the specified interface.
- */
 static HRESULT
 SHLWAPI_GetCachedZonesManagerInner(
     _In_ REFIID riid,
@@ -48,6 +42,12 @@ SHLWAPI_GetCachedZonesManagerInner(
     return g_pZoneMgrCF->lpVtbl->CreateInstance(g_pZoneMgrCF, NULL, riid, ppv);
 }
 
+/*************************************************************************
+ * SHLWAPI_GetCachedZonesManager
+ *
+ * An internal helper that caches the InternetSecurityManager's IClassFactory and
+ * returns an instance of the specified interface.
+ */
 static HRESULT
 SHLWAPI_GetCachedZonesManager(
     _In_ REFIID riid,

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -112,8 +112,7 @@ ZoneCheckUrlExCacheW(
 {
     HRESULT hr;
     IInternetSecurityManager *pNewISM;
-    DWORD dwPolicyBuf, dwContextBuf, cbPolicyUse, cbContextUse;
-    PBYTE pbPolicyUse, pbContextUse;
+    DWORD dwPolicyBuf, dwContextBuf;
 
     if (!pszUrl)
         return E_INVALIDARG;
@@ -138,35 +137,25 @@ ZoneCheckUrlExCacheW(
     if (FAILED(hr))
         return hr;
 
-    dwPolicyBuf = dwContextBuf = 0;
-
     if (pSecuritySite)
         pNewISM->lpVtbl->SetSecuritySite(pNewISM, pSecuritySite);
 
-    if (pbContext)
+    if (!pbContext)
     {
-        pbContextUse = pbContext;
-        cbContextUse = cbContext;
-    }
-    else
-    {
-        pbContextUse = (PBYTE)&dwContextBuf;
-        cbContextUse = sizeof(dwContextBuf);
+        dwContextBuf = 0;
+        pbContext = (PBYTE)&dwContextBuf;
+        cbContext = sizeof(dwContextBuf);
     }
 
-    if (pbPolicy)
+    if (!pbPolicy)
     {
-        pbPolicyUse = pbPolicy;
-        cbPolicyUse = cbPolicy;
-    }
-    else
-    {
-        pbPolicyUse = (PBYTE)&dwPolicyBuf;
-        cbPolicyUse = sizeof(dwPolicyBuf);
+        dwPolicyBuf = 0;
+        pbPolicy = (PBYTE)&dwPolicyBuf;
+        cbPolicy = sizeof(dwPolicyBuf);
     }
 
-    hr = pNewISM->lpVtbl->ProcessUrlAction(pNewISM, pszUrl, dwAction, pbPolicyUse, cbPolicyUse,
-                                           pbContextUse, cbContextUse, dwFlags, 0);
+    hr = pNewISM->lpVtbl->ProcessUrlAction(pNewISM, pszUrl, dwAction, pbPolicy, cbPolicy,
+                                           pbContext, cbContext, dwFlags, 0);
 
     if (pSecuritySite)
         pNewISM->lpVtbl->SetSecuritySite(pNewISM, NULL);
@@ -294,36 +283,25 @@ ZoneCheckHostEx(
     _In_z_                           PCWSTR                     pszUrl,
     _In_                             DWORD                      dwAction)
 {
-    DWORD dwPolicyBuf, dwContextBuf, cbPolicyUse, cbContextUse;
-    PBYTE pbPolicyUse, pbContextUse;
+    DWORD dwPolicyBuf, dwContextBuf;
 
     if (!pISM)
         return E_INVALIDARG;
 
-    dwPolicyBuf = dwContextBuf = 0;
-
-    if (pbPolicy)
+    if (!pbPolicy)
     {
-        pbPolicyUse = pbPolicy;
-        cbPolicyUse = cbPolicy;
-    }
-    else
-    {
-        pbPolicyUse = (PBYTE)&dwPolicyBuf;
-        cbPolicyUse = sizeof(dwPolicyBuf);
+        dwPolicyBuf = 0;
+        pbPolicy = (PBYTE)&dwPolicyBuf;
+        cbPolicy = sizeof(dwPolicyBuf);
     }
 
-    if (pbContext)
+    if (!pbContext)
     {
-        pbContextUse = pbContext;
-        cbContextUse = cbContext;
-    }
-    else
-    {
-        pbContextUse = (PBYTE)&dwContextBuf;
-        cbContextUse = sizeof(dwContextBuf);
+        dwContextBuf = 0;
+        pbContext = (PBYTE)&dwContextBuf;
+        cbContext = sizeof(dwContextBuf);
     }
 
-    return pISM->lpVtbl->ProcessUrlAction(pISM, pszUrl, dwAction, pbPolicyUse, cbPolicyUse,
-                                          pbContextUse, cbContextUse, 0, 0);
+    return pISM->lpVtbl->ProcessUrlAction(pISM, pszUrl, dwAction, pbPolicy, cbPolicy,
+                                          pbContext, cbContext, 0, 0);
 }

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -16,6 +16,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(zonechk);
 
 static IClassFactory *g_pZoneMgrCF = NULL; /* Internet Zone Manager's Class Factory (cached) */
 CRITICAL_SECTION g_csZoneMgrLock; /* Guards g_pZoneMgrCF (ReactOS only) */
+static HINSTANCE g_hinstZoneMgr = NULL;
 
 static HRESULT
 SHLWAPI_GetCachedZonesManagerInner(
@@ -36,7 +37,7 @@ SHLWAPI_GetCachedZonesManagerInner(
         }
 
         g_pZoneMgrCF = pCF;
-        SHPinDllOfCLSID(&CLSID_InternetSecurityManager);
+        g_hinstZoneMgr = SHPinDllOfCLSID(&CLSID_InternetSecurityManager);
     }
 
     return g_pZoneMgrCF->lpVtbl->CreateInstance(g_pZoneMgrCF, NULL, riid, ppv);
@@ -67,6 +68,11 @@ EXTERN_C VOID SHLWAPI_DeleteCachedZonesManager(VOID)
     {
         g_pZoneMgrCF->lpVtbl->Release(g_pZoneMgrCF);
         g_pZoneMgrCF = NULL;
+    }
+    if (g_hinstZoneMgr)
+    {
+        FreeLibrary(g_hinstZoneMgr);
+        g_hinstZoneMgr = NULL;
     }
     LeaveCriticalSection(&g_csZoneMgrLock);
 }

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -1,0 +1,260 @@
+/*
+ * PROJECT:     ReactOS Shell
+ * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
+ * PURPOSE:     Implementing ZoneCheck* functions
+ * COPYRIGHT:   Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <windef.h>
+#include <winbase.h>
+#include <urlmon.h>
+#include <shlobj.h>
+#include <shobjidl.h>
+#define NO_SHLWAPI_REG
+#include <shlwapi.h>
+#include <shlwapi_undoc.h>
+#include <wine/debug.h>
+
+WINE_DEFAULT_DEBUG_CHANNEL(zonechk);
+
+static IClassFactory *g_pcf = NULL;
+
+/* FIXME: CLSID_InternetSecurityManager */
+/* FIXME: ZoneCheckHost, ZoneCheckHostEx */
+
+/*************************************************************************
+ * SHLWAPI_GetCachedZonesManager
+ *
+ * An internal helper that caches the InternetSecurityManager's IClassFactory and
+ * returns an instance of the specified interface.
+ */
+static HRESULT
+SHLWAPI_GetCachedZonesManager(
+    _In_  const IID  *riid,
+    _Out_ void      **ppv)
+{
+    if (g_pcf)
+        return g_pcf->lpVtbl->CreateInstance(g_pcf, NULL, riid, ppv);
+
+    CoGetClassObject(&CLSID_InternetSecurityManager,
+                     CLSCTX_INPROC_SERVER,
+                     NULL,
+                     &IID_IClassFactory,
+                     (LPVOID *)&g_pcf);
+
+    SHPinDllOfCLSID(&CLSID_InternetSecurityManager);
+
+    if (!g_pcf)
+    {
+        *ppv = NULL;
+        return E_FAIL;
+    }
+
+    return g_pcf->lpVtbl->CreateInstance(g_pcf, NULL, riid, ppv);
+}
+
+/*************************************************************************
+ * ZoneCheckUrlExCacheA [SHLWAPI.232]
+ */
+HRESULT WINAPI
+ZoneCheckUrlExCacheA(
+    _In_z_       PCSTR                     pszUrl,
+    _In_opt_     PBYTE                     pbPolicy,
+    _In_         DWORD                     cbPolicy,
+    _In_opt_     PBYTE                     pbContext,
+    _In_         DWORD                     cbContext,
+    _In_         DWORD                     dwAction,
+    _In_         DWORD                     dwFlags,
+    _In_opt_     IInternetSecurityMgrSite  *pSecuritySite,
+    _In_opt_     IInternetSecurityManager  *pISM)
+{
+    WCHAR szUrl[2084];
+    SHAnsiToUnicode(pszUrl, szUrl, _countof(szUrl));
+    return ZoneCheckUrlExCacheW(NULL, szUrl, pbPolicy, cbPolicy, pbContext, cbContext,
+                                dwAction, dwFlags, pSecuritySite, pISM);
+}
+
+/*************************************************************************
+ * ZoneCheckUrlExCacheW [SHLWAPI.233]
+ */
+HRESULT WINAPI
+ZoneCheckUrlExCacheW(
+    _Inout_opt_  LPVOID                    pvReserved,
+    _In_z_       PCWSTR                    pszUrl,
+    _Out_writes_bytes_opt_(cbPolicy)
+                 PBYTE                     pbPolicy,
+    _In_         DWORD                     cbPolicy,
+    _In_reads_bytes_opt_(cbContext)
+                 PBYTE                     pbContext,
+    _In_         DWORD                     cbContext,
+    _In_         DWORD                     dwAction,
+    _In_         DWORD                     dwFlags,
+    _In_opt_     IInternetSecurityMgrSite  *pSecuritySite,
+    _In_opt_     IInternetSecurityManager  *pISM)
+{
+    HRESULT hr;
+    IInternetSecurityManager *pNewISM;
+    DWORD dwPolicyBuf, dwContextBuf, cbPolicyEffect;
+    PBYTE pbPolicyEffect, pbContextEffect;
+
+    if (!pszUrl)
+        return E_INVALIDARG;
+
+    if (pISM && pISM->lpVtbl)
+    {
+        hr = pISM->lpVtbl->QueryInterface(pISM, &IID_IInternetSecurityManager,
+                                          (LPVOID *)&pNewISM);
+    }
+    else
+    {
+        hr = SHLWAPI_GetCachedZonesManager(&IID_IInternetSecurityManager,
+                                           (LPVOID *)&pNewISM);
+        if (FAILED(hr))
+            return hr;
+
+        if (pISM)
+            hr = pISM->lpVtbl->QueryInterface(pISM, &IID_IInternetSecurityManager,
+                                              (LPVOID *)&pNewISM);
+    }
+
+    if (FAILED(hr))
+        return hr;
+
+    dwPolicyBuf  = 0;
+    dwContextBuf = 0;
+
+    if (pSecuritySite)
+        pNewISM->lpVtbl->SetSecuritySite(pNewISM, pSecuritySite);
+
+    if (pbContext)
+    {
+        pbContextEffect = pbContext;
+    }
+    else
+    {
+        pbContextEffect = (PBYTE)&dwContextBuf;
+        cbContext = sizeof(dwContextBuf);
+    }
+
+    if (pbPolicy)
+    {
+        pbPolicyEffect = pbPolicy;
+        cbPolicyEffect = cbPolicy;
+    }
+    else
+    {
+        pbPolicyEffect = (PBYTE)&dwPolicyBuf;
+        cbPolicyEffect = sizeof(dwPolicyBuf);
+    }
+
+    hr = pNewISM->lpVtbl->ProcessUrlAction(
+        pNewISM,
+        pszUrl,
+        dwAction,
+        pbPolicyEffect,
+        cbPolicyEffect,
+        pbContextEffect,
+        cbContext,
+        dwFlags,
+        PtrToUlong(pvReserved));
+
+    if (pSecuritySite)
+        pNewISM->lpVtbl->SetSecuritySite(pNewISM, NULL);
+
+    pNewISM->lpVtbl->Release(pNewISM);
+    return hr;
+}
+
+/*************************************************************************
+ * ZoneCheckPathA [SHLWAPI.226]
+ */
+HRESULT WINAPI
+ZoneCheckPathA(
+    _In_z_   PCSTR   pszPath,
+    _In_     DWORD   dwAction,
+    _In_     DWORD   dwFlags,
+    _In_opt_ IInternetSecurityMgrSite *pSecuritySite)
+{
+    WCHAR szPath[2084];
+    SHAnsiToUnicode(pszPath, szPath, _countof(szPath));
+    return ZoneCheckPathW(szPath, dwAction, dwFlags, pSecuritySite);
+}
+
+/*************************************************************************
+ * ZoneCheckPathW [SHLWAPI.227]
+ */
+HRESULT WINAPI
+ZoneCheckPathW(
+    _In_z_   PCWSTR  pszPath,
+    _In_     DWORD   dwAction,
+    _In_     DWORD   dwFlags,
+    _In_opt_ IInternetSecurityMgrSite *pSecuritySite)
+{
+    return ZoneCheckUrlW(pszPath, dwAction, dwFlags | PUAF_ISFILE, pSecuritySite);
+}
+
+/*************************************************************************
+ * ZoneCheckUrlA [SHLWAPI.228]
+ */
+HRESULT WINAPI
+ZoneCheckUrlA(
+    _In_z_   PCSTR   pszUrl,
+    _In_     DWORD   dwAction,
+    _In_     DWORD   dwFlags,
+    _In_opt_ IInternetSecurityMgrSite *pSecuritySite)
+{
+    WCHAR szUrl[2084];
+    SHAnsiToUnicode(pszUrl, szUrl, _countof(szUrl));
+    return ZoneCheckUrlW(szUrl, dwAction, dwFlags, pSecuritySite);
+}
+
+/*************************************************************************
+ * ZoneCheckUrlW [SHLWAPI.229]
+ */
+HRESULT WINAPI
+ZoneCheckUrlW(
+    _In_z_   PCWSTR  pszUrl,
+    _In_     DWORD   dwAction,
+    _In_     DWORD   dwFlags,
+    _In_opt_ IInternetSecurityMgrSite *pSecuritySite)
+{
+    return ZoneCheckUrlExW(pszUrl, NULL, 0, NULL, 0, dwAction, dwFlags, pSecuritySite);
+}
+
+/*************************************************************************
+ * ZoneCheckUrlExA [SHLWAPI.230]
+ */
+HRESULT WINAPI
+ZoneCheckUrlExA(
+    _In_z_       PCSTR   pszUrl,
+    _In_opt_     PBYTE   pbPolicy,
+    _In_         DWORD   cbPolicy,
+    _In_opt_     PBYTE   pbContext,
+    _In_         DWORD   cbContext,
+    _In_         DWORD   dwAction,
+    _In_         DWORD   dwFlags,
+    _In_opt_     IInternetSecurityMgrSite *pSecuritySite)
+{
+    WCHAR szUrl[2084];
+    SHAnsiToUnicode(pszUrl, szUrl, _countof(szUrl));
+    return ZoneCheckUrlExW(szUrl, pbPolicy, cbPolicy, pbContext, cbContext,
+                           dwAction, dwFlags, pSecuritySite);
+}
+
+/*************************************************************************
+ * ZoneCheckUrlExW [SHLWAPI.231]
+ */
+HRESULT WINAPI
+ZoneCheckUrlExW(
+    _In_z_       PCWSTR  pszUrl,
+    _In_opt_     PBYTE   pbPolicy,
+    _In_         DWORD   cbPolicy,
+    _In_opt_     PBYTE   pbContext,
+    _In_         DWORD   cbContext,
+    _In_         DWORD   dwAction,
+    _In_         DWORD   dwFlags,
+    _In_opt_     IInternetSecurityMgrSite *pSecuritySite)
+{
+    return ZoneCheckUrlExCacheW(NULL, pszUrl, pbPolicy, cbPolicy, pbContext, cbContext,
+                                dwAction, dwFlags, pSecuritySite, NULL);
+}

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -125,9 +125,6 @@ ZoneCheckUrlExCacheW(
     IInternetSecurityManager *pWorkISM;
     DWORD dwPolicyBuf, dwContextBuf;
 
-    TRACE("(%s, %p, %ld, %p, %ld, %ld, 0x%lX, %p, %p)\n", wine_dbgstr_w(pszUrl),
-          pbPolicy, cbPolicy, pbContext, cbContext, dwAction, dwFlags, pSecuritySite, pISM);
-
     if (!pszUrl)
     {
         ERR("pszUrl was NULL\n");
@@ -292,9 +289,6 @@ ZoneCheckHostEx(
     _In_                             DWORD                      dwAction)
 {
     DWORD dwPolicyBuf, dwContextBuf;
-
-    TRACE("(%p, %p, %ld, %p, %ld, %s, %ld)\n", pISM, pbPolicy, cbPolicy, pbContext, cbContext,
-          wine_dbgstr_w(pszUrl), dwAction);
 
     if (!pISM)
         return E_INVALIDARG;

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -16,8 +16,6 @@ WINE_DEFAULT_DEBUG_CHANNEL(zonechk);
 
 static IClassFactory *g_pcf = NULL;
 
-/* FIXME: CLSID_InternetSecurityManager */
-
 /*************************************************************************
  * SHLWAPI_GetCachedZonesManager
  *

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -112,6 +112,9 @@ ZoneCheckUrlExCacheW(
     IInternetSecurityManager *pWorkISM;
     DWORD dwPolicyBuf, dwContextBuf;
 
+    TRACE("(%s, %p, %ld, %p, %ld, %ld, 0x%lX, %p, %p)\n", wine_dbgstr_w(pszUrl),
+          pbPolicy, cbPolicy, pbContext, cbContext, dwAction, dwFlags, pSecuritySite, pISM);
+
     if (!pszUrl)
         return E_INVALIDARG;
 
@@ -270,6 +273,9 @@ ZoneCheckHostEx(
     _In_                             DWORD                      dwAction)
 {
     DWORD dwPolicyBuf, dwContextBuf;
+
+    TRACE("(%p, %p, %ld, %p, %ld, %s, %ld)\n", pISM, pbPolicy, cbPolicy, pbContext, cbContext,
+          wine_dbgstr_w(pszUrl), dwAction);
 
     if (!pISM)
         return E_INVALIDARG;

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -9,7 +9,6 @@
 #include <winbase.h>
 #include <urlmon.h>
 #include <shlobj.h>
-#include <shobjidl.h>
 #define NO_SHLWAPI_REG
 #include <shlwapi.h>
 #include <shlwapi_undoc.h>

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -109,34 +109,22 @@ ZoneCheckUrlExCacheW(
     _In_opt_     IInternetSecurityManager  *pISM)
 {
     HRESULT hr;
-    IInternetSecurityManager *pNewISM;
+    IInternetSecurityManager *pWorkISM;
     DWORD dwPolicyBuf, dwContextBuf;
 
     if (!pszUrl)
         return E_INVALIDARG;
 
-    if (pISM && pISM->lpVtbl)
-    {
-        hr = pISM->lpVtbl->QueryInterface(pISM, &IID_IInternetSecurityManager,
-                                          (PVOID *)&pNewISM);
-    }
+    if (pISM)
+        hr = pISM->lpVtbl->QueryInterface(pISM, &IID_IInternetSecurityManager, (PVOID *)&pWorkISM);
     else
-    {
-        hr = SHLWAPI_GetCachedZonesManager(&IID_IInternetSecurityManager,
-                                           (PVOID *)&pNewISM);
-        if (FAILED(hr))
-            return hr;
-
-        if (pISM)
-            hr = pISM->lpVtbl->QueryInterface(pISM, &IID_IInternetSecurityManager,
-                                              (PVOID *)&pNewISM);
-    }
+        hr = SHLWAPI_GetCachedZonesManager(&IID_IInternetSecurityManager, (PVOID *)&pWorkISM);
 
     if (FAILED(hr))
         return hr;
 
     if (pSecuritySite)
-        pNewISM->lpVtbl->SetSecuritySite(pNewISM, pSecuritySite);
+        pWorkISM->lpVtbl->SetSecuritySite(pWorkISM, pSecuritySite);
 
     if (!pbContext)
     {
@@ -147,18 +135,18 @@ ZoneCheckUrlExCacheW(
 
     if (!pbPolicy)
     {
-        dwPolicyBuf = 0;
+        dwPolicyBuf  = 0;
         pbPolicy = (PBYTE)&dwPolicyBuf;
         cbPolicy = sizeof(dwPolicyBuf);
     }
 
-    hr = pNewISM->lpVtbl->ProcessUrlAction(pNewISM, pszUrl, dwAction, pbPolicy, cbPolicy,
-                                           pbContext, cbContext, dwFlags, 0);
+    hr = pWorkISM->lpVtbl->ProcessUrlAction(pWorkISM, pszUrl, dwAction, pbPolicy, cbPolicy,
+                                            pbContext, cbContext, dwFlags, 0);
 
     if (pSecuritySite)
-        pNewISM->lpVtbl->SetSecuritySite(pNewISM, NULL);
+        pWorkISM->lpVtbl->SetSecuritySite(pWorkISM, NULL);
 
-    pNewISM->lpVtbl->Release(pNewISM);
+    pWorkISM->lpVtbl->Release(pWorkISM);
     return hr;
 }
 

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -88,10 +88,12 @@ HRESULT SuperPrivate_ZoneCheckPath(PCWSTR pwszUrl, DWORD dwExpectedZone)
  */
 HRESULT WINAPI
 ZoneCheckUrlExCacheA(
-    _In_z_       PCSTR                     pszUrl,
-    _In_opt_     PBYTE                     pbPolicy,
+    _In_         PCSTR                     pszUrl,
+    _Out_writes_bytes_opt_(cbPolicy)
+                 PBYTE                     pbPolicy,
     _In_         DWORD                     cbPolicy,
-    _In_opt_     PBYTE                     pbContext,
+    _In_reads_bytes_opt_(cbContext)
+                 PBYTE                     pbContext,
     _In_         DWORD                     cbContext,
     _In_         DWORD                     dwAction,
     _In_         DWORD                     dwFlags,
@@ -109,7 +111,7 @@ ZoneCheckUrlExCacheA(
  */
 HRESULT WINAPI
 ZoneCheckUrlExCacheW(
-    _In_z_       PCWSTR                    pszUrl,
+    _In_         PCWSTR                    pszUrl,
     _Out_writes_bytes_opt_(cbPolicy)
                  PBYTE                     pbPolicy,
     _In_         DWORD                     cbPolicy,
@@ -174,9 +176,9 @@ ZoneCheckUrlExCacheW(
  */
 HRESULT WINAPI
 ZoneCheckPathA(
-    _In_z_   PCSTR   pszPath,
-    _In_     DWORD   dwAction,
-    _In_     DWORD   dwFlags,
+    _In_     PCSTR pszPath,
+    _In_     DWORD dwAction,
+    _In_     DWORD dwFlags,
     _In_opt_ IInternetSecurityMgrSite *pSecuritySite)
 {
     WCHAR szPath[2048];
@@ -189,7 +191,7 @@ ZoneCheckPathA(
  */
 HRESULT WINAPI
 ZoneCheckPathW(
-    _In_z_   PCWSTR  pszPath,
+    _In_     PCWSTR  pszPath,
     _In_     DWORD   dwAction,
     _In_     DWORD   dwFlags,
     _In_opt_ IInternetSecurityMgrSite *pSecuritySite)
@@ -202,7 +204,7 @@ ZoneCheckPathW(
  */
 HRESULT WINAPI
 ZoneCheckUrlA(
-    _In_z_   PCSTR   pszUrl,
+    _In_     PCSTR   pszUrl,
     _In_     DWORD   dwAction,
     _In_     DWORD   dwFlags,
     _In_opt_ IInternetSecurityMgrSite *pSecuritySite)
@@ -217,7 +219,7 @@ ZoneCheckUrlA(
  */
 HRESULT WINAPI
 ZoneCheckUrlW(
-    _In_z_   PCWSTR  pszUrl,
+    _In_     PCWSTR  pszUrl,
     _In_     DWORD   dwAction,
     _In_     DWORD   dwFlags,
     _In_opt_ IInternetSecurityMgrSite *pSecuritySite)
@@ -230,14 +232,14 @@ ZoneCheckUrlW(
  */
 HRESULT WINAPI
 ZoneCheckUrlExA(
-    _In_z_       PCSTR   pszUrl,
-    _In_opt_     PBYTE   pbPolicy,
-    _In_         DWORD   cbPolicy,
-    _In_opt_     PBYTE   pbContext,
-    _In_         DWORD   cbContext,
-    _In_         DWORD   dwAction,
-    _In_         DWORD   dwFlags,
-    _In_opt_     IInternetSecurityMgrSite *pSecuritySite)
+    _In_                             PCSTR   pszUrl,
+    _Out_writes_bytes_opt_(cbPolicy) PBYTE   pbPolicy,
+    _In_                             DWORD   cbPolicy,
+    _In_reads_bytes_opt_(cbContext)  PBYTE   pbContext,
+    _In_                             DWORD   cbContext,
+    _In_                             DWORD   dwAction,
+    _In_                             DWORD   dwFlags,
+    _In_opt_                         IInternetSecurityMgrSite *pSecuritySite)
 {
     WCHAR szUrl[2048];
     SHAnsiToUnicode(pszUrl, szUrl, _countof(szUrl));
@@ -250,14 +252,14 @@ ZoneCheckUrlExA(
  */
 HRESULT WINAPI
 ZoneCheckUrlExW(
-    _In_z_       PCWSTR  pszUrl,
-    _In_opt_     PBYTE   pbPolicy,
-    _In_         DWORD   cbPolicy,
-    _In_opt_     PBYTE   pbContext,
-    _In_         DWORD   cbContext,
-    _In_         DWORD   dwAction,
-    _In_         DWORD   dwFlags,
-    _In_opt_     IInternetSecurityMgrSite *pSecuritySite)
+    _In_                             PCWSTR  pszUrl,
+    _Out_writes_bytes_opt_(cbPolicy) PBYTE   pbPolicy,
+    _In_                             DWORD   cbPolicy,
+    _In_reads_bytes_opt_(cbContext)  PBYTE   pbContext,
+    _In_                             DWORD   cbContext,
+    _In_                             DWORD   dwAction,
+    _In_                             DWORD   dwFlags,
+    _In_opt_                         IInternetSecurityMgrSite *pSecuritySite)
 {
     return ZoneCheckUrlExCacheW(pszUrl, pbPolicy, cbPolicy, pbContext, cbContext,
                                 dwAction, dwFlags, pSecuritySite, NULL);
@@ -268,8 +270,8 @@ ZoneCheckUrlExW(
  */
 HRESULT WINAPI
 ZoneCheckHost(
-    _In_z_ IInternetSecurityManager  *pISM,
-    _In_z_ PCWSTR                     pszUrl,
+    _In_   IInternetSecurityManager  *pISM,
+    _In_   PCWSTR                     pszUrl,
     _In_   DWORD                      dwAction)
 {
     return ZoneCheckHostEx(pISM, NULL, 0, NULL, 0, pszUrl, dwAction);
@@ -280,13 +282,13 @@ ZoneCheckHost(
  */
 HRESULT WINAPI
 ZoneCheckHostEx(
-    _In_                             IInternetSecurityManager  *pISM,
-    _Out_writes_bytes_opt_(cbPolicy) PBYTE                      pbPolicy,
-    _In_                             DWORD                      cbPolicy,
-    _In_reads_bytes_opt_(cbContext)  PBYTE                      pbContext,
-    _In_                             DWORD                      cbContext,
-    _In_z_                           PCWSTR                     pszUrl,
-    _In_                             DWORD                      dwAction)
+    _In_                             IInternetSecurityManager *pISM,
+    _Out_writes_bytes_opt_(cbPolicy) PBYTE                     pbPolicy,
+    _In_                             DWORD                     cbPolicy,
+    _In_reads_bytes_opt_(cbContext)  PBYTE                     pbContext,
+    _In_                             DWORD                     cbContext,
+    _In_                             PCWSTR                    pszUrl,
+    _In_                             DWORD                     dwAction)
 {
     DWORD dwPolicyBuf, dwContextBuf;
 

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -31,19 +31,19 @@ SHLWAPI_GetCachedZonesManagerInner(
     HRESULT hr;
     IClassFactory *pCF;
 
-    if (g_pZoneMgrCF)
-        return g_pZoneMgrCF->lpVtbl->CreateInstance(g_pZoneMgrCF, NULL, riid, ppv);
-
-    hr = CoGetClassObject(&CLSID_InternetSecurityManager, CLSCTX_INPROC_SERVER, NULL,
-                          &IID_IClassFactory, (PVOID *)&pCF);
-    if (FAILED(hr))
+    if (!g_pZoneMgrCF)
     {
-        *ppv = NULL;
-        return E_FAIL;
-    }
+        hr = CoGetClassObject(&CLSID_InternetSecurityManager, CLSCTX_INPROC_SERVER, NULL,
+                              &IID_IClassFactory, (PVOID *)&pCF);
+        if (FAILED(hr))
+        {
+            *ppv = NULL;
+            return E_FAIL;
+        }
 
-    g_pZoneMgrCF = pCF;
-    SHPinDllOfCLSID(&CLSID_InternetSecurityManager);
+        g_pZoneMgrCF = pCF;
+        SHPinDllOfCLSID(&CLSID_InternetSecurityManager);
+    }
 
     return g_pZoneMgrCF->lpVtbl->CreateInstance(g_pZoneMgrCF, NULL, riid, ppv);
 }

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -32,7 +32,7 @@ SHLWAPI_GetCachedZonesManagerInner(
         if (FAILED(hr))
         {
             *ppv = NULL;
-            return E_FAIL;
+            return hr;
         }
 
         g_pZoneMgrCF = pCF;
@@ -101,6 +101,11 @@ ZoneCheckUrlExCacheA(
     _In_opt_     IInternetSecurityManager  *pISM)
 {
     WCHAR szUrl[2048];
+    if (!pszUrl)
+    {
+        ERR("pszUrl was NULL\n");
+        return E_INVALIDARG;
+    }
     SHAnsiToUnicode(pszUrl, szUrl, _countof(szUrl));
     return ZoneCheckUrlExCacheW(szUrl, pbPolicy, cbPolicy, pbContext, cbContext,
                                 dwAction, dwFlags, pSecuritySite, pISM);
@@ -182,6 +187,11 @@ ZoneCheckPathA(
     _In_opt_ IInternetSecurityMgrSite *pSecuritySite)
 {
     WCHAR szPath[2048];
+    if (!pszPath)
+    {
+        ERR("pszPath was NULL\n");
+        return E_INVALIDARG;
+    }
     SHAnsiToUnicode(pszPath, szPath, _countof(szPath));
     return ZoneCheckPathW(szPath, dwAction, dwFlags, pSecuritySite);
 }
@@ -210,6 +220,11 @@ ZoneCheckUrlA(
     _In_opt_ IInternetSecurityMgrSite *pSecuritySite)
 {
     WCHAR szUrl[2048];
+    if (!pszUrl)
+    {
+        ERR("pszUrl was NULL\n");
+        return E_INVALIDARG;
+    }
     SHAnsiToUnicode(pszUrl, szUrl, _countof(szUrl));
     return ZoneCheckUrlW(szUrl, dwAction, dwFlags, pSecuritySite);
 }
@@ -242,6 +257,11 @@ ZoneCheckUrlExA(
     _In_opt_                         IInternetSecurityMgrSite *pSecuritySite)
 {
     WCHAR szUrl[2048];
+    if (!pszUrl)
+    {
+        ERR("pszUrl was NULL\n");
+        return E_INVALIDARG;
+    }
     SHAnsiToUnicode(pszUrl, szUrl, _countof(szUrl));
     return ZoneCheckUrlExW(szUrl, pbPolicy, cbPolicy, pbContext, cbContext,
                            dwAction, dwFlags, pSecuritySite);

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -269,3 +269,65 @@ ZoneCheckUrlExW(
     return ZoneCheckUrlExCacheW(pszUrl, pbPolicy, cbPolicy, pbContext, cbContext,
                                 dwAction, dwFlags, pSecuritySite, NULL);
 }
+
+/*************************************************************************
+ * ZoneCheckHost [SHLWAPI.234]
+ */
+HRESULT WINAPI
+ZoneCheckHost(
+    _In_z_ IInternetSecurityManager  *pISM,
+    _In_z_ PCWSTR                     pszUrl,
+    _In_   DWORD                      dwAction)
+{
+    return ZoneCheckHostEx(pISM, NULL, 0, NULL, 0, pszUrl, dwAction);
+}
+
+/*************************************************************************
+ * ZoneCheckHostEx [SHLWAPI.235]
+ */
+HRESULT WINAPI
+ZoneCheckHostEx(
+    _In_                             IInternetSecurityManager  *pISM,
+    _Out_writes_bytes_opt_(cbPolicy) PBYTE                      pbPolicy,
+    _In_                             DWORD                      cbPolicy,
+    _In_reads_bytes_opt_(cbContext)  PBYTE                      pbContext,
+    _In_                             DWORD                      cbContext,
+    _In_z_                           PCWSTR                     pszUrl,
+    _In_                             DWORD                      dwAction)
+{
+    DWORD dwPolicyBuf, dwContextBuf, cbPolicyEff, cbContextEff;
+    PBYTE pbPolicyEffective;
+    PBYTE pbContextEffective;
+
+    if (!pISM)
+        return E_INVALIDARG;
+
+    dwPolicyBuf = dwContextBuf = 0;
+
+    if (pbPolicy)
+    {
+        pbPolicyEffective = pbPolicy;
+        cbPolicyEff = cbPolicy;
+    }
+    else
+    {
+        pbPolicyEffective = (PBYTE)&dwPolicyBuf;
+        cbPolicyEff = sizeof(dwPolicyBuf);
+    }
+
+    if (pbContext)
+    {
+        pbContextEffective = pbContext;
+        cbContextEff = cbContext;
+    }
+    else
+    {
+        pbContextEffective = (PBYTE)&dwContextBuf;
+        cbContextEff = sizeof(dwContextBuf);
+    }
+
+    return pISM->lpVtbl->ProcessUrlAction(pISM, pszUrl, dwAction,
+                                          pbPolicyEffective, cbPolicyEff,
+                                          pbContextEffective, cbContextEff,
+                                          0, 0);
+}

--- a/dll/win32/shlwapi/zonechk.c
+++ b/dll/win32/shlwapi/zonechk.c
@@ -17,7 +17,6 @@ WINE_DEFAULT_DEBUG_CHANNEL(zonechk);
 static IClassFactory *g_pcf = NULL;
 
 /* FIXME: CLSID_InternetSecurityManager */
-/* FIXME: ZoneCheckHost, ZoneCheckHostEx */
 
 /*************************************************************************
  * SHLWAPI_GetCachedZonesManager

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -470,31 +470,27 @@ DECLARE_INTERFACE_(IAssociationElementOld, IUnknown) // {E58B1ABF-9596-4DBA-8997
 
 HRESULT WINAPI
 ZoneCheckUrlExCacheA(
-    _In_         PCSTR                     pszUrl,
-    _Out_writes_bytes_opt_(cbPolicy)
-                 PBYTE                     pbPolicy,
-    _In_         DWORD                     cbPolicy,
-    _In_reads_bytes_opt_(cbContext)
-                 PBYTE                     pbContext,
-    _In_         DWORD                     cbContext,
-    _In_         DWORD                     dwAction,
-    _In_         DWORD                     dwFlags,
-    _In_opt_     IInternetSecurityMgrSite  *pSecuritySite,
-    _In_opt_     IInternetSecurityManager  *pISM);
+    _In_                             PCSTR                     pszUrl,
+    _Out_writes_bytes_opt_(cbPolicy) PBYTE                     pbPolicy,
+    _In_                             DWORD                     cbPolicy,
+    _In_reads_bytes_opt_(cbContext)  PBYTE                     pbContext,
+    _In_                             DWORD                     cbContext,
+    _In_                             DWORD                     dwAction,
+    _In_                             DWORD                     dwFlags,
+    _In_opt_                         IInternetSecurityMgrSite *pSecuritySite,
+    _In_opt_                         IInternetSecurityManager *pISM);
 
 HRESULT WINAPI
 ZoneCheckUrlExCacheW(
-    _In_         PCWSTR                    pszUrl,
-    _Out_writes_bytes_opt_(cbPolicy)
-                 PBYTE                     pbPolicy,
-    _In_         DWORD                     cbPolicy,
-    _In_reads_bytes_opt_(cbContext)
-                 PBYTE                     pbContext,
-    _In_         DWORD                     cbContext,
-    _In_         DWORD                     dwAction,
-    _In_         DWORD                     dwFlags,
-    _In_opt_     IInternetSecurityMgrSite  *pSecuritySite,
-    _In_opt_     IInternetSecurityManager  *pISM);
+    _In_                             PCWSTR                    pszUrl,
+    _Out_writes_bytes_opt_(cbPolicy) PBYTE                     pbPolicy,
+    _In_                             DWORD                     cbPolicy,
+    _In_reads_bytes_opt_(cbContext)  PBYTE                     pbContext,
+    _In_                             DWORD                     cbContext,
+    _In_                             DWORD                     dwAction,
+    _In_                             DWORD                     dwFlags,
+    _In_opt_                         IInternetSecurityMgrSite *pSecuritySite,
+    _In_opt_                         IInternetSecurityManager *pISM);
 
 HRESULT WINAPI
 ZoneCheckPathA(

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -470,10 +470,12 @@ DECLARE_INTERFACE_(IAssociationElementOld, IUnknown) // {E58B1ABF-9596-4DBA-8997
 
 HRESULT WINAPI
 ZoneCheckUrlExCacheA(
-    _In_z_       PCSTR                     pszUrl,
-    _In_opt_     PBYTE                     pbPolicy,
+    _In_         PCSTR                     pszUrl,
+    _Out_writes_bytes_opt_(cbPolicy)
+                 PBYTE                     pbPolicy,
     _In_         DWORD                     cbPolicy,
-    _In_opt_     PBYTE                     pbContext,
+    _In_reads_bytes_opt_(cbContext)
+                 PBYTE                     pbContext,
     _In_         DWORD                     cbContext,
     _In_         DWORD                     dwAction,
     _In_         DWORD                     dwFlags,
@@ -482,7 +484,7 @@ ZoneCheckUrlExCacheA(
 
 HRESULT WINAPI
 ZoneCheckUrlExCacheW(
-    _In_z_       PCWSTR                    pszUrl,
+    _In_         PCWSTR                    pszUrl,
     _Out_writes_bytes_opt_(cbPolicy)
                  PBYTE                     pbPolicy,
     _In_         DWORD                     cbPolicy,
@@ -496,69 +498,62 @@ ZoneCheckUrlExCacheW(
 
 HRESULT WINAPI
 ZoneCheckPathA(
-    _In_z_   PCSTR   pszPath,
-    _In_     DWORD   dwAction,
-    _In_     DWORD   dwFlags,
-    _In_opt_ IInternetSecurityMgrSite *pSecuritySite);
-
-HRESULT WINAPI
-ZoneCheckPathW(
-    _In_z_   PCWSTR  pszPath,
-    _In_     DWORD   dwAction,
-    _In_     DWORD   dwFlags,
+    _In_     PCSTR pszPath,
+    _In_     DWORD dwAction,
+    _In_     DWORD dwFlags,
     _In_opt_ IInternetSecurityMgrSite *pSecuritySite);
 
 HRESULT WINAPI
 ZoneCheckUrlA(
-    _In_z_   PCSTR   pszUrl,
+    _In_     PCSTR   pszUrl,
     _In_     DWORD   dwAction,
     _In_     DWORD   dwFlags,
     _In_opt_ IInternetSecurityMgrSite *pSecuritySite);
 
 HRESULT WINAPI
 ZoneCheckUrlW(
-    _In_z_   PCWSTR  pszUrl,
+    _In_     PCWSTR  pszUrl,
     _In_     DWORD   dwAction,
     _In_     DWORD   dwFlags,
     _In_opt_ IInternetSecurityMgrSite *pSecuritySite);
 
 HRESULT WINAPI
 ZoneCheckUrlExA(
-    _In_z_       PCSTR   pszUrl,
-    _In_opt_     PBYTE   pbPolicy,
-    _In_         DWORD   cbPolicy,
-    _In_opt_     PBYTE   pbContext,
-    _In_         DWORD   cbContext,
-    _In_         DWORD   dwAction,
-    _In_         DWORD   dwFlags,
-    _In_opt_     IInternetSecurityMgrSite *pSecuritySite);
+    _In_                             PCSTR   pszUrl,
+    _Out_writes_bytes_opt_(cbPolicy) PBYTE   pbPolicy,
+    _In_                             DWORD   cbPolicy,
+    _In_reads_bytes_opt_(cbContext)  PBYTE   pbContext,
+    _In_                             DWORD   cbContext,
+    _In_                             DWORD   dwAction,
+    _In_                             DWORD   dwFlags,
+    _In_opt_                         IInternetSecurityMgrSite *pSecuritySite);
 
 HRESULT WINAPI
 ZoneCheckUrlExW(
-    _In_z_       PCWSTR  pszUrl,
-    _In_opt_     PBYTE   pbPolicy,
-    _In_         DWORD   cbPolicy,
-    _In_opt_     PBYTE   pbContext,
-    _In_         DWORD   cbContext,
-    _In_         DWORD   dwAction,
-    _In_         DWORD   dwFlags,
-    _In_opt_     IInternetSecurityMgrSite *pSecuritySite);
+    _In_                             PCWSTR  pszUrl,
+    _Out_writes_bytes_opt_(cbPolicy) PBYTE   pbPolicy,
+    _In_                             DWORD   cbPolicy,
+    _In_reads_bytes_opt_(cbContext)  PBYTE   pbContext,
+    _In_                             DWORD   cbContext,
+    _In_                             DWORD   dwAction,
+    _In_                             DWORD   dwFlags,
+    _In_opt_                         IInternetSecurityMgrSite *pSecuritySite);
 
 HRESULT WINAPI
 ZoneCheckHost(
-    _In_z_ IInternetSecurityManager  *pISM,
-    _In_z_ PCWSTR                     pszUrl,
+    _In_   IInternetSecurityManager  *pISM,
+    _In_   PCWSTR                     pszUrl,
     _In_   DWORD                      dwAction);
 
 HRESULT WINAPI
 ZoneCheckHostEx(
-    _In_                             IInternetSecurityManager  *pISM,
-    _Out_writes_bytes_opt_(cbPolicy) PBYTE                      pbPolicy,
-    _In_                             DWORD                      cbPolicy,
-    _In_reads_bytes_opt_(cbContext)  PBYTE                      pbContext,
-    _In_                             DWORD                      cbContext,
-    _In_z_                           PCWSTR                     pszUrl,
-    _In_                             DWORD                      dwAction);
+    _In_                             IInternetSecurityManager *pISM,
+    _Out_writes_bytes_opt_(cbPolicy) PBYTE                     pbPolicy,
+    _In_                             DWORD                     cbPolicy,
+    _In_reads_bytes_opt_(cbContext)  PBYTE                     pbContext,
+    _In_                             DWORD                     cbContext,
+    _In_                             PCWSTR                    pszUrl,
+    _In_                             DWORD                     dwAction);
 
 #ifdef UNICODE
     #define ZoneCheckUrlExCache ZoneCheckUrlExCacheW

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -504,6 +504,13 @@ ZoneCheckPathA(
     _In_opt_ IInternetSecurityMgrSite *pSecuritySite);
 
 HRESULT WINAPI
+ZoneCheckPathW(
+    _In_     PCWSTR pszPath,
+    _In_     DWORD dwAction,
+    _In_     DWORD dwFlags,
+    _In_opt_ IInternetSecurityMgrSite *pSecuritySite);
+
+HRESULT WINAPI
 ZoneCheckUrlA(
     _In_     PCSTR   pszUrl,
     _In_     DWORD   dwAction,

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -544,6 +544,22 @@ ZoneCheckUrlExW(
     _In_         DWORD   dwFlags,
     _In_opt_     IInternetSecurityMgrSite *pSecuritySite);
 
+HRESULT WINAPI
+ZoneCheckHost(
+    _In_z_ IInternetSecurityManager  *pISM,
+    _In_z_ PCWSTR                     pszUrl,
+    _In_   DWORD                      dwAction);
+
+HRESULT WINAPI
+ZoneCheckHostEx(
+    _In_                             IInternetSecurityManager  *pISM,
+    _Out_writes_bytes_opt_(cbPolicy) PBYTE                      pbPolicy,
+    _In_                             DWORD                      cbPolicy,
+    _In_reads_bytes_opt_(cbContext)  PBYTE                      pbContext,
+    _In_                             DWORD                      cbContext,
+    _In_z_                           PCWSTR                     pszUrl,
+    _In_                             DWORD                      dwAction);
+
 #ifdef UNICODE
     #define ZoneCheckUrlExCache ZoneCheckUrlExCacheW
     #define ZoneCheckPath ZoneCheckPathW

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -482,7 +482,6 @@ ZoneCheckUrlExCacheA(
 
 HRESULT WINAPI
 ZoneCheckUrlExCacheW(
-    _Inout_opt_  LPVOID                    pvReserved,
     _In_z_       PCWSTR                    pszUrl,
     _Out_writes_bytes_opt_(cbPolicy)
                  PBYTE                     pbPolicy,

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -464,6 +464,99 @@ DECLARE_INTERFACE_(IAssociationElementOld, IUnknown) // {E58B1ABF-9596-4DBA-8997
 #define IAssociationElementOld_QueryObject(T,a,b,c,d) (T)->lpVtbl->QueryObject(T,a,b,c,d)
 #endif
 
+/*****************************************************************************
+ * ZoneCheck*
+ */
+
+HRESULT WINAPI
+ZoneCheckUrlExCacheA(
+    _In_z_       PCSTR                     pszUrl,
+    _In_opt_     PBYTE                     pbPolicy,
+    _In_         DWORD                     cbPolicy,
+    _In_opt_     PBYTE                     pbContext,
+    _In_         DWORD                     cbContext,
+    _In_         DWORD                     dwAction,
+    _In_         DWORD                     dwFlags,
+    _In_opt_     IInternetSecurityMgrSite  *pSecuritySite,
+    _In_opt_     IInternetSecurityManager  *pISM);
+
+HRESULT WINAPI
+ZoneCheckUrlExCacheW(
+    _Inout_opt_  LPVOID                    pvReserved,
+    _In_z_       PCWSTR                    pszUrl,
+    _Out_writes_bytes_opt_(cbPolicy)
+                 PBYTE                     pbPolicy,
+    _In_         DWORD                     cbPolicy,
+    _In_reads_bytes_opt_(cbContext)
+                 PBYTE                     pbContext,
+    _In_         DWORD                     cbContext,
+    _In_         DWORD                     dwAction,
+    _In_         DWORD                     dwFlags,
+    _In_opt_     IInternetSecurityMgrSite  *pSecuritySite,
+    _In_opt_     IInternetSecurityManager  *pISM);
+
+HRESULT WINAPI
+ZoneCheckPathA(
+    _In_z_   PCSTR   pszPath,
+    _In_     DWORD   dwAction,
+    _In_     DWORD   dwFlags,
+    _In_opt_ IInternetSecurityMgrSite *pSecuritySite);
+
+HRESULT WINAPI
+ZoneCheckPathW(
+    _In_z_   PCWSTR  pszPath,
+    _In_     DWORD   dwAction,
+    _In_     DWORD   dwFlags,
+    _In_opt_ IInternetSecurityMgrSite *pSecuritySite);
+
+HRESULT WINAPI
+ZoneCheckUrlA(
+    _In_z_   PCSTR   pszUrl,
+    _In_     DWORD   dwAction,
+    _In_     DWORD   dwFlags,
+    _In_opt_ IInternetSecurityMgrSite *pSecuritySite);
+
+HRESULT WINAPI
+ZoneCheckUrlW(
+    _In_z_   PCWSTR  pszUrl,
+    _In_     DWORD   dwAction,
+    _In_     DWORD   dwFlags,
+    _In_opt_ IInternetSecurityMgrSite *pSecuritySite);
+
+HRESULT WINAPI
+ZoneCheckUrlExA(
+    _In_z_       PCSTR   pszUrl,
+    _In_opt_     PBYTE   pbPolicy,
+    _In_         DWORD   cbPolicy,
+    _In_opt_     PBYTE   pbContext,
+    _In_         DWORD   cbContext,
+    _In_         DWORD   dwAction,
+    _In_         DWORD   dwFlags,
+    _In_opt_     IInternetSecurityMgrSite *pSecuritySite);
+
+HRESULT WINAPI
+ZoneCheckUrlExW(
+    _In_z_       PCWSTR  pszUrl,
+    _In_opt_     PBYTE   pbPolicy,
+    _In_         DWORD   cbPolicy,
+    _In_opt_     PBYTE   pbContext,
+    _In_         DWORD   cbContext,
+    _In_         DWORD   dwAction,
+    _In_         DWORD   dwFlags,
+    _In_opt_     IInternetSecurityMgrSite *pSecuritySite);
+
+#ifdef UNICODE
+    #define ZoneCheckUrlExCache ZoneCheckUrlExCacheW
+    #define ZoneCheckPath ZoneCheckPathW
+    #define ZoneCheckUrl ZoneCheckUrlW
+    #define ZoneCheckUrlEx ZoneCheckUrlExW
+#else
+    #define ZoneCheckUrlExCache ZoneCheckUrlExCacheA
+    #define ZoneCheckPath ZoneCheckPathA
+    #define ZoneCheckUrl ZoneCheckUrlA
+    #define ZoneCheckUrlEx ZoneCheckUrlExA
+#endif
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif


### PR DESCRIPTION
## Purpose
Implementing missing features... Utility functions for [Internet Zone Manager](https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/ms537027(v=vs.85)).
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Add `zonechk.c` and implement `ZoneCheckPathA/W`, `ZoneCheckUrlA/W`, `ZoneCheckUrlExA/W`, `ZoneCheckUrlExCacheA/W`, and `ZoneCheckHost[Ex]` functions.
- Modify `shlwapi.spec`.
- Add prototypes to `<shlwapi_undoc.h>`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: