### PR TITLE
[BOOTVID] Fix boundary check in the screen to buffer blit routine 

### DIFF
--- a/drivers/base/bootvid/i386/pc/vga.c
+++ b/drivers/base/bootvid/i386/pc/vga.c
@@ -370,6 +370,9 @@ VidScreenToBufferBlt(
     LeftDelta = Left & 7;
     RightDelta = 8 - LeftDelta;
 
+    /* Set Mode 0 */
+    ReadWriteMode(0);
+
     /* Calculate the pixel offset and convert the X distance into byte form */
     PixelOffset = Top * (SCREEN_WIDTH / 8) + (Left >> 3);
 
@@ -379,9 +382,6 @@ VidScreenToBufferBlt(
         /* Set the current pixel position and reset buffer loop variable */
         PixelPosition = (PUCHAR)(VgaBase + PixelOffset);
         i = Buffer;
-
-        /* Set Mode 0 */
-        ReadWriteMode(0);
 
         /* Set the current plane */
         __outpw(VGA_BASE_IO_PORT + GRAPH_ADDRESS_PORT, (Plane << 8) | IND_READ_MAP);

--- a/drivers/base/bootvid/i386/pc/vga.c
+++ b/drivers/base/bootvid/i386/pc/vga.c
@@ -45,7 +45,7 @@ const UCHAR PixelMask[8] =
     (1 << 1),
     (1 << 0),
 };
-static const ULONG lookup[16] =
+static const ULONG ReverseAndUnpackMonochromePixels[16] =
 {
     0x0000,
     0x0100,
@@ -337,17 +337,10 @@ VidScreenToBufferBlt(
     _In_ ULONG Height,
     _In_ ULONG Stride)
 {
-    ULONG Plane;
     ULONG LineStart, LineEnd, LineWidth;
-    ULONG LeftDelta, RightDelta;
-    ULONG PixelOffset;
-    PUCHAR PixelPosition;
-    PUCHAR k, i;
-    PULONG m;
-    UCHAR Value, Value2;
-    UCHAR a;
-    ULONG b;
-    ULONG x, y;
+    ULONG LeftShift, RightShift;
+    PUCHAR PixelPtr;
+    ULONG Plane, X, Y;
 
     /* Clear the destination buffer */
     RtlZeroMemory(Buffer, Height * Stride);
@@ -355,7 +348,11 @@ VidScreenToBufferBlt(
     if (Height == 0)
         return;
 
-    /* Calculate total distance to copy on X */
+    /*
+     * The VGA bootvid does not read pixels
+     * that do not fall into a byte block (i.e. Width % 8 != 0).
+     * This is by design.
+     */
     LineStart = Left / 8;
     LineEnd = (Left + Width - 1) / 8;
     if (LineStart > LineEnd)
@@ -366,66 +363,50 @@ VidScreenToBufferBlt(
     if (LineWidth == 0)
         return;
 
-    /* Calculate the 8-byte left and right deltas */
-    LeftDelta = Left & 7;
-    RightDelta = 8 - LeftDelta;
+    LeftShift = Left & 7;
+    RightShift = 8 - LeftShift;
 
-    /* Set Mode 0 */
+    /* Select read mode 0 */
     ReadWriteMode(0);
 
-    /* Calculate the pixel offset and convert the X distance into byte form */
-    PixelOffset = Top * (SCREEN_WIDTH / 8) + (Left >> 3);
-
-    /* Loop the 4 planes */
+    PixelPtr = (PUCHAR)(VgaBase + (Left / 8) + Top * (SCREEN_WIDTH / 8));
     for (Plane = 0; Plane < 4; ++Plane)
     {
-        /* Set the current pixel position and reset buffer loop variable */
-        PixelPosition = (PUCHAR)(VgaBase + PixelOffset);
-        i = Buffer;
+        PUCHAR OutputBuffer = Buffer;
+        PUCHAR PixelPosition = PixelPtr;
 
-        /* Set the current plane */
+        /* Select the current plane to read the pixels */
         __outpw(VGA_BASE_IO_PORT + GRAPH_ADDRESS_PORT, (Plane << 8) | IND_READ_MAP);
 
-        /* Start the outer Y height loop */
-        for (y = Height; y > 0; --y)
+        for (Y = 0; Y < Height; ++Y)
         {
-            /* Read the current value */
-            m = (PULONG)i;
-            Value = READ_REGISTER_UCHAR(PixelPosition);
+            PULONG Destination = (PULONG)OutputBuffer;
+            UCHAR CurrPixels;
+            PUCHAR NextPosition;
 
-            /* Set Pixel Position loop variable */
-            k = PixelPosition + 1;
+            CurrPixels = READ_REGISTER_UCHAR(PixelPosition);
+            NextPosition = PixelPosition;
 
-            /* Start the X inner loop */
-            for (x = LineWidth; x > 0; --x)
+            for (X = 0; X < LineWidth; ++X)
             {
-                /* Read the current value */
-                Value2 = READ_REGISTER_UCHAR(k);
+                UCHAR NextPixels, Px;
+                ULONG Result;
 
-                /* Increase pixel position */
-                k++;
+                NextPixels = READ_REGISTER_UCHAR(++NextPosition);
 
-                /* Do the blt */
-                a = Value2 >> (UCHAR)RightDelta;
-                a |= Value << (UCHAR)LeftDelta;
-                b = lookup[a & 0xF];
-                a >>= 4;
-                b <<= 16;
-                b |= lookup[a];
+                /* Store 8 pixels at once */
+                Px = CurrPixels << LeftShift;
+                Px |= NextPixels >> RightShift;
+                Result = ReverseAndUnpackMonochromePixels[Px >> 4];
+                Result |= ReverseAndUnpackMonochromePixels[Px & 0x0F] << 16;
 
-                /* Save new value to buffer */
-                *m |= (b << Plane);
+                *Destination++ |= Result << Plane;
 
-                /* Move to next destination location */
-                m++;
-
-                /* Write new value */
-                Value = Value2;
+                CurrPixels = NextPixels;
             }
 
-            /* Update pixel position */
             PixelPosition += (SCREEN_WIDTH / 8);
-            i += Stride;
+            OutputBuffer += Stride;
         }
     }
 }

--- a/drivers/base/bootvid/i386/pc/vga.c
+++ b/drivers/base/bootvid/i386/pc/vga.c
@@ -352,10 +352,19 @@ VidScreenToBufferBlt(
     /* Clear the destination buffer */
     RtlZeroMemory(Buffer, Height * Stride);
 
+    if (Height == 0)
+        return;
+
     /* Calculate total distance to copy on X */
     LineStart = Left / 8;
     LineEnd = (Left + Width - 1) / 8;
+    if (LineStart > LineEnd)
+        return;
     LineWidth = (LineEnd - LineStart) + 1;
+
+    /* This check helps the compiler to compile the inner loop into a do-while loop */
+    if (LineWidth == 0)
+        return;
 
     /* Calculate the 8-byte left and right deltas */
     LeftDelta = Left & 7;
@@ -387,35 +396,31 @@ VidScreenToBufferBlt(
             /* Set Pixel Position loop variable */
             k = PixelPosition + 1;
 
-            /* Check if we're still within bounds */
-            if (LineStart <= LineEnd)
+            /* Start the X inner loop */
+            for (x = LineWidth; x > 0; --x)
             {
-                /* Start the X inner loop */
-                for (x = LineWidth; x > 0; --x)
-                {
-                    /* Read the current value */
-                    Value2 = READ_REGISTER_UCHAR(k);
+                /* Read the current value */
+                Value2 = READ_REGISTER_UCHAR(k);
 
-                    /* Increase pixel position */
-                    k++;
+                /* Increase pixel position */
+                k++;
 
-                    /* Do the blt */
-                    a = Value2 >> (UCHAR)RightDelta;
-                    a |= Value << (UCHAR)LeftDelta;
-                    b = lookup[a & 0xF];
-                    a >>= 4;
-                    b <<= 16;
-                    b |= lookup[a];
+                /* Do the blt */
+                a = Value2 >> (UCHAR)RightDelta;
+                a |= Value << (UCHAR)LeftDelta;
+                b = lookup[a & 0xF];
+                a >>= 4;
+                b <<= 16;
+                b |= lookup[a];
 
-                    /* Save new value to buffer */
-                    *m |= (b << Plane);
+                /* Save new value to buffer */
+                *m |= (b << Plane);
 
-                    /* Move to next destination location */
-                    m++;
+                /* Move to next destination location */
+                m++;
 
-                    /* Write new value */
-                    Value = Value2;
-                }
+                /* Write new value */
+                Value = Value2;
             }
 
             /* Update pixel position */

--- a/drivers/base/bootvid/i386/pc/vga.c
+++ b/drivers/base/bootvid/i386/pc/vga.c
@@ -338,7 +338,7 @@ VidScreenToBufferBlt(
     _In_ ULONG Stride)
 {
     ULONG Plane;
-    ULONG XDistance;
+    ULONG LineStart, LineEnd, LineWidth;
     ULONG LeftDelta, RightDelta;
     ULONG PixelOffset;
     PUCHAR PixelPosition;
@@ -353,7 +353,9 @@ VidScreenToBufferBlt(
     RtlZeroMemory(Buffer, Height * Stride);
 
     /* Calculate total distance to copy on X */
-    XDistance = Left + Width - 1;
+    LineStart = Left / 8;
+    LineEnd = (Left + Width - 1) / 8;
+    LineWidth = (LineEnd - LineStart) + 1;
 
     /* Calculate the 8-byte left and right deltas */
     LeftDelta = Left & 7;
@@ -361,7 +363,6 @@ VidScreenToBufferBlt(
 
     /* Calculate the pixel offset and convert the X distance into byte form */
     PixelOffset = Top * (SCREEN_WIDTH / 8) + (Left >> 3);
-    XDistance >>= 3;
 
     /* Loop the 4 planes */
     for (Plane = 0; Plane < 4; ++Plane)
@@ -387,10 +388,10 @@ VidScreenToBufferBlt(
             k = PixelPosition + 1;
 
             /* Check if we're still within bounds */
-            if (Left <= XDistance)
+            if (LineStart <= LineEnd)
             {
                 /* Start the X inner loop */
-                for (x = (XDistance - Left) + 1; x > 0; --x)
+                for (x = LineWidth; x > 0; --x)
                 {
                     /* Read the current value */
                     Value2 = READ_REGISTER_UCHAR(k);


### PR DESCRIPTION
## Purpose

Fix a bug discovered while working on PC-98 bootvid and small refactoring for performance optimization. The boundary check was broken when left offset is larger than 70-90 pixels:
```
static UCHAR LocalBuffer[0x100];

memset(LocalBuffer, 0xCC, sizeof(LocalBuffer));
LocalBuffer[0] = 0x12;
LocalBuffer[1] = 0x34;
LocalBuffer[2] = 0x56;
LocalBuffer[3] = 0x78;

VidBufferToScreenBlt(LocalBuffer, 90, SCREEN_HEIGHT-6, 8, 1, 8);

memset(LocalBuffer, 0xCC, sizeof(LocalBuffer));

VidScreenToBufferBlt(LocalBuffer, 90, SCREEN_HEIGHT-6, 6, 1, 6);

DumpBuffer(LocalBuffer, 8);
```

DumpBuffer
**BEFORE:**
0000:   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xcc, 0xcc,
**AFTER:**
0000:   0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0xcc, 0xcc,

**BEFORE:**
<img width="640" height="480" alt="b" src="https://github.com/user-attachments/assets/771560e6-a417-4abd-9d99-0186ec7729f2" />

**AFTER:**
<img width="640" height="480" alt="a" src="https://github.com/user-attachments/assets/ec783f7a-d30e-46fa-a9a2-e1a45424fc9e" />


JIRA issue: none

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: