### PR TITLE
[SHLWAPI] PathIsDirectory: Support UNC Server Share

### DIFF
--- a/dll/win32/shlwapi/path.c
+++ b/dll/win32/shlwapi/path.c
@@ -1712,8 +1712,30 @@ BOOL WINAPI PathIsDirectoryA(LPCSTR lpszPath)
 
   if (PathIsUNCServerShareA(lpszPath))
   {
+#ifdef __REACTOS__
+    LPSTR lpSystem = NULL;
+    BYTE buffer[512] = {0};
+    DWORD cbBuffer = sizeof(buffer);
+    LPNETRESOURCEA pNetRes = (LPNETRESOURCEA)buffer;
+    DWORD dwError;
+
+    pNetRes->dwScope      = RESOURCE_GLOBALNET;
+    pNetRes->dwType       = RESOURCETYPE_ANY;
+    pNetRes->lpRemoteName = (LPSTR)lpszPath;
+
+    dwError = WNetGetResourceInformationA(pNetRes, pNetRes, &cbBuffer, &lpSystem);
+    if (dwError == NO_ERROR && pNetRes->dwDisplayType != RESOURCEDISPLAYTYPE_GENERIC)
+    {
+      if (pNetRes->dwDisplayType != RESOURCEDISPLAYTYPE_SHARE)
+        return FALSE;
+      if (pNetRes->dwType != RESOURCETYPE_ANY && pNetRes->dwType != RESOURCETYPE_DISK)
+        return FALSE;
+      return TRUE;
+    }
+#else
     FIXME("UNC Server Share not yet supported - FAILING\n");
     return FALSE;
+#endif
   }
 
   if ((dwAttr = GetFileAttributesA(lpszPath)) == INVALID_FILE_ATTRIBUTES)
@@ -1737,8 +1759,30 @@ BOOL WINAPI PathIsDirectoryW(LPCWSTR lpszPath)
 
   if (PathIsUNCServerShareW(lpszPath))
   {
+#ifdef __REACTOS__
+    LPWSTR lpSystem = NULL;
+    BYTE buffer[1024] = {0};
+    DWORD cbBuffer = sizeof(buffer);
+    LPNETRESOURCEW pNetRes = (LPNETRESOURCEW)buffer;
+    DWORD dwError;
+
+    pNetRes->dwScope      = RESOURCE_GLOBALNET;
+    pNetRes->dwType       = RESOURCETYPE_ANY;
+    pNetRes->lpRemoteName = (LPWSTR)lpszPath;
+
+    dwError = WNetGetResourceInformationW(pNetRes, pNetRes, &cbBuffer, &lpSystem);
+    if (dwError == NO_ERROR && pNetRes->dwDisplayType != RESOURCEDISPLAYTYPE_GENERIC)
+    {
+      if (pNetRes->dwDisplayType != RESOURCEDISPLAYTYPE_SHARE)
+        return FALSE;
+      if (pNetRes->dwType != RESOURCETYPE_ANY && pNetRes->dwType != RESOURCETYPE_DISK)
+        return FALSE;
+      return TRUE;
+    }
+#else
     FIXME("UNC Server Share not yet supported - FAILING\n");
     return FALSE;
+#endif
   }
 
   if ((dwAttr = GetFileAttributesW(lpszPath)) == INVALID_FILE_ATTRIBUTES)

--- a/dll/win32/shlwapi/path.c
+++ b/dll/win32/shlwapi/path.c
@@ -1726,11 +1726,8 @@ BOOL WINAPI PathIsDirectoryA(LPCSTR lpszPath)
     dwError = WNetGetResourceInformationA(pNetRes, pNetRes, &cbBuffer, &lpSystem);
     if (dwError == NO_ERROR && pNetRes->dwDisplayType != RESOURCEDISPLAYTYPE_GENERIC)
     {
-      if (pNetRes->dwDisplayType != RESOURCEDISPLAYTYPE_SHARE)
-        return FALSE;
-      if (pNetRes->dwType != RESOURCETYPE_ANY && pNetRes->dwType != RESOURCETYPE_DISK)
-        return FALSE;
-      return TRUE;
+      return (pNetRes->dwDisplayType == RESOURCEDISPLAYTYPE_SHARE) &&
+             (pNetRes->dwType == RESOURCETYPE_ANY || pNetRes->dwType == RESOURCETYPE_DISK);
     }
 #else
     FIXME("UNC Server Share not yet supported - FAILING\n");
@@ -1773,11 +1770,8 @@ BOOL WINAPI PathIsDirectoryW(LPCWSTR lpszPath)
     dwError = WNetGetResourceInformationW(pNetRes, pNetRes, &cbBuffer, &lpSystem);
     if (dwError == NO_ERROR && pNetRes->dwDisplayType != RESOURCEDISPLAYTYPE_GENERIC)
     {
-      if (pNetRes->dwDisplayType != RESOURCEDISPLAYTYPE_SHARE)
-        return FALSE;
-      if (pNetRes->dwType != RESOURCETYPE_ANY && pNetRes->dwType != RESOURCETYPE_DISK)
-        return FALSE;
-      return TRUE;
+      return (pNetRes->dwDisplayType == RESOURCEDISPLAYTYPE_SHARE) &&
+             (pNetRes->dwType == RESOURCETYPE_ANY || pNetRes->dwType == RESOURCETYPE_DISK);
     }
 #else
     FIXME("UNC Server Share not yet supported - FAILING\n");

--- a/dll/win32/shlwapi/path.c
+++ b/dll/win32/shlwapi/path.c
@@ -35,6 +35,9 @@
 #include "winternl.h"
 #define NO_SHLWAPI_STREAM
 #include "shlwapi.h"
+#ifdef __REACTOS__
+#include "winnetwk.h"
+#endif
 #include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);


### PR DESCRIPTION
## Purpose

Implementing missing features... We lack network support.
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278), [CORE-17923](https://jira.reactos.org/browse/CORE-17923)

## Proposed changes

- Implement network support on `PathIsDirectoryA/W` functions.

## Screenshots

WinXP:
<img width="640" height="480" alt="WinXP" src="https://github.com/user-attachments/assets/8f18a137-f4b3-498d-9a71-2488c8c3262d" />

ReactOS (AFTER):
<img width="640" height="480" alt="after" src="https://github.com/user-attachments/assets/3a225173-0d56-4bfb-807e-7e5a4dd5caf0" />

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107009,107054
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107011,107055