### PR TITLE
[CMD] Added clear command as alias to cls

### DIFF
--- a/base/shell/cmd/cmdtable.c
+++ b/base/shell/cmd/cmdtable.c
@@ -59,6 +59,7 @@ COMMAND cmds[] =
 
 #ifdef INCLUDE_CMD_CLS
     {_T("cls"), 0, cmd_cls},
+    {_T("clear"), 0, cmd_cls},
 #endif
 
 #ifdef INCLUDE_CMD_COLOR


### PR DESCRIPTION
- Added _clear_ as an alias to _cls_ command for convenience

## Purpose

_CMD doesn't support clear command out of the box. Devs working with Linux are used to clear. This PR adds clear as an alias to cls._

JIRA issue: N/A

## Proposed changes

_This PR suggest to add clear as an alias to cls command, hence supporting both for convenience._

## Testbot runs (Filled in by Devs)

- [x] Tested with VirtualBox running ReactOS x86.
- A manual test can be seen at this link: [CLEAR in CMD](https://www.youtube.com/watch?v=ETgMa7Mm9tQ)
