### PR TITLE
[SHLWAPI][SHLWAPI_APITEST][SDK] Support IStream_ReadPidl and IStream_WritePidl

### DIFF
--- a/dll/win32/shlwapi/istream.c
+++ b/dll/win32/shlwapi/istream.c
@@ -736,7 +736,7 @@ IStream_ReadPidl(_In_ IStream *pstm, _Out_ LPITEMIDLIST *ppidlOut)
 /*************************************************************************
  * IStream_WritePidl [SHLWAPI.513]
  *
- * @see https://www.geoffchappell.com/studies/windows/shell/shlwapi/api/util/istream/writepidl.htm
+ * https://www.geoffchappell.com/studies/windows/shell/shlwapi/api/util/istream/writepidl.htm
  */
 HRESULT WINAPI
 IStream_WritePidl(_In_ IStream *pstm, _In_ LPCITEMIDLIST pidlWrite)

--- a/dll/win32/shlwapi/istream.c
+++ b/dll/win32/shlwapi/istream.c
@@ -697,7 +697,10 @@ IStream_ReadPidl(_In_ IStream *pstm, _Out_ LPITEMIDLIST *ppidlOut)
     if (FAILED(hr))
         return hr;
 
-    pidl = (LPITEMIDLIST)CoTaskMemAlloc(cbSize);
+    if (cbSize < sizeof(USHORT))
+        return E_INVALIDARG;
+
+    pidl = CoTaskMemAlloc(cbSize);
     if (!pidl)
         return E_OUTOFMEMORY;
 
@@ -708,12 +711,12 @@ IStream_ReadPidl(_In_ IStream *pstm, _Out_ LPITEMIDLIST *ppidlOut)
         return hr;
     }
 
-    pidlEnd = (LPITEMIDLIST)((PBYTE)pidl + cbSize - sizeof(WORD));
-    for (pItem = &pidl->mkid; pItem <= (LPSHITEMID)pidlEnd;)
+    pidlEnd = (LPITEMIDLIST)((PBYTE)pidl + cbSize - sizeof(USHORT));
+    for (pItem = &pidl->mkid; pItem <= (LPSHITEMID)pidlEnd;
+         pItem = (LPSHITEMID)((PBYTE)pItem + pItem->cb))
     {
-        if (pItem->cb == 0)
+        if (!pItem->cb)
             break;
-        pItem = (LPSHITEMID)((PBYTE)pItem + pItem->cb);
     }
 
     if ((LPITEMIDLIST)pItem == pidlEnd && !pItem->cb)
@@ -723,10 +726,10 @@ IStream_ReadPidl(_In_ IStream *pstm, _Out_ LPITEMIDLIST *ppidlOut)
     }
     else
     {
+        CoTaskMemFree(pidl);
         hr = E_INVALIDARG;
     }
 
-    CoTaskMemFree(pidl);
     return hr;
 }
 

--- a/dll/win32/shlwapi/istream.c
+++ b/dll/win32/shlwapi/istream.c
@@ -741,10 +741,10 @@ IStream_ReadPidl(_In_ IStream *pstm, _Out_ LPITEMIDLIST *ppidlOut)
 HRESULT WINAPI
 IStream_WritePidl(_In_ IStream *pstm, _In_ LPCITEMIDLIST pidlWrite)
 {
-    UINT size = ILGetSize(pidlWrite);
-    HRESULT hr = SHIStream_Write(pstm, &size, sizeof(size));
+    UINT cbSize = ILGetSize(pidlWrite);
+    HRESULT hr = SHIStream_Write(pstm, &cbSize, sizeof(cbSize));
     if (FAILED(hr))
         return hr;
-    return SHIStream_Write(pstm, pidlWrite, size);
+    return SHIStream_Write(pstm, pidlWrite, cbSize);
 }
 #endif /* def __REACTOS__ */

--- a/dll/win32/shlwapi/istream.c
+++ b/dll/win32/shlwapi/istream.c
@@ -30,6 +30,9 @@
 #define NO_SHLWAPI_REG
 #define NO_SHLWAPI_PATH
 #include "shlwapi.h"
+#ifdef __REACTOS__
+#include "shlobj.h"
+#endif
 #include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
@@ -673,3 +676,72 @@ HRESULT WINAPI IStream_Size(IStream *lpStream, ULARGE_INTEGER* lpulSize)
     *lpulSize = statstg.cbSize;
   return hRet;
 }
+
+#ifdef __REACTOS__
+/*************************************************************************
+ * IStream_ReadPidl [SHLWAPI.512]
+ *
+ * https://www.geoffchappell.com/studies/windows/shell/shlwapi/api/util/istream/readpidl.htm
+ */
+HRESULT WINAPI
+IStream_ReadPidl(_In_ IStream *pstm, _Out_ LPITEMIDLIST *ppidlOut)
+{
+    LPITEMIDLIST pidl, pidlEnd;
+    LPSHITEMID pItem;
+    UINT cbSize;
+    HRESULT hr;
+
+    *ppidlOut = NULL;
+
+    hr = SHIStream_Read(pstm, &cbSize, sizeof(cbSize));
+    if (FAILED(hr))
+        return hr;
+
+    pidl = (LPITEMIDLIST)CoTaskMemAlloc(cbSize);
+    if (!pidl)
+        return E_OUTOFMEMORY;
+
+    hr = SHIStream_Read(pstm, pidl, cbSize);
+    if (FAILED(hr))
+    {
+        CoTaskMemFree(pidl);
+        return hr;
+    }
+
+    pidlEnd = (LPITEMIDLIST)((PBYTE)pidl + cbSize - sizeof(WORD));
+    for (pItem = &pidl->mkid; pItem <= (LPSHITEMID)pidlEnd;)
+    {
+        if (pItem->cb == 0)
+            break;
+        pItem = (LPSHITEMID)((PBYTE)pItem + pItem->cb);
+    }
+
+    if ((LPITEMIDLIST)pItem == pidlEnd && !pItem->cb)
+    {
+        *ppidlOut = pidl;
+        hr = S_OK;
+    }
+    else
+    {
+        hr = E_INVALIDARG;
+    }
+
+    CoTaskMemFree(pidl);
+    return hr;
+}
+
+/*************************************************************************
+ * IStream_WritePidl [SHLWAPI.513]
+ *
+ * @see https://www.geoffchappell.com/studies/windows/shell/shlwapi/api/util/istream/writepidl.htm
+ */
+HRESULT WINAPI
+IStream_WritePidl(_In_ IStream *pstm, _In_ LPCITEMIDLIST pidlWrite)
+{
+    UINT size = ILGetSize(pidlWrite);
+    HRESULT hr = SHIStream_Write(pstm, &size, sizeof(size));
+    if (FAILED(hr))
+        return hr;
+    return SHIStream_Write(pstm, pidlWrite, size);
+}
+#endif /* def __REACTOS__ */

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -509,8 +509,8 @@
 509 stdcall -noname IUnknown_OnFocusChangeIS(ptr ptr long)
 510 stdcall -noname SHLockSharedEx(ptr long long)
 511 stdcall -noname PathFileExistsDefExtAndAttributesW(wstr long ptr)
-512 stub -ordinal IStream_ReadPidl
-513 stub -ordinal IStream_WritePidl
+512 stdcall -noname IStream_ReadPidl(ptr ptr)
+513 stdcall -noname IStream_WritePidl(ptr ptr)
 514 stdcall -noname IUnknown_ProfferService(ptr ptr ptr ptr)
 515 stdcall -ordinal SHGetViewStatePropertyBag(ptr wstr long ptr ptr)
 516 stdcall -noname SKGetValueW(long wstr wstr ptr ptr ptr)

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND SOURCE
     AssocQueryString.c
     IShellFolderHelpers.cpp
     IsQSForward.cpp
+    IStreamPidl.cpp
     PathFileExistsDefExtAndAttributesW.c
     PathFindOnPath.c
     PathIsUNC.c

--- a/modules/rostests/apitests/shlwapi/IStreamPidl.cpp
+++ b/modules/rostests/apitests/shlwapi/IStreamPidl.cpp
@@ -47,6 +47,13 @@ static void Test_RoundTrip_SimplePidl(void)
     HRESULT hr;
     IStream *pstm;
 
+    ok(pidlSrc != NULL, "pidlSrc was NULL.\n");
+    if (!pidlSrc)
+    {
+        skip("pidlSrc was NULL.\n");
+        return;
+    }
+
     pstm = SHCreateMemStream(NULL, 0);
     ok(pstm != NULL, "pstm was NULL.\n");
     if (!pstm)
@@ -279,6 +286,13 @@ static void Test_Write_StreamPosition(void)
     LARGE_INTEGER zero;
     HRESULT hr;
     UINT expectedPos;
+
+    ok(pidlSrc != NULL, "pidlSrc was NULL\n");
+    if (!pidlSrc)
+    {
+        skip("pidlSrc was NULL\n");
+        return;
+    }
 
     ok(pstm != NULL, "pstm was NULL.\n");
     if (!pstm)

--- a/modules/rostests/apitests/shlwapi/IStreamPidl.cpp
+++ b/modules/rostests/apitests/shlwapi/IStreamPidl.cpp
@@ -1,0 +1,305 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Tests for g_fnIStream_ReadPidl and g_fnIStream_WritePidl
+ * COPYRIGHT:   Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <apitest.h>
+#include <shlwapi.h>
+#include <shlobj.h>
+#include <stdio.h>
+#include <shlwapi_undoc.h>
+#include <versionhelpers.h>
+#include <strsafe.h>
+
+typedef HRESULT (WINAPI *FN_IStream_ReadPidl)(IStream *, _Out_ LPITEMIDLIST *);
+typedef HRESULT (WINAPI *FN_IStream_WritePidl)(IStream *, LPCITEMIDLIST);
+typedef UINT (WINAPI *FN_ILGetSize)(LPCITEMIDLIST);
+
+static FN_IStream_ReadPidl g_fnIStream_ReadPidl = NULL;
+static FN_IStream_WritePidl g_fnIStream_WritePidl = NULL;
+static FN_ILGetSize g_fnILGetSize = NULL;
+
+static LPITEMIDLIST MakeSimplePidl(const BYTE *data, UINT dataLen)
+{
+    UINT cbItem = (UINT)(sizeof(USHORT) + dataLen);
+    UINT cbTotal = cbItem + sizeof(USHORT);
+    LPITEMIDLIST pidl = (LPITEMIDLIST)CoTaskMemAlloc(cbTotal);
+    if (!pidl)
+        return NULL;
+    ZeroMemory(pidl, cbTotal);
+    pidl->mkid.cb = (USHORT)cbItem;
+    if (dataLen)
+        memcpy(pidl->mkid.abID, data, dataLen);
+    return pidl;
+}
+
+static void RewindStream(IStream *pstm)
+{
+    LARGE_INTEGER li;
+    li.QuadPart = 0;
+    pstm->Seek(li, STREAM_SEEK_SET, NULL);
+}
+
+static void Test_RoundTrip_SimplePidl(void)
+{
+    const BYTE data[] = {0x11, 0x22, 0x33};
+    LPITEMIDLIST pidlSrc = MakeSimplePidl(data, sizeof(data));
+    LPITEMIDLIST pidlDst = NULL;
+    HRESULT hr;
+    IStream *pstm;
+
+    pstm = SHCreateMemStream(NULL, 0);
+
+    hr = g_fnIStream_WritePidl(pstm, pidlSrc);
+    ok_hr(hr, S_OK);
+
+    RewindStream(pstm);
+    hr = g_fnIStream_ReadPidl(pstm, &pidlDst);
+    ok_hr(hr, S_OK);
+    ok(pidlDst != NULL, "pidlDst was NULL\n");
+
+    if (pidlDst)
+    {
+        UINT cbSrc = g_fnILGetSize(pidlSrc);
+        UINT cbDst = g_fnILGetSize(pidlDst);
+        ok_int(cbSrc, cbDst);
+        ok_int(memcmp(pidlSrc, pidlDst, cbSrc), 0);
+        CoTaskMemFree(pidlDst);
+    }
+
+    pstm->Release();
+    CoTaskMemFree(pidlSrc);
+}
+
+static void Test_RoundTrip_EmptyPidl(void)
+{
+    /* cb=0 の終端だけ */
+    LPITEMIDLIST pidlSrc = (LPITEMIDLIST)CoTaskMemAlloc(sizeof(USHORT));
+    LPITEMIDLIST pidlDst = NULL;
+    HRESULT hr;
+    IStream *pstm;
+
+    ZeroMemory(pidlSrc, sizeof(USHORT));
+
+    pstm = SHCreateMemStream(NULL, 0);
+
+    hr = g_fnIStream_WritePidl(pstm, pidlSrc);
+    ok_hr(hr, S_OK);
+
+    RewindStream(pstm);
+    hr = g_fnIStream_ReadPidl(pstm, &pidlDst);
+    ok_hr(hr, S_OK);
+    ok(pidlDst != NULL, "pidlDst was NULL\n");
+
+    if (pidlDst)
+    {
+        UINT cbSrc = g_fnILGetSize(pidlSrc);
+        UINT cbDst = g_fnILGetSize(pidlDst);
+        ok_int(cbSrc, cbDst);
+        ok_int(memcmp(pidlSrc, pidlDst, cbSrc), 0);
+        CoTaskMemFree(pidlDst);
+    }
+
+    pstm->Release();
+    CoTaskMemFree(pidlSrc);
+}
+
+static void Test_RoundTrip_MultiItemPidl(void)
+{
+    UINT cbTotal = 4 + 5 + 2; /* 11 バイト */
+    LPITEMIDLIST pidlSrc = (LPITEMIDLIST)CoTaskMemAlloc(cbTotal);
+    LPITEMIDLIST pidlDst = NULL;
+    PBYTE p;
+    HRESULT hr;
+    IStream *pstm;
+
+    ZeroMemory(pidlSrc, cbTotal);
+    p = (PBYTE)pidlSrc;
+
+    *(USHORT *)p = 4; p += 2;
+    *p++ = 0xAA; *p++ = 0xBB;
+
+    *(USHORT *)p = 5; p += 2;
+    *p++ = 0x01; *p++ = 0x02; *p++ = 0x03;
+
+    pstm = SHCreateMemStream(NULL, 0);
+
+    hr = g_fnIStream_WritePidl(pstm, pidlSrc);
+    ok_hr(hr, S_OK);
+
+    RewindStream(pstm);
+    hr = g_fnIStream_ReadPidl(pstm, &pidlDst);
+    ok_hr(hr, S_OK);
+    ok(pidlDst != NULL, "pidlDst was NULL\n");
+
+    if (pidlDst)
+    {
+        ok_int(g_fnILGetSize(pidlSrc), g_fnILGetSize(pidlDst));
+        ok_int(memcmp(pidlSrc, pidlDst, g_fnILGetSize(pidlSrc)), 0);
+        CoTaskMemFree(pidlDst);
+    }
+
+    pstm->Release();
+    CoTaskMemFree(pidlSrc);
+}
+
+static void Test_Read_EmptyStream(void)
+{
+    IStream *pstm = SHCreateMemStream(NULL, 0);
+    LPITEMIDLIST pidl = NULL;
+    HRESULT hr;
+
+    hr = g_fnIStream_ReadPidl(pstm, &pidl);
+    ok(FAILED(hr), "hr was wrongly succeeded\n");
+    ok(pidl == NULL, "pidl was not NULL\n");
+
+    pstm->Release();
+}
+
+static void Test_Read_TooSmallCbSize(void)
+{
+    IStream *pstm = SHCreateMemStream(NULL, 0);
+    LPITEMIDLIST pidl = NULL;
+    UINT cbSize = 1;
+    ULONG cbWritten;
+    HRESULT hr;
+
+    pstm->Write(&cbSize, sizeof(cbSize), &cbWritten);
+
+    RewindStream(pstm);
+    hr = g_fnIStream_ReadPidl(pstm, &pidl);
+    ok(FAILED(hr), "hr was 0x%X\n", hr);
+    ok(pidl == NULL, "pidl was not NULL\n");
+
+    pstm->Release();
+}
+
+static void Test_Read_TruncatedData(void)
+{
+    IStream *pstm = SHCreateMemStream(NULL, 0);
+    LPITEMIDLIST pidl = NULL;
+    UINT cbSize = 100;
+    ULONG cbWritten;
+    HRESULT hr;
+
+    pstm->Write(&cbSize, sizeof(cbSize), &cbWritten);
+
+    RewindStream(pstm);
+    hr = g_fnIStream_ReadPidl(pstm, &pidl);
+    ok(FAILED(hr), "hr was 0x%X\n", hr);
+    ok(pidl == NULL, "pidl was not NULL\n");
+
+    pstm->Release();
+}
+
+static void Test_Read_MissingTerminator(void)
+{
+    IStream *pstm = SHCreateMemStream(NULL, 0);
+    LPITEMIDLIST pidl = NULL;
+    UINT cbSize = 4;
+    BYTE rawData[4] = {0x04, 0x00, 0x11, 0x22};
+    ULONG cbWritten;
+    HRESULT hr;
+
+    pstm->Write(&cbSize, sizeof(cbSize), &cbWritten);
+    pstm->Write(rawData, cbSize, &cbWritten);
+
+    RewindStream(pstm);
+    hr = g_fnIStream_ReadPidl(pstm, &pidl);
+    ok(FAILED(hr), "hr was 0x%X\n", hr);
+    ok(pidl == NULL, "pidl was not NULL\n");
+
+    pstm->Release();
+}
+
+static void Test_Write_StreamPosition(void)
+{
+    const BYTE data[] = {0xDE, 0xAD};
+    LPITEMIDLIST pidlSrc = MakeSimplePidl(data, sizeof(data));
+    IStream *pstm = SHCreateMemStream(NULL, 0);
+    ULARGE_INTEGER pos;
+    LARGE_INTEGER zero;
+    HRESULT hr;
+    UINT expectedPos;
+
+    zero.QuadPart = 0;
+
+    hr = g_fnIStream_WritePidl(pstm, pidlSrc);
+    ok_hr(hr, S_OK);
+
+    pstm->Seek(zero, STREAM_SEEK_CUR, &pos);
+
+    expectedPos = sizeof(UINT) + g_fnILGetSize(pidlSrc);
+    ok_eq_longlong(pos.QuadPart, expectedPos);
+
+    pstm->Release();
+    CoTaskMemFree(pidlSrc);
+}
+
+static void Test_Read_OutputNullOnFailure(void)
+{
+    IStream *pstm = SHCreateMemStream(NULL, 0);
+    LPITEMIDLIST pidl = (LPITEMIDLIST)(void *)0xDEADBEEF;
+    HRESULT hr;
+
+    hr = g_fnIStream_ReadPidl(pstm, &pidl);
+    ok(FAILED(hr), "hr was 0x%X\n", hr);
+    ok(pidl == NULL, "pidl was not NULL\n");
+
+    pstm->Release();
+}
+
+START_TEST(IStreamPidl)
+{
+    HINSTANCE hSHLWAPI = LoadLibraryW(L"shlwapi");
+    if (!hSHLWAPI)
+    {
+        skip("shlwapi not found\n");
+        return;
+    }
+
+    g_fnIStream_ReadPidl = (FN_IStream_ReadPidl)GetProcAddress(hSHLWAPI, MAKEINTRESOURCEA(512));
+    g_fnIStream_WritePidl = (FN_IStream_WritePidl)GetProcAddress(hSHLWAPI, MAKEINTRESOURCEA(513));
+    if (!g_fnIStream_ReadPidl || !g_fnIStream_WritePidl)
+    {
+        skip("IStream_ReadPidl or IStream_WritePidl not found\n");
+        return;
+    }
+
+    HINSTANCE hSHELL32 = LoadLibraryW(L"shell32");
+    if (!hSHELL32)
+    {
+        skip("shell32 not found\n");
+        FreeLibrary(hSHLWAPI);
+        return;
+    }
+
+    g_fnILGetSize = (FN_ILGetSize)GetProcAddress(hSHELL32, "ILGetSize");
+    if (!g_fnILGetSize)
+    {
+        skip("ILGetSize not found\n");
+        FreeLibrary(hSHELL32);
+        FreeLibrary(hSHLWAPI);
+        return;
+    }
+
+    HRESULT hrCoInit = CoInitialize(NULL);
+
+    Test_RoundTrip_SimplePidl();
+    Test_RoundTrip_EmptyPidl();
+    Test_RoundTrip_MultiItemPidl();
+    Test_Read_EmptyStream();
+    Test_Read_TooSmallCbSize();
+    Test_Read_TruncatedData();
+    Test_Read_MissingTerminator();
+    Test_Write_StreamPosition();
+    Test_Read_OutputNullOnFailure();
+
+    if (SUCCEEDED(hrCoInit))
+        CoUninitialize();
+
+    FreeLibrary(hSHELL32);
+    FreeLibrary(hSHLWAPI);
+}

--- a/modules/rostests/apitests/shlwapi/IStreamPidl.cpp
+++ b/modules/rostests/apitests/shlwapi/IStreamPidl.cpp
@@ -8,10 +8,7 @@
 #include <apitest.h>
 #include <shlwapi.h>
 #include <shlobj.h>
-#include <stdio.h>
 #include <shlwapi_undoc.h>
-#include <versionhelpers.h>
-#include <strsafe.h>
 
 typedef HRESULT (WINAPI *FN_IStream_ReadPidl)(IStream *, _Out_ LPITEMIDLIST *);
 typedef HRESULT (WINAPI *FN_IStream_WritePidl)(IStream *, LPCITEMIDLIST);
@@ -51,6 +48,12 @@ static void Test_RoundTrip_SimplePidl(void)
     IStream *pstm;
 
     pstm = SHCreateMemStream(NULL, 0);
+    ok(pstm != NULL, "pstm was NULL.\n");
+    if (!pstm)
+    {
+        skip("pstm was NULL.\n");
+        return;
+    }
 
     hr = g_fnIStream_WritePidl(pstm, pidlSrc);
     ok_hr(hr, S_OK);
@@ -80,9 +83,22 @@ static void Test_RoundTrip_EmptyPidl(void)
     HRESULT hr;
     IStream *pstm;
 
+    ok(pidlSrc != NULL, "CoTaskMemAlloc failed\n");
+    if (!pidlSrc)
+    {
+        skip("pidlSrc was NULL\n");
+        return;
+    }
+
     ZeroMemory(pidlSrc, sizeof(USHORT));
 
     pstm = SHCreateMemStream(NULL, 0);
+    ok(pstm != NULL, "pstm was NULL\n");
+    if (!pstm)
+    {
+        skip("pstm was NULL\n");
+        return;
+    }
 
     hr = g_fnIStream_WritePidl(pstm, pidlSrc);
     ok_hr(hr, S_OK);
@@ -114,6 +130,13 @@ static void Test_RoundTrip_MultiItemPidl(void)
     HRESULT hr;
     IStream *pstm;
 
+    ok(pidlSrc != NULL, "CoTaskMemAlloc failed\n");
+    if (!pidlSrc)
+    {
+        skip("pidlSrc was NULL\n");
+        return;
+    }
+
     ZeroMemory(pidlSrc, cbTotal);
     p = (PBYTE)pidlSrc;
 
@@ -124,6 +147,12 @@ static void Test_RoundTrip_MultiItemPidl(void)
     *p++ = 0x01; *p++ = 0x02; *p++ = 0x03;
 
     pstm = SHCreateMemStream(NULL, 0);
+    ok(pstm != NULL, "pstm was NULL\n");
+    if (!pstm)
+    {
+        skip("pstm was NULL\n");
+        return;
+    }
 
     hr = g_fnIStream_WritePidl(pstm, pidlSrc);
     ok_hr(hr, S_OK);
@@ -150,6 +179,13 @@ static void Test_Read_EmptyStream(void)
     LPITEMIDLIST pidl = NULL;
     HRESULT hr;
 
+    ok(pstm != NULL, "pstm was NULL\n");
+    if (!pstm)
+    {
+        skip("pstm was NULL\n");
+        return;
+    }
+
     hr = g_fnIStream_ReadPidl(pstm, &pidl);
     ok(FAILED(hr), "hr was wrongly succeeded\n");
     ok(pidl == NULL, "pidl was not NULL\n");
@@ -164,6 +200,13 @@ static void Test_Read_TooSmallCbSize(void)
     UINT cbSize = 1;
     ULONG cbWritten;
     HRESULT hr;
+
+    ok(pstm != NULL, "pstm was NULL.\n");
+    if (!pstm)
+    {
+        skip("pstm was NULL.\n");
+        return;
+    }
 
     pstm->Write(&cbSize, sizeof(cbSize), &cbWritten);
 
@@ -183,6 +226,13 @@ static void Test_Read_TruncatedData(void)
     ULONG cbWritten;
     HRESULT hr;
 
+    ok(pstm != NULL, "pstm was NULL.\n");
+    if (!pstm)
+    {
+        skip("pstm was NULL.\n");
+        return;
+    }
+
     pstm->Write(&cbSize, sizeof(cbSize), &cbWritten);
 
     RewindStream(pstm);
@@ -201,6 +251,13 @@ static void Test_Read_MissingTerminator(void)
     BYTE rawData[4] = {0x04, 0x00, 0x11, 0x22};
     ULONG cbWritten;
     HRESULT hr;
+
+    ok(pstm != NULL, "pstm was NULL.\n");
+    if (!pstm)
+    {
+        skip("pstm was NULL.\n");
+        return;
+    }
 
     pstm->Write(&cbSize, sizeof(cbSize), &cbWritten);
     pstm->Write(rawData, cbSize, &cbWritten);
@@ -223,6 +280,13 @@ static void Test_Write_StreamPosition(void)
     HRESULT hr;
     UINT expectedPos;
 
+    ok(pstm != NULL, "pstm was NULL.\n");
+    if (!pstm)
+    {
+        skip("pstm was NULL.\n");
+        return;
+    }
+
     zero.QuadPart = 0;
 
     hr = g_fnIStream_WritePidl(pstm, pidlSrc);
@@ -242,6 +306,13 @@ static void Test_Read_OutputNullOnFailure(void)
     IStream *pstm = SHCreateMemStream(NULL, 0);
     LPITEMIDLIST pidl = (LPITEMIDLIST)UlongToPtr(0xDEADBEEF);
     HRESULT hr;
+
+    ok(pstm != NULL, "pstm was NULL.\n");
+    if (!pstm)
+    {
+        skip("pstm was NULL.\n");
+        return;
+    }
 
     hr = g_fnIStream_ReadPidl(pstm, &pidl);
     ok(FAILED(hr), "hr was 0x%X\n", hr);

--- a/modules/rostests/apitests/shlwapi/IStreamPidl.cpp
+++ b/modules/rostests/apitests/shlwapi/IStreamPidl.cpp
@@ -241,7 +241,7 @@ static void Test_Write_StreamPosition(void)
 static void Test_Read_OutputNullOnFailure(void)
 {
     IStream *pstm = SHCreateMemStream(NULL, 0);
-    LPITEMIDLIST pidl = (LPITEMIDLIST)(void *)0xDEADBEEF;
+    LPITEMIDLIST pidl = (LPITEMIDLIST)UlongToPtr(0xDEADBEEF);
     HRESULT hr;
 
     hr = g_fnIStream_ReadPidl(pstm, &pidl);

--- a/modules/rostests/apitests/shlwapi/IStreamPidl.cpp
+++ b/modules/rostests/apitests/shlwapi/IStreamPidl.cpp
@@ -75,7 +75,6 @@ static void Test_RoundTrip_SimplePidl(void)
 
 static void Test_RoundTrip_EmptyPidl(void)
 {
-    /* cb=0 の終端だけ */
     LPITEMIDLIST pidlSrc = (LPITEMIDLIST)CoTaskMemAlloc(sizeof(USHORT));
     LPITEMIDLIST pidlDst = NULL;
     HRESULT hr;
@@ -108,7 +107,7 @@ static void Test_RoundTrip_EmptyPidl(void)
 
 static void Test_RoundTrip_MultiItemPidl(void)
 {
-    UINT cbTotal = 4 + 5 + 2; /* 11 バイト */
+    UINT cbTotal = 4 + 5 + 2;
     LPITEMIDLIST pidlSrc = (LPITEMIDLIST)CoTaskMemAlloc(cbTotal);
     LPITEMIDLIST pidlDst = NULL;
     PBYTE p;

--- a/modules/rostests/apitests/shlwapi/IStreamPidl.cpp
+++ b/modules/rostests/apitests/shlwapi/IStreamPidl.cpp
@@ -349,6 +349,7 @@ START_TEST(IStreamPidl)
     if (!g_fnIStream_ReadPidl || !g_fnIStream_WritePidl)
     {
         skip("IStream_ReadPidl or IStream_WritePidl not found\n");
+        FreeLibrary(hSHLWAPI);
         return;
     }
 

--- a/modules/rostests/apitests/shlwapi/testlist.c
+++ b/modules/rostests/apitests/shlwapi/testlist.c
@@ -6,6 +6,7 @@ extern void func_PathFileExistsDefExtAndAttributesW(void);
 extern void func_PathFindOnPath(void);
 extern void func_IShellFolderHelpers(void);
 extern void func_IsQSForward(void);
+extern void func_IStreamPidl(void);
 extern void func_isuncpath(void);
 extern void func_isuncpathserver(void);
 extern void func_isuncpathservershare(void);
@@ -27,6 +28,7 @@ const struct test winetest_testlist[] =
     { "PathFindOnPath", func_PathFindOnPath },
     { "IShellFolderHelpers", func_IShellFolderHelpers },
     { "IsQSForward", func_IsQSForward },
+    { "IStreamPidl", func_IStreamPidl },
     { "PathIsUNC", func_isuncpath },
     { "PathIsUNCServer", func_isuncpathserver },
     { "PathIsUNCServerShare", func_isuncpathservershare },

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -144,6 +144,9 @@ HRESULT WINAPI SHWriteDataBlockList(IStream* lpStream, LPDBLIST lpList);
 HRESULT WINAPI SHReadDataBlockList(IStream* lpStream, LPDBLIST* lppList);
 VOID WINAPI SHFreeDataBlockList(LPDBLIST lpList);
 
+HRESULT WINAPI IStream_ReadPidl(_In_ IStream *pstm, _Out_ LPITEMIDLIST *ppidlOut);
+HRESULT WINAPI IStream_WritePidl(_In_ IStream *pstm, _In_ LPCITEMIDLIST pidlWrite);
+
 LONG
 WINAPI
 RegCreateKeyExWrapW(


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)
## Proposed changes

- Implement `IStream_ReadPidl` and `IStream_WritePidl` functions.
- Add prototypes to `<shlwapi_undoc.h>`.
- Add `IStreamPidl` testcase.

## Screenshots

WinXP (Japanese):
<img width="640" height="480" alt="IStreamPidl_WinXP" src="https://github.com/user-attachments/assets/2e76b1ca-cf03-4603-9cf6-958adc68e31a" />

Win10 x64 (Japanese):
<img width="579" height="382" alt="IStreamPidl_Win10" src="https://github.com/user-attachments/assets/1791941f-a0e3-41e8-91ab-989b63bbee15" />

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107062,107101
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107063,107102