### PR TITLE
[SHELL32] Implement SHUpdateImageA

### DIFF
--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2506,7 +2506,7 @@ void WINAPI SHUpdateImageW(LPCWSTR pszHashItem, int iIndex, UINT uFlags, int iIm
  *
  * See SHUpdateImageW.
 #ifdef __REACTOS__
- * https://learn.microsoft.com/tr-tr/windows/win32/api/shlobj_core/nf-shlobj_core-shupdateimagea
+ * https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shupdateimagea
 #endif
  */
 VOID WINAPI SHUpdateImageA(LPCSTR pszHashItem, INT iIndex, UINT uFlags, INT iImageIndex)

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2505,10 +2505,20 @@ void WINAPI SHUpdateImageW(LPCWSTR pszHashItem, int iIndex, UINT uFlags, int iIm
  *		SHUpdateImageA (SHELL32.191)
  *
  * See SHUpdateImageW.
+#ifdef __REACTOS__
+ * https://learn.microsoft.com/tr-tr/windows/win32/api/shlobj_core/nf-shlobj_core-shupdateimagea
+#endif
  */
 VOID WINAPI SHUpdateImageA(LPCSTR pszHashItem, INT iIndex, UINT uFlags, INT iImageIndex)
 {
+#ifdef __REACTOS__
+    TRACE("(%s, %d, 0x%x, %d)\n", wine_debugstr_a(pszHashItem), iIndex, uFlags, iImageIndex);
+    WCHAR szHashItem[MAX_PATH];
+    SHAnsiToUnicode(pszHashItem, szHashItem, _countof(szHashItem));
+    SHUpdateImageW(szHashItem, iIndex, uFlags, iImageIndex);
+#else
     FIXME("%s, %d, 0x%x, %d - stub\n", debugstr_a(pszHashItem), iIndex, uFlags, iImageIndex);
+#endif
 }
 
 INT WINAPI SHHandleUpdateImage(PCIDLIST_ABSOLUTE pidlExtra)

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2512,7 +2512,7 @@ void WINAPI SHUpdateImageW(LPCWSTR pszHashItem, int iIndex, UINT uFlags, int iIm
 VOID WINAPI SHUpdateImageA(LPCSTR pszHashItem, INT iIndex, UINT uFlags, INT iImageIndex)
 {
 #ifdef __REACTOS__
-    TRACE("(%s, %d, 0x%x, %d)\n", wine_debugstr_a(pszHashItem), iIndex, uFlags, iImageIndex);
+    TRACE("(%s, %d, 0x%x, %d)\n", wine_dbgstr_a(pszHashItem), iIndex, uFlags, iImageIndex);
     WCHAR szHashItem[MAX_PATH];
     SHAnsiToUnicode(pszHashItem, szHashItem, _countof(szHashItem));
     SHUpdateImageW(szHashItem, iIndex, uFlags, iImageIndex);


### PR DESCRIPTION
## Purpose
Implementing missing features...

JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Implement `SHUpdateImageA` function.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: