### PR TITLE
[SHLWAPI][SDK] Support SHRegSetPathA/W

### DIFF
--- a/dll/win32/shlwapi/reg.c
+++ b/dll/win32/shlwapi/reg.c
@@ -1159,6 +1159,8 @@ DWORD WINAPI SHRegSetPathA(HKEY hKey, LPCSTR lpszSubKey, LPCSTR lpszValue,
   LPCSTR pszData;
   INT cch;
 
+  UNREFERENCED_PARAMETER(dwFlags);
+
   if (PathUnExpandEnvStringsA(lpszPath, szBuff, _countof(szBuff)))
   {
     dwType  = REG_EXPAND_SZ;
@@ -1198,6 +1200,8 @@ DWORD WINAPI SHRegSetPathW(HKEY hKey, LPCWSTR lpszSubKey, LPCWSTR lpszValue,
   DWORD dwType;
   LPCWSTR pszData;
   INT cch;
+
+  UNREFERENCED_PARAMETER(dwFlags);
 
   if (PathUnExpandEnvStringsW(lpszPath, szBuff, _countof(szBuff)))
   {

--- a/dll/win32/shlwapi/reg.c
+++ b/dll/win32/shlwapi/reg.c
@@ -1154,7 +1154,25 @@ DWORD WINAPI SHRegSetPathA(HKEY hKey, LPCSTR lpszSubKey, LPCSTR lpszValue,
                            LPCSTR lpszPath, DWORD dwFlags)
 {
   char szBuff[MAX_PATH];
+#ifdef __REACTOS__
+  DWORD dwType;
+  LPCSTR pszData;
+  INT cch;
 
+  if (PathUnExpandEnvStringsA(lpszPath, szBuff, _countof(szBuff)))
+  {
+    dwType  = REG_EXPAND_SZ;
+    pszData = szBuff;
+  }
+  else
+  {
+    dwType  = REG_SZ;
+    pszData = lpszPath;
+  }
+
+  cch = lstrlenA(pszData);
+  return SHSetValueA(hKey, lpszSubKey, lpszValue, dwType, pszData, (cch + 1) * sizeof(CHAR));
+#else
   FIXME("(hkey=%p,%s,%s,%p,%d) - semi-stub\n",hKey, debugstr_a(lpszSubKey),
         debugstr_a(lpszValue), lpszPath, dwFlags);
 
@@ -1164,6 +1182,7 @@ DWORD WINAPI SHRegSetPathA(HKEY hKey, LPCSTR lpszSubKey, LPCSTR lpszValue,
 
   return SHSetValueA(hKey,lpszSubKey, lpszValue, REG_SZ, szBuff,
                      lstrlenA(szBuff));
+#endif
 }
 
 /*************************************************************************
@@ -1175,7 +1194,25 @@ DWORD WINAPI SHRegSetPathW(HKEY hKey, LPCWSTR lpszSubKey, LPCWSTR lpszValue,
                            LPCWSTR lpszPath, DWORD dwFlags)
 {
   WCHAR szBuff[MAX_PATH];
+#ifdef __REACTOS__
+  DWORD dwType;
+  LPCWSTR pszData;
+  INT cch;
 
+  if (PathUnExpandEnvStringsW(lpszPath, szBuff, _countof(szBuff)))
+  {
+    dwType  = REG_EXPAND_SZ;
+    pszData = szBuff;
+  }
+  else
+  {
+    dwType  = REG_SZ;
+    pszData = lpszPath;
+  }
+
+  cch = lstrlenW(pszData);
+  return SHSetValueW(hKey, lpszSubKey, lpszValue, dwType, pszData, (cch + 1) * sizeof(WCHAR));
+#else
   FIXME("(hkey=%p,%s,%s,%p,%d) - semi-stub\n",hKey, debugstr_w(lpszSubKey),
         debugstr_w(lpszValue), lpszPath, dwFlags);
 
@@ -1185,6 +1222,7 @@ DWORD WINAPI SHRegSetPathW(HKEY hKey, LPCWSTR lpszSubKey, LPCWSTR lpszValue,
 
   return SHSetValueW(hKey,lpszSubKey, lpszValue, REG_SZ, szBuff,
                      lstrlenW(szBuff));
+#endif
 }
 
 /*************************************************************************

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -342,22 +342,6 @@ ShellMessageBoxWrapW(
   _In_ UINT fuStyle,
   ...);
 
-DWORD WINAPI
-SHRegSetPathA(
-    _In_ HKEY hKey,
-    _In_ LPCSTR lpszSubKey,
-    _In_ LPCSTR lpszValue,
-    _In_ LPCSTR lpszPath,
-    _In_ DWORD dwFlags);
-
-DWORD WINAPI
-SHRegSetPathW(
-    _In_ HKEY hKey,
-    _In_ LPCWSTR lpszSubKey,
-    _In_ LPCWSTR lpszValue,
-    _In_ LPCWSTR lpszPath,
-    _In_ DWORD dwFlags);
-
 /* dwWhich flags for PathFileExistsDefExtW, PathFindOnPathExW,
  * and PathFileExistsDefExtAndAttributesW */
 #define WHICH_PIF       (1 << 0)

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -3,7 +3,7 @@
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     Undocumented SHLWAPI definitions
  * COPYRIGHT:   Copyright 2009 Andrew Hill <ash77 at domain reactos.org>
- *              Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *              Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once
@@ -341,6 +341,22 @@ ShellMessageBoxWrapW(
   _In_opt_ LPCWSTR lpcTitle,
   _In_ UINT fuStyle,
   ...);
+
+DWORD WINAPI
+SHRegSetPathA(
+    _In_ HKEY hKey,
+    _In_ LPCSTR lpszSubKey,
+    _In_ LPCSTR lpszValue,
+    _In_ LPCSTR lpszPath,
+    _In_ DWORD dwFlags);
+
+DWORD WINAPI
+SHRegSetPathW(
+    _In_ HKEY hKey,
+    _In_ LPCWSTR lpszSubKey,
+    _In_ LPCWSTR lpszValue,
+    _In_ LPCWSTR lpszPath,
+    _In_ DWORD dwFlags);
 
 /* dwWhich flags for PathFileExistsDefExtW, PathFindOnPathExW,
  * and PathFileExistsDefExtAndAttributesW */


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Implement `SHRegSetPathA` and `SHRegSetPathW` functions.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: