### PR TITLE
[WINESYNC] Remove reference to 'winfile' removed in 2023

### DIFF
--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -266,7 +266,6 @@ base/applications/write             # Synced to WineStaging-3.3
 base/services/rpcss                 # Synced to Wine-10.0
 base/system/expand                  # Synced to WineStaging-3.3
 base/system/msiexec                 # Synced to Wine-9.8
-modules/rosapps/applications/winfile # Autosync
 
 In addition the following libs, dlls and source files are mostly based on code ported
 from Winehq CVS. If you are looking to update something in these files


### PR DESCRIPTION
## Purpose

_Housekeeping only. Remove reference to 'winfile' from WINESYNC.txt._

JIRA issue: NONE

## Proposed changes

_Remove single line in WINESYNC.txt which references 'winfile'._
_This was removed from the ReactOS tree in 2023 by Victor Perevertkin._
_Reference commit: https://github.com/reactos/reactos/commit/b82353c._

## Testbot runs (Filled in by Devs)

None required. Only housekeeping for TXT file here.