### PR TITLE
[ACPI][UEFI] Use loader-provided ACPI root pointer in OSL

### DIFF
--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -6,6 +6,8 @@
 
 #include "precomp.h"
 
+#include <arc/arc.h>
+#include <reactos/drivers/acpi/acpi.h>
 #include <pseh/pseh2.h>
 
 #define NDEBUG
@@ -16,6 +18,170 @@ static BOOLEAN AcpiInterruptHandlerRegistered = FALSE;
 static ACPI_OSD_HANDLER AcpiIrqHandler = NULL;
 static PVOID AcpiIrqContext = NULL;
 static ULONG AcpiIrqNumber = 0;
+extern NTSYSAPI PLOADER_PARAMETER_BLOCK KeLoaderBlock;
+extern NTSYSAPI
+PCONFIGURATION_COMPONENT_DATA
+NTAPI
+KeFindConfigurationNextEntry(
+    _In_ PCONFIGURATION_COMPONENT_DATA Child,
+    _In_ CONFIGURATION_CLASS Class,
+    _In_ CONFIGURATION_TYPE Type,
+    _In_opt_ PULONG ComponentKey,
+    _Inout_ PCONFIGURATION_COMPONENT_DATA *NextLink);
+
+static ACPI_TABLE_RSDP *AcpiLoaderRsdp = NULL;
+static ACPI_PHYSICAL_ADDRESS AcpiLoaderRsdpAddress = 0;
+
+static
+UCHAR
+AcpiChecksumBuffer(
+    _In_reads_bytes_(Length) const UCHAR *Buffer,
+    _In_ ULONG Length)
+{
+    ULONG Index;
+    UCHAR Sum;
+
+    Sum = 0;
+    for (Index = 0; Index < Length; ++Index)
+        Sum = (UCHAR)(Sum + Buffer[Index]);
+
+    return (UCHAR)(0 - Sum);
+}
+
+static
+PACPI_BIOS_MULTI_NODE
+AcpiGetLoaderAcpiBiosNode(VOID)
+{
+    PCONFIGURATION_COMPONENT_DATA ComponentEntry, Next;
+    PCM_PARTIAL_RESOURCE_LIST ResourceList;
+
+    if (!KeLoaderBlock || !KeLoaderBlock->ConfigurationRoot)
+        return NULL;
+
+    ComponentEntry = KeFindConfigurationNextEntry(KeLoaderBlock->ConfigurationRoot,
+                                                  AdapterClass,
+                                                  MultiFunctionAdapter,
+                                                  0,
+                                                  &Next);
+    while (ComponentEntry)
+    {
+        if ((ComponentEntry->ComponentEntry.Identifier != NULL) &&
+            !_stricmp(ComponentEntry->ComponentEntry.Identifier, "ACPI BIOS"))
+        {
+            break;
+        }
+
+        Next = ComponentEntry;
+        ComponentEntry = KeFindConfigurationNextEntry(KeLoaderBlock->ConfigurationRoot,
+                                                      AdapterClass,
+                                                      MultiFunctionAdapter,
+                                                      NULL,
+                                                      &Next);
+    }
+
+    if (!ComponentEntry)
+        return NULL;
+
+    ResourceList = ComponentEntry->ConfigurationData;
+    if (!ResourceList ||
+        (ComponentEntry->ComponentEntry.ConfigurationDataLength <
+         FIELD_OFFSET(CM_PARTIAL_RESOURCE_LIST, PartialDescriptors[1]) +
+         FIELD_OFFSET(ACPI_BIOS_MULTI_NODE, E820Entry)) ||
+        (ResourceList->Count < 1) ||
+        (ResourceList->PartialDescriptors[0].Type != CmResourceTypeDeviceSpecific))
+    {
+        DPRINT1("Loader ACPI BIOS node is missing valid device-specific data\n");
+        return NULL;
+    }
+
+    return (PACPI_BIOS_MULTI_NODE)(ResourceList + 1);
+}
+
+static
+ACPI_PHYSICAL_ADDRESS
+AcpiBuildLoaderRootPointer(VOID)
+{
+    PACPI_BIOS_MULTI_NODE NodeData;
+    ACPI_TABLE_HEADER *RootTable;
+    PHYSICAL_ADDRESS PhysicalAddress;
+
+    if (AcpiLoaderRsdpAddress != 0)
+        return AcpiLoaderRsdpAddress;
+
+    NodeData = AcpiGetLoaderAcpiBiosNode();
+    if (!NodeData || (NodeData->RsdtAddress.QuadPart == 0))
+        return 0;
+
+    RootTable = MmMapIoSpace(NodeData->RsdtAddress, sizeof(*RootTable), MmNonCached);
+    if (!RootTable)
+    {
+        DPRINT1("Unable to map loader ACPI root table at 0x%I64x\n",
+                NodeData->RsdtAddress.QuadPart);
+        return 0;
+    }
+
+    AcpiLoaderRsdp = ExAllocatePoolWithTag(NonPagedPool,
+                                           sizeof(*AcpiLoaderRsdp),
+                                           'dspR');
+    if (!AcpiLoaderRsdp)
+    {
+        MmUnmapIoSpace(RootTable, sizeof(*RootTable));
+        DPRINT1("Unable to allocate synthetic RSDP for loader ACPI tables\n");
+        return 0;
+    }
+
+    RtlZeroMemory(AcpiLoaderRsdp, sizeof(*AcpiLoaderRsdp));
+    RtlCopyMemory(AcpiLoaderRsdp->Signature,
+                  ACPI_SIG_RSDP,
+                  sizeof(AcpiLoaderRsdp->Signature));
+    RtlCopyMemory(AcpiLoaderRsdp->OemId, "ROS   ", sizeof(AcpiLoaderRsdp->OemId));
+
+    if (RtlEqualMemory(RootTable->Signature, ACPI_SIG_XSDT, ACPI_NAMESEG_SIZE))
+    {
+        AcpiLoaderRsdp->Revision = 2;
+        AcpiLoaderRsdp->Length = sizeof(*AcpiLoaderRsdp);
+        AcpiLoaderRsdp->XsdtPhysicalAddress = NodeData->RsdtAddress.QuadPart;
+    }
+    else if (RtlEqualMemory(RootTable->Signature, ACPI_SIG_RSDT, ACPI_NAMESEG_SIZE))
+    {
+        if (NodeData->RsdtAddress.QuadPart > MAXULONG)
+        {
+            DPRINT1("Loader RSDT address does not fit in 32 bits: 0x%I64x\n",
+                    NodeData->RsdtAddress.QuadPart);
+            ExFreePoolWithTag(AcpiLoaderRsdp, 'dspR');
+            AcpiLoaderRsdp = NULL;
+            MmUnmapIoSpace(RootTable, sizeof(*RootTable));
+            return 0;
+        }
+
+        AcpiLoaderRsdp->Revision = 0;
+        AcpiLoaderRsdp->RsdtPhysicalAddress = NodeData->RsdtAddress.LowPart;
+    }
+    else
+    {
+        DPRINT1("Loader ACPI root table has unexpected signature '%.4s'\n",
+                RootTable->Signature);
+        ExFreePoolWithTag(AcpiLoaderRsdp, 'dspR');
+        AcpiLoaderRsdp = NULL;
+        MmUnmapIoSpace(RootTable, sizeof(*RootTable));
+        return 0;
+    }
+
+    AcpiLoaderRsdp->Checksum = AcpiChecksumBuffer((const UCHAR *)AcpiLoaderRsdp,
+                                                  ACPI_RSDP_CHECKSUM_LENGTH);
+    if (AcpiLoaderRsdp->Revision >= 2)
+    {
+        AcpiLoaderRsdp->ExtendedChecksum =
+            AcpiChecksumBuffer((const UCHAR *)AcpiLoaderRsdp,
+                               sizeof(*AcpiLoaderRsdp));
+    }
+
+    PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
+    AcpiLoaderRsdpAddress = (ACPI_PHYSICAL_ADDRESS)PhysicalAddress.QuadPart;
+
+    MmUnmapIoSpace(RootTable, sizeof(*RootTable));
+    return AcpiLoaderRsdpAddress;
+}
 
 ACPI_STATUS
 AcpiOsInitialize (void)
@@ -46,6 +212,10 @@ AcpiOsGetRootPointer (
     ACPI_PHYSICAL_ADDRESS pa = 0;
 
     DPRINT("AcpiOsGetRootPointer\n");
+
+    pa = AcpiBuildLoaderRootPointer();
+    if (pa != 0)
+        return pa;
 
     AcpiFindRootPointer(&pa);
     return pa;
@@ -114,7 +284,7 @@ AcpiOsMapMemory (
 
     DPRINT("AcpiOsMapMemory(phys 0x%p  size 0x%X)\n", phys, length);
 
-    Address.QuadPart = (ULONG)phys;
+    Address.QuadPart = (ULONGLONG)phys;
     Ptr = MmMapIoSpace(Address, length, MmNonCached);
     if (!Ptr)
     {

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -30,7 +30,6 @@ KeFindConfigurationNextEntry(
     _Inout_ PCONFIGURATION_COMPONENT_DATA *NextLink);
 
 static ACPI_TABLE_RSDP *AcpiLoaderRsdp = NULL;
-static ACPI_PHYSICAL_ADDRESS AcpiLoaderRsdpAddress = 0;
 
 static
 UCHAR
@@ -105,8 +104,16 @@ AcpiBuildLoaderRootPointer(VOID)
     ACPI_TABLE_HEADER *RootTable;
     PHYSICAL_ADDRESS PhysicalAddress;
 
-    if (AcpiLoaderRsdpAddress != 0)
-        return AcpiLoaderRsdpAddress;
+    /*
+     * ACPICA may call us more than once during driver startup.
+     * Keep the synthetic RSDP alive and return the same physical
+     * address every time instead of rebuilding it.
+     */
+    if (AcpiLoaderRsdp != NULL)
+    {
+        PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
+        return (ACPI_PHYSICAL_ADDRESS)PhysicalAddress.QuadPart;
+    }
 
     NodeData = AcpiGetLoaderAcpiBiosNode();
     if (!NodeData || (NodeData->RsdtAddress.QuadPart == 0))
@@ -176,11 +183,9 @@ AcpiBuildLoaderRootPointer(VOID)
                                sizeof(*AcpiLoaderRsdp));
     }
 
-    PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
-    AcpiLoaderRsdpAddress = (ACPI_PHYSICAL_ADDRESS)PhysicalAddress.QuadPart;
-
     MmUnmapIoSpace(RootTable, sizeof(*RootTable));
-    return AcpiLoaderRsdpAddress;
+    PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
+    return (ACPI_PHYSICAL_ADDRESS)PhysicalAddress.QuadPart;
 }
 
 ACPI_STATUS

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -51,7 +51,8 @@ static
 PACPI_BIOS_MULTI_NODE
 AcpiGetLoaderAcpiBiosNode(VOID)
 {
-    PCONFIGURATION_COMPONENT_DATA ComponentEntry, Next;
+    PCONFIGURATION_COMPONENT_DATA ComponentEntry = NULL;
+    PCONFIGURATION_COMPONENT_DATA Next = NULL;
     PCM_PARTIAL_RESOURCE_LIST ResourceList;
 
     if (!KeLoaderBlock || !KeLoaderBlock->ConfigurationRoot)
@@ -187,8 +188,6 @@ ACPI_STATUS
 AcpiOsInitialize (void)
 {
     DPRINT("AcpiOsInitialize called\n");
-
-    AcpiBuildLoaderRootPointer();
 
 #ifndef NDEBUG
     /* Verboseness level of the acpica core */

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -60,7 +60,7 @@ AcpiGetLoaderAcpiBiosNode(VOID)
     ComponentEntry = KeFindConfigurationNextEntry(KeLoaderBlock->ConfigurationRoot,
                                                   AdapterClass,
                                                   MultiFunctionAdapter,
-                                                  0,
+                                                  NULL,
                                                   &Next);
     while (ComponentEntry)
     {
@@ -104,11 +104,6 @@ AcpiBuildLoaderRootPointer(VOID)
     ACPI_TABLE_HEADER *RootTable;
     PHYSICAL_ADDRESS PhysicalAddress;
 
-    /*
-     * ACPICA may call us more than once during driver startup.
-     * Keep the synthetic RSDP alive and return the same physical
-     * address every time instead of rebuilding it.
-     */
     if (AcpiLoaderRsdp != NULL)
     {
         PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
@@ -193,6 +188,8 @@ AcpiOsInitialize (void)
 {
     DPRINT("AcpiOsInitialize called\n");
 
+    AcpiBuildLoaderRootPointer();
+
 #ifndef NDEBUG
     /* Verboseness level of the acpica core */
     AcpiDbgLevel = 0x00FFFFFF;
@@ -215,8 +212,15 @@ AcpiOsGetRootPointer (
     void)
 {
     ACPI_PHYSICAL_ADDRESS pa = 0;
+    PHYSICAL_ADDRESS PhysicalAddress;
 
     DPRINT("AcpiOsGetRootPointer\n");
+
+    if (AcpiLoaderRsdp != NULL)
+    {
+        PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
+        return (ACPI_PHYSICAL_ADDRESS)PhysicalAddress.QuadPart;
+    }
 
     pa = AcpiBuildLoaderRootPointer();
     if (pa != 0)

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -18,6 +18,9 @@ static BOOLEAN AcpiInterruptHandlerRegistered = FALSE;
 static ACPI_OSD_HANDLER AcpiIrqHandler = NULL;
 static PVOID AcpiIrqContext = NULL;
 static ULONG AcpiIrqNumber = 0;
+/* TODO: Replace these local declarations with <ndk/kefuncs.h> once the
+ * acpi.sys build context can consume the required NDK dependencies cleanly.
+ */
 extern NTSYSAPI PLOADER_PARAMETER_BLOCK KeLoaderBlock;
 extern NTSYSAPI
 PCONFIGURATION_COMPONENT_DATA

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -126,9 +126,9 @@ AcpiBuildLoaderRootPointer(VOID)
         return 0;
     }
 
-    AcpiLoaderRsdp = ExAllocatePoolWithTag(NonPagedPool,
-                                           sizeof(*AcpiLoaderRsdp),
-                                           'dspR');
+    AcpiLoaderRsdp = ExAllocatePoolZero(NonPagedPool,
+                                        sizeof(*AcpiLoaderRsdp),
+                                        'dspR');
     if (!AcpiLoaderRsdp)
     {
         MmUnmapIoSpace(RootTable, sizeof(*RootTable));
@@ -136,7 +136,6 @@ AcpiBuildLoaderRootPointer(VOID)
         return 0;
     }
 
-    RtlZeroMemory(AcpiLoaderRsdp, sizeof(*AcpiLoaderRsdp));
     RtlCopyMemory(AcpiLoaderRsdp->Signature,
                   ACPI_SIG_RSDP,
                   sizeof(AcpiLoaderRsdp->Signature));
@@ -198,6 +197,8 @@ AcpiOsInitialize (void)
     AcpiDbgLayer = 0xFFFFFFFF;
 #endif
 
+    (VOID)AcpiBuildLoaderRootPointer();
+
     return AE_OK;
 }
 
@@ -223,10 +224,6 @@ AcpiOsGetRootPointer (
         PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
         return (ACPI_PHYSICAL_ADDRESS)PhysicalAddress.QuadPart;
     }
-
-    pa = AcpiBuildLoaderRootPointer();
-    if (pa != 0)
-        return pa;
 
     AcpiFindRootPointer(&pa);
     return pa;

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -13,6 +13,8 @@
 #define NDEBUG
 #include <debug.h>
 
+#define TAG_ACPI_LOADER_RSDP_TABLE   'RpcA'
+
 static PKINTERRUPT AcpiInterrupt;
 static BOOLEAN AcpiInterruptHandlerRegistered = FALSE;
 static ACPI_OSD_HANDLER AcpiIrqHandler = NULL;
@@ -116,24 +118,23 @@ AcpiBuildLoaderRootPointer(VOID)
 
     NodeData = AcpiGetLoaderAcpiBiosNode();
     if (!NodeData || (NodeData->RsdtAddress.QuadPart == 0))
-        return 0;
+        goto Failure;
 
     RootTable = MmMapIoSpace(NodeData->RsdtAddress, sizeof(*RootTable), MmNonCached);
     if (!RootTable)
     {
         DPRINT1("Unable to map loader ACPI root table at 0x%I64x\n",
                 NodeData->RsdtAddress.QuadPart);
-        return 0;
+        goto Failure;
     }
 
     AcpiLoaderRsdp = ExAllocatePoolZero(NonPagedPool,
                                         sizeof(*AcpiLoaderRsdp),
-                                        'dspR');
+                                        TAG_ACPI_LOADER_RSDP_TABLE);
     if (!AcpiLoaderRsdp)
     {
-        MmUnmapIoSpace(RootTable, sizeof(*RootTable));
         DPRINT1("Unable to allocate synthetic RSDP for loader ACPI tables\n");
-        return 0;
+        goto Failure;
     }
 
     RtlCopyMemory(AcpiLoaderRsdp->Signature,
@@ -153,10 +154,7 @@ AcpiBuildLoaderRootPointer(VOID)
         {
             DPRINT1("Loader RSDT address does not fit in 32 bits: 0x%I64x\n",
                     NodeData->RsdtAddress.QuadPart);
-            ExFreePoolWithTag(AcpiLoaderRsdp, 'dspR');
-            AcpiLoaderRsdp = NULL;
-            MmUnmapIoSpace(RootTable, sizeof(*RootTable));
-            return 0;
+            goto Failure;
         }
 
         AcpiLoaderRsdp->Revision = 0;
@@ -166,10 +164,7 @@ AcpiBuildLoaderRootPointer(VOID)
     {
         DPRINT1("Loader ACPI root table has unexpected signature '%.4s'\n",
                 RootTable->Signature);
-        ExFreePoolWithTag(AcpiLoaderRsdp, 'dspR');
-        AcpiLoaderRsdp = NULL;
-        MmUnmapIoSpace(RootTable, sizeof(*RootTable));
-        return 0;
+        goto Failure;
     }
 
     AcpiLoaderRsdp->Checksum = AcpiChecksumBuffer((const UCHAR *)AcpiLoaderRsdp,
@@ -184,6 +179,16 @@ AcpiBuildLoaderRootPointer(VOID)
     MmUnmapIoSpace(RootTable, sizeof(*RootTable));
     PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
     return (ACPI_PHYSICAL_ADDRESS)PhysicalAddress.QuadPart;
+
+Failure:
+    if (AcpiLoaderRsdp)
+    {
+        ExFreePoolWithTag(AcpiLoaderRsdp, TAG_ACPI_LOADER_RSDP_TABLE);
+        AcpiLoaderRsdp = NULL;
+    }
+    if (RootTable)
+        MmUnmapIoSpace(RootTable, sizeof(*RootTable));
+    return 0;
 }
 
 ACPI_STATUS

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -212,6 +212,15 @@ AcpiOsTerminate(void)
 {
     DPRINT("AcpiOsTerminate() called\n");
 
+    /* Release the synthetic RSDP built from the loader-provided ACPI tables.
+     * ACPICA has already torn down its table mappings (AcpiUtSubsystemShutdown)
+     * by the time it calls us, so nothing references this buffer anymore. */
+    if (AcpiLoaderRsdp != NULL)
+    {
+        ExFreePoolWithTag(AcpiLoaderRsdp, TAG_ACPI_LOADER_RSDP_TABLE);
+        AcpiLoaderRsdp = NULL;
+    }
+
     return AE_OK;
 }
 

--- a/drivers/bus/acpi/pnp.c
+++ b/drivers/bus/acpi/pnp.c
@@ -293,7 +293,7 @@ Bus_StartFdo (
         DPRINT1("Unable to AcpiInitializeTables: %s (0x%08X)\n",
                 AcpiFormatException(AcpiStatus),
                 AcpiStatus);
-			return STATUS_UNSUCCESSFUL;
+        return STATUS_UNSUCCESSFUL;
     }
 
     AcpiStatus = AcpiLoadTables();

--- a/drivers/bus/acpi/pnp.c
+++ b/drivers/bus/acpi/pnp.c
@@ -20,6 +20,8 @@ Bus_PlugInDevice (
 #endif
 
 
+
+
 NTSTATUS
 NTAPI
 Bus_PnP (
@@ -282,19 +284,25 @@ Bus_StartFdo (
 
     AcpiStatus = AcpiInitializeSubsystem();
     if(ACPI_FAILURE(AcpiStatus)){
-        DPRINT1("Unable to AcpiInitializeSubsystem\n");
+        DPRINT1("Unable to AcpiInitializeSubsystem: %s (0x%08X)\n",
+                AcpiFormatException(AcpiStatus),
+                AcpiStatus);
         return STATUS_UNSUCCESSFUL;
     }
 
     AcpiStatus = AcpiInitializeTables(NULL, 16, 0);
     if (ACPI_FAILURE(AcpiStatus)){
-        DPRINT1("Unable to AcpiInitializeTables\n");
-		return STATUS_UNSUCCESSFUL;
+        DPRINT1("Unable to AcpiInitializeTables: %s (0x%08X)\n",
+                AcpiFormatException(AcpiStatus),
+                AcpiStatus);
+			return STATUS_UNSUCCESSFUL;
     }
 
     AcpiStatus = AcpiLoadTables();
     if(ACPI_FAILURE(AcpiStatus)){
-        DPRINT1("Unable to AcpiLoadTables\n");
+        DPRINT1("Unable to AcpiLoadTables: %s (0x%08X)\n",
+                AcpiFormatException(AcpiStatus),
+                AcpiStatus);
         AcpiTerminate();
         return STATUS_UNSUCCESSFUL;
     }
@@ -309,7 +317,9 @@ Bus_StartFdo (
     /* Initialize ACPI bus manager */
     AcpiStatus = acpi_init();
     if (!ACPI_SUCCESS(AcpiStatus)) {
-        DPRINT1("acpi_init() failed with status 0x%X\n", AcpiStatus);
+        DPRINT1("acpi_init() failed: %s (0x%08X)\n",
+                AcpiFormatException(AcpiStatus),
+                AcpiStatus);
         AcpiTerminate();
         return STATUS_UNSUCCESSFUL;
     }
@@ -596,5 +606,3 @@ DbgDeviceIDString(
 }
 
 #endif
-
-

--- a/drivers/bus/acpi/pnp.c
+++ b/drivers/bus/acpi/pnp.c
@@ -19,9 +19,6 @@ Bus_PlugInDevice (
 #pragma alloc_text (PAGE, Bus_SendIrpSynchronously)
 #endif
 
-
-
-
 NTSTATUS
 NTAPI
 Bus_PnP (

--- a/drivers/bus/acpi/pnp.c
+++ b/drivers/bus/acpi/pnp.c
@@ -604,3 +604,5 @@ DbgDeviceIDString(
 }
 
 #endif
+
+

--- a/drivers/bus/acpi/pnp.c
+++ b/drivers/bus/acpi/pnp.c
@@ -19,6 +19,7 @@ Bus_PlugInDevice (
 #pragma alloc_text (PAGE, Bus_SendIrpSynchronously)
 #endif
 
+
 NTSTATUS
 NTAPI
 Bus_PnP (


### PR DESCRIPTION
This PR reintroduces previously proposed changes from https://github.com/reactos/reactos/pull/8824#event-25138512498
, now thoroughly tested.

full old description:

This fixes ACPI table discovery on the UEFI boot path by teaching the ACPI OSL to use the loader-provided ACPI root table information instead of relying only on legacy BIOS RSDP scanning. 

The ACPI driver now builds a synthetic RSDP from the ACPI BIOS configuration node populated by FreeLDR, falls back to the old scan only if that data is unavailable, and keeps full 64-bit physical addresses when mapping ACPI tables. 

This lets ACPICA initialize from the UEFI-provided XSDT/RSDT path and improves failure diagnostics if initialization still fails.

## Result:

With this patch, QEMU Q35 on UEFI can discover ACPI tables through the loader-provided root table path and fix The kernel crash 0x7B, INACCESSIBLE_BOOT_DEVICE 

<img width="500" height="435" alt="image" src="https://github.com/user-attachments/assets/25d4d9c9-4197-496b-84f9-e5642c65809d" />





## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108831,108835
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108832,108836