### PR TITLE
[SHELL32][SDK] Implement SHHandleUpdateImage and SHUpdateImageW

### DIFF
--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2495,10 +2495,40 @@ BOOL WINAPI SHFindFiles( PCIDLIST_ABSOLUTE pidlFolder, PCIDLIST_ABSOLUTE pidlSav
  *  uFlags can be one or more of the following flags:
  *  GIL_NOTFILENAME - pszHashItem is not a file name.
  *  GIL_SIMULATEDOC - Create a document icon using the specified icon.
+#ifdef __REACTOS__
+ * https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shupdateimagew
+#endif
  */
 void WINAPI SHUpdateImageW(LPCWSTR pszHashItem, int iIndex, UINT uFlags, int iImageIndex)
 {
+#ifdef __REACTOS__
+    // If iImageIndex == -1 (undetermined), it will fall back to the default value of 1.
+    INT iEffectiveImageIndex = (iImageIndex == -1) ? 1 : iImageIndex;
+
+    SHCNF_UPDATEIMAGE_DATA_1 item1;
+    item1.cbSize      = sizeof(item1);
+    item1.iIndex      = iIndex;
+    item1.iEffective  = iEffectiveImageIndex;
+    item1.uFlags      = uFlags;
+    item1.iEffective2 = iEffectiveImageIndex;
+    item1.terminator  = 0;
+
+    SHCNF_UPDATEIMAGE_DATA_2 item2;
+
+    LPWSTR pEnd = StrCpyNXW(item2.szHashItem, pszHashItem, _countof(item2.szHashItem));
+    *pEnd = UNICODE_NULL;
+
+    item2.cbOffset             = (WORD)((PBYTE)pEnd - (PBYTE)&item2);
+    item2.iIndex               = iIndex;
+    item2.iEffectiveImageIndex = iEffectiveImageIndex;
+    item2.uFlags               = uFlags;
+    item2.dwProcessId          = GetCurrentProcessId();
+    item2.terminator           = 0;
+
+    SHChangeNotify(SHCNE_UPDATEIMAGE, SHCNF_IDLIST, &item1, &item2);
+#else
     FIXME("%s, %d, 0x%x, %d - stub\n", debugstr_w(pszHashItem), iIndex, uFlags, iImageIndex);
+#endif
 }
 
 /*************************************************************************
@@ -2512,7 +2542,6 @@ void WINAPI SHUpdateImageW(LPCWSTR pszHashItem, int iIndex, UINT uFlags, int iIm
 VOID WINAPI SHUpdateImageA(LPCSTR pszHashItem, INT iIndex, UINT uFlags, INT iImageIndex)
 {
 #ifdef __REACTOS__
-    TRACE("(%s, %d, 0x%x, %d)\n", wine_dbgstr_a(pszHashItem), iIndex, uFlags, iImageIndex);
     WCHAR szHashItem[MAX_PATH];
     SHAnsiToUnicode(pszHashItem, szHashItem, _countof(szHashItem));
     SHUpdateImageW(szHashItem, iIndex, uFlags, iImageIndex);
@@ -2521,11 +2550,33 @@ VOID WINAPI SHUpdateImageA(LPCSTR pszHashItem, INT iIndex, UINT uFlags, INT iIma
 #endif
 }
 
+#ifdef __REACTOS__
+/**
+ * Upon receiving the SHCNE_UPDATEIMAGE notification, this function returns the
+ * corresponding icon index in its system image list.
+ * https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shhandleupdateimage
+ */
+#endif
 INT WINAPI SHHandleUpdateImage(PCIDLIST_ABSOLUTE pidlExtra)
 {
+#ifdef __REACTOS__
+    if (!pidlExtra)
+        return -1;
+
+    UNALIGNED const SHCNF_UPDATEIMAGE_DATA_2* pData =
+        (UNALIGNED const SHCNF_UPDATEIMAGE_DATA_2*)pidlExtra;
+    if (pData->dwProcessId == GetCurrentProcessId())
+        return pData->iEffectiveImageIndex;
+
+    WCHAR szHashItem[MAX_PATH];
+    StrCpyNW(szHashItem, pData->szHashItem, _countof(szHashItem));
+
+    return SHLookupIconIndexW(szHashItem, pData->iIndex, pData->uFlags);
+#else
     FIXME("%p - stub\n", pidlExtra);
 
     return -1;
+#endif
 }
 
 BOOL WINAPI SHObjectProperties(HWND hwnd, DWORD dwType, LPCWSTR szObject, LPCWSTR szPage)

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -389,6 +389,17 @@ BOOL WINAPI PathFileExistsAndAttributesA(LPCSTR lpszPath, DWORD* dwAttr);
 BOOL WINAPI PathFileExistsAndAttributesW(LPCWSTR lpszPath, DWORD* dwAttr);
 #endif
 
+LPSTR  WINAPI StrCpyNXA(LPSTR lpszDest, LPCSTR lpszSrc, int iLen);
+LPWSTR WINAPI StrCpyNXW(LPWSTR lpszDest, LPCWSTR lpszSrc, int iLen);
+
+#ifdef UNICODE
+    #define PathIsValidChar PathIsValidCharW
+    #define StrCpyNX StrCpyNXW
+#else
+    #define PathIsValidChar PathIsValidCharA
+    #define StrCpyNX StrCpyNXA
+#endif
+
 BOOL WINAPI
 IContextMenu_Invoke(
     _In_ IContextMenu *pContextMenu,

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -175,6 +175,29 @@ typedef struct _SHCNF_PRINTJOB_INFO
 
 HRESULT WINAPI SHUpdateRecycleBinIcon(void);
 
+// Used in SHChangeNotify(SHCNE_UPDATEIMAGE)
+#include <pshpack1.h>
+typedef struct tagSHCNF_UPDATEIMAGE_DATA_1
+{
+    WORD   cbSize;
+    INT    iIndex;
+    INT    iEffective;
+    UINT   uFlags;
+    INT    iEffective2;
+    USHORT terminator;
+} SHCNF_UPDATEIMAGE_DATA_1, *PSHCNF_UPDATEIMAGE_DATA_1;
+typedef struct tagSHCNF_UPDATEIMAGE_DATA_2
+{
+    WORD  cbOffset;
+    INT   iIndex;
+    INT   iEffectiveImageIndex;
+    UINT  uFlags;
+    DWORD dwProcessId;
+    WCHAR szHashItem[MAX_PATH];
+    USHORT terminator;
+} SHCNF_UPDATEIMAGE_DATA_2, *PSHCNF_UPDATEIMAGE_DATA_2;
+#include <poppack.h>
+
 /****************************************************************************
  * Shell Common Dialogs
  */
@@ -314,6 +337,17 @@ ExtractIconResInfoW(
     _In_ WORD wIndex,
     _Out_ LPWORD lpSize,
     _Out_ LPHANDLE lpIcon);
+
+INT WINAPI SHLookupIconIndexA(LPCSTR  lpName, INT iIndex, UINT uFlags);
+INT WINAPI SHLookupIconIndexW(LPCWSTR lpName, INT iIndex, UINT uFlags);
+
+#ifdef UNICODE
+    #define ExtractIconResInfo ExtractIconResInfoW
+    #define SHLookupIconIndex SHLookupIconIndexW
+#else
+    #define ExtractIconResInfo ExtractIconResInfoA
+    #define SHLookupIconIndex SHLookupIconIndexA
+#endif
 
 /****************************************************************************
  * File Menu Routines


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Add `SHLookupIconIndexA/W` prototypes into `<undocshell.h>`.
- Add `StrCpyNXA/W` prototypes into `<shlwapi_undoc.h>`.
- Define `SHCNF_UPDATEIMAGE_DATA_1` and `SHCNF_UPDATEIMAGE_DATA_2` structures in `<undocshell.h>`.
- Implement `SHHandleUpdateImage` and `SHUpdateImageW` functions.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: