### PR TITLE
[NTUSER] IntImmProcessKey: Use KF_... flags

### DIFF
--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -295,7 +295,7 @@ IntCheckImeHotKey(
 {
     PIMEHOTKEY pHotKey;
     UINT uModifiers;
-    BOOL bKeyUp = (lParam & 0x80000000);
+    BOOL bKeyUp = (HIWORD(lParam) & KF_UP);
     const BYTE *KeyState = MessageQueue->afKeyState;
     static UINT s_uKeyUpVKey = 0;
 

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -681,7 +681,7 @@ IntImmProcessKey(
         if (!pIMC)
             return 0;
 
-        if (HIWORD(lParam) & KF_UP) &&
+        if ((HIWORD(lParam) & KF_UP) &&
             (pKL->piiex->ImeInfo.fdwProperty & IME_PROP_IGNORE_UPKEYS))
         {
             return 0;

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -681,7 +681,7 @@ IntImmProcessKey(
         if (!pIMC)
             return 0;
 
-        if ((lParam & (KF_UP << 16)) &&
+        if (HIWORD(lParam) & KF_UP) &&
             (pKL->piiex->ImeInfo.fdwProperty & IME_PROP_IGNORE_UPKEYS))
         {
             return 0;
@@ -709,7 +709,7 @@ IntImmProcessKey(
 
                 if (!(pKL->piiex->ImeInfo.fdwProperty & IME_PROP_NEED_ALTKEY))
                 {
-                    if (uVirtualKey == VK_MENU || (lParam & 0x20000000))
+                    if (uVirtualKey == VK_MENU || (HIWORD(lParam) & KF_ALTDOWN))
                         return 0;
                 }
                 break;


### PR DESCRIPTION
## Purpose

A tiny refactoring for code readability.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Use `HIWORD` macro and `KF_...` constants.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: