### PR TITLE
[RTL] Initialize generic table lookup output on empty tree

### DIFF
--- a/sdk/lib/rtl/generictable.c
+++ b/sdk/lib/rtl/generictable.c
@@ -34,7 +34,6 @@ RtlpFindGenericTableNodeOrParent(IN PRTL_GENERIC_TABLE Table,
     /* Quick check to see if the table is empty */
     if (RtlIsGenericTableEmpty(Table))
     {
-        *NodeOrParent = NULL;
         return TableEmptyTree;
     }
 
@@ -126,7 +125,7 @@ RtlInsertElementGenericTable(IN PRTL_GENERIC_TABLE Table,
                              IN ULONG BufferSize,
                              OUT PBOOLEAN NewElement OPTIONAL)
 {
-    PRTL_SPLAY_LINKS NodeOrParent;
+    PRTL_SPLAY_LINKS NodeOrParent = NULL;
     TABLE_SEARCH_RESULT Result;
 
     /* Get the splay links and table search result immediately */

--- a/sdk/lib/rtl/generictable.c
+++ b/sdk/lib/rtl/generictable.c
@@ -34,6 +34,7 @@ RtlpFindGenericTableNodeOrParent(IN PRTL_GENERIC_TABLE Table,
     /* Quick check to see if the table is empty */
     if (RtlIsGenericTableEmpty(Table))
     {
+        *NodeOrParent = NULL;
         return TableEmptyTree;
     }
 


### PR DESCRIPTION
## Summary

While doing local Clang/LLVM 21 amd64 bring-up work, the boot crashed in the section page table code during early LiveCD startup. The immediate crash was seen with the Clang build, but the root cause was not Clang-specific.

`RtlpFindGenericTableNodeOrParent()` returns `TableEmptyTree` for an empty generic table without initializing its `NodeOrParent` output parameter. That leaves the caller with an indeterminate value for a documented output argument.

## Details

For an empty splay tree there is no node or parent, so explicitly return `NULL` through `NodeOrParent` before returning `TableEmptyTree`.

This makes the empty-tree result deterministic and avoids depending on compiler code generation or stack contents.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: