### PR TITLE
[NTOS:PNP] IopGetBusTypeGuidIndex(): Remove 1 unwanted ExFreePool()

### DIFF
--- a/ntoskrnl/io/pnpmgr/pnpmgr.c
+++ b/ntoskrnl/io/pnpmgr/pnpmgr.c
@@ -445,7 +445,6 @@ IopGetBusTypeGuidIndex(LPGUID BusTypeGuid)
         if (!NewList)
         {
             /* Fail */
-            ExFreePool(PnpBusTypeGuidList);
             goto Quickie;
         }
 


### PR DESCRIPTION
## Purpose

in a failure case.

JIRA issue: [CORE-12791](https://jira.reactos.org/browse/CORE-12791)

## Proposed changes

- Remove 1 unwanted ExFreePool()

## TODO

Agreed minimal fix. Extended rework postponed.