### PR TITLE
[BOOTDATA] Initialize ShellState registry entry

### DIFF
--- a/boot/bootdata/hivedef.inf
+++ b/boot/bootdata/hivedef.inf
@@ -1890,6 +1890,8 @@ HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer","SearchHidden",0x00010001,0x00000000
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer","SelectExtOnRename",0x00010001,0x00000000
+HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer","ShellState",0x00000003,24,00,00,00,23,00,\
+00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,0d,00,00,00,00,00,00,00,00,00,00,00
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts",,0x00000012

--- a/boot/bootdata/hivedef.inf
+++ b/boot/bootdata/hivedef.inf
@@ -1890,8 +1890,8 @@ HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer","SearchHidden",0x00010001,0x00000000
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer","SelectExtOnRename",0x00010001,0x00000000
-HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer","ShellState",0x00000003,24,00,00,00,23,00,\
-00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,0d,00,00,00,00,00,00,00,00,00,00,00
+HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer","ShellState",0x00000003,24,00,00,00,33,08,\
+00,00,00,00,00,00,00,00,00,00,00,00,00,00,01,00,00,00,0d,00,00,00,00,00,00,00,02,00,00,00
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts",,0x00000012


### PR DESCRIPTION
CORE-20585

## Purpose

_Initialize ShellState registry entry so we always start with default values when installing._

JIRA issue: [CORE-20585](https://jira.reactos.org/browse/CORE-20585)

## Proposed changes

_Add entry into hivedef.inf to initialize ShellState to match W2K3's defaults._

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107435,107438 LGTM (shell32:ShellState improved)
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107436,107439 LGTM (shell32:ShellState more tests)