### PR TITLE
[CMLIB] Fix hive validation loop for missing bins

### DIFF
--- a/sdk/lib/cmlib/cmcheck.c
+++ b/sdk/lib/cmlib/cmcheck.c
@@ -1537,6 +1537,7 @@ HvValidateHive(
             /* Go to the next if this bin does not exist */
             if (Hive->Storage[StorageIndex].BlockList[BlockIndex].BinAddress == (ULONG_PTR)NULL)
             {
+                BlockIndex++;
                 continue;
             }
 


### PR DESCRIPTION
## Purpose

HvValidateHive skips NULL BinAddress entries, but previously continued without advancing BlockIndex. Advance by one block in that case, since there is no bin header from which a larger span can be derived.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: