### PR TITLE
[MSPAINT] Update cursor shape for brush and rubber

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -21,8 +21,8 @@ CStyledCursor::CreateStyledCursor(BrushStyle style, INT radius, COLORREF color, 
         return hCursor ? CopyCursor(hCursor) : NULL;
     }
 
-    const INT aim1 = 6, aim2 = aim1 - 2;
-    const INT width = diameter + 2 * aim1, height = diameter + 2 * aim1;
+    const INT crosshair1 = 6, crosshair2 = crosshair1 - 2;
+    const INT width = diameter + 2 * crosshair1, height = diameter + 2 * crosshair1;
     const DWORD hotX = width / 2, hotY = height / 2;
 
     HDC hdcScreen = ::GetDC(NULL);
@@ -49,15 +49,15 @@ CStyledCursor::CreateStyledCursor(BrushStyle style, INT radius, COLORREF color, 
 
         if (!is_rubber)
         {
-            // Draw aim with white pen
+            // Draw crosshair with white pen
             ::SelectObject(hdcMem, (HPEN)::GetStockObject(WHITE_PEN));
             ::MoveToEx(hdcMem, 0, hotY, NULL);
-            ::LineTo(hdcMem, aim2, hotY);
-            ::MoveToEx(hdcMem, width - aim2, hotY, NULL);
+            ::LineTo(hdcMem, crosshair2, hotY);
+            ::MoveToEx(hdcMem, width - crosshair2, hotY, NULL);
             ::LineTo(hdcMem, width, hotY);
             ::MoveToEx(hdcMem, hotX, 0, NULL);
-            ::LineTo(hdcMem, hotX, aim2);
-            ::MoveToEx(hdcMem, hotX, height - aim2, NULL);
+            ::LineTo(hdcMem, hotX, crosshair2);
+            ::MoveToEx(hdcMem, hotX, height - crosshair2, NULL);
             ::LineTo(hdcMem, hotX, height);
         }
 
@@ -91,15 +91,15 @@ CStyledCursor::CreateStyledCursor(BrushStyle style, INT radius, COLORREF color, 
         }
         else
         {
-            // Draw aim with white pen
+            // Draw crosshair with white pen
             ::SelectObject(hdcMem, (HPEN)::GetStockObject(WHITE_PEN));
             ::MoveToEx(hdcMem, 0, hotY, NULL);
-            ::LineTo(hdcMem, aim2, hotY);
-            ::MoveToEx(hdcMem, width - aim2, hotY, NULL);
+            ::LineTo(hdcMem, crosshair2, hotY);
+            ::MoveToEx(hdcMem, width - crosshair2, hotY, NULL);
             ::LineTo(hdcMem, width, hotY);
             ::MoveToEx(hdcMem, hotX, 0, NULL);
-            ::LineTo(hdcMem, hotX, aim2);
-            ::MoveToEx(hdcMem, hotX, height - aim2, NULL);
+            ::LineTo(hdcMem, hotX, crosshair2);
+            ::MoveToEx(hdcMem, hotX, height - crosshair2, NULL);
             ::LineTo(hdcMem, hotX, height);
         }
 
@@ -122,21 +122,6 @@ CStyledCursor::CreateStyledCursor(BrushStyle style, INT radius, COLORREF color, 
     ::DeleteObject(hbmColor);
 
     return hCursor;
-}
-
-CStyledCursor::CStyledCursor()
-    : m_hCursor(NULL)
-    , m_style(BrushStyleRound)
-    , m_radius(0)
-    , m_color(CLR_INVALID)
-    , m_is_rubber(FALSE)
-{
-}
-
-CStyledCursor::~CStyledCursor()
-{
-    if (m_hCursor)
-        ::DestroyCursor(m_hCursor);
 }
 
 void CStyledCursor::SetStyle(BrushStyle style, INT radius, COLORREF color, BOOL is_rubber)
@@ -791,8 +776,7 @@ LRESULT CCanvasWindow::OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
             {
                 m_hRubberCursor.SetStyle(BrushStyleSquare, toolsModel.GetRubberRadius(),
                                          paletteModel.GetBgColor(), TRUE);
-                if (m_hRubberCursor)
-                    ::SetCursor(m_hRubberCursor);
+                m_hRubberCursor.SetCursor();
                 break;
             }
             case TOOL_BRUSH:
@@ -800,8 +784,7 @@ LRESULT CCanvasWindow::OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
                 m_hBrushCursor.SetStyle(toolsModel.GetBrushStyle(),
                                         toolsModel.GetBrushWidth() / 2,
                                         paletteModel.GetFgColor(), FALSE);
-                if (m_hBrushCursor)
-                    ::SetCursor(m_hBrushCursor);
+                m_hBrushCursor.SetCursor();
                 break;
             }
             default:

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -11,82 +11,11 @@ CCanvasWindow canvasWindow;
 
 /* FUNCTIONS ********************************************************/
 
-static HCURSOR CreateRubberCursor(INT diameter, COLORREF bgColor)
+HCURSOR
+CStyledCursor::CreateStyledCursor(BrushStyle style, INT radius, COLORREF color, BOOL is_rubber)
 {
+    const INT diameter = 2 * radius;
     if (diameter <= 2)
-    {
-        HCURSOR hCursor = ::LoadCursor(NULL, IDC_CROSS);
-        return hCursor ? CopyCursor(hCursor) : NULL;
-    }
-
-    const INT width = diameter, height = diameter;
-    const DWORD hotX = width / 2, hotY = height / 2;
-
-    HDC hdcScreen = ::GetDC(NULL);
-    if (!hdcScreen)
-        return NULL;
-    HDC hdcMem = ::CreateCompatibleDC(hdcScreen);
-    if (!hdcMem)
-    {
-        ::ReleaseDC(NULL, hdcScreen);
-        return NULL;
-    }
-
-    RECT rc = { 0, 0, width, height };
-
-    // Create the AND mask bitmap. This must be monochrome (1bpp):
-    // white bits are transparent, black bits are opaque.
-    HBITMAP hbmMask = ::CreateBitmap(width, height, 1, 1, NULL);
-    if (hbmMask)
-    {
-        HBITMAP hbmOld = (HBITMAP)::SelectObject(hdcMem, hbmMask);
-        ::FillRect(hdcMem, &rc, (HBRUSH)::GetStockObject(BLACK_BRUSH)); // Entire opaque
-        ::SelectObject(hdcMem, hbmOld);
-    }
-
-    // Create the color (XOR) bitmap
-    HBITMAP hbmColor = ::CreateCompatibleBitmap(hdcScreen, width, height);
-    if (hbmColor)
-    {
-        HBITMAP hbmOld = (HBITMAP)::SelectObject(hdcMem, hbmColor);
-
-        HBRUSH hBrush = CreateSolidBrush(bgColor);
-        if (hBrush)
-        {
-            INT sum = GetRValue(bgColor) + GetGValue(bgColor) + GetBValue(bgColor);
-            COLORREF rgbPenColor = (sum >= 255 / 3 / 2) ? RGB(0, 0, 0) : RGB(255, 255, 255);
-            HPEN hPen = CreatePen(PS_SOLID, 1, rgbPenColor);
-            if (hPen)
-            {
-                HGDIOBJ hbrOld = ::SelectObject(hdcMem, hBrush);
-                HGDIOBJ hPenOld = ::SelectObject(hdcMem, hPen);
-                ::Rectangle(hdcMem, rc.left, rc.top, rc.right, rc.bottom);
-                ::SelectObject(hdcMem, hPenOld);
-                ::SelectObject(hdcMem, hbrOld);
-
-                ::DeleteObject(hPen);
-            }
-            ::DeleteObject(hBrush);
-        }
-
-        ::SelectObject(hdcMem, hbmOld);
-    }
-
-    ::ReleaseDC(NULL, hdcScreen);
-    ::DeleteDC(hdcMem);
-
-    ICONINFO ii = { FALSE, hotX, hotY, hbmMask, hbmColor };
-    HCURSOR hCursor = (HCURSOR)::CreateIconIndirect(&ii);
-
-    ::DeleteObject(hbmMask);
-    ::DeleteObject(hbmColor);
-
-    return hCursor;
-}
-
-static HCURSOR CreateBrushCursor(BrushStyle style, INT diameter, COLORREF fgColor)
-{
-    if (diameter <= 1)
     {
         HCURSOR hCursor = ::LoadCursor(NULL, IDC_CROSS);
         return hCursor ? CopyCursor(hCursor) : NULL;
@@ -118,19 +47,28 @@ static HCURSOR CreateBrushCursor(BrushStyle style, INT diameter, COLORREF fgColo
         // Fill with white brush
         ::FillRect(hdcMem, &rc, (HBRUSH)::GetStockObject(WHITE_BRUSH));
 
-        // Draw aim with white pen
-        ::SelectObject(hdcMem, (HPEN)::GetStockObject(WHITE_PEN));
-        ::MoveToEx(hdcMem, 0, hotY, NULL);
-        ::LineTo(hdcMem, aim2, hotY);
-        ::MoveToEx(hdcMem, width - aim2, hotY, NULL);
-        ::LineTo(hdcMem, width, hotY);
-        ::MoveToEx(hdcMem, hotX, 0, NULL);
-        ::LineTo(hdcMem, hotX, aim2);
-        ::MoveToEx(hdcMem, hotX, height - aim2, NULL);
-        ::LineTo(hdcMem, hotX, height);
+        if (!is_rubber)
+        {
+            // Draw aim with white pen
+            ::SelectObject(hdcMem, (HPEN)::GetStockObject(WHITE_PEN));
+            ::MoveToEx(hdcMem, 0, hotY, NULL);
+            ::LineTo(hdcMem, aim2, hotY);
+            ::MoveToEx(hdcMem, width - aim2, hotY, NULL);
+            ::LineTo(hdcMem, width, hotY);
+            ::MoveToEx(hdcMem, hotX, 0, NULL);
+            ::LineTo(hdcMem, hotX, aim2);
+            ::MoveToEx(hdcMem, hotX, height - aim2, NULL);
+            ::LineTo(hdcMem, hotX, height);
+        }
 
-        // Draw brush by black
-        Brush(hdcMem, hotX, hotY, hotX, hotY, RGB(0, 0, 0), style, diameter);
+        // Draw brush or erase by black
+        if (is_rubber)
+            Erase(hdcMem, hotX, hotY, hotX, hotY, RGB(0, 0, 0), radius + 1);
+        else
+            Brush(hdcMem, hotX, hotY, hotX, hotY, RGB(0, 0, 0), style, diameter);
+
+        if (is_rubber)
+            InflateRect(&rc, -1, -1);
 
         ::SelectObject(hdcMem, hbmOld);
     }
@@ -144,19 +82,32 @@ static HCURSOR CreateBrushCursor(BrushStyle style, INT diameter, COLORREF fgColo
         // Fill with black brush
         ::FillRect(hdcMem, &rc, (HBRUSH)::GetStockObject(BLACK_BRUSH));
 
-        // Draw aim with white pen
-        ::SelectObject(hdcMem, (HPEN)::GetStockObject(WHITE_PEN));
-        ::MoveToEx(hdcMem, 0, hotY, NULL);
-        ::LineTo(hdcMem, aim2, hotY);
-        ::MoveToEx(hdcMem, width - aim2, hotY, NULL);
-        ::LineTo(hdcMem, width, hotY);
-        ::MoveToEx(hdcMem, hotX, 0, NULL);
-        ::LineTo(hdcMem, hotX, aim2);
-        ::MoveToEx(hdcMem, hotX, height - aim2, NULL);
-        ::LineTo(hdcMem, hotX, height);
+        if (is_rubber)
+        {
+            // Draw for rubber border
+            INT avg = (GetRValue(color) + GetGValue(color) + GetBValue(color)) / 3;
+            COLORREF color2 = (avg > 255 / 2) ? RGB(0, 0, 0) : RGB(255, 255, 255);
+            Erase(hdcMem, hotX, hotY, hotX, hotY, color2, radius + 1);
+        }
+        else
+        {
+            // Draw aim with white pen
+            ::SelectObject(hdcMem, (HPEN)::GetStockObject(WHITE_PEN));
+            ::MoveToEx(hdcMem, 0, hotY, NULL);
+            ::LineTo(hdcMem, aim2, hotY);
+            ::MoveToEx(hdcMem, width - aim2, hotY, NULL);
+            ::LineTo(hdcMem, width, hotY);
+            ::MoveToEx(hdcMem, hotX, 0, NULL);
+            ::LineTo(hdcMem, hotX, aim2);
+            ::MoveToEx(hdcMem, hotX, height - aim2, NULL);
+            ::LineTo(hdcMem, hotX, height);
+        }
 
-        // Draw brush with foreground color
-        Brush(hdcMem, hotX, hotY, hotX, hotY, fgColor, style, diameter);
+        // Draw brush or erase with color
+        if (is_rubber)
+            Erase(hdcMem, hotX, hotY, hotX, hotY, color, radius);
+        else
+            Brush(hdcMem, hotX, hotY, hotX, hotY, color, style, diameter);
 
         ::SelectObject(hdcMem, hbmOld);
     }
@@ -173,11 +124,42 @@ static HCURSOR CreateBrushCursor(BrushStyle style, INT diameter, COLORREF fgColo
     return hCursor;
 }
 
+CStyledCursor::CStyledCursor()
+    : m_hCursor(NULL)
+    , m_style(BrushStyleRound)
+    , m_radius(0)
+    , m_color(CLR_INVALID)
+    , m_is_rubber(FALSE)
+{
+}
+
+CStyledCursor::~CStyledCursor()
+{
+    if (m_hCursor)
+        ::DestroyCursor(m_hCursor);
+}
+
+void CStyledCursor::SetStyle(BrushStyle style, INT radius, COLORREF color, BOOL is_rubber)
+{
+    if (m_hCursor && m_style == style && m_radius == radius && m_color == color &&
+        m_is_rubber == is_rubber)
+    {
+        return;
+    }
+
+    if (m_hCursor)
+        DestroyCursor(m_hCursor);
+
+    m_hCursor = CreateStyledCursor(style, radius, color, is_rubber);
+    m_style = style;
+    m_radius = radius;
+    m_color = color;
+    m_is_rubber = is_rubber;
+}
+
 CCanvasWindow::CCanvasWindow()
     : m_drawing(FALSE)
     , m_hitCanvasSizeBox(HIT_NONE)
-    , m_hBrushCursor(NULL)
-    , m_hRubberCursor(NULL)
     , m_ptOrig { -1, -1 }
 {
     m_rcResizing.SetRectEmpty();
@@ -185,10 +167,6 @@ CCanvasWindow::CCanvasWindow()
 
 CCanvasWindow::~CCanvasWindow()
 {
-    if (m_hBrushCursor)
-        DestroyCursor(m_hBrushCursor);
-    if (m_hRubberCursor)
-        DestroyCursor(m_hRubberCursor);
 }
 
 RECT CCanvasWindow::GetBaseRect()
@@ -811,42 +789,17 @@ LRESULT CCanvasWindow::OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
                 break;
             case TOOL_RUBBER:
             {
-                // Cached for speed
-                static INT s_rubberRadius = -1;
-                static COLORREF s_bgColor;
-                INT rubberRadius = toolsModel.GetRubberRadius();
-                COLORREF bgColor = paletteModel.GetBgColor();
-                if (!m_hRubberCursor || s_rubberRadius != rubberRadius || s_bgColor != bgColor)
-                {
-                    if (m_hRubberCursor)
-                        DestroyCursor(m_hRubberCursor);
-                    m_hRubberCursor = CreateRubberCursor(2 * rubberRadius, bgColor);
-                    s_rubberRadius = rubberRadius;
-                    s_bgColor = bgColor;
-                }
+                m_hRubberCursor.SetStyle(BrushStyleSquare, toolsModel.GetRubberRadius(),
+                                         paletteModel.GetBgColor(), TRUE);
                 if (m_hRubberCursor)
                     ::SetCursor(m_hRubberCursor);
                 break;
             }
             case TOOL_BRUSH:
             {
-                // Cached for speed
-                static INT s_brushWidth = -1;
-                static BrushStyle s_brushStyle;
-                static COLORREF s_fgColor;
-                BrushStyle brushStyle = toolsModel.GetBrushStyle();
-                INT brushWidth = toolsModel.GetBrushWidth();
-                COLORREF fgColor = paletteModel.GetFgColor();
-                if (!m_hBrushCursor || s_brushWidth != brushWidth || s_brushStyle != brushStyle ||
-                    s_fgColor != fgColor)
-                {
-                    if (m_hBrushCursor)
-                        DestroyCursor(m_hBrushCursor);
-                    m_hBrushCursor = CreateBrushCursor(brushStyle, brushWidth, fgColor);
-                    s_brushWidth = brushWidth;
-                    s_brushStyle = brushStyle;
-                    s_fgColor = fgColor;
-                }
+                m_hBrushCursor.SetStyle(toolsModel.GetBrushStyle(),
+                                        toolsModel.GetBrushWidth() / 2,
+                                        paletteModel.GetFgColor(), FALSE);
                 if (m_hBrushCursor)
                     ::SetCursor(m_hBrushCursor);
                 break;

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -11,7 +11,7 @@ CCanvasWindow canvasWindow;
 
 /* FUNCTIONS ********************************************************/
 
-static HCURSOR CreateRubberCursor(INT diameter)
+static HCURSOR CreateRubberCursor(INT diameter, COLORREF bgColor)
 {
     if (diameter <= 2)
     {
@@ -50,9 +50,20 @@ static HCURSOR CreateRubberCursor(INT diameter)
     {
         HBITMAP hbmOld = (HBITMAP)::SelectObject(hdcMem, hbmColor);
 
-        ::SelectObject(hdcMem, (HBRUSH)::GetStockObject(WHITE_BRUSH));
-        ::SelectObject(hdcMem, (HPEN)::GetStockObject(BLACK_PEN));
+        HBRUSH hBrush = CreateSolidBrush(bgColor);
+        INT sum = GetRValue(bgColor) + GetGValue(bgColor) + GetBValue(bgColor);
+        COLORREF rgbPenColor = (sum >= 255 / 3 / 2) ? RGB(0, 0, 0) : RGB(255, 255, 255);
+
+        HPEN hPen = CreatePen(PS_SOLID, 1, rgbPenColor);
+
+        HGDIOBJ hbrOld = ::SelectObject(hdcMem, hBrush);
+        HGDIOBJ hPenOld = ::SelectObject(hdcMem, hPen);
         ::Rectangle(hdcMem, rc.left, rc.top, rc.right, rc.bottom);
+        ::SelectObject(hdcMem, hPenOld);
+        ::SelectObject(hdcMem, hbrOld);
+
+        ::DeleteObject(hPen);
+        ::DeleteObject(hBrush);
 
         ::SelectObject(hdcMem, hbmOld);
     }
@@ -798,13 +809,16 @@ LRESULT CCanvasWindow::OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
             {
                 // Cached for speed
                 static INT s_rubberRadius = -1;
+                static COLORREF s_bgColor;
                 INT rubberRadius = toolsModel.GetRubberRadius();
-                if (!m_hRubberCursor || s_rubberRadius != rubberRadius)
+                COLORREF bgColor = paletteModel.GetBgColor();
+                if (!m_hRubberCursor || s_rubberRadius != rubberRadius || s_bgColor != bgColor)
                 {
                     if (m_hRubberCursor)
                         DestroyCursor(m_hRubberCursor);
-                    m_hRubberCursor = CreateRubberCursor(2 * rubberRadius);
+                    m_hRubberCursor = CreateRubberCursor(2 * rubberRadius, bgColor);
                     s_rubberRadius = rubberRadius;
+                    s_bgColor = bgColor;
                 }
                 if (m_hRubberCursor)
                     ::SetCursor(m_hRubberCursor);

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -11,9 +11,158 @@ CCanvasWindow canvasWindow;
 
 /* FUNCTIONS ********************************************************/
 
+static HCURSOR CreateRubberCursor(INT diameter)
+{
+    if (diameter <= 2)
+    {
+        HCURSOR hCursor = ::LoadCursor(NULL, IDC_CROSS);
+        return hCursor ? CopyCursor(hCursor) : NULL;
+    }
+
+    const INT width = diameter, height = diameter;
+    const DWORD hotX = width / 2, hotY = height / 2;
+
+    HDC hdcScreen = ::GetDC(NULL);
+    if (!hdcScreen)
+        return NULL;
+    HDC hdcMem = ::CreateCompatibleDC(hdcScreen);
+    if (!hdcMem)
+    {
+        ::ReleaseDC(NULL, hdcScreen);
+        return NULL;
+    }
+
+    RECT rc = { 0, 0, width, height };
+
+    // Create the AND mask bitmap. This must be monochrome (1bpp):
+    // white bits are transparent, black bits are opaque.
+    HBITMAP hbmMask = ::CreateBitmap(width, height, 1, 1, NULL);
+    if (hbmMask)
+    {
+        HBITMAP hbmOld = (HBITMAP)::SelectObject(hdcMem, hbmMask);
+        ::FillRect(hdcMem, &rc, (HBRUSH)::GetStockObject(BLACK_BRUSH)); // Entire opaque
+        ::SelectObject(hdcMem, hbmOld);
+    }
+
+    // Create the color (XOR) bitmap
+    HBITMAP hbmColor = ::CreateCompatibleBitmap(hdcScreen, width, height);
+    if (hbmColor)
+    {
+        HBITMAP hbmOld = (HBITMAP)::SelectObject(hdcMem, hbmColor);
+
+        ::SelectObject(hdcMem, (HBRUSH)::GetStockObject(WHITE_BRUSH));
+        ::SelectObject(hdcMem, (HPEN)::GetStockObject(BLACK_PEN));
+        ::Rectangle(hdcMem, rc.left, rc.top, rc.right, rc.bottom);
+
+        ::SelectObject(hdcMem, hbmOld);
+    }
+
+    ::ReleaseDC(NULL, hdcScreen);
+    ::DeleteDC(hdcMem);
+
+    ICONINFO ii = { FALSE, hotX, hotY, hbmMask, hbmColor };
+    HCURSOR hCursor = (HCURSOR)::CreateIconIndirect(&ii);
+
+    ::DeleteObject(hbmMask);
+    ::DeleteObject(hbmColor);
+
+    return hCursor;
+}
+
+static HCURSOR CreateBrushCursor(BrushStyle style, INT diameter, COLORREF fgColor)
+{
+    if (diameter <= 1)
+    {
+        HCURSOR hCursor = ::LoadCursor(NULL, IDC_CROSS);
+        return hCursor ? CopyCursor(hCursor) : NULL;
+    }
+
+    const INT aim1 = 6, aim2 = aim1 - 2;
+    const INT width = diameter + 2 * aim1, height = diameter + 2 * aim1;
+    const DWORD hotX = width / 2, hotY = height / 2;
+
+    HDC hdcScreen = ::GetDC(NULL);
+    if (!hdcScreen)
+        return NULL;
+    HDC hdcMem = ::CreateCompatibleDC(hdcScreen);
+    if (!hdcMem)
+    {
+        ::ReleaseDC(NULL, hdcScreen);
+        return NULL;
+    }
+
+    RECT rc = { 0, 0, width, height };
+
+    // Create the AND mask bitmap. This must be monochrome (1bpp):
+    // white bits are transparent, black bits are opaque.
+    HBITMAP hbmMask = ::CreateBitmap(width, height, 1, 1, NULL);
+    if (hbmMask)
+    {
+        HBITMAP hbmOld = (HBITMAP)::SelectObject(hdcMem, hbmMask);
+
+        // Fill with white brush
+        ::FillRect(hdcMem, &rc, (HBRUSH)::GetStockObject(WHITE_BRUSH));
+
+        // Draw aim with white pen
+        ::SelectObject(hdcMem, (HPEN)::GetStockObject(WHITE_PEN));
+        ::MoveToEx(hdcMem, 0, hotY, NULL);
+        ::LineTo(hdcMem, aim2, hotY);
+        ::MoveToEx(hdcMem, width - aim2, hotY, NULL);
+        ::LineTo(hdcMem, width, hotY);
+        ::MoveToEx(hdcMem, hotX, 0, NULL);
+        ::LineTo(hdcMem, hotX, aim2);
+        ::MoveToEx(hdcMem, hotX, height - aim2, NULL);
+        ::LineTo(hdcMem, hotX, height);
+
+        // Draw brush by black
+        Brush(hdcMem, hotX, hotY, hotX, hotY, RGB(0, 0, 0), style, diameter);
+
+        ::SelectObject(hdcMem, hbmOld);
+    }
+
+    // Create the color (XOR) bitmap
+    HBITMAP hbmColor = ::CreateCompatibleBitmap(hdcScreen, width, height);
+    if (hbmColor)
+    {
+        HBITMAP hbmOld = (HBITMAP)::SelectObject(hdcMem, hbmColor);
+
+        // Fill with black brush
+        ::FillRect(hdcMem, &rc, (HBRUSH)::GetStockObject(BLACK_BRUSH));
+
+        // Draw aim with white pen
+        ::SelectObject(hdcMem, (HPEN)::GetStockObject(WHITE_PEN));
+        ::MoveToEx(hdcMem, 0, hotY, NULL);
+        ::LineTo(hdcMem, aim2, hotY);
+        ::MoveToEx(hdcMem, width - aim2, hotY, NULL);
+        ::LineTo(hdcMem, width, hotY);
+        ::MoveToEx(hdcMem, hotX, 0, NULL);
+        ::LineTo(hdcMem, hotX, aim2);
+        ::MoveToEx(hdcMem, hotX, height - aim2, NULL);
+        ::LineTo(hdcMem, hotX, height);
+
+        // Draw brush with foreground color
+        Brush(hdcMem, hotX, hotY, hotX, hotY, fgColor, style, diameter);
+
+        ::SelectObject(hdcMem, hbmOld);
+    }
+
+    ::ReleaseDC(NULL, hdcScreen);
+    ::DeleteDC(hdcMem);
+
+    ICONINFO ii = { FALSE, hotX, hotY, hbmMask, hbmColor };
+    HCURSOR hCursor = (HCURSOR)::CreateIconIndirect(&ii);
+
+    ::DeleteObject(hbmMask);
+    ::DeleteObject(hbmColor);
+
+    return hCursor;
+}
+
 CCanvasWindow::CCanvasWindow()
     : m_drawing(FALSE)
     , m_hitCanvasSizeBox(HIT_NONE)
+    , m_hBrushCursor(NULL)
+    , m_hRubberCursor(NULL)
     , m_ptOrig { -1, -1 }
 {
     m_rcResizing.SetRectEmpty();
@@ -21,6 +170,10 @@ CCanvasWindow::CCanvasWindow()
 
 CCanvasWindow::~CCanvasWindow()
 {
+    if (m_hBrushCursor)
+        DestroyCursor(m_hBrushCursor);
+    if (m_hRubberCursor)
+        DestroyCursor(m_hRubberCursor);
 }
 
 RECT CCanvasWindow::GetBaseRect()
@@ -641,6 +794,45 @@ LRESULT CCanvasWindow::OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
             case TOOL_AIRBRUSH:
                 ::SetCursor(::LoadCursorW(g_hinstExe, MAKEINTRESOURCEW(IDC_AIRBRUSH)));
                 break;
+            case TOOL_RUBBER:
+            {
+                // Cached for speed
+                static INT s_rubberRadius = -1;
+                INT rubberRadius = toolsModel.GetRubberRadius();
+                if (!m_hRubberCursor || s_rubberRadius != rubberRadius)
+                {
+                    if (m_hRubberCursor)
+                        DestroyCursor(m_hRubberCursor);
+                    m_hRubberCursor = CreateRubberCursor(2 * rubberRadius);
+                    s_rubberRadius = rubberRadius;
+                }
+                if (m_hRubberCursor)
+                    ::SetCursor(m_hRubberCursor);
+                break;
+            }
+            case TOOL_BRUSH:
+            {
+                // Cached for speed
+                static INT s_brushWidth = -1;
+                static BrushStyle s_brushStyle;
+                static COLORREF s_fgColor;
+                BrushStyle brushStyle = toolsModel.GetBrushStyle();
+                INT brushWidth = toolsModel.GetBrushWidth();
+                COLORREF fgColor = paletteModel.GetFgColor();
+                if (!m_hBrushCursor || s_brushWidth != brushWidth || s_brushStyle != brushStyle ||
+                    s_fgColor != fgColor)
+                {
+                    if (m_hBrushCursor)
+                        DestroyCursor(m_hBrushCursor);
+                    m_hBrushCursor = CreateBrushCursor(brushStyle, brushWidth, fgColor);
+                    s_brushWidth = brushWidth;
+                    s_brushStyle = brushStyle;
+                    s_fgColor = fgColor;
+                }
+                if (m_hBrushCursor)
+                    ::SetCursor(m_hBrushCursor);
+                break;
+            }
             default:
                 ::SetCursor(::LoadCursorW(NULL, (LPCWSTR)IDC_CROSS));
         }

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -3,6 +3,7 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    Providing the canvas window class
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
+ *             Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include "precomp.h"

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -51,19 +51,23 @@ static HCURSOR CreateRubberCursor(INT diameter, COLORREF bgColor)
         HBITMAP hbmOld = (HBITMAP)::SelectObject(hdcMem, hbmColor);
 
         HBRUSH hBrush = CreateSolidBrush(bgColor);
-        INT sum = GetRValue(bgColor) + GetGValue(bgColor) + GetBValue(bgColor);
-        COLORREF rgbPenColor = (sum >= 255 / 3 / 2) ? RGB(0, 0, 0) : RGB(255, 255, 255);
+        if (hBrush)
+        {
+            INT sum = GetRValue(bgColor) + GetGValue(bgColor) + GetBValue(bgColor);
+            COLORREF rgbPenColor = (sum >= 255 / 3 / 2) ? RGB(0, 0, 0) : RGB(255, 255, 255);
+            HPEN hPen = CreatePen(PS_SOLID, 1, rgbPenColor);
+            if (hPen)
+            {
+                HGDIOBJ hbrOld = ::SelectObject(hdcMem, hBrush);
+                HGDIOBJ hPenOld = ::SelectObject(hdcMem, hPen);
+                ::Rectangle(hdcMem, rc.left, rc.top, rc.right, rc.bottom);
+                ::SelectObject(hdcMem, hPenOld);
+                ::SelectObject(hdcMem, hbrOld);
 
-        HPEN hPen = CreatePen(PS_SOLID, 1, rgbPenColor);
-
-        HGDIOBJ hbrOld = ::SelectObject(hdcMem, hBrush);
-        HGDIOBJ hPenOld = ::SelectObject(hdcMem, hPen);
-        ::Rectangle(hdcMem, rc.left, rc.top, rc.right, rc.bottom);
-        ::SelectObject(hdcMem, hPenOld);
-        ::SelectObject(hdcMem, hbrOld);
-
-        ::DeleteObject(hPen);
-        ::DeleteObject(hBrush);
+                ::DeleteObject(hPen);
+            }
+            ::DeleteObject(hBrush);
+        }
 
         ::SelectObject(hdcMem, hbmOld);
     }

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -61,7 +61,7 @@ CStyledCursor::CreateStyledCursor(BrushStyle style, INT radius, COLORREF color, 
             ::LineTo(hdcMem, hotX, height);
         }
 
-        // Draw brush or erase by black
+        // Draw brush or erase with black color
         if (is_rubber)
             Erase(hdcMem, hotX, hotY, hotX, hotY, RGB(0, 0, 0), radius + 1);
         else

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -56,6 +56,8 @@ public:
 
 protected:
     HITTEST m_hitCanvasSizeBox;
+    HCURSOR m_hBrushCursor;
+    HCURSOR m_hRubberCursor;
     POINT m_ptOrig; // The origin of drag start
     CRect m_rcResizing; // Resizing rectagle
 

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -7,21 +7,33 @@
 
 #pragma once
 
+enum BrushStyle : int;
+
 class CStyledCursor
 {
 public:
-    CStyledCursor();
-    ~CStyledCursor();
+    ~CStyledCursor()
+    {
+        if (m_hCursor)
+            ::DestroyCursor(m_hCursor);
+    }
 
     void SetStyle(BrushStyle style, INT radius, COLORREF color, BOOL is_rubber);
+
+    void SetCursor()
+    {
+        if (m_hCursor)
+            ::SetCursor(m_hCursor);
+    }
+
     operator HCURSOR() const { return m_hCursor; }
 
 protected:
-    HCURSOR m_hCursor;
+    HCURSOR m_hCursor = NULL;
     BrushStyle m_style;
-    INT m_radius;
-    COLORREF m_color;
-    BOOL m_is_rubber;
+    INT m_radius = -1;
+    COLORREF m_color = CLR_INVALID;
+    BOOL m_is_rubber = FALSE;
 
     static HCURSOR CreateStyledCursor(BrushStyle style, INT radius, COLORREF color, BOOL is_rubber);
 };

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -3,6 +3,7 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    Providing the canvas window class
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
+ *             Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -7,6 +7,25 @@
 
 #pragma once
 
+class CStyledCursor
+{
+public:
+    CStyledCursor();
+    ~CStyledCursor();
+
+    void SetStyle(BrushStyle style, INT radius, COLORREF color, BOOL is_rubber);
+    operator HCURSOR() const { return m_hCursor; }
+
+protected:
+    HCURSOR m_hCursor;
+    BrushStyle m_style;
+    INT m_radius;
+    COLORREF m_color;
+    BOOL m_is_rubber;
+
+    static HCURSOR CreateStyledCursor(BrushStyle style, INT radius, COLORREF color, BOOL is_rubber);
+};
+
 class CCanvasWindow : public CWindowImpl<CCanvasWindow>
 {
 public:
@@ -56,8 +75,8 @@ public:
 
 protected:
     HITTEST m_hitCanvasSizeBox;
-    HCURSOR m_hBrushCursor;
-    HCURSOR m_hRubberCursor;
+    CStyledCursor m_hBrushCursor;
+    CStyledCursor m_hRubberCursor;
     POINT m_ptOrig; // The origin of drag start
     CRect m_rcResizing; // Resizing rectagle
 

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -66,6 +66,14 @@ enum HITTEST // hit
     HIT_INNER,
 };
 
+enum BrushStyle
+{
+    BrushStyleRound,
+    BrushStyleSquare,
+    BrushStyleForeSlash,
+    BrushStyleBackSlash,
+};
+
 /* COMMON FUNCTIONS *************************************************/
 
 void ShowOutOfMemory(void);

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -66,14 +66,6 @@ enum HITTEST // hit
     HIT_INNER,
 };
 
-enum BrushStyle
-{
-    BrushStyleRound,
-    BrushStyleSquare,
-    BrushStyleForeSlash,
-    BrushStyleBackSlash,
-};
-
 /* COMMON FUNCTIONS *************************************************/
 
 void ShowOutOfMemory(void);

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -74,7 +74,7 @@ INT ToolsModel::GetBrushWidth() const
 
 void ToolsModel::SendSetCursor()
 {
-    canvasWindow.SendMessage(WM_SETCURSOR, (WPARAM)((HWND)canvasWindow),
+    canvasWindow.SendMessage(WM_SETCURSOR, (WPARAM)(HWND)canvasWindow,
                              MAKELPARAM(HTCLIENT, WM_MOUSEMOVE));
 }
 

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -72,10 +72,17 @@ INT ToolsModel::GetBrushWidth() const
     return m_brushWidth;
 }
 
+void ToolsModel::SendSetCursor()
+{
+    canvasWindow.SendMessage(WM_SETCURSOR, (WPARAM)((HWND)canvasWindow),
+                             MAKELPARAM(HTCLIENT, WM_MOUSEMOVE));
+}
+
 void ToolsModel::SetBrushWidth(INT nBrushWidth)
 {
     m_brushWidth = nBrushWidth;
     NotifyToolSettingsChanged();
+    SendSetCursor();
     imageModel.NotifyImageChanged();
 }
 
@@ -128,6 +135,7 @@ BrushStyle ToolsModel::GetBrushStyle() const
 void ToolsModel::SetBrushStyle(BrushStyle nBrushStyle)
 {
     m_brushStyle = nBrushStyle;
+    SendSetCursor();
     NotifyToolSettingsChanged();
 }
 
@@ -199,6 +207,7 @@ int ToolsModel::GetRubberRadius() const
 void ToolsModel::SetRubberRadius(int nRubberRadius)
 {
     m_rubberRadius = nRubberRadius;
+    SendSetCursor();
     NotifyToolSettingsChanged();
 }
 

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -28,6 +28,14 @@ enum TOOLTYPE
     TOOL_MAX = TOOL_RRECT,
 };
 
+enum BrushStyle : int
+{
+    BrushStyleRound,
+    BrushStyleSquare,
+    BrushStyleForeSlash,
+    BrushStyleBackSlash,
+};
+
 /* CLASSES **********************************************************/
 
 struct ToolBase

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -28,14 +28,6 @@ enum TOOLTYPE
     TOOL_MAX = TOOL_RRECT,
 };
 
-enum BrushStyle
-{
-    BrushStyleRound,
-    BrushStyleSquare,
-    BrushStyleForeSlash,
-    BrushStyleBackSlash,
-};
-
 /* CLASSES **********************************************************/
 
 struct ToolBase

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -81,6 +81,7 @@ private:
     ToolBase *m_pToolObject;
 
     ToolBase *GetOrCreateTool(TOOLTYPE nTool);
+    void SendSetCursor();
 
 public:
     ToolsModel();


### PR DESCRIPTION
## Purpose

Improve UI/UX by updating mouse cursor shape.
JIRA issue: [CORE-20520](https://jira.reactos.org/browse/CORE-20520)

## Proposed changes

- Add `CStyledCursor` class.
- Enhance `CCanvasWindow::OnSetCursor` for `TOOL_BRUSH` and `TOOL_RUBBER`.
- Add `CCanvasWindow::m_hBrushCursor` `CCanvasWindow::m_hRubberCursor` to keep cursor shapes.
- Send `WM_SETCURSOR` from `ToolsModel` to update the cursor shape.

## Screenshots

<img width="430" height="370" alt="185" src="https://github.com/user-attachments/assets/e5f5db07-e70b-4710-892b-83d57bf68caa" />

<img width="430" height="370" alt="11" src="https://github.com/user-attachments/assets/2e823726-b869-4b24-9534-f66beefeb011" />

<img width="430" height="370" alt="121" src="https://github.com/user-attachments/assets/a70bec9a-9f2e-4fee-ba49-c417b082cdc7" />

<img width="430" height="370" alt="174" src="https://github.com/user-attachments/assets/3dcf873b-f380-4662-bcee-3f29569e8a77" />

## Movie

https://github.com/user-attachments/assets/1828e921-7531-415d-8724-834ca810ab9e

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107629,107635
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107632,107636