### PR TITLE
[NTOS] Gate debug-only sanity checks behind #if DBG

### DIFF
--- a/ntoskrnl/ke/spinlock.c
+++ b/ntoskrnl/ke/spinlock.c
@@ -197,6 +197,7 @@ VOID
 NTAPI
 KeAcquireSpinLockAtDpcLevel(IN PKSPIN_LOCK SpinLock)
 {
+#if DBG
     /* Make sure we are at DPC or above! */
     if (KeGetCurrentIrql() < DISPATCH_LEVEL)
     {
@@ -207,6 +208,7 @@ KeAcquireSpinLockAtDpcLevel(IN PKSPIN_LOCK SpinLock)
                      0,
                      0);
     }
+#endif
 
     /* Do the inlined function */
     KxAcquireSpinLock(SpinLock);
@@ -220,6 +222,7 @@ VOID
 NTAPI
 KeReleaseSpinLockFromDpcLevel(IN PKSPIN_LOCK SpinLock)
 {
+#if DBG
     /* Make sure we are at DPC or above! */
     if (KeGetCurrentIrql() < DISPATCH_LEVEL)
     {
@@ -230,6 +233,7 @@ KeReleaseSpinLockFromDpcLevel(IN PKSPIN_LOCK SpinLock)
                      0,
                      0);
     }
+#endif
 
     /* Do the inlined function */
     KxReleaseSpinLock(SpinLock);
@@ -242,6 +246,7 @@ VOID
 FASTCALL
 KefAcquireSpinLockAtDpcLevel(IN PKSPIN_LOCK SpinLock)
 {
+#if DBG
     /* Make sure we are at DPC or above! */
     if (KeGetCurrentIrql() < DISPATCH_LEVEL)
     {
@@ -252,6 +257,7 @@ KefAcquireSpinLockAtDpcLevel(IN PKSPIN_LOCK SpinLock)
                      0,
                      0);
     }
+#endif
 
     /* Do the inlined function */
     KxAcquireSpinLock(SpinLock);
@@ -264,6 +270,7 @@ VOID
 FASTCALL
 KefReleaseSpinLockFromDpcLevel(IN PKSPIN_LOCK SpinLock)
 {
+#if DBG
     /* Make sure we are at DPC or above! */
     if (KeGetCurrentIrql() < DISPATCH_LEVEL)
     {
@@ -274,6 +281,7 @@ KefReleaseSpinLockFromDpcLevel(IN PKSPIN_LOCK SpinLock)
                      0,
                      0);
     }
+#endif
 
     /* Do the inlined function */
     KxReleaseSpinLock(SpinLock);
@@ -370,6 +378,7 @@ KeAcquireInStackQueuedSpinLockAtDpcLevel(IN PKSPIN_LOCK SpinLock,
 #if 0
     KeAcquireQueuedSpinLockAtDpcLevel(LockHandle->LockQueue.Next);
 #else
+#if DBG
     /* Make sure we are at DPC or above! */
     if (KeGetCurrentIrql() < DISPATCH_LEVEL)
     {
@@ -380,6 +389,7 @@ KeAcquireInStackQueuedSpinLockAtDpcLevel(IN PKSPIN_LOCK SpinLock,
                      0,
                      0);
     }
+#endif
 #endif
 #endif
 
@@ -399,6 +409,7 @@ KeReleaseInStackQueuedSpinLockFromDpcLevel(IN PKLOCK_QUEUE_HANDLE LockHandle)
     /* Call the internal function */
     KeReleaseQueuedSpinLockFromDpcLevel(LockHandle->LockQueue.Next);
 #else
+#if DBG
     /* Make sure we are at DPC or above! */
     if (KeGetCurrentIrql() < DISPATCH_LEVEL)
     {
@@ -409,6 +420,7 @@ KeReleaseInStackQueuedSpinLockFromDpcLevel(IN PKLOCK_QUEUE_HANDLE LockHandle)
                      0,
                      0);
     }
+#endif
 #endif
 #endif
 

--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -192,6 +192,7 @@ VOID
 NTAPI
 ExpCheckPoolHeader(IN PPOOL_HEADER Entry)
 {
+#if DBG
     PPOOL_HEADER PreviousEntry, NextEntry;
 
     /* Is there a block before this one? */
@@ -289,6 +290,8 @@ ExpCheckPoolHeader(IN PPOOL_HEADER Entry)
                          (ULONG_PTR)Entry);
         }
     }
+#endif
+    UNREFERENCED_PARAMETER(Entry);
 }
 
 VOID
@@ -375,6 +378,7 @@ VOID
 NTAPI
 ExpCheckPoolBlocks(IN PVOID Block)
 {
+#if DBG
     BOOLEAN FoundBlock = FALSE;
     SIZE_T Size = 0;
     PPOOL_HEADER Entry;
@@ -409,6 +413,8 @@ ExpCheckPoolBlocks(IN PVOID Block)
         /* Otherwise, the blocks are messed up */
         KeBugCheckEx(BAD_POOL_HEADER, 10, (ULONG_PTR)Block, __LINE__, (ULONG_PTR)Entry);
     }
+#endif
+    UNREFERENCED_PARAMETER(Block);
 }
 
 FORCEINLINE
@@ -417,6 +423,7 @@ ExpCheckPoolIrqlLevel(IN POOL_TYPE PoolType,
                       IN SIZE_T NumberOfBytes,
                       IN PVOID Entry)
 {
+#if DBG
     //
     // Validate IRQL: It must be APC_LEVEL or lower for Paged Pool, and it must
     // be DISPATCH_LEVEL or lower for Non Paged Pool
@@ -434,6 +441,7 @@ ExpCheckPoolIrqlLevel(IN POOL_TYPE PoolType,
                      PoolType,
                      !Entry ? NumberOfBytes : (ULONG_PTR)Entry);
     }
+#endif
 }
 
 FORCEINLINE


### PR DESCRIPTION
## Purpose

spinlock.c: skip the KeGetCurrentIrql() < DISPATCH_LEVEL probe in AtDpcLevel / FromDpcLevel paths in retail builds - matches NT free behavior and removes a per-acquire FS/GS read.

expool.c: gate ExpCheckPoolHeader, ExpCheckPoolBlocks, and ExpCheckPoolIrqlLevel under #if DBG. ExpCheckPoolLinks is left live in retail (per the file's own comment, Vista+ NT keeps the encoded list-link integrity check on as a security tripwire).

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: