### PR TITLE
[USER32][COMCTL32] EDIT control: Fix vertical scrolling past line number 32767

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -5146,11 +5146,13 @@ static LRESULT CALLBACK EDIT_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
     {
         SCROLLINFO si;
 
-        ZeroMemory(&si, sizeof(si));
         si.cbSize = sizeof(si);
         si.fMask = SIF_TRACKPOS;
         if (!GetScrollInfo(hwnd, SB_VERT, &si))
-            return 1;
+        {
+            result = 1;
+            break;
+        }
         result = EDIT_WM_VScroll(es, LOWORD(wParam), si.nTrackPos);
     }
 #else

--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -5142,7 +5142,20 @@ static LRESULT CALLBACK EDIT_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
         break;
 
     case WM_VSCROLL:
+#ifdef __REACTOS__
+    {
+        SCROLLINFO si;
+
+        ZeroMemory(&si, sizeof(si));
+        si.cbSize = sizeof(si);
+        si.fMask = SIF_TRACKPOS;
+        if (!GetScrollInfo(hwnd, SB_VERT, &si))
+            return 1;
+        result = EDIT_WM_VScroll(es, LOWORD(wParam), si.nTrackPos);
+    }
+#else
         result = EDIT_WM_VScroll(es, LOWORD(wParam), (short)HIWORD(wParam));
+#endif
         break;
 
     case WM_MOUSEWHEEL:

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -5350,7 +5350,20 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 		break;
 
 	case WM_VSCROLL:
+#ifdef __REACTOS__
+    {
+        SCROLLINFO si;
+
+        ZeroMemory(&si, sizeof(si));
+        si.cbSize = sizeof(si);
+        si.fMask = SIF_TRACKPOS;
+        if (!GetScrollInfo(hwnd, SB_VERT, &si))
+            return 1;
+        result = EDIT_WM_VScroll(es, LOWORD(wParam), si.nTrackPos);
+    }
+#else
 		result = EDIT_WM_VScroll(es, LOWORD(wParam), (short)HIWORD(wParam));
+#endif
 		break;
 
         case WM_MOUSEWHEEL:

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -5354,11 +5354,13 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
     {
         SCROLLINFO si;
 
-        ZeroMemory(&si, sizeof(si));
         si.cbSize = sizeof(si);
         si.fMask = SIF_TRACKPOS;
         if (!GetScrollInfo(hwnd, SB_VERT, &si))
-            return 1;
+        {
+            result = 1;
+            break;
+        }
         result = EDIT_WM_VScroll(es, LOWORD(wParam), si.nTrackPos);
     }
 #else


### PR DESCRIPTION
CORE-19305

## Purpose

_Change how WM_VSCROLL is handled to allow higher line counts to be passed to EDIT_WM_VScroll._
_Based on a proposed patch by @zecarlos1957._

JIRA issue: [CORE-19305](https://jira.reactos.org/browse/CORE-19305)

## Proposed changes

_Use the GetScrollInfo() function to determine vertical scroll position and pass this to EDIT_WM_VScroll._

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107120,107144,107146 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107241,107243 LGTM

## Before PR showing scroll bar pulled to the bottom but showing the start of the file:

<img width="1042" height="856" alt="scroll-test-bad" src="https://github.com/user-attachments/assets/66015915-69d0-4199-8034-12837b9132e1" />

## Afer PR with scroll bar pulled to the bottom and showing the files ending:

<img width="1042" height="856" alt="scroll-test-good" src="https://github.com/user-attachments/assets/6c24277f-68fc-41ff-9751-8d3ffa84368f" />
