### PR TITLE
[CHKDSK][FMIFS] Improve chkdsk output fail message to include error code

### DIFF
--- a/base/system/chkdsk/chkdsk.c
+++ b/base/system/chkdsk/chkdsk.c
@@ -307,7 +307,11 @@ ChkdskCallback(
             status = (PBOOLEAN)Argument;
             if (*status == FALSE)
             {
-                ConResPuts(StdOut, IDS_CHKDSK_FAIL);
+                ConResPrintf(StdOut, IDS_CHKDSK_FAIL, Modifier);
+                if (Modifier == STATUS_DISK_CORRUPT_ERROR)
+                    ConResPuts(StdOut, IDS_RUN_AGAIN);
+                else
+                    ConPrintf(StdOut, L"\n");
                 Error = TRUE;
             }
             break;

--- a/base/system/chkdsk/lang/de-DE.rc
+++ b/base/system/chkdsk/lang/de-DE.rc
@@ -24,10 +24,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_VOLUME_IN_USE "Das Laufwerk ist in Benutzung und kann nicht gesperrt werden.\n"
-    IDS_CHKDSK_FAIL "Chkdsk konnte den Vorgang nicht erfolgreich ausführen.\n\n"
+    IDS_CHKDSK_FAIL "Chkdsk konnte den Vorgang nicht erfolgreich ausführen. Error: 0x%08X.\n"
     IDS_NO_ENTRY_POINT "FMIFS-Einstiegspunkte konnten nicht gefunden werden.\n\n"
     IDS_BAD_ARGUMENT "Unbekannte Option: %s\n"
     IDS_NO_CURRENT_DIR "Das aktuelle Verzeichnis konnte nicht abgerufen werden. Fehlercode: "
     IDS_NO_QUERY_VOL "Das Laufwerk konnte nicht abgefragt werden. Fehlercode: "
     IDS_VOLUME_IN_USE_PROC "Chkdsk konnte nicht ausgeführt werden, da das\nLaufwerk durch einen anderen Prozess in Benutzung ist.\n\n"
+    IDS_RUN_AGAIN "It may be possible to fix this by running chkdsk again.\n\n"
 END

--- a/base/system/chkdsk/lang/en-US.rc
+++ b/base/system/chkdsk/lang/en-US.rc
@@ -22,10 +22,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_VOLUME_IN_USE "Volume is in use and cannot be locked\n"
-    IDS_CHKDSK_FAIL "Chkdsk was unable to complete successfully.\n\n"
+    IDS_CHKDSK_FAIL "Chkdsk was unable to complete successfully. Error: 0x%08X.\n"
     IDS_NO_ENTRY_POINT "Could not located FMIFS entry points.\n\n"
     IDS_BAD_ARGUMENT "Unknown argument: %s\n"
     IDS_NO_CURRENT_DIR "Could not get current directory. Error code: "
     IDS_NO_QUERY_VOL "Could not query volume. Error code: "
     IDS_VOLUME_IN_USE_PROC "Chkdsk cannot run because the volume is in use by another process.\n\n"
+    IDS_RUN_AGAIN "It may be possible to fix this by running chkdsk again.\n\n"
 END

--- a/base/system/chkdsk/lang/fr-FR.rc
+++ b/base/system/chkdsk/lang/fr-FR.rc
@@ -22,10 +22,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_VOLUME_IN_USE "Le volume est en cours d'utilisation et ne peut pas être verrouillé\n"
-    IDS_CHKDSK_FAIL "Chkdsk n'a pas pu terminer avec succès.\n\n"
+    IDS_CHKDSK_FAIL "Chkdsk n'a pas pu terminer avec succès. Error: 0x%08X.\n"
     IDS_NO_ENTRY_POINT "Impossible de trouver les points d'entrée FMIFS.\n\n"
     IDS_BAD_ARGUMENT "Argument inconnu : %s\n"
     IDS_NO_CURRENT_DIR "Impossible de récupérer le répertoire courant. Code d'erreur : "
     IDS_NO_QUERY_VOL "Impossible de requête le volume. Code d'erreur : "
     IDS_VOLUME_IN_USE_PROC "Chkdsk ne peut pas s'exécuter car le volume est en cours d'utilisation par un autre processus.\n\n"
+    IDS_RUN_AGAIN "It may be possible to fix this by running chkdsk again.\n\n"
 END

--- a/base/system/chkdsk/lang/it-IT.rc
+++ b/base/system/chkdsk/lang/it-IT.rc
@@ -30,10 +30,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_VOLUME_IN_USE "Il volume è in uso e non può essere bloccato\n"
-    IDS_CHKDSK_FAIL "Chkdsk non è stato in grado di finire con successo.\n\n"
+    IDS_CHKDSK_FAIL "Chkdsk non è stato in grado di finire con successo. Error: 0x%08X.\n"
     IDS_NO_ENTRY_POINT "Impossibile trovare i punti d'ingresso FMIFS.\n\n"
     IDS_BAD_ARGUMENT "Argomento sconosciuto: %s\n"
     IDS_NO_CURRENT_DIR "Impossibile ottenere la directory corrente. Codice errore: "
     IDS_NO_QUERY_VOL "Impossibile interrogare il volume. Codice errore: "
     IDS_VOLUME_IN_USE_PROC "Impossibile eseguire Chkdsk perché il volume è in uso da un altro processo.\n\n"
+    IDS_RUN_AGAIN "It may be possible to fix this by running chkdsk again.\n\n"
 END

--- a/base/system/chkdsk/lang/pl-PL.rc
+++ b/base/system/chkdsk/lang/pl-PL.rc
@@ -22,10 +22,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_VOLUME_IN_USE "Wolumin jest w użyciu i nie może być zablokowany.\n"
-    IDS_CHKDSK_FAIL "Program Chkdsk nie mógł zakończyć się pomyślnie.\n\n"
+    IDS_CHKDSK_FAIL "Program Chkdsk nie mógł zakończyć się pomyślnie. Error: 0x%08X.\n"
     IDS_NO_ENTRY_POINT "Nie znaleziono punktów wejścia FMIFS.\n\n"
     IDS_BAD_ARGUMENT "Nieznany argument: %s\n"
     IDS_NO_CURRENT_DIR "Aktualna ścieżka jest nieosiągalna. Kod błedu: "
     IDS_NO_QUERY_VOL "Nie można wysłać kwerendy do woluminu. Kod błedu: "
     IDS_VOLUME_IN_USE_PROC "Program Chkdsk nie może działać, ponieważ wolumin jest używany przez inny proces.\n\n"
+    IDS_RUN_AGAIN "It may be possible to fix this by running chkdsk again.\n\n"
 END

--- a/base/system/chkdsk/lang/pt-PT.rc
+++ b/base/system/chkdsk/lang/pt-PT.rc
@@ -23,10 +23,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_VOLUME_IN_USE "O volume está em uso e não pode ser bloqueado\n"
-    IDS_CHKDSK_FAIL "O chkdsk não consegui terminar com sucesso.\n\n"
+    IDS_CHKDSK_FAIL "O chkdsk não consegui terminar com sucesso. Error: 0x%08X.\n"
     IDS_NO_ENTRY_POINT "O ponto de entrada FMIFS não foi encontrado.\n\n"
     IDS_BAD_ARGUMENT "Argumento desconhecido: %s\n"
     IDS_NO_CURRENT_DIR "Não foi possível obter o directório actual. Código de erro: "
     IDS_NO_QUERY_VOL "Não foi possível consultar o volume. Código de erro: "
     IDS_VOLUME_IN_USE_PROC "Chkdsk não pode ser executado porque o volume está em uso por outro processo.\n\n"
+    IDS_RUN_AGAIN "It may be possible to fix this by running chkdsk again.\n\n"
 END

--- a/base/system/chkdsk/lang/ro-RO.rc
+++ b/base/system/chkdsk/lang/ro-RO.rc
@@ -30,10 +30,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_VOLUME_IN_USE "Volumul este în uz și nu poate fi blocat\n"
-    IDS_CHKDSK_FAIL "Operația programului Chkdsk a eșuat.\n\n"
+    IDS_CHKDSK_FAIL "Operația programului Chkdsk a eșuat. Error: 0x%08X.\n"
     IDS_NO_ENTRY_POINT "Nu s-au putut găsi punctele de intrare FMIFS.\n\n"
     IDS_BAD_ARGUMENT "Argument necunoscut: %s\n"
     IDS_NO_CURRENT_DIR "Nu s-a putut găsi directorul respectiv. Cod de eroare: "
     IDS_NO_QUERY_VOL "Nu s-a putut interoga volumul. Cod de eroare: "
     IDS_VOLUME_IN_USE_PROC "Execuția Chkdsk a eșuat pentru că volumul este folosit de către un alt proces.\n\n"
+    IDS_RUN_AGAIN "It may be possible to fix this by running chkdsk again.\n\n"
 END

--- a/base/system/chkdsk/lang/ru-RU.rc
+++ b/base/system/chkdsk/lang/ru-RU.rc
@@ -23,10 +23,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_VOLUME_IN_USE "Этот том используется в данный момент и не может быть заблокирован\n"
-    IDS_CHKDSK_FAIL "Chkdsk завершил работу с ошибками.\n\n"
+    IDS_CHKDSK_FAIL "Chkdsk завершил работу с ошибками. Error: 0x%08X.\n"
     IDS_NO_ENTRY_POINT "Не удалось найти точки входа FMIFS.\n\n"
     IDS_BAD_ARGUMENT "Неизвестный аргумент: %s\n"
     IDS_NO_CURRENT_DIR "Не удалось получить текущую директорию. Код ошибки: "
     IDS_NO_QUERY_VOL "Не удалось запросить том. Код ошибки: "
     IDS_VOLUME_IN_USE_PROC "Chkdsk не может быть запущен, так как том занят другим процессом.\n\n"
+    IDS_RUN_AGAIN "It may be possible to fix this by running chkdsk again.\n\n"
 END

--- a/base/system/chkdsk/lang/tr-TR.rc
+++ b/base/system/chkdsk/lang/tr-TR.rc
@@ -24,10 +24,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_VOLUME_IN_USE "Bölüm kullanımda ve kilitlenmiyor.\n"
-    IDS_CHKDSK_FAIL "Chkdsk, başarıyla tamamlanamadı.\n\n"
+    IDS_CHKDSK_FAIL "Chkdsk, başarıyla tamamlanamadı. Error: 0x%08X.\n"
     IDS_NO_ENTRY_POINT "FMIFS giriş noktaların yerleri saptanamıyor.\n\n"
     IDS_BAD_ARGUMENT "Bilinmeyen argüman: %s\n"
     IDS_NO_CURRENT_DIR "Gerçerli dizin alınamıyor. Hata kodu: "
     IDS_NO_QUERY_VOL "Bölüm sorgulanamıyor. Hata kodu: "
     IDS_VOLUME_IN_USE_PROC "Chkdsk çalıştırılamıyor; çünkü, bölüm, bir başka işlem tarafından kullanılıyor.\n\n"
+    IDS_RUN_AGAIN "It may be possible to fix this by running chkdsk again.\n\n"
 END

--- a/base/system/chkdsk/lang/zh-CN.rc
+++ b/base/system/chkdsk/lang/zh-CN.rc
@@ -24,10 +24,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_VOLUME_IN_USE "卷正在被使用，无法锁定。\n"
-    IDS_CHKDSK_FAIL "Chkdsk 没有成功完成。\n\n"
+    IDS_CHKDSK_FAIL "Chkdsk 没有成功完成。 Error: 0x%08X.\n"
     IDS_NO_ENTRY_POINT "无法找到 FMIFS 入口点。\n\n"
     IDS_BAD_ARGUMENT "未知参数: %s\n"
     IDS_NO_CURRENT_DIR "无法获得当前目录。错误代码: "
     IDS_NO_QUERY_VOL "无法查询卷。错误代码: "
     IDS_VOLUME_IN_USE_PROC "Chkdsk 无法运行，因为该卷正在被另一个进程所使用。\n\n"
+    IDS_RUN_AGAIN "It may be possible to fix this by running chkdsk again.\n\n"
 END

--- a/base/system/chkdsk/lang/zh-TW.rc
+++ b/base/system/chkdsk/lang/zh-TW.rc
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * PROJECT:     ReactOS Disk Checking Utility
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Chinese (Traditional) resource file
@@ -30,10 +30,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_VOLUME_IN_USE "磁碟區正被使用，無法鎖定。\n"
-    IDS_CHKDSK_FAIL "Chkdsk 沒有成功完成。\n\n"
+    IDS_CHKDSK_FAIL "Chkdsk 沒有成功完成。 Error: 0x%08X.\n"
     IDS_NO_ENTRY_POINT "無法找到 FMIFS 進入點。\n\n"
     IDS_BAD_ARGUMENT "未知參數: %s\n"
     IDS_NO_CURRENT_DIR "無法獲得目前的目錄。錯誤碼: "
     IDS_NO_QUERY_VOL "無法查詢磁碟區。錯誤碼: "
     IDS_VOLUME_IN_USE_PROC "Chkdsk 無法執行，因為該磁碟區正被另一個處理程序所使用。\n\n"
+    IDS_RUN_AGAIN "It may be possible to fix this by running chkdsk again.\n\n"
 END

--- a/base/system/chkdsk/resource.h
+++ b/base/system/chkdsk/resource.h
@@ -14,5 +14,6 @@
 #define IDS_NO_CURRENT_DIR      204
 #define IDS_NO_QUERY_VOL        205
 #define IDS_VOLUME_IN_USE_PROC  206
+#define IDS_RUN_AGAIN           207
 
 /* EOF */

--- a/dll/win32/fmifs/chkdsk.c
+++ b/dll/win32/fmifs/chkdsk.c
@@ -89,7 +89,7 @@ Chkdsk(
 
 Quit:
     /* Report result */
-    Callback(DONE, 0, &Success);
+    Callback(DONE, Status, &Success);
 }
 
 /* EOF */


### PR DESCRIPTION
CORE-20573

## Purpose

_Improve chkdsk output when failing to complete successfully by adding returned error code._
_If the error returned is STATUS_DISK_CORRUPT_ERROR then display a message that running again may fix it._

JIRA issue: [CORE-20573](https://jira.reactos.org/browse/CORE-20573)

## Proposed changes

_Return status code from fmifs/chkdsk.c in the "modifier" parameter._
_Use the returned parameter to show error and advise if running again might fix this._

## Testbot runs (Filled in by Devs)

Nothing to test here. This code only runs on operator request.

## Chkdsk before PR:

<img width="1170" height="952" alt="16-2498-chkdsk-unable-to-complete-successfully" src="https://github.com/user-attachments/assets/9ca05542-3f4e-4cec-bf8d-ffbe0b7a30d3" />


## Output of chkdsk after PR:

<img width="1042" height="856" alt="chkdsk-show-errors-02a" src="https://github.com/user-attachments/assets/9438c3de-594c-4cd3-986f-1ddc6479b1b4" />
