### PR TITLE
[ROSTESTS] Implement tests for RtlQueryEnvironmentVariable(_U) / GetEnvironmentVariable(A/W)

### DIFF
--- a/modules/rostests/apitests/kernel32/CMakeLists.txt
+++ b/modules/rostests/apitests/kernel32/CMakeLists.txt
@@ -17,6 +17,7 @@ list(APPEND SOURCE
     GetCPInfo.c
     GetCurrentDirectory.c
     GetDriveType.c
+    GetEnvironmentVariable.c
     GetFinalPathNameByHandle.c
     GetLocaleInfo.c
     GetModuleFileName.c

--- a/modules/rostests/apitests/kernel32/GetEnvironmentVariable.c
+++ b/modules/rostests/apitests/kernel32/GetEnvironmentVariable.c
@@ -1,0 +1,125 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for GetEnvironmentVariable(A/W)
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include "precomp.h"
+
+static void Test_GetEnvironmentVariableA(void)
+{
+    CHAR Buffer[MAX_PATH];
+    ULONG ActualLength, Length;
+
+    /* Get the COMSPEC variable */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Length = GetEnvironmentVariableA("COMSPEC", Buffer, ARRAYSIZE(Buffer));
+    Buffer[MAX_PATH - 1] = '\0';
+    ActualLength = (ULONG)strlen(Buffer);
+    ok(ActualLength < ARRAYSIZE(Buffer) - 1, "ActualLength == ARRAYSIZE(Buffer) - 1. Not null-terminated?\n");
+    ok_eq_ulong(Length, ActualLength);
+    ok_eq_char(Buffer[ActualLength + 1], '\xAB');
+
+    /* Get the length only (return value is including NULL char) */
+    Length = GetEnvironmentVariableA("COMSPEC", NULL, 0);
+    ok_eq_ulong(Length, ActualLength + 1);
+
+    /* Test a buffer size that is too small */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Length = GetEnvironmentVariableA("COMSPEC", Buffer, 5);
+    ok_eq_ulong(Length, ActualLength + 1);
+    ok_eq_char(Buffer[0], '\xAB');
+
+    /* Test a buffer size that doesn't fit the terminating NULL char */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Length = GetEnvironmentVariableA("COMSPEC", Buffer, ActualLength);
+    ok_eq_ulong(Length, ActualLength + 1);
+    ok_eq_char(Buffer[0], '\xAB');
+
+    /* Test a buffer size that is just large enough */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Length = GetEnvironmentVariableA("COMSPEC", Buffer, ActualLength + 1);
+    ok_eq_ulong(Length, ActualLength);
+    ok_eq_wchar(Buffer[ActualLength], '\0');
+    ok_eq_wchar(Buffer[ActualLength + 1], '\xAB');
+
+    /* Test non-existant variable name */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Length = GetEnvironmentVariableA("ThisVariableDoesNotExit", Buffer, ARRAYSIZE(Buffer));
+    ok_eq_ulong(Length, 0);
+    ok_eq_wchar(Buffer[0], '\xAB');
+
+    /* Test NULL variable name */
+    Length = GetEnvironmentVariableA(NULL, Buffer, ARRAYSIZE(Buffer));
+    ok_eq_ulong(Length, 0);
+
+    /* Test NULL buffer with non-null size */
+    StartSeh()
+        Length = GetEnvironmentVariableA("COMSPEC", NULL, ARRAYSIZE(Buffer));
+    EndSeh(STATUS_ACCESS_VIOLATION);
+}
+
+static void Test_GetEnvironmentVariableW(void)
+{
+    WCHAR Buffer[MAX_PATH];
+    ULONG ActualLength, Length;
+
+    /* Get the COMSPEC variable */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Length = GetEnvironmentVariableW(L"COMSPEC", Buffer, ARRAYSIZE(Buffer));
+    Buffer[MAX_PATH - 1] = L'\0';
+    ActualLength = (ULONG)wcslen(Buffer);
+    ok(ActualLength < ARRAYSIZE(Buffer) - 1, "ActualLength == ARRAYSIZE(Buffer) - 1. Not null-terminated?\n");
+    ok_eq_ulong(Length, ActualLength);
+    ok_eq_wchar(Buffer[ActualLength + 1], 0xABAB);
+
+    /* Get the length only (return value is including NULL char) */
+    Length = GetEnvironmentVariableW(L"COMSPEC", NULL, 0);
+    ok_eq_ulong(Length, ActualLength + 1);
+
+    /* Test a buffer size that is too small */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Length = GetEnvironmentVariableW(L"COMSPEC", Buffer, 2);
+    ok_eq_ulong(Length, ActualLength + 1);
+    ok(Buffer[0] == UNICODE_NULL || broken(/* Windows 2003 */ Buffer[0] == 0xABAB), "Buffer[0] = 0x%x\n", Buffer[0]);
+    ok_eq_wchar(Buffer[1], 0xABAB);
+
+    /* Test a buffer size that doesn't fit the terminating NULL char */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Length = GetEnvironmentVariableW(L"COMSPEC", Buffer, ActualLength);
+    ok_eq_ulong(Length, ActualLength + 1);
+    ok(Buffer[0] == UNICODE_NULL || broken(/* Windows 2003 */ Buffer[0] == 0xABAB), "Buffer[0] = 0x%x\n", Buffer[0]);
+    ok_eq_wchar(Buffer[1], 0xABAB);
+
+    /* Test a buffer size that is just large enough */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Length = GetEnvironmentVariableW(L"COMSPEC", Buffer, ActualLength + 1);
+    ok_eq_ulong(Length, ActualLength);
+    ok_eq_wchar(Buffer[ActualLength], L'\0');
+    ok_eq_wchar(Buffer[ActualLength + 1], 0xABAB);
+
+    /* Test non-existant variable name */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Length = GetEnvironmentVariableW(L"ThisVariableDoesNotExit", Buffer, ARRAYSIZE(Buffer));
+    ok_eq_ulong(Length, 0);
+    ok_eq_wchar(Buffer[0], 0xABAB);
+
+    /* Test NULL variable name */
+    StartSeh()
+        Length = GetEnvironmentVariableW(NULL, Buffer, ARRAYSIZE(Buffer));
+    EndSeh(STATUS_SUCCESS);
+    ok_eq_ulong(Length, 0);
+
+    /* Test NULL buffer with non-null size */
+    StartSeh()
+        Length = GetEnvironmentVariableW(L"COMSPEC", NULL, ARRAYSIZE(Buffer));
+    EndSeh(STATUS_SUCCESS);
+    ok((Length == ActualLength + 1) || broken(/* Windows 2003 */ Length == 0), "Length == %lu, ActualLength == %lu\n", Length, ActualLength);
+}
+
+START_TEST(GetEnvironmentVariable)
+{
+    Test_GetEnvironmentVariableA();
+    Test_GetEnvironmentVariableW();
+}

--- a/modules/rostests/apitests/kernel32/testlist.c
+++ b/modules/rostests/apitests/kernel32/testlist.c
@@ -16,6 +16,7 @@ extern void func_GetComputerNameEx(void);
 extern void func_GetCPInfo(void);
 extern void func_GetCurrentDirectory(void);
 extern void func_GetDriveType(void);
+extern void func_GetEnvironmentVariable(void);
 extern void func_GetFinalPathNameByHandle(void);
 extern void func_GetLocaleInfo(void);
 extern void func_GetModuleFileName(void);
@@ -60,6 +61,7 @@ const struct test winetest_testlist[] =
     { "GetCPInfo",                   func_GetCPInfo },
     { "GetCurrentDirectory",         func_GetCurrentDirectory },
     { "GetDriveType",                func_GetDriveType },
+    { "GetEnvironmentVariable",      func_GetEnvironmentVariable },
     { "GetFinalPathNameByHandle",    func_GetFinalPathNameByHandle },
     { "GetLocaleInfo",               func_GetLocaleInfo },
     { "GetModuleFileName",           func_GetModuleFileName },

--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -129,6 +129,8 @@ list(APPEND SOURCE
     RtlNtPathNameToDosPathName.c
     RtlpApplyLengthFunction.c
     RtlpEnsureBufferSize.c
+    RtlQueryEnvironmentVariable.c
+    RtlQueryEnvironmentVariable_U.c
     RtlQueryTimeZoneInfo.c
     RtlReAllocateHeap.c
     RtlRemovePrivileges.c

--- a/modules/rostests/apitests/ntdll/RtlQueryEnvironmentVariable.c
+++ b/modules/rostests/apitests/ntdll/RtlQueryEnvironmentVariable.c
@@ -1,0 +1,98 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for RtlQueryEnvironmentVariable
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include "precomp.h"
+
+typedef
+NTSTATUS
+NTAPI
+FN_RtlQueryEnvironmentVariable(
+    _In_opt_ PVOID Environment,
+    _In_reads_(NameLength) PWSTR Name,
+    _In_ SIZE_T NameLength,
+    _Out_writes_(ValueLength) PWSTR Value,
+    _In_ SIZE_T ValueLength,
+    _Out_ PSIZE_T ReturnLength);
+
+static FN_RtlQueryEnvironmentVariable* pRtlQueryEnvironmentVariable;
+
+START_TEST(RtlQueryEnvironmentVariable)
+{
+    static WCHAR TestEnv[] = L"TestVar=TestVal\0Foo=4\0EmptyVar\0Bar=8\0\0";
+    WCHAR Buffer[32];
+    SIZE_T ReturnLength;
+    NTSTATUS Status;
+
+    HINSTANCE hinst = GetModuleHandleA("ntdll.dll");
+    pRtlQueryEnvironmentVariable = (FN_RtlQueryEnvironmentVariable*)
+        GetProcAddress(hinst, "RtlQueryEnvironmentVariable");
+    if (pRtlQueryEnvironmentVariable == NULL)
+    {
+        ok(GetNTVersion() < _WIN32_WINNT_VISTA, "RtlQueryEnvironmentVariable not available on NT6+\n");
+        skip("RtlQueryEnvironmentVariable is not available\n");
+        return;
+    }
+
+    /* Query the TestVar environment variable length */
+    Status = pRtlQueryEnvironmentVariable(TestEnv, L"TestVar", 7, NULL, 0, &ReturnLength);
+    ok_ntstatus(Status, STATUS_BUFFER_TOO_SMALL);
+    ok_eq_size(ReturnLength, 8);
+
+    /* Test a buffer size that is too small */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Status = pRtlQueryEnvironmentVariable(TestEnv, L"TestVar", 7, Buffer, 2, &ReturnLength);
+    ok_ntstatus(Status, STATUS_BUFFER_TOO_SMALL);
+    ok_eq_size(ReturnLength, 8);
+    ok_eq_wchar(Buffer[0], UNICODE_NULL);
+    ok_eq_wchar(Buffer[1], 0xABAB);
+
+    /* Test a buffer size that doesn't fit the terminating NULL char */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Status = pRtlQueryEnvironmentVariable(TestEnv, L"TestVar", 7, Buffer, 7, &ReturnLength);
+    ok_ntstatus(Status, STATUS_BUFFER_TOO_SMALL);
+    ok_eq_size(ReturnLength, 8);
+    ok_eq_wchar(Buffer[0], UNICODE_NULL);
+    ok_eq_wchar(Buffer[1], 0xABAB);
+
+    /* Test a buffer size that is just large enough */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Status = pRtlQueryEnvironmentVariable(TestEnv, L"TestVar", 7, Buffer, 8, &ReturnLength);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok_eq_size(ReturnLength, 7);
+    ok_eq_wstr(Buffer, L"TestVal");
+    ok_eq_wchar(Buffer[7], UNICODE_NULL);
+    ok_eq_wchar(Buffer[8], 0xABAB);
+
+    /* Test a buffer size that is larger than needed */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Status = pRtlQueryEnvironmentVariable(TestEnv, L"TestVar", 7, Buffer, ARRAYSIZE(Buffer), &ReturnLength);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok_eq_size(ReturnLength, 7);
+    ok_eq_wstr(Buffer, L"TestVal");
+    ok_eq_wchar(Buffer[7], UNICODE_NULL);
+    ok_eq_wchar(Buffer[8], 0xABAB);
+
+    /* Test a too big variable Length */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Status = pRtlQueryEnvironmentVariable(TestEnv, L"TestVar", 8, Buffer, 8, &ReturnLength);
+    ok_ntstatus(Status, STATUS_VARIABLE_NOT_FOUND);
+    ok_eq_wchar(Buffer[0], 0xABAB);
+
+    /* Query the EmptyVar environment variable */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Status = pRtlQueryEnvironmentVariable(TestEnv, L"EmptyVar", 8, Buffer, ARRAYSIZE(Buffer), &ReturnLength);
+    ok_ntstatus(Status, STATUS_VARIABLE_NOT_FOUND);
+    ok_eq_wchar(Buffer[0], 0xABAB);
+
+    /* Query the Bar environment variable */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    Status = pRtlQueryEnvironmentVariable(TestEnv, L"Bar", 3, Buffer, 8, &ReturnLength);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok_eq_wchar(Buffer[0], L'8');
+    ok_eq_wchar(Buffer[1], UNICODE_NULL);
+    ok_eq_wchar(Buffer[2], 0xABAB);
+}

--- a/modules/rostests/apitests/ntdll/RtlQueryEnvironmentVariable_U.c
+++ b/modules/rostests/apitests/ntdll/RtlQueryEnvironmentVariable_U.c
@@ -1,0 +1,128 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for RtlQueryEnvironmentVariable_U
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include "precomp.h"
+
+START_TEST(RtlQueryEnvironmentVariable_U)
+{
+    static WCHAR TestEnvironment[] = L"TestVar=TestVal\0Foo=4\0EmptyVar\0Bar=8\0\0";
+    WCHAR Buffer[32];
+    UNICODE_STRING NameString, ValueString;
+    NTSTATUS Status;
+
+    /* Query the TestVar environment variable length */
+    RtlInitUnicodeString(&NameString, L"TestVar");
+    RtlInitEmptyUnicodeString(&ValueString, NULL, 0);
+    Status = RtlQueryEnvironmentVariable_U(TestEnvironment, &NameString, &ValueString);
+    ok_ntstatus(Status, STATUS_BUFFER_TOO_SMALL);
+    ok_eq_pointer(ValueString.Buffer, NULL);
+    ok_eq_ulong(ValueString.Length, 7 * sizeof(WCHAR));
+    ok_eq_ulong(ValueString.MaximumLength, 0);
+
+    /* Test passing an empty sized buffer */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    RtlInitEmptyUnicodeString(&ValueString, Buffer, 0);
+    Status = RtlQueryEnvironmentVariable_U(TestEnvironment, &NameString, &ValueString);
+    ok_ntstatus(Status, STATUS_BUFFER_TOO_SMALL);
+    ok_eq_pointer(ValueString.Buffer, Buffer);
+    ok_eq_ulong(ValueString.Length, 7 * sizeof(WCHAR));
+    ok_eq_ulong(ValueString.MaximumLength, 0);
+    ok_eq_wchar(Buffer[0], 0xABAB);
+
+    /* Test a buffer size that is too small */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    RtlInitEmptyUnicodeString(&ValueString, Buffer, 2 * sizeof(WCHAR));
+    Status = RtlQueryEnvironmentVariable_U(TestEnvironment, &NameString, &ValueString);
+    ok_ntstatus(Status, STATUS_BUFFER_TOO_SMALL);
+    ok_eq_pointer(ValueString.Buffer, Buffer);
+    ok_eq_ulong(ValueString.Length, 7 * sizeof(WCHAR));
+    ok_eq_ulong(ValueString.MaximumLength, 2 * sizeof(WCHAR));
+    ok(Buffer[0] == UNICODE_NULL || broken(/* Windows 2003 */ Buffer[0] == 0xABAB), "Buffer[0] = 0x%x\n", Buffer[0]);
+    ok_eq_wchar(Buffer[1], 0xABAB);
+
+    /* Test a buffer size that doesn't fit the terminating NULL char */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    RtlInitEmptyUnicodeString(&ValueString, Buffer, 7 * sizeof(WCHAR));
+    Status = RtlQueryEnvironmentVariable_U(TestEnvironment, &NameString, &ValueString);
+    ok(Status == STATUS_BUFFER_TOO_SMALL || broken(/* Windows 2003 */ Status == STATUS_SUCCESS), "Status = 0x%lx\n", Status);
+    ok_eq_pointer(ValueString.Buffer, Buffer);
+    ok_eq_ulong(ValueString.Length, 7 * sizeof(WCHAR));
+    ok_eq_ulong(ValueString.MaximumLength, 7 * sizeof(WCHAR));
+    if (Status == STATUS_BUFFER_TOO_SMALL)
+    {
+        ok_eq_wchar(Buffer[0], UNICODE_NULL);
+        ok_eq_wchar(Buffer[1], 0xABAB);
+    }
+
+    /* Test a buffer size that is just large enough */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    RtlInitEmptyUnicodeString(&ValueString, Buffer, 8 * sizeof(WCHAR));
+    Status = RtlQueryEnvironmentVariable_U(TestEnvironment, &NameString, &ValueString);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok_eq_pointer(ValueString.Buffer, Buffer);
+    ok_eq_ulong(ValueString.Length, 7 * sizeof(WCHAR));
+    ok_eq_ulong(ValueString.MaximumLength, 8 * sizeof(WCHAR));
+    ok_eq_wstr(Buffer, L"TestVal");
+    ok_eq_wchar(Buffer[7], UNICODE_NULL);
+    ok_eq_wchar(Buffer[8], 0xABAB);
+
+    /* Test a buffer size that is larger than needed */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    RtlInitEmptyUnicodeString(&ValueString, Buffer, sizeof(Buffer));
+    Status = RtlQueryEnvironmentVariable_U(TestEnvironment, &NameString, &ValueString);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok_eq_pointer(ValueString.Buffer, Buffer);
+    ok_eq_ulong(ValueString.Length, 7 * sizeof(WCHAR));
+    ok_eq_ulong(ValueString.MaximumLength, sizeof(Buffer));
+    ok_eq_wstr(Buffer, L"TestVal");
+    ok_eq_wchar(Buffer[7], UNICODE_NULL);
+    ok_eq_wchar(Buffer[8], 0xABAB);
+
+    /* Test a too big variable Length */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    NameString.Length += sizeof(WCHAR);
+    RtlInitEmptyUnicodeString(&ValueString, Buffer, sizeof(Buffer));
+    Status = RtlQueryEnvironmentVariable_U(TestEnvironment, &NameString, &ValueString);
+    ok_ntstatus(Status, STATUS_VARIABLE_NOT_FOUND);
+    ok_eq_wchar(Buffer[0], 0xABAB);
+
+    /* Query the EmptyVar environment variable */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    RtlInitUnicodeString(&NameString, L"EmptyVar");
+    RtlInitEmptyUnicodeString(&ValueString, Buffer, sizeof(Buffer));
+    Status = RtlQueryEnvironmentVariable_U(TestEnvironment, &NameString, &ValueString);
+    ok_ntstatus(Status, STATUS_VARIABLE_NOT_FOUND);
+    ok_eq_pointer(ValueString.Buffer, Buffer);
+    ok_eq_ulong(ValueString.Length, 0);
+    ok_eq_ulong(ValueString.MaximumLength, sizeof(Buffer));
+    ok_eq_wchar(Buffer[0], 0xABAB);
+
+    /* Query the Bar environment variable */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    RtlInitUnicodeString(&NameString, L"Bar");
+    RtlInitEmptyUnicodeString(&ValueString, Buffer, sizeof(Buffer));
+    Status = RtlQueryEnvironmentVariable_U(TestEnvironment, &NameString, &ValueString);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok_eq_pointer(ValueString.Buffer, Buffer);
+    ok_eq_ulong(ValueString.Length, 1 * sizeof(WCHAR));
+    ok_eq_ulong(ValueString.MaximumLength, sizeof(Buffer));
+    ok_eq_wstr(Buffer, L"8");
+    ok_eq_wchar(Buffer[1], UNICODE_NULL);
+    ok_eq_wchar(Buffer[2], 0xABAB);
+
+    /* Test NULL Variable name */
+    memset(Buffer, 0xAB, sizeof(Buffer));
+    RtlInitEmptyUnicodeString(&NameString, NULL, 0);
+    RtlInitEmptyUnicodeString(&ValueString, Buffer, sizeof(Buffer));
+    Status = RtlQueryEnvironmentVariable_U(TestEnvironment, &NameString, &ValueString);
+    ok_ntstatus(Status, STATUS_VARIABLE_NOT_FOUND);
+    ok_eq_pointer(ValueString.Buffer, Buffer);
+    ok_eq_ulong(ValueString.Length, 0);
+    ok_eq_ulong(ValueString.MaximumLength, sizeof(Buffer));
+    ok_eq_wchar(Buffer[0], 0xABAB);
+
+}

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -117,6 +117,8 @@ extern void func_RtlMultipleAllocateHeap(void);
 extern void func_RtlNtPathNameToDosPathName(void);
 extern void func_RtlpApplyLengthFunction(void);
 extern void func_RtlpEnsureBufferSize(void);
+extern void func_RtlQueryEnvironmentVariable(void);
+extern void func_RtlQueryEnvironmentVariable_U(void);
 extern void func_RtlQueryTimeZoneInformation(void);
 extern void func_RtlReAllocateHeap(void);
 extern void func_RtlRemovePrivileges(void);
@@ -250,6 +252,8 @@ const struct test winetest_testlist[] =
     { "RtlNtPathNameToDosPathName",     func_RtlNtPathNameToDosPathName },
     { "RtlpApplyLengthFunction",        func_RtlpApplyLengthFunction },
     { "RtlpEnsureBufferSize",           func_RtlpEnsureBufferSize },
+    { "RtlQueryEnvironmentVariable",    func_RtlQueryEnvironmentVariable },
+    { "RtlQueryEnvironmentVariable_U",  func_RtlQueryEnvironmentVariable_U },
     { "RtlQueryTimeZoneInformation",    func_RtlQueryTimeZoneInformation },
     { "RtlReAllocateHeap",              func_RtlReAllocateHeap },
     { "RtlRemovePrivileges",            func_RtlRemovePrivileges },


### PR DESCRIPTION
## Purpose

Implement tests for RtlQueryEnvironmentVariable(_U) / GetEnvironmentVariable(A/W)

## Testbot runs (Filled in by Devs)

- [x] WHS x86: https://reactos.org/testman/compare.php?ids=107303,107319
- [x] Vista x64: https://reactos.org/testman/compare.php?ids=107318,107320
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107316,107321
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107315,107323
