### PR TITLE
[EXPLORER] Initialize ShellState registry entry (2nd Try)

### DIFF
--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -1684,10 +1684,8 @@ ChangePos:
             ZeroMemory(&rss, REGSHELLSTATE_SIZE);
             rss.dwSize = REGSHELLSTATE_SIZE;
             rss.ss.fDoubleClickInWebView = 1;
-            rss.ss.fShowCompColor = 1;
             rss.ss.fShowExtensions = 1;
             rss.ss.fShowAllObjects = 1;
-            rss.ss.fShowInfoTip = 1;
             rss.ss.iSortDirection = 1;
             rss.ss.fStartPanelOn = 1;
             rss.ss.version = REGSHELLSTATE_VERSION;

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -1601,6 +1601,10 @@ ChangePos:
         RECT rcScreen;
         SIZE WndSize, EdgeSize, DlgFrameSize;
         SIZE StartBtnSize = m_StartButton.GetSize();
+        REGSHELLSTATE rss = { 0 };
+        DWORD dwSize = sizeof(REGSHELLSTATE);
+        DWORD dwType;
+        LSTATUS err;
 
         EdgeSize.cx = GetSystemMetrics(SM_CXEDGE);
         EdgeSize.cy = GetSystemMetrics(SM_CYEDGE);
@@ -1671,6 +1675,26 @@ ChangePos:
         /* Determine which monitor we are on. It shouldn't matter which docked
            position rectangle we use */
         m_Monitor = GetMonitorFromRect(&m_TrayRects[ABE_LEFT]);
+
+        /* See if we have a good ShellState registry entry. If not, create one. */
+        err = SHGetValueW(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer",
+                          L"ShellState", &dwType, &rss, &dwSize);
+        if (err != ERROR_SUCCESS || dwType != REG_BINARY || rss.dwSize < REGSHELLSTATE_SIZE)
+        {
+            ZeroMemory(&rss, REGSHELLSTATE_SIZE);
+            rss.dwSize = REGSHELLSTATE_SIZE;
+            rss.ss.fDoubleClickInWebView = 1;
+            rss.ss.fShowCompColor = 1;
+            rss.ss.fShowExtensions = 1;
+            rss.ss.fShowAllObjects = 1;
+            rss.ss.fShowInfoTip = 1;
+            rss.ss.iSortDirection = 1;
+            rss.ss.fStartPanelOn = 1;
+            rss.ss.version = REGSHELLSTATE_VERSION;
+            TRACE("No Registry ShellState, so setting Defaults\n");
+            SHSetValueW(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer",
+                        L"ShellState", REG_BINARY, &rss, REGSHELLSTATE_SIZE);
+        }
     }
 
     VOID AlignControls(IN PRECT prcClient OPTIONAL)


### PR DESCRIPTION
CORE-20585

## Purpose

_Initialize ShellState registry entry in Explorer so we always start with good values._

JIRA issue: [CORE-20585](https://jira.reactos.org/browse/CORE-20585)

## Proposed changes

_Check in Explorer if we have a good ShellState registry key and if not create a default one._

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107487,107492 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107488,107493 LGTM

After commit # 2
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107487,107495 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107488,107496 LGTM

KVM x86 - shell32:ShellState
Before: ShellState: 4 tests executed (0 marked as todo, 1 failure), 1 skipped.
After: ShellState: 36 tests executed (0 marked as todo, 0 failures), 0 skipped.

KVM x64 - shell32:ShellState
Before: ShellState: 4 tests executed (0 marked as todo, 1 failure), 1 skipped.
After: ShellState: 36 tests executed (0 marked as todo, 1 failure), 0 skipped.