### PR TITLE
[SDK] <shlwapi.h>: Fix conflict of PathFileExistsAndAttributes

### DIFF
--- a/sdk/include/wine/shlwapi.h
+++ b/sdk/include/wine/shlwapi.h
@@ -407,10 +407,6 @@ WINSHLWAPI BOOL WINAPI PathFileExistsA(LPCSTR);
 WINSHLWAPI BOOL WINAPI PathFileExistsW(LPCWSTR);
 #define PathFileExists WINELIB_NAME_AW(PathFileExists)
 
-WINSHLWAPI BOOL WINAPI PathFileExistsAndAttributesA(LPCSTR,DWORD*);
-WINSHLWAPI BOOL WINAPI PathFileExistsAndAttributesW(LPCWSTR,DWORD*);
-#define PathFileExistsAndAttributes WINELIB_NAME_AW(PathFileExistsAndAttributes)
-
 WINSHLWAPI LPSTR  WINAPI PathFindExtensionA(LPCSTR);
 WINSHLWAPI LPWSTR WINAPI PathFindExtensionW(LPCWSTR);
 #define PathFindExtension WINELIB_NAME_AW(PathFindExtension)

--- a/sdk/include/wine/shlwapi.h
+++ b/sdk/include/wine/shlwapi.h
@@ -407,6 +407,12 @@ WINSHLWAPI BOOL WINAPI PathFileExistsA(LPCSTR);
 WINSHLWAPI BOOL WINAPI PathFileExistsW(LPCWSTR);
 #define PathFileExists WINELIB_NAME_AW(PathFileExists)
 
+#ifndef __REACTOS__
+WINSHLWAPI BOOL WINAPI PathFileExistsAndAttributesA(LPCSTR,DWORD*);
+WINSHLWAPI BOOL WINAPI PathFileExistsAndAttributesW(LPCWSTR,DWORD*);
+#define PathFileExistsAndAttributes WINELIB_NAME_AW(PathFileExistsAndAttributes)
+#endif
+
 WINSHLWAPI LPSTR  WINAPI PathFindExtensionA(LPCSTR);
 WINSHLWAPI LPWSTR WINAPI PathFindExtensionW(LPCWSTR);
 #define PathFindExtension WINELIB_NAME_AW(PathFindExtension)


### PR DESCRIPTION
## Purpose
`<shlwapi_undoc.h>` and `<shlwapi.h>` were conflicting.
`PathFileExistsAndAttributes` prototype was duplicated with `<shlwapi_undoc.h>` in #8884.
JIRA issue: N/A

```txt
In file included from ../src/dll/win32/shlwapi/propbag.cpp:11:
../src/sdk/include/reactos/shlwapi_undoc.h:397: error: "PathFileExistsAndAttributes" redefined [-Werror]
     #define PathFileExistsAndAttributes PathFileExistsAndAttributesW
 
In file included from ../src/dll/win32/shlwapi/precomp.h:24,
                 from ../src/dll/win32/shlwapi/propbag.cpp:9:
../src/sdk/include/wine/shlwapi.h:412: note: this is the location of the previous definition
 #define PathFileExistsAndAttributes WINELIB_NAME_AW(PathFileExistsAndAttributes)
```
## Proposed changes

- Enclose `PathFileExistsAndAttributes/A/W` in `<shlwapi.h>` with `#ifndef __REACTOS__ ... #endif`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: