### PR TITLE
[KERNEL32_APITEST] Add tests for EnumSystemCodePages

### DIFF
--- a/modules/rostests/apitests/kernel32/CMakeLists.txt
+++ b/modules/rostests/apitests/kernel32/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND SOURCE
     DefaultActCtx.c
     DeviceIoControl.c
     dosdev.c
+    EnumSystemCodePages.c
     FindActCtxSectionStringW.c
     FindFiles.c
     FLS.c

--- a/modules/rostests/apitests/kernel32/EnumSystemCodePages.c
+++ b/modules/rostests/apitests/kernel32/EnumSystemCodePages.c
@@ -1,0 +1,104 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Test for EnumSystemCodePages
+ * COPYRIGHT:   Copyright 2026 Aliaksandr Lebiadzevich <bsalex2025@gmail.com>
+ *              Copyright 2026 Stanislav Motylkov <x86corez@gmail.com>
+ */
+
+#include "precomp.h"
+
+char* func = NULL;
+ULONG cntInstalled, cntSupported, cntLast;
+
+BOOL
+CALLBACK
+EnumCodePagesProcW(
+    LPWSTR lpCodePageString)
+{
+    ULONG CodePage = 0;
+    int ret = swscanf(lpCodePageString, L"%u", &CodePage);
+
+    ok(ret == 1, "%s: '%S' is not a valid number\n", func, lpCodePageString);
+    if (ret == 1)
+        trace("%s: '%S' is a valid number (%lu)\n", func, lpCodePageString, CodePage);
+
+    cntLast++;
+    return TRUE;
+}
+
+BOOL
+CALLBACK
+EnumCodePagesProcA(
+    LPSTR lpCodePageString)
+{
+    BOOL ret;
+    int len = MultiByteToWideChar(CP_ACP, 0, lpCodePageString, -1, NULL, 0);
+    WCHAR *str = HeapAlloc(GetProcessHeap(), 0, len * sizeof(WCHAR));
+    if (!str)
+        return FALSE;
+
+    MultiByteToWideChar(CP_ACP, 0, lpCodePageString, -1, str, len);
+    ret = EnumCodePagesProcW(str);
+    HeapFree(GetProcessHeap(), 0, str);
+
+    return ret;
+}
+
+typedef struct ENTRY
+{
+    DWORD dwFlags;
+    BOOL bReturn;
+    DWORD dwError;
+} ENTRY;
+
+VOID
+RunEnumTests(
+    BOOL Ansi)
+{
+    BOOL ret;
+    int i;
+
+    static const ENTRY Tests[] =
+    {
+        { /* 1 */ CP_INSTALLED, TRUE, 0xDEADF00D },
+        { /* 2 */ CP_SUPPORTED, TRUE, 0xDEADF00D },
+        { 0, TRUE, 0xDEADF00D }, /* Windows handles this as CP_SUPPORTED */
+        { 3, FALSE, ERROR_INVALID_FLAGS },
+        { (DWORD)-1, FALSE, ERROR_INVALID_FLAGS },
+    };
+
+    for (i = 0; i < _countof(Tests); i++)
+    {
+        cntLast = 0;
+        SetLastError(Tests[0].dwError);
+        func = Ansi
+            ? "EnumSystemCodePagesA"
+            : "EnumSystemCodePagesW";
+        ret = Ansi
+            ? EnumSystemCodePagesA(EnumCodePagesProcA, Tests[i].dwFlags)
+            : EnumSystemCodePagesW(EnumCodePagesProcW, Tests[i].dwFlags);
+        if (ret) trace("%s enumerated %u entries\n", func, cntLast);
+        ok(Tests[i].bReturn == ret, "%s unexpected return: %u, expected %u\n", func, ret, Tests[i].bReturn);
+        ok(Tests[i].dwError == GetLastError(), "%s unexpected error: %u, expected %u\n", func, GetLastError(), Tests[i].dwError);
+
+        if (Tests[i].dwFlags == CP_INSTALLED)
+        {
+            cntInstalled = cntLast;
+            ok(cntInstalled > 0, "No installed codepages enumerated\n");
+        }
+        else if (Tests[i].dwFlags == CP_SUPPORTED)
+        {
+            cntSupported = cntLast;
+            ok(cntSupported > 0, "No supported codepages enumerated\n");
+        }
+        else if (Tests[i].dwFlags == 0)
+            ok(cntLast == cntSupported, "Number of codepages expected: %u, got %u\n", cntSupported, cntLast);
+    }
+}
+
+START_TEST(EnumSystemCodePages)
+{
+    RunEnumTests(FALSE);
+    RunEnumTests(TRUE);
+}

--- a/modules/rostests/apitests/kernel32/testlist.c
+++ b/modules/rostests/apitests/kernel32/testlist.c
@@ -8,6 +8,7 @@ extern void func_CreateProcess(void);
 extern void func_DefaultActCtx(void);
 extern void func_DeviceIoControl(void);
 extern void func_dosdev(void);
+extern void func_EnumSystemCodePages(void);
 extern void func_FindActCtxSectionStringW(void);
 extern void func_FindFiles(void);
 extern void func_FLS(void);
@@ -53,6 +54,7 @@ const struct test winetest_testlist[] =
     { "DefaultActCtx",               func_DefaultActCtx },
     { "DeviceIoControl",             func_DeviceIoControl },
     { "dosdev",                      func_dosdev },
+    { "EnumSystemCodePages",         func_EnumSystemCodePages },
     { "FindActCtxSectionStringW",    func_FindActCtxSectionStringW },
     { "FindFiles",                   func_FindFiles },
     { "FLS",                         func_FLS },


### PR DESCRIPTION
Inspired by PoC test code by Aliaksandr in CORE-20535. These tests are passing on Windows.

## Purpose

Add tests for EnumSystemCodePages.

- Windows XP (Service Pack 3):
  - `EnumSystemCodePages: 672 tests executed (0 marked as todo, 0 failures), 0 skipped.`

- Windows Server 2003 R2:
  - `EnumSystemCodePages: 798 tests executed (0 marked as todo, 0 failures), 0 skipped.`

- Windows 10:
  - `EnumSystemCodePages: 866 tests executed (0 marked as todo, 0 failures), 0 skipped.`

- ReactOS:
  - `EnumSystemCodePages: 518 tests executed (0 marked as todo, 18 failures), 0 skipped.` (to be fixed in kernel32)

JIRA issue: [CORE-20535](https://jira.reactos.org/browse/CORE-20535)

## Testbot runs

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107487,107489
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107488,107490