### PR TITLE
[PNPMGR] Fix PnpBusTypeGuidList dereference

### DIFF
--- a/ntoskrnl/io/pnpmgr/pnpmgr.c
+++ b/ntoskrnl/io/pnpmgr/pnpmgr.c
@@ -445,7 +445,6 @@ IopGetBusTypeGuidIndex(LPGUID BusTypeGuid)
         if (!NewList)
         {
             /* Fail */
-            ExFreePool(PnpBusTypeGuidList);
             goto Quickie;
         }
 
@@ -471,6 +470,13 @@ IopGetBusTypeGuidIndex(LPGUID BusTypeGuid)
 
 Quickie:
     ExReleaseFastMutex(&PnpBusTypeGuidList->Lock);
+
+    if (!NewList)
+    {
+        /* It failed, cleanup after releasing the lock */
+        ExFreePool(PnpBusTypeGuidList);
+    }
+
     return FoundIndex;
 }
 


### PR DESCRIPTION
CORE-12791

## Purpose

Fix a PnpBusTypeGuidList dereference in IopGetBusTypeGuidIndex in pnpmgr

JIRA issue: [CORE-12791](https://jira.reactos.org/browse/CORE-12791)

## Proposed changes

- Instead of freeing PnpBusTypeGuidList and then moving to quickie (effectively dereferencing it there) just free the pointer after FastMutex is released.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: