### PR TITLE
[SHELL32][SDK] Implement LinkWindow_RegisterClass

### DIFF
--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -2200,18 +2200,19 @@ EXTERN_C BOOL WINAPI LinkWindow_RegisterClass(VOID)
     INITCOMMONCONTROLSEX iccx = { sizeof(iccx), ICC_LINK_CLASS };
     InitCommonControlsEx(&iccx);
 
-    WNDCLASSW wc;
-    if (!GetClassInfoW(NULL, L"SysLink", &wc))
+    WNDCLASSEXW wcx = { sizeof(wcx) };
+    if (!GetClassInfoExW(NULL, L"SysLink", &wcx))
         return FALSE;
 
-    wc.lpszClassName = L"Link Window";
-    return !!RegisterClassW(&wc); /* Superclassing! */
+    /* Superclassing! */
+    wcx.lpszClassName = L"Link Window";
+    return RegisterClassExW(&wcx) || (GetLastError() == ERROR_CLASS_ALREADY_EXISTS);
 }
 
 /*************************************************************************
  *              LinkWindow_UnregisterClass (SHELL32.259)
  */
-EXTERN_C BOOL WINAPI LinkWindow_UnregisterClass(DWORD dwUnused)
+EXTERN_C BOOL WINAPI LinkWindow_UnregisterClass(_In_ DWORD dwUnused)
 {
     /* Do nothing. This is correct. */
     return TRUE;

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -2189,3 +2189,30 @@ SHELL32_AliasTranslatePidl(
 {
     return SHELL32_ReparentAsAliasPidl(NULL, NULL, pidl, ppidlNew, dwFlags) ? S_OK : E_FAIL;
 }
+
+/*************************************************************************
+ *              LinkWindow_RegisterClass (SHELL32.258)
+ *
+ * https://learn.microsoft.com/en-us/windows/win32/shell/linkwindow-registerclass
+ */
+EXTERN_C BOOL WINAPI LinkWindow_RegisterClass(VOID)
+{
+    INITCOMMONCONTROLSEX iccx = { sizeof(iccx), ICC_LINK_CLASS };
+    InitCommonControlsEx(&iccx);
+
+    WNDCLASSW wc;
+    if (!GetClassInfoW(NULL, L"SysLink", &wc))
+        return FALSE;
+
+    wc.lpszClassName = L"Link Window";
+    return !!RegisterClassW(&wc); /* Superclassing! */
+}
+
+/*************************************************************************
+ *              LinkWindow_UnregisterClass (SHELL32.259)
+ */
+EXTERN_C BOOL WINAPI LinkWindow_UnregisterClass(DWORD dwUnused)
+{
+    /* Do nothing. This is correct. */
+    return TRUE;
+}

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2662,8 +2662,13 @@ BOOL WINAPI LinkWindow_RegisterClass(void)
  */
 BOOL WINAPI LinkWindow_UnregisterClass(DWORD dwUnused)
 {
+#ifdef __REACTOS__
+    TRACE("()\n");
+    return TRUE; /* Do nothing. This is correct. */
+#else
     FIXME("()\n");
     return TRUE;
+#endif
 }
 
 /*************************************************************************

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2661,12 +2661,11 @@ BOOL WINAPI LinkWindow_RegisterClass(void)
 BOOL WINAPI LinkWindow_UnregisterClass(DWORD dwUnused)
 {
 #ifdef __REACTOS__
-    TRACE("()\n");
-    return TRUE; /* Do nothing. This is correct. */
+    /* Do nothing. This is correct. */
 #else
     FIXME("()\n");
-    return TRUE;
 #endif
+    return TRUE;
 }
 
 /*************************************************************************

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2632,11 +2632,29 @@ HRESULT WINAPI SHSetLocalizedName(LPCWSTR pszPath, LPCWSTR pszResModule, int ids
 
 /*************************************************************************
  *              LinkWindow_RegisterClass (SHELL32.258)
+#ifdef __REACTOS__
+ *
+ * https://learn.microsoft.com/en-us/windows/win32/shell/linkwindow-registerclass
+#endif
  */
 BOOL WINAPI LinkWindow_RegisterClass(void)
 {
+#ifdef __REACTOS__
+    TRACE("()\n");
+
+    INITCOMMONCONTROLSEX iccx = { sizeof(iccx), ICC_LINK_CLASS };
+    InitCommonControlsEx(&iccx);
+
+    WNDCLASSW wc;
+    if (!GetClassInfoW(NULL, L"SysLink", &wc))
+        return FALSE;
+
+    wc.lpszClassName = L"Link Window";
+    return !!RegisterClassW(&wc); /* Superclassing! */
+#else
     FIXME("()\n");
     return TRUE;
+#endif
 }
 
 /*************************************************************************

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2630,29 +2630,14 @@ HRESULT WINAPI SHSetLocalizedName(LPCWSTR pszPath, LPCWSTR pszResModule, int ids
     return S_OK;
 }
 
+#ifndef __REACTOS__ // See ../utils.cpp
 /*************************************************************************
  *              LinkWindow_RegisterClass (SHELL32.258)
-#ifdef __REACTOS__
- *
- * https://learn.microsoft.com/en-us/windows/win32/shell/linkwindow-registerclass
-#endif
  */
 BOOL WINAPI LinkWindow_RegisterClass(void)
 {
-#ifdef __REACTOS__
-    INITCOMMONCONTROLSEX iccx = { sizeof(iccx), ICC_LINK_CLASS };
-    InitCommonControlsEx(&iccx);
-
-    WNDCLASSW wc;
-    if (!GetClassInfoW(NULL, L"SysLink", &wc))
-        return FALSE;
-
-    wc.lpszClassName = L"Link Window";
-    return !!RegisterClassW(&wc); /* Superclassing! */
-#else
     FIXME("()\n");
     return TRUE;
-#endif
 }
 
 /*************************************************************************
@@ -2660,13 +2645,10 @@ BOOL WINAPI LinkWindow_RegisterClass(void)
  */
 BOOL WINAPI LinkWindow_UnregisterClass(DWORD dwUnused)
 {
-#ifdef __REACTOS__
-    /* Do nothing. This is correct. */
-#else
     FIXME("()\n");
-#endif
     return TRUE;
 }
+#endif
 
 /*************************************************************************
  *              SHFlushSFCache (SHELL32.526)

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2640,8 +2640,6 @@ HRESULT WINAPI SHSetLocalizedName(LPCWSTR pszPath, LPCWSTR pszResModule, int ids
 BOOL WINAPI LinkWindow_RegisterClass(void)
 {
 #ifdef __REACTOS__
-    TRACE("()\n");
-
     INITCOMMONCONTROLSEX iccx = { sizeof(iccx), ICC_LINK_CLASS };
     InitCommonControlsEx(&iccx);
 

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -910,7 +910,7 @@ Activate_RunDLL(
 
 BOOL WINAPI SHSettingsChanged(LPCVOID unused, LPCWSTR pszKey);
 
-BOOL WINAPI LinkWindow_RegisterClass(void);
+BOOL WINAPI LinkWindow_RegisterClass(VOID);
 BOOL WINAPI LinkWindow_UnregisterClass(DWORD dwUnused);
 
 /*****************************************************************************

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -911,7 +911,7 @@ Activate_RunDLL(
 BOOL WINAPI SHSettingsChanged(LPCVOID unused, LPCWSTR pszKey);
 
 BOOL WINAPI LinkWindow_RegisterClass(VOID);
-BOOL WINAPI LinkWindow_UnregisterClass(DWORD dwUnused);
+BOOL WINAPI LinkWindow_UnregisterClass(_In_ DWORD dwUnused);
 
 /*****************************************************************************
  * Shell32 resources

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -911,6 +911,7 @@ Activate_RunDLL(
 BOOL WINAPI SHSettingsChanged(LPCVOID unused, LPCWSTR pszKey);
 
 BOOL WINAPI LinkWindow_RegisterClass(void);
+BOOL WINAPI LinkWindow_UnregisterClass(DWORD dwUnused);
 
 /*****************************************************************************
  * Shell32 resources

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -910,6 +910,8 @@ Activate_RunDLL(
 
 BOOL WINAPI SHSettingsChanged(LPCVOID unused, LPCWSTR pszKey);
 
+BOOL WINAPI LinkWindow_RegisterClass(void);
+
 /*****************************************************************************
  * Shell32 resources
  */


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Implement `LinkWindow_RegisterClass` function by using "superclassing".
- Add prototype to `<undocshell.h>`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: