### PR TITLE
[NOTEPAD] Make loading file faster

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -342,7 +342,7 @@ VOID DoOpenFile(LPCTSTR szFileName)
 {
     HANDLE hFile;
     TCHAR log[5];
-    HLOCAL hLocal;
+    HLOCAL hOldLocal, hNewLocal;
 
     /* Close any files and prompt to save changes */
     if (!DoCloseFile())
@@ -360,13 +360,15 @@ VOID DoOpenFile(LPCTSTR szFileName)
     }
 
     /* To make loading file quicker, we use the internal handle of EDIT control */
-    hLocal = (HLOCAL)SendMessageW(Globals.hEdit, EM_GETHANDLE, 0, 0);
-    if (!ReadText(hFile, &hLocal, &Globals.encFile, &Globals.iEoln))
+    hOldLocal = (HLOCAL)SendMessageW(Globals.hEdit, EM_GETHANDLE, 0, 0);
+    hNewLocal = ReadText(hFile, &Globals.encFile, &Globals.iEoln);
+    if (!hNewLocal)
     {
         ShowLastError();
         goto done;
     }
-    SendMessageW(Globals.hEdit, EM_SETHANDLE, (WPARAM)hLocal, 0);
+    SendMessageW(Globals.hEdit, EM_SETHANDLE, (WPARAM)hNewLocal, 0);
+    LocalFree(hOldLocal);
     /* No need of EM_SETMODIFY and EM_EMPTYUNDOBUFFER here. EM_SETHANDLE does instead. */
 
     SetFocus(Globals.hEdit);

--- a/base/applications/notepad/notepad.h
+++ b/base/applications/notepad/notepad.h
@@ -89,7 +89,7 @@ typedef struct
 
 extern NOTEPAD_GLOBALS Globals;
 
-BOOL ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln);
+HLOCAL ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln);
 BOOL WriteText(HANDLE hFile, LPCWSTR pszText, DWORD dwTextLen, ENCODING encFile, EOLN iEoln);
 
 void NOTEPAD_LoadSettingsFromRegistry(PWINDOWPLACEMENT pWP);

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -273,7 +273,7 @@ ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln)
         if (cbContent > 0)
         {
             cchText = MultiByteToWideChar(iCodePage, 0,
-                                          (PCSTR)&pBytes[dwPos], (INT)cbContent,
+                                          (LPCSTR)&pBytes[dwPos], (INT)cbContent,
                                           pszNewText, (INT)cbContent);
             if (!cchText)
                 goto done;

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -83,9 +83,11 @@ static BOOL
 ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, SIZE_T *pcchText, EOLN *piEoln)
 {
     SIZE_T ich, cchText = *pcchText, adwEolnCount[3] = { 0, 0, 0 }, cNonCRLFs;
-    LPWSTR pszText = *ppszText;
+    LPWSTR pszText = *ppszText, pszNew;
     EOLN iEoln;
     BOOL bPrevCR = FALSE;
+    SIZE_T cchNew;
+    HLOCAL hLocal;
 
     /* Replace '\0' with SPACE. Count newlines. */
     for (ich = 0; ich < cchText; ++ich)
@@ -126,9 +128,12 @@ ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, SIZE_T *pcchText, EOL
     if (cNonCRLFs != 0)
     {
         /* Allocate a buffer for EM_SETHANDLE */
-        SIZE_T cchNew = cchText + cNonCRLFs;
-        HLOCAL hLocal = LocalAlloc(LMEM_MOVEABLE, (cchNew + 1) * sizeof(WCHAR));
-        LPWSTR pszNew = LocalLock(hLocal);
+        cchNew = cchText + cNonCRLFs;
+        hLocal = LocalAlloc(LMEM_MOVEABLE, (cchNew + 1) * sizeof(WCHAR));
+        if (!hLocal)
+            return FALSE; /* Failure */
+
+        pszNew = LocalLock(hLocal);
         if (!pszNew)
         {
             LocalFree(hLocal);
@@ -152,7 +157,7 @@ ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, SIZE_T *pcchText, EOL
 HLOCAL
 ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln)
 {
-    LPBYTE pBytes = NULL;
+    PBYTE pBytes = NULL;
     LPWSTR pszText, pszNewText = NULL;
     DWORD dwSize, dwPos;
     SIZE_T i, cchText, cbContent;
@@ -169,8 +174,11 @@ ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln)
     if (dwSize == 0) // If file is empty
     {
         hNewLocal = LocalAlloc(LMEM_MOVEABLE, sizeof(UNICODE_NULL));
+        if (!hNewLocal)
+            goto done;
+
         pszNewText = LocalLock(hNewLocal);
-        if (hNewLocal == NULL || pszNewText == NULL)
+        if (!pszNewText)
             goto done;
 
         *pszNewText = UNICODE_NULL;
@@ -213,60 +221,68 @@ ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln)
 
     switch(encFile)
     {
-    case ENCODING_UTF16BE:
-    case ENCODING_UTF16LE:
-    {
-        /* Allocate the buffer for EM_SETHANDLE */
-        pszText = (LPWSTR) &pBytes[dwPos];
-        cchText = (dwSize - dwPos) / sizeof(WCHAR);
-        hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cchText + 1) * sizeof(WCHAR));
-        pszNewText = LocalLock(hNewLocal);
-        if (pszNewText == NULL)
-            goto done;
-
-        CopyMemory(pszNewText, pszText, cchText * sizeof(WCHAR));
-
-        if (encFile == ENCODING_UTF16BE) /* big endian; Swap bytes */
+        case ENCODING_UTF16BE:
+        case ENCODING_UTF16LE:
         {
-            BYTE tmp, *pb = (LPBYTE)pszNewText;
-            for (i = 0; i < cchText * 2; i += 2)
-            {
-                tmp = pb[i];
-                pb[i] = pb[i + 1];
-                pb[i + 1] = tmp;
-            }
-        }
-        break;
-    }
-
-    case ENCODING_ANSI:
-    case ENCODING_UTF8:
-    case ENCODING_UTF8BOM:
-    {
-        iCodePage = ((encFile == ENCODING_UTF8 || encFile == ENCODING_UTF8BOM) ? CP_UTF8 : CP_ACP);
-        cbContent = dwSize - dwPos;
-
-        /* Allocate the buffer for EM_SETHANDLE */
-        hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cbContent + 1) * sizeof(WCHAR));
-        if (hNewLocal == NULL)
-            goto done;
-        pszNewText = LocalLock(hNewLocal);
-        if (!pszNewText)
-            goto done;
-
-        /* Do conversion */
-        cchText = 0;
-        if (cbContent > 0)
-        {
-            cchText = MultiByteToWideChar(iCodePage, 0, (LPCSTR)&pBytes[dwPos], (INT)cbContent,
-                                          pszNewText, (INT)cbContent);
-            if (!cchText)
+            /* Allocate the buffer for EM_SETHANDLE */
+            pszText = (LPWSTR)&pBytes[dwPos];
+            cchText = (dwSize - dwPos) / sizeof(WCHAR);
+            hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cchText + 1) * sizeof(WCHAR));
+            if (!hNewLocal)
                 goto done;
-        }
-        break;
-    }
 
-    DEFAULT_UNREACHABLE;
+            pszNewText = LocalLock(hNewLocal);
+            if (pszNewText == NULL)
+                goto done;
+
+            CopyMemory(pszNewText, pszText, cchText * sizeof(WCHAR));
+
+            if (encFile == ENCODING_UTF16BE) /* big endian; Swap bytes */
+            {
+                BYTE tmp, *pb = (PBYTE)pszNewText;
+                for (i = 0; i < cchText * 2; i += 2)
+                {
+                    tmp = pb[i];
+                    pb[i] = pb[i + 1];
+                    pb[i + 1] = tmp;
+                }
+            }
+            break;
+        }
+
+        case ENCODING_ANSI:
+        case ENCODING_UTF8:
+        case ENCODING_UTF8BOM:
+        {
+            iCodePage = ((encFile == ENCODING_UTF8 || encFile == ENCODING_UTF8BOM)
+                         ? CP_UTF8 : CP_ACP);
+            cbContent = dwSize - dwPos;
+            if (cbContent > MAXLONG)
+                goto done;
+
+            /* Allocate the buffer for EM_SETHANDLE */
+            hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cbContent + 1) * sizeof(WCHAR));
+            if (hNewLocal == NULL)
+                goto done;
+
+            pszNewText = LocalLock(hNewLocal);
+            if (!pszNewText)
+                goto done;
+
+            /* Do conversion */
+            cchText = 0;
+            if (cbContent > 0)
+            {
+                cchText = MultiByteToWideChar(iCodePage, 0,
+                                              (PCSTR)&pBytes[dwPos], (INT)cbContent,
+                                              pszNewText, (INT)cbContent);
+                if (!cchText)
+                    goto done;
+            }
+            break;
+        }
+
+        DEFAULT_UNREACHABLE;
     }
 
     pszNewText[cchText] = UNICODE_NULL;

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -156,7 +156,7 @@ ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, SIZE_T *pcchText, EOL
 HLOCAL
 ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln)
 {
-    PBYTE pBytes = NULL;
+    LPBYTE pBytes = NULL;
     LPWSTR pszText, pszNewText = NULL;
     DWORD dwSize, dwPos;
     SIZE_T i, cchText, cbContent;
@@ -238,7 +238,7 @@ ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln)
 
             if (encFile == ENCODING_UTF16BE) /* big endian; Swap bytes */
             {
-                BYTE tmp, *pb = (PBYTE)pszNewText;
+                BYTE tmp, *pb = (LPBYTE)pszNewText;
                 for (i = 0; i < cchText * 2; i += 2)
                 {
                     tmp = pb[i];

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -130,12 +130,16 @@ ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, SIZE_T *pcchText, EOL
         cchNew = cchText + cNonCRLFs;
         hLocal = LocalAlloc(LMEM_MOVEABLE, (cchNew + 1) * sizeof(WCHAR));
         if (!hLocal)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             return FALSE; /* Failure */
+        }
 
         pszNew = LocalLock(hLocal);
         if (!pszNew)
         {
             LocalFree(hLocal);
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             return FALSE; /* Failure */
         }
 
@@ -174,11 +178,17 @@ ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln)
     {
         hNewLocal = LocalAlloc(LMEM_MOVEABLE, sizeof(UNICODE_NULL));
         if (!hNewLocal)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             goto done;
+        }
 
         pszNewText = LocalLock(hNewLocal);
         if (!pszNewText)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             goto done;
+        }
 
         *pszNewText = UNICODE_NULL;
         LocalUnlock(hNewLocal);
@@ -226,13 +236,25 @@ ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln)
         /* Allocate the buffer for EM_SETHANDLE */
         pszText = (LPWSTR)&pBytes[dwPos];
         cchText = (dwSize - dwPos) / sizeof(WCHAR);
+        if (cchText >= MAXLONG / sizeof(WCHAR))
+        {
+            SetLastError(ERROR_FILE_TOO_LARGE);
+            goto done;
+        }
+
         hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cchText + 1) * sizeof(WCHAR));
         if (!hNewLocal)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             goto done;
+        }
 
         pszNewText = LocalLock(hNewLocal);
-        if (pszNewText == NULL)
+        if (!pszNewText)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             goto done;
+        }
 
         CopyMemory(pszNewText, pszText, cchText * sizeof(WCHAR));
 
@@ -256,17 +278,26 @@ ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln)
         iCodePage = ((encFile == ENCODING_UTF8 || encFile == ENCODING_UTF8BOM)
                      ? CP_UTF8 : CP_ACP);
         cbContent = dwSize - dwPos;
-        if (cbContent > MAXLONG)
+        if (cbContent >= MAXLONG / sizeof(WCHAR))
+        {
+            SetLastError(ERROR_FILE_TOO_LARGE);
             goto done;
+        }
 
         /* Allocate the buffer for EM_SETHANDLE */
         hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cbContent + 1) * sizeof(WCHAR));
         if (!hNewLocal)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             goto done;
+        }
 
         pszNewText = LocalLock(hNewLocal);
         if (!pszNewText)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             goto done;
+        }
 
         /* Do conversion */
         cchText = 0;

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -149,8 +149,8 @@ ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, SIZE_T *pcchText, EOL
     return TRUE;
 }
 
-BOOL
-ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
+HLOCAL
+ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln)
 {
     LPBYTE pBytes = NULL;
     LPWSTR pszText, pszNewText = NULL;
@@ -160,7 +160,7 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
     ENCODING encFile;
     UINT iCodePage;
     HANDLE hMapping = INVALID_HANDLE_VALUE;
-    HLOCAL hNewLocal;
+    HLOCAL hNewLocal = NULL;
 
     dwSize = GetFileSize(hFile, NULL);
     if (dwSize == INVALID_FILE_SIZE)
@@ -168,7 +168,7 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
 
     if (dwSize == 0) // If file is empty
     {
-        hNewLocal = LocalReAlloc(*phLocal, sizeof(UNICODE_NULL), LMEM_MOVEABLE);
+        hNewLocal = LocalAlloc(LMEM_MOVEABLE, sizeof(UNICODE_NULL));
         pszNewText = LocalLock(hNewLocal);
         if (hNewLocal == NULL || pszNewText == NULL)
             goto done;
@@ -176,10 +176,9 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
         *pszNewText = UNICODE_NULL;
         LocalUnlock(hNewLocal);
 
-        *phLocal = hNewLocal;
         *piEoln = EOLN_CRLF;
         *pencFile = ENCODING_DEFAULT;
-        return TRUE;
+        return hNewLocal;
     }
 
     hMapping = CreateFileMappingW(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
@@ -217,15 +216,14 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
     case ENCODING_UTF16BE:
     case ENCODING_UTF16LE:
     {
-        /* Re-allocate the buffer for EM_SETHANDLE */
+        /* Allocate the buffer for EM_SETHANDLE */
         pszText = (LPWSTR) &pBytes[dwPos];
         cchText = (dwSize - dwPos) / sizeof(WCHAR);
-        hNewLocal = LocalReAlloc(*phLocal, (cchText + 1) * sizeof(WCHAR), LMEM_MOVEABLE);
+        hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cchText + 1) * sizeof(WCHAR));
         pszNewText = LocalLock(hNewLocal);
         if (pszNewText == NULL)
             goto done;
 
-        *phLocal = hNewLocal;
         CopyMemory(pszNewText, pszText, cchText * sizeof(WCHAR));
 
         if (encFile == ENCODING_UTF16BE) /* big endian; Swap bytes */
@@ -246,32 +244,24 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
     case ENCODING_UTF8BOM:
     {
         iCodePage = ((encFile == ENCODING_UTF8 || encFile == ENCODING_UTF8BOM) ? CP_UTF8 : CP_ACP);
-
-        /* Get ready for ANSI-to-Wide conversion */
         cbContent = dwSize - dwPos;
-        cchText = 0;
-        if (cbContent > 0)
-        {
-            cchText = MultiByteToWideChar(iCodePage, 0, (LPCSTR)&pBytes[dwPos], (INT)cbContent, NULL, 0);
-            if (cchText == 0)
-                goto done;
-        }
 
-        /* Re-allocate the buffer for EM_SETHANDLE */
-        hNewLocal = LocalReAlloc(*phLocal, (cchText + 1) * sizeof(WCHAR), LMEM_MOVEABLE);
+        /* Allocate the buffer for EM_SETHANDLE */
+        hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cbContent + 1) * sizeof(WCHAR));
+        if (hNewLocal == NULL)
+            goto done;
         pszNewText = LocalLock(hNewLocal);
         if (!pszNewText)
             goto done;
-        *phLocal = hNewLocal;
 
-        /* Do ANSI-to-Wide conversion */
+        /* Do conversion */
+        cchText = 0;
         if (cbContent > 0)
         {
-            if (!MultiByteToWideChar(iCodePage, 0, (LPCSTR)&pBytes[dwPos], (INT)cbContent,
-                                     pszNewText, (INT)cchText))
-            {
+            cchText = MultiByteToWideChar(iCodePage, 0, (LPCSTR)&pBytes[dwPos], (INT)cbContent,
+                                          pszNewText, (INT)cbContent);
+            if (!cchText)
                 goto done;
-            }
         }
         break;
     }
@@ -281,7 +271,7 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
 
     pszNewText[cchText] = UNICODE_NULL;
 
-    if (!ProcessNewLinesAndNulls(phLocal, &pszNewText, &cchText, piEoln))
+    if (!ProcessNewLinesAndNulls(&hNewLocal, &pszNewText, &cchText, piEoln))
         goto done;
 
     *pencFile = encFile;
@@ -293,8 +283,10 @@ done:
     if (hMapping != INVALID_HANDLE_VALUE)
         CloseHandle(hMapping);
     if (pszNewText)
-        LocalUnlock(*phLocal);
-    return bSuccess;
+        LocalUnlock(hNewLocal);
+    if (!bSuccess && hNewLocal)
+        hNewLocal = LocalFree(hNewLocal);
+    return hNewLocal;
 }
 
 static BOOL WriteEncodedText(HANDLE hFile, LPCWSTR pszText, DWORD dwTextLen, ENCODING encFile)

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -261,7 +261,7 @@ ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln)
 
         /* Allocate the buffer for EM_SETHANDLE */
         hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cbContent + 1) * sizeof(WCHAR));
-        if (hNewLocal == NULL)
+        if (!hNewLocal)
             goto done;
 
         pszNewText = LocalLock(hNewLocal);

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -331,7 +331,10 @@ done:
     if (pszNewText)
         LocalUnlock(hNewLocal);
     if (!bSuccess && hNewLocal)
-        hNewLocal = LocalFree(hNewLocal);
+    {
+        LocalFree(hNewLocal);
+        hNewLocal = NULL;
+    }
     return hNewLocal;
 }
 

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -82,11 +82,10 @@ ReplaceNewLines(LPWSTR pszNew, SIZE_T cchNew, LPCWSTR pszOld, SIZE_T cchOld)
 static BOOL
 ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, SIZE_T *pcchText, EOLN *piEoln)
 {
-    SIZE_T ich, cchText = *pcchText, adwEolnCount[3] = { 0, 0, 0 }, cNonCRLFs;
+    SIZE_T ich, cchText = *pcchText, adwEolnCount[3] = { 0, 0, 0 }, cNonCRLFs, cchNew;
     LPWSTR pszText = *ppszText, pszNew;
     EOLN iEoln;
     BOOL bPrevCR = FALSE;
-    SIZE_T cchNew;
     HLOCAL hLocal;
 
     /* Replace '\0' with SPACE. Count newlines. */

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -220,68 +220,68 @@ ReadText(HANDLE hFile, ENCODING *pencFile, EOLN *piEoln)
 
     switch(encFile)
     {
-        case ENCODING_UTF16BE:
-        case ENCODING_UTF16LE:
+    case ENCODING_UTF16BE:
+    case ENCODING_UTF16LE:
+    {
+        /* Allocate the buffer for EM_SETHANDLE */
+        pszText = (LPWSTR)&pBytes[dwPos];
+        cchText = (dwSize - dwPos) / sizeof(WCHAR);
+        hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cchText + 1) * sizeof(WCHAR));
+        if (!hNewLocal)
+            goto done;
+
+        pszNewText = LocalLock(hNewLocal);
+        if (pszNewText == NULL)
+            goto done;
+
+        CopyMemory(pszNewText, pszText, cchText * sizeof(WCHAR));
+
+        if (encFile == ENCODING_UTF16BE) /* big endian; Swap bytes */
         {
-            /* Allocate the buffer for EM_SETHANDLE */
-            pszText = (LPWSTR)&pBytes[dwPos];
-            cchText = (dwSize - dwPos) / sizeof(WCHAR);
-            hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cchText + 1) * sizeof(WCHAR));
-            if (!hNewLocal)
-                goto done;
-
-            pszNewText = LocalLock(hNewLocal);
-            if (pszNewText == NULL)
-                goto done;
-
-            CopyMemory(pszNewText, pszText, cchText * sizeof(WCHAR));
-
-            if (encFile == ENCODING_UTF16BE) /* big endian; Swap bytes */
+            BYTE tmp, *pb = (LPBYTE)pszNewText;
+            for (i = 0; i < cchText * 2; i += 2)
             {
-                BYTE tmp, *pb = (LPBYTE)pszNewText;
-                for (i = 0; i < cchText * 2; i += 2)
-                {
-                    tmp = pb[i];
-                    pb[i] = pb[i + 1];
-                    pb[i + 1] = tmp;
-                }
+                tmp = pb[i];
+                pb[i] = pb[i + 1];
+                pb[i + 1] = tmp;
             }
-            break;
         }
+        break;
+    }
 
-        case ENCODING_ANSI:
-        case ENCODING_UTF8:
-        case ENCODING_UTF8BOM:
+    case ENCODING_ANSI:
+    case ENCODING_UTF8:
+    case ENCODING_UTF8BOM:
+    {
+        iCodePage = ((encFile == ENCODING_UTF8 || encFile == ENCODING_UTF8BOM)
+                     ? CP_UTF8 : CP_ACP);
+        cbContent = dwSize - dwPos;
+        if (cbContent > MAXLONG)
+            goto done;
+
+        /* Allocate the buffer for EM_SETHANDLE */
+        hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cbContent + 1) * sizeof(WCHAR));
+        if (hNewLocal == NULL)
+            goto done;
+
+        pszNewText = LocalLock(hNewLocal);
+        if (!pszNewText)
+            goto done;
+
+        /* Do conversion */
+        cchText = 0;
+        if (cbContent > 0)
         {
-            iCodePage = ((encFile == ENCODING_UTF8 || encFile == ENCODING_UTF8BOM)
-                         ? CP_UTF8 : CP_ACP);
-            cbContent = dwSize - dwPos;
-            if (cbContent > MAXLONG)
+            cchText = MultiByteToWideChar(iCodePage, 0,
+                                          (PCSTR)&pBytes[dwPos], (INT)cbContent,
+                                          pszNewText, (INT)cbContent);
+            if (!cchText)
                 goto done;
-
-            /* Allocate the buffer for EM_SETHANDLE */
-            hNewLocal = LocalAlloc(LMEM_MOVEABLE, (cbContent + 1) * sizeof(WCHAR));
-            if (hNewLocal == NULL)
-                goto done;
-
-            pszNewText = LocalLock(hNewLocal);
-            if (!pszNewText)
-                goto done;
-
-            /* Do conversion */
-            cchText = 0;
-            if (cbContent > 0)
-            {
-                cchText = MultiByteToWideChar(iCodePage, 0,
-                                              (PCSTR)&pBytes[dwPos], (INT)cbContent,
-                                              pszNewText, (INT)cbContent);
-                if (!cchText)
-                    goto done;
-            }
-            break;
         }
+        break;
+    }
 
-        DEFAULT_UNREACHABLE;
+    DEFAULT_UNREACHABLE;
     }
 
     pszNewText[cchText] = UNICODE_NULL;


### PR DESCRIPTION
## Purpose
Performance improvement. This PR will improve the speed of loading a large file.
JIRA issue: [CORE-19898](https://jira.reactos.org/browse/CORE-19898)

## Proposed changes

- Change 2 passes to 1 pass on ANSI/UTF-8, omitting precise buffer size calculation.
- Change `LocalReAlloc` calls to `LocalAlloc`.
- `ReadText` function now returns `HLOCAL` and no longer takes `phLocal`.

## Test and results

```c
    DWORD dw0 = GetTickCount();
    hNewLocal = ReadText(hFile, &Globals.encFile, &Globals.iEoln);
    DWORD dw1 = GetTickCount();
    printf("%ld\n", dw1 - dw0);
```

```txt
BEFORE:
437
437
437
438

AFTER:
375
375
360
343
```

## TODO

- [x] Do tests.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: