### PR TITLE
[HDAUDBUS] Sync to the current upstream

### DIFF
--- a/drivers/wdm/audio/hdaudbus/hdac_stream.cpp
+++ b/drivers/wdm/audio/hdaudbus/hdac_stream.cpp
@@ -112,7 +112,7 @@ UINT16 hdac_format(PHDAC_STREAM stream) {
 			return 0;
 		format |= channels - 1;
 
-		switch (stream->streamFormat.ContainerSize) {
+		switch (stream->streamFormat.ValidBitsPerSample) {
 		case 8:
 			format |= AC_FMT_BITS_8;
 			break;
@@ -171,6 +171,5 @@ void hdac_stream_setup(PHDAC_STREAM stream) {
 	/* set the interrupt enable bits in the descriptor control register */
 	stream_update32(stream, SD_CTL, 0, SD_INT_MASK);
 
-	stream->fifoSize = 0;
 	stream->fifoSize = stream_read16(stream, SD_FIFOSIZE) + 1;
 }

--- a/drivers/wdm/audio/hdaudbus/hdaudbus.inf
+++ b/drivers/wdm/audio/hdaudbus/hdaudbus.inf
@@ -39,6 +39,9 @@ ExcludeFromSelect = PCI\CC_0403
 %HDAudio.DeviceDesc% = HDAudio_Device, PCI\VEN_8086&DEV_7E28&CC_0401 ;Intel Meteor Lake-P
 %HDAudio.DeviceDesc% = HDAudio_Device, PCI\VEN_8086&DEV_7728&CC_0401 ;Intel Arrow Lake-P
 %HDAudio.DeviceDesc% = HDAudio_Device, PCI\VEN_8086&DEV_A828&CC_0401 ;Intel Lunar Lake-P
+%HDAudio.DeviceDesc% = HDAudio_Device, PCI\VEN_8086&DEV_D328&CC_0401 ;Intel Nova Lake
+%HDAudio.DeviceDesc% = HDAudio_Device, PCI\VEN_8086&DEV_E328&CC_0401 ;Intel Panther Lake-H
+%HDAudio.DeviceDesc% = HDAudio_Device, PCI\VEN_8086&DEV_E428&CC_0401 ;Intel Panther Lake
 
 [HDAudio_Device.NT]
 CopyFiles = Drivers_Dir

--- a/drivers/wdm/audio/hdaudbus/hdaudio.cpp
+++ b/drivers/wdm/audio/hdaudbus/hdaudio.cpp
@@ -928,7 +928,7 @@ HDA_SetupDmaEngineWithBdl(
 	WdfInterruptAcquireLock(devData->FdoContext->Interrupt);
 
 	stream->bufSz = BufferLength;
-	stream->numBlocks = (UINT16)Lvi;
+	stream->numBlocks = (UINT16)(Lvi + 1);
 
 	RtlZeroMemory(&stream->isr, sizeof(HDAC_ISR_CALLBACK));
 	stream->isr.IOC = TRUE;

--- a/media/doc/3rd Party Files.txt
+++ b/media/doc/3rd Party Files.txt
@@ -176,7 +176,7 @@ URL: https://code.google.com/archive/p/cmediadrivers/
 
 Title: HD Audio Driver for Windows 10 / 11 with Skylake -> Raptor Lake DSP support
 Path: drivers/wdm/audio/hdaudbus
-Used Version: git commit ad50bcc
+Used Version: git commit 5477b93
 License: BSD-3-Clause (https://opensource.org/licenses/BSD-3-Clause)
 URL: https://github.com/coolstar/sklhdaudbus/tree/master
 


### PR DESCRIPTION
## Purpose

Import the following upstream commits:
https://github.com/coolstar/sklhdaudbus/commit/30a807de7d7934045161afc93f8ef11ac7a73c91
https://github.com/coolstar/sklhdaudbus/commit/76dbc244c36645796df03c53ddc6122e059e2d62
https://github.com/coolstar/sklhdaudbus/commit/afb1d55817a233707344cb47c5f80863685f1d76
https://github.com/coolstar/sklhdaudbus/commit/da286c7824405f3255dc3d97700042f2245f854f
https://github.com/coolstar/sklhdaudbus/commit/5477b93a3b68c474819abf2094a49d0e2d8d9799
which contain new supported devices added in inf file and two bugfixes from me, which fix all playback distortions with all XP-compatible HD audio codecs.
Tested and works fine with Realtek HD audio codec R2.74 on Asus-F5R Notebook with ALC660 controller at least, but it still needs to be tested with other codecs as well (like SigmaTel etc.).
Also update the commit hash in 3rd party files.txt appropriately.

JIRA issue: None

## Proposed changes

- Add Intel Nova Lake, Panther Lake and Panther Lake-H to supported devices list.
- Increment Last Valid Index (LVI) in `SetupDmaEngineWithBdl()` by `1` when writing it to the stream handle. MSDN says LVI always starts from `1`, not `0`, so it needs an additional increment for the last element in BDL list. This completely fixes sound distortions for left audio output channel, which plays the sound properly now.
- Remove unnecessary zero-initialization of `fifoSize` in `hdac_stream_setup()`. It's properly initialized on the next line anyway, so zeroing does not affect an initialization in any way.
- Use `ValidBitsPerSample` instead of `ContainerSize` to get the actual BPS value, since according to MSDN, only it contains correct value which is left-justified within the container. This fixes streaming problems in the case when the value of `ValidBitsPerSample` is different from the one from `ContainerSize` (e. g., for Realtek R2.74 WDM codec, `ContainerSize` is `32` while `ValidBitsPerSample` is `24` in that case).

## TODO

- [x] Update the sync commit hash appropriately once https://github.com/coolstar/sklhdaudbus/pull/19 is merged into an upstream. **EDIT: done now.**

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:

## Result

How it sounds before:
[ROS-playback-before.mp3](https://github.com/user-attachments/files/27123091/ROS-playback-before.mp3)

And after:
[ROS-playback-after.mp3](https://github.com/user-attachments/files/27123125/ROS-playback-after.mp3)

And the video which demonstrates how the playback works with stereo output channels (desktop speakers) for the configuration mentioned above, after these changes:

https://github.com/user-attachments/assets/b6474c2c-160b-4eb8-992c-3608854c92f5