### PR TITLE
[SETUPAPI] Fix the creation of symbolic link passed to SetupDiCreateDeviceInterfaceRegKeyW()

### DIFF
--- a/dll/win32/setupapi/devinst.c
+++ b/dll/win32/setupapi/devinst.c
@@ -2689,6 +2689,7 @@ HKEY WINAPI SetupDiCreateDeviceInterfaceRegKeyW(
         if (SymbolicLink[Index] == L'}' && SymbolicLink[Index + 1] == L'\\')
         {
             /* Found it */
+            SymbolicLink[Index + 1] = L'#';
             break;
         }
         /* Replace all '\' backslashes by '#' pounds in symbolic link */
@@ -2709,8 +2710,7 @@ HKEY WINAPI SetupDiCreateDeviceInterfaceRegKeyW(
         return INVALID_HANDLE_VALUE;
     }
 
-    ReferenceString[0] = L'#';
-    wcscpy(ReferenceString + 1, &SymbolicLink[Index + 2]); /* Skip first '\' backslash */
+    wcscpy(ReferenceString, &SymbolicLink[Index + 1]);
 
     /* Null-terminate symbolic link at the beginning of the reference part,
      * as we don't need a ref part in key name. */
@@ -2744,17 +2744,19 @@ HKEY WINAPI SetupDiCreateDeviceInterfaceRegKeyW(
     {
         if (InfHandle && InfSectionName)
         {
-            if (!SetupInstallFromInfSection(NULL /*FIXME */,
-                                            InfHandle,
-                                            InfSectionName,
-                                            SPINST_INIFILES | SPINST_REGISTRY | SPINST_INI2REG | SPINST_FILES | SPINST_BITREG | SPINST_REGSVR | SPINST_UNREGSVR | SPINST_PROFILEITEMS | SPINST_COPYINF,
-                                            hDevParamKey,
-                                            NULL,
-                                            0,
-                                            set->SelectedDevice->InstallParams.InstallMsgHandler,
-                                            set->SelectedDevice->InstallParams.InstallMsgHandlerContext,
-                                            INVALID_HANDLE_VALUE,
-                                            NULL))
+            if (!SetupInstallFromInfSectionW(NULL /*FIXME */,
+                                             InfHandle,
+                                             InfSectionName,
+                                             SPINST_INIFILES | SPINST_REGISTRY | SPINST_INI2REG |
+                                                 SPINST_FILES | SPINST_BITREG | SPINST_REGSVR |
+                                                 SPINST_UNREGSVR | SPINST_PROFILEITEMS | SPINST_COPYINF,
+                                             hDevParamKey,
+                                             NULL,
+                                             0,
+                                             set->SelectedDevice->InstallParams.InstallMsgHandler,
+                                             set->SelectedDevice->InstallParams.InstallMsgHandlerContext,
+                                             INVALID_HANDLE_VALUE,
+                                             NULL))
             {
                 RegCloseKey(hDevParamKey);
                 return INVALID_HANDLE_VALUE;

--- a/dll/win32/setupapi/interface.c
+++ b/dll/win32/setupapi/interface.c
@@ -301,34 +301,32 @@ CreateSymbolicLink(
     IN LPCWSTR ReferenceString,
     IN struct DeviceInfo *devInfo)
 {
-    DWORD Length, Index, Offset;
-    LPWSTR Key;
+    SIZE_T ActualLength, Length;
+    WCHAR GuidString[MAX_GUID_STRING_LEN];
+    LPWSTR SymbolicLink;
 
-    Length = wcslen(devInfo->instanceId) + 4 /* prepend ##?# */ + 41 /* #{GUID} + */ + 1 /* zero byte */;
+    Length = 4 + // "\\\\?\\"
+             wcslen(devInfo->instanceId) +
+             1 + (MAX_GUID_STRING_LEN - 1) + 1 + // "#{GUID}\\"
+             wcslen(ReferenceString) +
+             1; // UNICODE_NULL
 
-    Key = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, Length * sizeof(WCHAR));
-    if (!Key)
+    SymbolicLink = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, Length * sizeof(WCHAR));
+    if (!SymbolicLink)
         return NULL;
 
-    wcscpy(Key, L"##?#");
-    wcscat(Key, devInfo->instanceId);
+    pSetupStringFromGuid(InterfaceGuid, GuidString, ARRAYSIZE(GuidString));
 
-    for(Index = 4; Index < Length; Index++)
-    {
-        if (Key[Index] == L'\\')
-        {
-            Key[Index] = L'#';
-        }
-    }
+    ActualLength = swprintf(SymbolicLink,
+                            Length,
+                            L"\\\\?\\%s#%s\\%s",
+                            devInfo->instanceId,
+                            GuidString,
+                            ReferenceString);
+    ASSERT(ActualLength == Length - 1);
 
-    wcscat(Key, L"#");
-
-    Offset = wcslen(Key);
-    pSetupStringFromGuid(InterfaceGuid, Key + Offset, Length - Offset);
-
-    return Key;
+    return SymbolicLink;
 }
-
 
 static BOOL
 InstallOneInterface(


### PR DESCRIPTION
## Purpose

Fix the creation of symbolic link passed to `SetupDiCreateDeviceInterfaceRegKeyW()`.
This fixes regression with improper writing "CLSID" and "FriendlyName" values in "Device Parameters" subkey of device interfaces in Registry, because of reference key open failure, and therefore it also fixes detection of the audio device name in Sound Properties from Control Panel in particular.
Follow-up of #7703.

JIRA issue: [CORE-20603](https://jira.reactos.org/browse/CORE-20603)

## Proposed changes

- Create the actual symbolic link, instead of just instance key name (don't replace all `\` by `#` and don't cut reference string from it) inside `CreateSymbolicLink()` internal helper of `SetupDiInstallDeviceInterfaces()`, to pass it in `SetupDiCreateDeviceInterfaceRegKeyW()` inside `InstallOneInterface()` internal helper later.
- Fix handling the received symbolic link inside `SetupDiCreateDeviceInterfaceRegKeyW()` itself. Except it to be the fully unmodified one, instead of transformed to an instance key name.
- Additionally, change the `SetupInstallFromInfSection()` call to `SetupInstallFromInfSectionW()`, since it's actually called with Unicode parameters from Unicode version of `SetupDiCreateDeviceInterfaceRegKeyW()`. Otherwise, if to not precisely specify Unicode version call, it might call ANSI function instead and hence will obviously not work correctly because of that.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:

## Result

Before:
<img width="800" height="600" alt="0 4 16-dev-2538-gb205c04_1" src="https://github.com/user-attachments/assets/afe68079-b0ff-40c2-a702-641474fcf48b" />
<img width="800" height="600" alt="0 4 16-dev-2538-gb205c04_2" src="https://github.com/user-attachments/assets/9b617243-4f04-4320-a06c-0c4457b84f6b" />

Registry values are not written properly:
<img width="1152" height="864" alt="registry_values_before" src="https://github.com/user-attachments/assets/15b322e8-7c7c-4fbe-9969-1a815d7a4a89" />

After:
<img width="800" height="600" alt="0 4 16-dev-2537-g9a7f64a_1" src="https://github.com/user-attachments/assets/62fe219a-01ad-4cdd-9199-1dc259e5c1a8" />
<img width="800" height="600" alt="0 4 16-dev-2537-g9a7f64a_2" src="https://github.com/user-attachments/assets/950f9563-cca3-4df4-8a59-e717b077f191" />

Registry values are written properly again:
<img width="1152" height="864" alt="registry_values_after" src="https://github.com/user-attachments/assets/26f3a811-fa61-4e8c-9e16-20016772af89" />

As you can see from the screenshot above, mentioned regression is fixed with my changes. :smirk: 