### PR TITLE
[PCI] Fix data type checking for the bus interface

### DIFF
--- a/drivers/bus/pci/pdo.c
+++ b/drivers/bus/pci/pdo.c
@@ -1036,7 +1036,7 @@ InterfaceBusSetBusData(
     DPRINT("InterfaceBusSetBusData(%p 0x%lx %p 0x%lx 0x%lx)\n",
            Context, DataType, Buffer, Offset, Length);
 
-    if (DataType != PCI_WHICHSPACE_CONFIG)
+    if (DataType != PCI_WHICHSPACE_CONFIG && DataType != PCIConfiguration)
     {
         DPRINT("Unknown DataType %lu\n", DataType);
         return 0;
@@ -1072,7 +1072,7 @@ InterfaceBusGetBusData(
     DPRINT("InterfaceBusGetBusData(%p 0x%lx %p 0x%lx 0x%lx) called\n",
            Context, DataType, Buffer, Offset, Length);
 
-    if (DataType != PCI_WHICHSPACE_CONFIG)
+    if (DataType != PCI_WHICHSPACE_CONFIG && DataType != PCIConfiguration)
     {
         DPRINT("Unknown DataType %lu\n", DataType);
         return 0;


### PR DESCRIPTION
## Purpose

Fixes MS `storport.sys` not being able to work with the `qla1xxx.sys` driver.

JIRA issue: [CORE-20545](https://jira.reactos.org/browse/CORE-20545) [CORE-13866](https://jira.reactos.org/browse/CORE-13866)

## Proposed changes

Storport miniport drivers use the `PCIConfiguration` value to access the PCI configuration space (see `StorPortGetBusData` and `StorPortSetBusDataByOffset`). I somehow doubt it's the correct fix though.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: