### PR TITLE
[BOOTDATA] Add unattend.inf to livecd target

### DIFF
--- a/boot/bootdata/CMakeLists.txt
+++ b/boot/bootdata/CMakeLists.txt
@@ -55,6 +55,7 @@ add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/bootcd_regtest.ini DESTINATION root
 # Unattend
 add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/bootcd/unattend.inf DESTINATION reactos NO_CAB FOR bootcd)
 add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/bootcdregtest/unattend.inf DESTINATION reactos NO_CAB FOR regtest)
+add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/livecd/unattend.inf DESTINATION reactos NO_CAB FOR livecd)
 
 # LiveImage shortcuts
 macro(add_livecd_shortcut name app dest)

--- a/boot/bootdata/livecd/unattend.inf
+++ b/boot/bootdata/livecd/unattend.inf
@@ -9,3 +9,8 @@ UnattendSetupEnabled = no
 ; Set this option to automatically specify language in the language setup.
 ; See hivesys.inf for available languages.
 LocaleID = 409
+
+; Enable this section to enable the default ReactOS theme.
+;[Shell]
+;DefaultThemesOff = no
+;CustomDefaultThemeFile = "%WINDIR%\Resources\Themes\Lautus\lautus.msstyles"


### PR DESCRIPTION
## Purpose

Add unattend.inf to live environment. This is needed to set a default visual style for the live environment for releases.

## Proposed changes
- Add livecd unattend.inf to livecd target

## Testbot runs (Filled in by Devs)
N/A