### PR TITLE
[MLANG] Fix class registration regression

### DIFF
--- a/dll/win32/mlang/CMakeLists.txt
+++ b/dll/win32/mlang/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND SOURCE
 
 add_library(mlang MODULE ${SOURCE} mlang.rc)
 set_module_type(mlang win32dll UNICODE)
+add_idl_reg_scripts(mlang registry mlang_classes.idl)
 target_link_libraries(mlang uuid wine wine_dll_canunload wine_dll_register oldnames)
 add_delay_importlibs(mlang oleaut32)
 add_importlibs(mlang gdi32 advapi32 msvcrt kernel32 kernel32_vista ntdll)


### PR DESCRIPTION
## Purpose

Fix regression due to overwritten .rgs file.
The class registration is now autogenerated from the .idl.

JIRA issue: [CORE-20611](https://jira.reactos.org/browse/CORE-20611)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107483,107487,107499
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107486,107488,107500
