### PR TITLE
[FREELDR] Fix UEFI IA-32 boot

### DIFF
--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -455,6 +455,12 @@ WinLdrSetProcessorContext(
     /* Re-initialize EFLAGS */
     __writeeflags(0);
 
+    /* Disable paging first before disabling PAE to avoid crash
+     * because UEFI might have enabled paged mode with PAE.
+     * Our kernel doesn't support PAE, so disable it. */
+    __writecr0(__readcr0() & ~CR0_PG);
+    __writecr4(__readcr4() & ~CR4_PAE);
+
     /* Set the PDBR */
     __writecr3((ULONG_PTR)PDE);
 


### PR DESCRIPTION
## Purpose

The PAE (cr4) flag was enabled on my x86-32 UEFI causing the crash later.
I tested using qemu with `OVMF32_CODE_4M.fd` firmware!

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Registers dump at the crash moment

The registers are like this because i forgot to set the architecture mode on gdb

```C
rax            0x4255000           69554176
rbx            0x8009c000          2148122624
rcx            0x3f8               1016
rdx            0x2                 2
rsi            0x34c14             216084
rdi            0x39000             233472
rbp            0x349f4             0x349f4
rsp            0x349ac             0x349ac
r8             0x0                 0
r9             0x0                 0
r10            0x0                 0
r11            0x0                 0
r12            0x0                 0
r13            0x0                 0
r14            0x0                 0
r15            0x0                 0
rip            0x41cae7            0x41cae7 // __writecr3((ULONG_PTR)PDE);
eflags         0x10002             [ RF IOPL=0 ]
cs             0x10                16
ss             0x8                 8
ds             0x8                 8
es             0x8                 8
fs             0x8                 8
gs             0x8                 8
fs_base        0x0                 0
gs_base        0x0                 0
k_gs_base      0x0                 0
cr0            0x80010033          [ PG WP NE ET MP PE ]
cr2            0x0                 0
cr3            0x3fc01000          [ PDBR=261121 PCID=0 ]
cr4            0x660               [ OSXMMEXCPT OSFXSR MCE PAE ] // here its is the PAE
cr8            0x0                 0

// it crashed because the page directory was not on PAE format
```

## Testbot runs (Filled in by Devs)

- [ ] KVM x86: WIP: https://build.reactos.org/#/builders/6/builds/40377

After most recent commit of 27-Apr-2026:
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107058,107065,107075 LGTM
- [x] KVM x64:  https://reactos.org/testman/compare.php?ids=107066,107074 LGTM