### PR TITLE
[PEFIXUP] Recalculate checksums for kernel-mode images

### DIFF
--- a/sdk/tools/pefixup.c
+++ b/sdk/tools/pefixup.c
@@ -521,8 +521,17 @@ int main(int argc, char **argv)
 
     if (!result)
     {
-        /* Success. Recalculate the checksum only if this is not a reproducible build file */
-        if (nt_header->OptionalHeader.CheckSum != 0)
+        int is_kernel_image = (mode == MODE_KERNELDRIVER ||
+                               mode == MODE_WDMDRIVER ||
+                               mode == MODE_KERNELDLL ||
+                               mode == MODE_KERNEL);
+
+        /*
+         * Preserve linker-produced zero checksums unless this is a kernel-mode
+         * image, where the NT loader requires a valid checksum. This fixes
+         * lld-built drivers, which otherwise keep the reproducible zero value.
+         */
+        if (nt_header->OptionalHeader.CheckSum != 0 || is_kernel_image)
             fix_checksum(buffer, len, nt_header);
 
         /* We could optimize by only writing the changed parts, but keep it simple for now */


### PR DESCRIPTION
lld can leave the PE checksum field as zero for reproducible output. That is acceptable for user-mode images, but Windows 7 rejects kernel-mode drivers whose checksum is missing or invalid.

This was found while validating Clang-built amd64 kmtest drivers against Windows 7: the same driver source built with GCC loaded, while the Clang/lld-built .sys failed with ERROR_BAD_EXE_FORMAT / 0xC1. Recalculating the PE checksum made the Clang-built driver load and the tests run correctly.

ReactOS checksum enforcement is simply disabled

this was tested with LLVM-MinGW (Clang) 21.1.7

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: