### PR TITLE
[HALX86:DMA] Improve limitation of Scatter/Gather memory allocation

### DIFF
--- a/hal/halx86/generic/dma.c
+++ b/hal/halx86/generic/dma.c
@@ -981,7 +981,6 @@ typedef struct _SCATTER_GATHER_CONTEXT {
 } SCATTER_GATHER_CONTEXT, *PSCATTER_GATHER_CONTEXT;
 
 #define MAX_SG_ELEMENTS 0x30
-#define SG_ELEMENT_MIN 4096 // Minimum bytes in a S/G element
 
 IO_ALLOCATION_ACTION
 NTAPI
@@ -996,9 +995,10 @@ HalpScatterGatherAdapterControl(IN PDEVICE_OBJECT DeviceObject,
 	PSCATTER_GATHER_ELEMENT TempElements;
 	ULONG ElementCount = 0, RemainingLength = AdapterControlContext->Length;
 	PUCHAR CurrentVa = AdapterControlContext->CurrentVa;
-    // RemainingLength / Minimum BYTES in S/G element
-    //  + 1 for remainder of division + 1 for a safety cushion
-    ULONG Est_SG_Elements = min(RemainingLength / SG_ELEMENT_MIN + 2, MAX_SG_ELEMENTS);
+    // RemainingLength / PAGE_SIZE + 1 for the remainder of our division
+    // + 1 for a safety cushion gives a good safe value. Using the
+    // min function with MAX_SG_ELEMENTS keeps us from getting too large.
+    ULONG Est_SG_Elements = min(RemainingLength / PAGE_SIZE + 2, MAX_SG_ELEMENTS);
 
 	/* Store the map register base for later in HalPutScatterGatherList */
 	AdapterControlContext->MapRegisterBase = MapRegisterBase;

--- a/hal/halx86/generic/dma.c
+++ b/hal/halx86/generic/dma.c
@@ -980,6 +980,7 @@ typedef struct _SCATTER_GATHER_CONTEXT {
 	WAIT_CONTEXT_BLOCK Wcb;
 } SCATTER_GATHER_CONTEXT, *PSCATTER_GATHER_CONTEXT;
 
+// FIXME: This value needs to be calculated at runtime
 #define MAX_SG_ELEMENTS 0x30
 
 IO_ALLOCATION_ACTION

--- a/hal/halx86/generic/dma.c
+++ b/hal/halx86/generic/dma.c
@@ -77,9 +77,6 @@
 #define NDEBUG
 #include <debug.h>
 
-// FIXME: This value needs to be calculated at runtime
-#define MAX_SG_ELEMENTS 0x20
-
 #ifndef _MINIHAL_
 static KEVENT HalpDmaLock;
 static KSPIN_LOCK HalpDmaAdapterListLock;
@@ -983,6 +980,8 @@ typedef struct _SCATTER_GATHER_CONTEXT {
 	WAIT_CONTEXT_BLOCK Wcb;
 } SCATTER_GATHER_CONTEXT, *PSCATTER_GATHER_CONTEXT;
 
+#define MAX_SG_ELEMENTS 0x30
+#define SG_ELEMENT_MIN 4096 // Minimum bytes in a S/G element
 
 IO_ALLOCATION_ACTION
 NTAPI
@@ -997,6 +996,9 @@ HalpScatterGatherAdapterControl(IN PDEVICE_OBJECT DeviceObject,
 	PSCATTER_GATHER_ELEMENT TempElements;
 	ULONG ElementCount = 0, RemainingLength = AdapterControlContext->Length;
 	PUCHAR CurrentVa = AdapterControlContext->CurrentVa;
+    // RemainingLength / Minimum BYTES in S/G element
+    //  + 1 for remainder of division + 1 for a safety cushion
+    ULONG Est_SG_Elements = min(RemainingLength / SG_ELEMENT_MIN + 2, MAX_SG_ELEMENTS);
 
 	/* Store the map register base for later in HalPutScatterGatherList */
 	AdapterControlContext->MapRegisterBase = MapRegisterBase;
@@ -1004,7 +1006,7 @@ HalpScatterGatherAdapterControl(IN PDEVICE_OBJECT DeviceObject,
     // FIXME: HACK Allocate TempElements from pool to minimize stack usage.
     // A more efficient algorithm should be found to avoid allocations during S/G I/O operations.
     TempElements = ExAllocatePoolUninitialized(NonPagedPool,
-                                               sizeof(*TempElements) * MAX_SG_ELEMENTS,
+                                               sizeof(*TempElements) * Est_SG_Elements,
                                                TAG_DMA);
     if (!TempElements)
 	{
@@ -1033,6 +1035,9 @@ HalpScatterGatherAdapterControl(IN PDEVICE_OBJECT DeviceObject,
 		RemainingLength -= TempElements[ElementCount].Length;
 		ElementCount++;
 	}
+
+    DPRINT("Est_SG_Elements %d\n", Est_SG_Elements);
+    DPRINT("ElementCount is %d\n", ElementCount);
 
 	if (RemainingLength > 0)
 	{


### PR DESCRIPTION
CORE-20565

## Purpose

_Implement dynamic sizing for memory allocation for DMA transfers._

JIRA issue: [CORE-20565](https://jira.reactos.org/browse/CORE-20565)

## Proposed changes

_Fix hang as noted in referenced Jira issue._
_Estimate DMA memory needed staying conservative and use this for memory allocation._

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107030,107032 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107011,107033 LGTM