### PR TITLE
[NTOS:KE] Provide a minimal KiIdleSchedule implementation

### DIFF
--- a/ntoskrnl/ke/thrdschd.c
+++ b/ntoskrnl/ke/thrdschd.c
@@ -31,9 +31,10 @@ PKTHREAD
 FASTCALL
 KiIdleSchedule(IN PKPRCB Prcb)
 {
-    /* FIXME: TODO */
-    ASSERTMSG("SMP: Not yet implemented\n", FALSE);
-    return NULL;
+    /* TODO: real SMP semantics should be done here : should drain Prcb->DeferredReadyListHead
+     * and promote a queued thread per KiSelectNextThread, instead of unconditionally staying on the idle thread
+      */
+    return Prcb->IdleThread;
 }
 
 VOID


### PR DESCRIPTION
## Purpose

The previous body bug-checked in DBG and returned NULL in retail; both violate the non-null PKTHREAD contract from include/internal/ke.h. 

Return Prcb->IdleThread, which is set during KiSystemStartup before the idle loop runs. TODO retained for real SMP semantics (drain DeferredReadyListHead and promote per KiSelectNextThread).

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: