### PR TITLE
[GDI32] Fix pptviewer '97 and calls to PolylineTo and PolyBezierTo

### DIFF
--- a/win32ss/gdi/gdi32/objects/painting.c
+++ b/win32ss/gdi/gdi32/objects/painting.c
@@ -322,8 +322,6 @@ PolyBezierTo(
             cpt++;
             ret = NtGdiPolyPolyDraw(hdc , (PPOINT)pts, &cpt, 1, GdiPolyBezierTo);
         }
-        else
-            ret = FALSE;
         HeapFree(GetProcessHeap(), 0, pts);
     }
     else
@@ -417,8 +415,6 @@ PolylineTo(
             cpt++;
             ret = NtGdiPolyPolyDraw(hdc , (PPOINT)pts, &cpt, 1, GdiPolyLineTo);
         }
-        else
-            ret = FALSE;
         HeapFree(GetProcessHeap(), 0, pts);
     }
     else

--- a/win32ss/gdi/gdi32/objects/painting.c
+++ b/win32ss/gdi/gdi32/objects/painting.c
@@ -299,7 +299,6 @@ PolyBezierTo(
         if (apt[0].x == apt[1].x && apt[1].x == apt[2].x &&
             apt[0].y == apt[1].y && apt[1].y == apt[2].y)
         {
-            POINT pt1 = { 0, 0 }; // Current Position
             /* If all points are equal and they equal the start point,
              * then we can just return TRUE as an optimization. */
             if (GetCurrentPositionEx(hdc, &pt1) &&
@@ -315,7 +314,6 @@ PolyBezierTo(
 
     /* Following based on Wine 10.0 nulldrv_PolyBezierTo function */
     POINT *pts = HeapAlloc(GetProcessHeap(), 0, (cpt + 1) * sizeof(*apt));
-
     if (!pts)
     {
         SetLastError(ERROR_NOT_ENOUGH_MEMORY);
@@ -410,7 +408,6 @@ PolylineTo(
 
     /* Following based on Wine 10.0 nulldrv_PolylineTo function */
     POINT *pts = HeapAlloc(GetProcessHeap(), 0, (cpt + 1) * sizeof(*apt));
-
     if (!pts)
     {
         SetLastError(ERROR_NOT_ENOUGH_MEMORY);

--- a/win32ss/gdi/gdi32/objects/painting.c
+++ b/win32ss/gdi/gdi32/objects/painting.c
@@ -283,11 +283,53 @@ PolyBezierTo(
     _In_reads_(cpt) const POINT *apt,
     _In_ DWORD cpt)
 {
+    POINT pt1 = { 0, 0 };
+    BOOL ret = FALSE;
+
     HANDLE_EMETAFDC(BOOL, PolyBezierTo, FALSE, hdc, apt, cpt);
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
-    return NtGdiPolyPolyDraw(hdc , (PPOINT)apt, &cpt, 1, GdiPolyBezierTo);
+    if (cpt == 3)
+    {
+        /* If there are exactly 3 points, see if all three points of
+         * the PolyBezierTo are equal. */
+        if (apt[0].x == apt[1].x && apt[1].x == apt[2].x &&
+            apt[0].y == apt[1].y && apt[1].y == apt[2].y)
+        {
+            POINT pt1 = { 0, 0 }; // Current Position
+            /* If all points are equal and they equal the start point,
+             * then we can just return TRUE as an optimization. */
+            if (GetCurrentPositionEx(hdc, &pt1) &&
+                pt1.x == apt[0].x && pt1.y == apt[0].y)
+                return TRUE;
+            /* If they are all equal, but not equal to the start point,
+             * then we can just do a LineTo and return as an optimization. */
+            else
+                return LineTo(hdc, apt[0].x, apt[0].y); 
+        }
+    }
+
+    /* Following based on Wine 10.0 nulldrv_PolyBezierTo function */
+    POINT *pts = HeapAlloc(GetProcessHeap(), 0, (cpt + 1) * sizeof(*apt));
+
+    if (pts)
+    {
+        if (GetCurrentPositionEx(hdc, &pt1))
+        {
+            pts[0] = pt1;
+            memcpy(&pts[1], apt,  sizeof(*apt) * cpt);
+            cpt++;
+            ret = NtGdiPolyPolyDraw(hdc , (PPOINT)pts, &cpt, 1, GdiPolyBezierTo);
+        }
+        else
+            ret = FALSE;
+        HeapFree(GetProcessHeap(), 0, pts);
+    }
+    else
+        SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+
+    return ret;
 }
 
 
@@ -356,11 +398,33 @@ PolylineTo(
     _In_reads_(cpt) const POINT *apt,
     _In_ DWORD cpt)
 {
+    POINT pt1 = { 0, 0 };
+    BOOL ret = FALSE;
+
     HANDLE_EMETAFDC(BOOL, PolylineTo, FALSE, hdc, apt, cpt);
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
-    return NtGdiPolyPolyDraw(hdc , (PPOINT)apt, &cpt, 1, GdiPolyLineTo);
+    /* Following based on Wine 10.0 nulldrv_PolylineTo function */
+    POINT *pts = HeapAlloc(GetProcessHeap(), 0, (cpt + 1) * sizeof(*apt));
+
+    if (pts)
+    {
+        if (GetCurrentPositionEx(hdc, &pt1))
+        {
+            pts[0] = pt1;
+            memcpy(&pts[1], apt,  sizeof(*apt) * cpt);
+            cpt++;
+            ret = NtGdiPolyPolyDraw(hdc , (PPOINT)pts, &cpt, 1, GdiPolyLineTo);
+        }
+        else
+            ret = FALSE;
+        HeapFree(GetProcessHeap(), 0, pts);
+    }
+    else
+        SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+
+    return ret;
 }
 
 

--- a/win32ss/gdi/gdi32/objects/painting.c
+++ b/win32ss/gdi/gdi32/objects/painting.c
@@ -290,6 +290,8 @@ PolyBezierTo(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    /* This section of code is just an optimization so we can do an early return.
+     * Everything would work the same even if this code were removed. */
     if (cpt == 3)
     {
         /* If there are exactly 3 points, see if all three points of
@@ -302,30 +304,33 @@ PolyBezierTo(
              * then we can just return TRUE as an optimization. */
             if (GetCurrentPositionEx(hdc, &pt1) &&
                 pt1.x == apt[0].x && pt1.y == apt[0].y)
+            {
                 return TRUE;
+            }
             /* If they are all equal, but not equal to the start point,
              * then we can just do a LineTo and return as an optimization. */
-            else
-                return LineTo(hdc, apt[0].x, apt[0].y); 
+            return LineTo(hdc, apt[0].x, apt[0].y);
         }
     }
 
     /* Following based on Wine 10.0 nulldrv_PolyBezierTo function */
     POINT *pts = HeapAlloc(GetProcessHeap(), 0, (cpt + 1) * sizeof(*apt));
 
-    if (pts)
+    if (!pts)
     {
-        if (GetCurrentPositionEx(hdc, &pt1))
-        {
-            pts[0] = pt1;
-            memcpy(&pts[1], apt,  sizeof(*apt) * cpt);
-            cpt++;
-            ret = NtGdiPolyPolyDraw(hdc , (PPOINT)pts, &cpt, 1, GdiPolyBezierTo);
-        }
-        HeapFree(GetProcessHeap(), 0, pts);
-    }
-    else
         SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+        return FALSE;
+    }
+
+    if (GetCurrentPositionEx(hdc, &pt1))
+    {
+        pts[0] = pt1;
+        memcpy(&pts[1], apt, sizeof(*apt) * cpt);
+        cpt++;
+        ret = NtGdiPolyPolyDraw(hdc, (PPOINT)pts, &cpt, 1, GdiPolyBezierTo);
+    }
+
+    HeapFree(GetProcessHeap(), 0, pts);
 
     return ret;
 }
@@ -406,19 +411,21 @@ PolylineTo(
     /* Following based on Wine 10.0 nulldrv_PolylineTo function */
     POINT *pts = HeapAlloc(GetProcessHeap(), 0, (cpt + 1) * sizeof(*apt));
 
-    if (pts)
+    if (!pts)
     {
-        if (GetCurrentPositionEx(hdc, &pt1))
-        {
-            pts[0] = pt1;
-            memcpy(&pts[1], apt,  sizeof(*apt) * cpt);
-            cpt++;
-            ret = NtGdiPolyPolyDraw(hdc , (PPOINT)pts, &cpt, 1, GdiPolyLineTo);
-        }
-        HeapFree(GetProcessHeap(), 0, pts);
-    }
-    else
         SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+        return FALSE;
+    }
+
+    if (GetCurrentPositionEx(hdc, &pt1))
+    {
+        pts[0] = pt1;
+        memcpy(&pts[1], apt, sizeof(*apt) * cpt);
+        cpt++;
+        ret = NtGdiPolyPolyDraw(hdc, (PPOINT)pts, &cpt, 1, GdiPolyLineTo);
+    }
+
+    HeapFree(GetProcessHeap(), 0, pts);
 
     return ret;
 }

--- a/win32ss/gdi/ntgdi/fillshap.c
+++ b/win32ss/gdi/ntgdi/fillshap.c
@@ -432,7 +432,7 @@ NtGdiPolyPolyDraw( IN HDC hDC,
         ProbeForRead(UnsafePoints, Count * sizeof(POINT), 1);
         ProbeForRead(UnsafeCounts, Count * sizeof(ULONG), 1);
 
-        /* Count points and validate poligons */
+        /* Count points and validate polygons */
         for (i = 0; i < Count; i++)
         {
             if (UnsafeCounts[i] < 2)
@@ -544,7 +544,18 @@ NtGdiPolyPolyDraw( IN HDC hDC,
             Ret = IntGdiPolylineTo(dc, SafePoints, *SafeCounts);
             break;
         case GdiPolyBezierTo:
-            Ret = IntGdiPolyBezierTo(dc, SafePoints, *SafeCounts);
+            /* From Wine 10.0 dlls/win32u/painting.c NtGdiPolyPolyDraw
+             * UnsafeCounts[0] must be 3 * n + 1 (where n >= 1) */
+            if (Count == 1 && UnsafeCounts[0] != 1 && UnsafeCounts[0] % 3 == 1)
+            {
+                SafeCounts[0]--;
+                Ret = IntGdiPolyBezierTo(dc, SafePoints, *SafeCounts);
+            }
+            else
+            {
+                EngSetLastError(ERROR_INVALID_PARAMETER);
+                Ret = FALSE;
+            }
             break;
         default:
             EngSetLastError(ERROR_INVALID_PARAMETER);

--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -323,6 +323,8 @@ PATH_ReserveEntries(
         pPointsNew = (POINT *)ExAllocatePoolWithTag(PagedPool, numEntriesToAllocate * sizeof(POINT), TAG_PATH);
         if (!pPointsNew)
             return FALSE;
+         else
+            memset(pPointsNew, 0, numEntriesToAllocate * sizeof(POINT));
 
         pFlagsNew = (BYTE *)ExAllocatePoolWithTag(PagedPool, numEntriesToAllocate * sizeof(BYTE), TAG_PATH);
         if (!pFlagsNew)
@@ -330,6 +332,8 @@ PATH_ReserveEntries(
             ExFreePoolWithTag(pPointsNew, TAG_PATH);
             return FALSE;
         }
+        else
+            memset(pFlagsNew, 0, numEntriesToAllocate * sizeof(BYTE));
 
         /* Copy old arrays to new arrays and discard old arrays */
         if (pPath->pPoints)
@@ -461,15 +465,25 @@ PATH_CheckRect(
 /* add a number of points, converting them to device coords */
 /* return a pointer to the first type byte so it can be fixed up if necessary */
 static BYTE *add_log_points( DC *dc, PPATH path, const POINT *points,
-                             DWORD count, BYTE type )
+                             DWORD count, BYTE type, BOOL bExtraPt )
 {
     BYTE *ret;
 
     if (!PATH_ReserveEntries( path, path->numEntriesUsed + count )) return NULL;
 
     ret = &path->pFlags[path->numEntriesUsed];
-    memcpy( &path->pPoints[path->numEntriesUsed], points, count * sizeof(*points) );
-    IntLPtoDP( dc, &path->pPoints[path->numEntriesUsed], count );
+
+    if (bExtraPt && path->numEntriesUsed == 1)
+    {
+        memcpy( &path->pPoints[0], points, (count + 1) * sizeof(*points) );
+        IntLPtoDP( dc, &path->pPoints[0], count + 1);
+    }
+    else
+    {
+        memcpy( &path->pPoints[path->numEntriesUsed], points, count * sizeof(*points) );
+        IntLPtoDP( dc, &path->pPoints[path->numEntriesUsed], count );
+    }
+
     memset( ret, type, count );
     path->numEntriesUsed += count;
     return ret;
@@ -531,10 +545,10 @@ static void close_figure( PPATH path )
 
 /* add a number of points, starting a new stroke if necessary */
 static BOOL add_log_points_new_stroke( DC *dc, PPATH path, const POINT *points,
-                                       DWORD count, BYTE type )
+                                       DWORD count, BYTE type, BOOL bExtraPt)
 {
     if (!start_new_stroke( path )) return FALSE;
-    if (!add_log_points( dc, path, points, count, type )) return FALSE;
+    if (!add_log_points( dc, path, points, count, type, bExtraPt )) return FALSE;
     update_current_pos( path );
 
     TRACE("ALPNS : Pos X %d Y %d\n",path->pos.x, path->pos.y);
@@ -612,7 +626,7 @@ PATH_LineTo(
            }
        }
     }
-    Ret = add_log_points_new_stroke( dc, pPath, &point, 1, PT_LINETO );
+    Ret = add_log_points_new_stroke( dc, pPath, &point, 1, PT_LINETO , FALSE);
     PATH_UnlockPath(pPath);
     return Ret;
 }
@@ -1143,7 +1157,7 @@ PATH_PolyBezierTo(
     pPath = PATH_LockPath(dc->dclevel.hPath);
     if (!pPath) return FALSE;
 
-    ret = add_log_points_new_stroke( dc, pPath, pts, cbPoints, PT_BEZIERTO );
+    ret = add_log_points_new_stroke( dc, pPath, pts, cbPoints, PT_BEZIERTO , TRUE);
 
     PATH_UnlockPath(pPath);
     return ret;
@@ -1166,7 +1180,7 @@ PATH_PolyBezier(
     pPath = PATH_LockPath(dc->dclevel.hPath);
     if (!pPath) return FALSE;
 
-    type = add_log_points( dc, pPath, pts, cbPoints, PT_BEZIERTO );
+    type = add_log_points( dc, pPath, pts, cbPoints, PT_BEZIERTO, FALSE );
     if (!type) return FALSE;
 
     type[0] = PT_MOVETO;
@@ -1217,7 +1231,7 @@ PATH_PolyDraw(
             break;
         case PT_LINETO:
         case PT_LINETO | PT_CLOSEFIGURE:
-            if (!add_log_points_new_stroke( dc, pPath, &pts[i], 1, PT_LINETO ))
+            if (!add_log_points_new_stroke( dc, pPath, &pts[i], 1, PT_LINETO , FALSE))
             {
                PATH_UnlockPath(pPath);
                return FALSE;
@@ -1227,7 +1241,7 @@ PATH_PolyDraw(
             if ((i + 2 < cbPoints) && (types[i + 1] == PT_BEZIERTO) &&
                 (types[i + 2] & ~PT_CLOSEFIGURE) == PT_BEZIERTO)
             {
-                if (!add_log_points_new_stroke( dc, pPath, &pts[i], 3, PT_BEZIERTO ))
+                if (!add_log_points_new_stroke( dc, pPath, &pts[i], 3, PT_BEZIERTO , FALSE))
                 {
                    PATH_UnlockPath(pPath);
                    return FALSE;
@@ -1278,7 +1292,10 @@ PATH_PolylineTo(
     pPath = PATH_LockPath(dc->dclevel.hPath);
     if (!pPath) return FALSE;
 
-    ret = add_log_points_new_stroke( dc, pPath, pts, cbPoints, PT_LINETO );
+    if (pPath->newStroke)
+        cbPoints--;
+
+    ret = add_log_points_new_stroke( dc, pPath, pts, cbPoints, PT_LINETO , TRUE);
     PATH_UnlockPath(pPath);
     return ret;
 }
@@ -1316,7 +1333,7 @@ PATH_PolyPolygon(
         count += counts[poly];
     }
 
-    type = add_log_points( dc, pPath, pts, count, PT_LINETO );
+    type = add_log_points( dc, pPath, pts, count, PT_LINETO, FALSE );
     if (!type)
     {
        PATH_UnlockPath(pPath);

--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -461,7 +461,7 @@ PATH_CheckRect(
 /* add a number of points, converting them to device coords */
 /* return a pointer to the first type byte so it can be fixed up if necessary */
 static BYTE *add_log_points( DC *dc, PPATH path, const POINT *points,
-                             DWORD count, BYTE type, BOOL bExtraPt )
+                             DWORD count, BYTE type, BOOL bExtraPt)
 {
     BYTE *ret;
 
@@ -544,7 +544,7 @@ static BOOL add_log_points_new_stroke( DC *dc, PPATH path, const POINT *points,
                                        DWORD count, BYTE type, BOOL bExtraPt)
 {
     if (!start_new_stroke( path )) return FALSE;
-    if (!add_log_points( dc, path, points, count, type, bExtraPt)) return FALSE;
+    if (!add_log_points(dc, path, points, count, type, bExtraPt)) return FALSE;
     update_current_pos( path );
 
     TRACE("ALPNS : Pos X %d Y %d\n",path->pos.x, path->pos.y);

--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -323,8 +323,6 @@ PATH_ReserveEntries(
         pPointsNew = (POINT *)ExAllocatePoolWithTag(PagedPool, numEntriesToAllocate * sizeof(POINT), TAG_PATH);
         if (!pPointsNew)
             return FALSE;
-         else
-            memset(pPointsNew, 0, numEntriesToAllocate * sizeof(POINT));
 
         pFlagsNew = (BYTE *)ExAllocatePoolWithTag(PagedPool, numEntriesToAllocate * sizeof(BYTE), TAG_PATH);
         if (!pFlagsNew)
@@ -332,8 +330,6 @@ PATH_ReserveEntries(
             ExFreePoolWithTag(pPointsNew, TAG_PATH);
             return FALSE;
         }
-        else
-            memset(pFlagsNew, 0, numEntriesToAllocate * sizeof(BYTE));
 
         /* Copy old arrays to new arrays and discard old arrays */
         if (pPath->pPoints)
@@ -475,13 +471,13 @@ static BYTE *add_log_points( DC *dc, PPATH path, const POINT *points,
 
     if (bExtraPt && path->numEntriesUsed == 1)
     {
-        memcpy( &path->pPoints[0], points, (count + 1) * sizeof(*points) );
-        IntLPtoDP( dc, &path->pPoints[0], count + 1);
+        memcpy(&path->pPoints[0], points, (count + 1) * sizeof(*points));
+        IntLPtoDP(dc, &path->pPoints[0], count + 1);
     }
     else
     {
-        memcpy( &path->pPoints[path->numEntriesUsed], points, count * sizeof(*points) );
-        IntLPtoDP( dc, &path->pPoints[path->numEntriesUsed], count );
+        memcpy(&path->pPoints[path->numEntriesUsed], points, count * sizeof(*points));
+        IntLPtoDP(dc, &path->pPoints[path->numEntriesUsed], count);
     }
 
     memset( ret, type, count );
@@ -548,7 +544,7 @@ static BOOL add_log_points_new_stroke( DC *dc, PPATH path, const POINT *points,
                                        DWORD count, BYTE type, BOOL bExtraPt)
 {
     if (!start_new_stroke( path )) return FALSE;
-    if (!add_log_points( dc, path, points, count, type, bExtraPt )) return FALSE;
+    if (!add_log_points( dc, path, points, count, type, bExtraPt)) return FALSE;
     update_current_pos( path );
 
     TRACE("ALPNS : Pos X %d Y %d\n",path->pos.x, path->pos.y);
@@ -626,7 +622,7 @@ PATH_LineTo(
            }
        }
     }
-    Ret = add_log_points_new_stroke( dc, pPath, &point, 1, PT_LINETO , FALSE);
+    Ret = add_log_points_new_stroke(dc, pPath, &point, 1, PT_LINETO , FALSE);
     PATH_UnlockPath(pPath);
     return Ret;
 }
@@ -1157,7 +1153,7 @@ PATH_PolyBezierTo(
     pPath = PATH_LockPath(dc->dclevel.hPath);
     if (!pPath) return FALSE;
 
-    ret = add_log_points_new_stroke( dc, pPath, pts, cbPoints, PT_BEZIERTO , TRUE);
+    ret = add_log_points_new_stroke(dc, pPath, pts, cbPoints, PT_BEZIERTO , TRUE);
 
     PATH_UnlockPath(pPath);
     return ret;
@@ -1180,7 +1176,7 @@ PATH_PolyBezier(
     pPath = PATH_LockPath(dc->dclevel.hPath);
     if (!pPath) return FALSE;
 
-    type = add_log_points( dc, pPath, pts, cbPoints, PT_BEZIERTO, FALSE );
+    type = add_log_points(dc, pPath, pts, cbPoints, PT_BEZIERTO, FALSE);
     if (!type) return FALSE;
 
     type[0] = PT_MOVETO;
@@ -1231,7 +1227,7 @@ PATH_PolyDraw(
             break;
         case PT_LINETO:
         case PT_LINETO | PT_CLOSEFIGURE:
-            if (!add_log_points_new_stroke( dc, pPath, &pts[i], 1, PT_LINETO , FALSE))
+            if (!add_log_points_new_stroke(dc, pPath, &pts[i], 1, PT_LINETO , FALSE))
             {
                PATH_UnlockPath(pPath);
                return FALSE;
@@ -1241,7 +1237,7 @@ PATH_PolyDraw(
             if ((i + 2 < cbPoints) && (types[i + 1] == PT_BEZIERTO) &&
                 (types[i + 2] & ~PT_CLOSEFIGURE) == PT_BEZIERTO)
             {
-                if (!add_log_points_new_stroke( dc, pPath, &pts[i], 3, PT_BEZIERTO , FALSE))
+                if (!add_log_points_new_stroke(dc, pPath, &pts[i], 3, PT_BEZIERTO , FALSE))
                 {
                    PATH_UnlockPath(pPath);
                    return FALSE;
@@ -1295,7 +1291,7 @@ PATH_PolylineTo(
     if (pPath->newStroke)
         cbPoints--;
 
-    ret = add_log_points_new_stroke( dc, pPath, pts, cbPoints, PT_LINETO , TRUE);
+    ret = add_log_points_new_stroke(dc, pPath, pts, cbPoints, PT_LINETO , TRUE);
     PATH_UnlockPath(pPath);
     return ret;
 }
@@ -1333,7 +1329,7 @@ PATH_PolyPolygon(
         count += counts[poly];
     }
 
-    type = add_log_points( dc, pPath, pts, count, PT_LINETO, FALSE );
+    type = add_log_points(dc, pPath, pts, count, PT_LINETO, FALSE);
     if (!type)
     {
        PATH_UnlockPath(pPath);


### PR DESCRIPTION
CORE-20553

## Purpose

_Revise code to fix PolylineTo and PolyBezierTo based on Wine 10.0 for PowerPoint Viewer '97._

JIRA issue: [CORE-20553](https://jira.reactos.org/browse/CORE-20553)

## Proposed changes

_Include starting point in the "POINTS" variable being passed to PolylineTo and PolyBezierTo._


## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107009,107013 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107011,107014 LGTM

Previous to PR:

<img width="1042" height="856" alt="16-2614-pptview97-Pg1-Before" src="https://github.com/user-attachments/assets/9c41895b-60d8-4cc6-9c31-76dacc8d8830" />

<img width="1042" height="856" alt="16-2614-pptview97-Pg2-Before" src="https://github.com/user-attachments/assets/b085e901-c747-4c31-a8a0-2c71ae4454ae" />

After PR:

<img width="1042" height="856" alt="16-2614-pptview97-Pg1-After" src="https://github.com/user-attachments/assets/a9ce7c01-aff8-4cc6-a5ac-66e45c539e02" />

<img width="1042" height="856" alt="16-2614-pptview97-Pg2-After" src="https://github.com/user-attachments/assets/5f5e0f92-b3f2-4419-886c-1118de6fff7d" />
