### PR TITLE
[SYSSETUP] Fix wine gecko install in second stage setup

### DIFF
--- a/dll/win32/syssetup/install.c
+++ b/dll/win32/syssetup/install.c
@@ -1569,6 +1569,7 @@ InstallReactOS(VOID)
     TOKEN_PRIVILEGES privs;
     HKEY hKey;
     HANDLE hHotkeyThread;
+    BOOL ret;
 
     InitializeSetupActionLog(FALSE);
     LogItem(NULL, L"Installing ReactOS");
@@ -1637,6 +1638,20 @@ InstallReactOS(VOID)
     PreprocessUnattend(TRUE);
     if (!CommonInstall())
         return 0;
+
+    /* Install the TCP/IP protocol driver */
+    ret = InstallNetworkComponent(L"MS_TCPIP");
+    if (!ret && GetLastError() != ERROR_FILE_NOT_FOUND)
+    {
+        DPRINT("InstallNetworkComponent() failed with error 0x%lx\n", GetLastError());
+    }
+    else
+    {
+        /* Start the TCP/IP protocol driver */
+        SetupStartService(L"Tcpip", FALSE);
+        SetupStartService(L"Dhcp", FALSE);
+        SetupStartService(L"Dnscache", FALSE);
+    }
 
     InstallWizard();
 


### PR DESCRIPTION
## Purpose

_Restore the ability to download ReactOS's Wine Gecko during the Second Stage Installer._
_Reverts a part of commit [6b9122b](https://github.com/reactos/reactos/commit/6b9122b5f55388a5f81c9fcd7ba7ac16f8634639)._
_This reverts all of the changes there to "win32/syssetup/install.c"._

JIRA issue: [CORE-20422](https://jira.reactos.org/browse/CORE-20422)

## Proposed changes

_Revert code causing regression from "win32/syssetup/install.c"._

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=106970,106971 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=106963,106964 LGTM

After PR:

<img width="818" height="688" alt="16-2621-Wine_Gecko_Download_Working" src="https://github.com/user-attachments/assets/9eac7c57-9ed1-4a78-be64-453f9be18c00" />
