### PR TITLE
[NTUSER] co_IntProcessKeyboardMessage: Return FALSE on some conditions

### DIFF
--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -1881,11 +1881,12 @@ BOOL co_IntProcessKeyboardMessage(MSG* Msg, BOOL* RemoveMessages)
         {
             if ( ImmRet & (IPHK_HOTKEY|IPHK_SKIPTHISKEY) )
             {
-               ImmRet = 0;
+               Ret = FALSE;
             }
             if ( ImmRet & IPHK_PROCESSBYIME )
             {
                Msg->wParam = VK_PROCESSKEY;
+               Ret = FALSE;
             }
         }
     }

--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -1886,7 +1886,6 @@ BOOL co_IntProcessKeyboardMessage(MSG* Msg, BOOL* RemoveMessages)
             if ( ImmRet & IPHK_PROCESSBYIME )
             {
                Msg->wParam = VK_PROCESSKEY;
-               Ret = FALSE;
             }
         }
     }


### PR DESCRIPTION
## Purpose
Make `Alt+VK_KANJI` (`Alt+[半/全]`) working.
JIRA issue: [CORE-19455](https://jira.reactos.org/browse/CORE-19455)

## Proposed changes

- Return `FALSE` on `IPHK_HOTKEY` or `IPHK_SKIPTHISKEY` in `co_IntProcessKeyboardMessage` function.

NOTE: The `Alt+...` key repeat bug is VirutalBox's bug.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: