### PR TITLE
[BOOTDATA] Fix legide.sys

### DIFF
--- a/boot/bootdata/txtsetup.sif
+++ b/boot/bootdata/txtsetup.sif
@@ -126,6 +126,7 @@ storport.sys = 1,,,,,,,4,,,,1,4
 fastfat.sys  = 1,,,,,,x,4,,,,1,4
 btrfs.sys    = 1,,,,,,x,4,,,,1,4
 ramdisk.sys  = 1,,,,,,x,4,,,,1,4
+legide.sys   = 1,,,,,,,4,,,,1,4
 pciide.sys   = 1,,,,,,x,4,,,,1,4
 pciidex.sys  = 1,,,,,,,4,,,,1,4
 pcix.sys     = 1,,,,,,,4,,,,1,4


### PR DESCRIPTION
## Purpose

After merging the new ATA driver, FreeLdr complains about not being able to load legide.sys. This patch fixes that.

## Proposed changes
- Add legide.sys to txtsetup.sif so FreeLdr can load the driver

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: