### PR TITLE
[NTOS:KE:x64] Pass syscall trap frame explicitly to C handler

### DIFF
--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -862,6 +862,11 @@ PUBLIC KiSystemCallEntry64
 
 GLOBAL_LABEL KiSystemCall64Again
 
+    /* Pass the trap frame pointer explicitly. Recovering it from
+     * _AddressOfReturnAddress() relies on compiler-specific frame layout
+     * at this assembly-to-C boundary. */
+    lea rcx, [rsp + MAX_SYSCALL_PARAM_SIZE]
+
     /* Call the C-handler (will enable interrupts) */
     call KiSystemCallHandler
 

--- a/ntoskrnl/ke/amd64/traphandler.c
+++ b/ntoskrnl/ke/amd64/traphandler.c
@@ -135,17 +135,13 @@ NtSyscallFailure(void)
 
 PVOID
 KiSystemCallHandler(
-    VOID)
+    PKTRAP_FRAME TrapFrame)
 {
-    PKTRAP_FRAME TrapFrame;
     PKSERVICE_TABLE_DESCRIPTOR DescriptorTable;
     PKTHREAD Thread;
     PULONG64 KernelParams, UserParams;
     ULONG ServiceNumber, TableIndex, Count;
     ULONG64 UserRsp;
-
-    /* Get a pointer to the trap frame */
-    TrapFrame = (PKTRAP_FRAME)((PULONG64)_AddressOfReturnAddress() + 1 + MAX_SYSCALL_PARAMS);
 
     /* Increase system call count */
     __addgsdword(FIELD_OFFSET(KIPCR, Prcb.KeSystemCalls), 1);

--- a/sdk/include/vcruntime/mingw32/intrin_x86.h
+++ b/sdk/include/vcruntime/mingw32/intrin_x86.h
@@ -79,7 +79,11 @@ __INTRIN_INLINE void* __cdecl memcpy(void* dest, const void* source, size_t num)
 
 /*** Stack frame juggling ***/
 #define _ReturnAddress() (__builtin_return_address(0))
+#ifdef __clang__
+void* _AddressOfReturnAddress(void);
+#else
 #define _AddressOfReturnAddress() (&(((void **)(__builtin_frame_address(0)))[1]))
+#endif
 /* TODO: __getcallerseflags but how??? */
 
 /*** Memory barriers ***/


### PR DESCRIPTION
## Purpose

Pass the amd64 syscall trap frame pointer explicitly from `KiSystemCallEntry64` to `KiSystemCallHandler`.

The previous code recovered the trap frame in C by walking past `_AddressOfReturnAddress()`:

```c
TrapFrame = (PKTRAP_FRAME)((PULONG64)_AddressOfReturnAddress() + 1 + MAX_SYSCALL_PARAMS);
```

That depends on compiler-specific frame layout at the assembly-to-C boundary.
The trap frame location is already known in `trap.S`, so pass it through the normal Win64 first-argument register instead.

## Why

`KiSystemCallEntry64` allocates the syscall parameter area followed by the `KTRAP_FRAME`. After that, the C handler needs the trap frame to read the syscall number, user stack pointer, previous mode, and to update return state.

Recovering this pointer from `_AddressOfReturnAddress()` is fragile because it assumes details about the generated C prologue/frame layout. Passing the pointer explicitly makes the assembly/C contract direct and compiler-independent.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: