### PR TITLE
[KERNEL32] Add some NULL checks

### DIFF
--- a/dll/win32/kernel32/client/file/deviceio.c
+++ b/dll/win32/kernel32/client/file/deviceio.c
@@ -264,13 +264,16 @@ DeviceIoControl(IN HANDLE hDevice,
         /* Check for success */
         if (NT_SUCCESS(Status))
         {
-            /* Return the byte count */
-            *lpBytesReturned = Iosb.Information;
+             /* Windows 2003 and Vista do not check for lpBytesReturned == NULL,
+              * but Windows 8+ does. Avoid crashing. */
+            if (lpBytesReturned != NULL)
+                *lpBytesReturned = Iosb.Information;
         }
         else
         {
             /* Check for informational or warning failure */
-            if (!NT_ERROR(Status)) *lpBytesReturned = Iosb.Information;
+            if (!NT_ERROR(Status) && (lpBytesReturned != NULL))
+                *lpBytesReturned = Iosb.Information;
 
             /* Return a failure */
             BaseSetLastNTError(Status);

--- a/dll/win32/kernel32/client/file/rw.c
+++ b/dll/win32/kernel32/client/file/rw.c
@@ -20,12 +20,14 @@ DEBUG_CHANNEL(kernel32file);
 /*
  * @implemented
  */
-BOOL WINAPI
-WriteFile(IN HANDLE hFile,
-          IN LPCVOID lpBuffer,
-          IN DWORD nNumberOfBytesToWrite OPTIONAL,
-          OUT LPDWORD lpNumberOfBytesWritten,
-          IN LPOVERLAPPED lpOverlapped OPTIONAL)
+BOOL
+WINAPI
+WriteFile(
+    _In_ HANDLE hFile,
+    _In_reads_bytes_opt_(nNumberOfBytesToWrite) LPCVOID lpBuffer,
+    _In_ DWORD nNumberOfBytesToWrite,
+    _Out_opt_ LPDWORD lpNumberOfBytesWritten,
+    _Inout_opt_ LPOVERLAPPED lpOverlapped)
 {
     NTSTATUS Status;
 
@@ -76,7 +78,7 @@ WriteFile(IN HANDLE hFile,
     }
     else
     {
-        IO_STATUS_BLOCK Iosb;
+        IO_STATUS_BLOCK Iosb = { 0 };
 
         Status = NtWriteFile(hFile,
                              NULL,
@@ -96,11 +98,13 @@ WriteFile(IN HANDLE hFile,
         }
 
         /*
-         * lpNumberOfBytesWritten must not be NULL here, in fact Win doesn't
-         * check that case either and crashes (only after the operation
-         * completed).
+         * Windows 2003 and Vista do not check for lpNumberOfBytesWritten == NULL,
+         * but Windows 8+ does and Wine code (crypt32) relies on this.
+         * We ignore Hyrum's Law and assume that crashing here is not a
+         * behavior that software relies on.
          */
-        *lpNumberOfBytesWritten = Iosb.Information;
+        if (lpNumberOfBytesWritten != NULL)
+            *lpNumberOfBytesWritten = Iosb.Information;
 
         if (!NT_SUCCESS(Status))
         {
@@ -117,12 +121,14 @@ WriteFile(IN HANDLE hFile,
 /*
  * @implemented
  */
-BOOL WINAPI
-ReadFile(IN HANDLE hFile,
-         IN LPVOID lpBuffer,
-         IN DWORD nNumberOfBytesToRead,
-         OUT LPDWORD lpNumberOfBytesRead OPTIONAL,
-         IN LPOVERLAPPED lpOverlapped OPTIONAL)
+BOOL
+WINAPI
+ReadFile(
+    _In_ HANDLE hFile,
+    _Out_writes_bytes_to_opt_(nNumberOfBytesToRead, *lpNumberOfBytesRead) __out_data_source(FILE) LPVOID lpBuffer,
+    _In_ DWORD nNumberOfBytesToRead,
+    _Out_opt_ LPDWORD lpNumberOfBytesRead,
+    _Inout_opt_ LPOVERLAPPED lpOverlapped)
 {
     NTSTATUS Status;
 
@@ -187,7 +193,7 @@ ReadFile(IN HANDLE hFile,
     }
     else
     {
-        IO_STATUS_BLOCK Iosb;
+        IO_STATUS_BLOCK Iosb = { 0 };
 
         Status = NtReadFile(hFile,
                             NULL,
@@ -209,20 +215,20 @@ ReadFile(IN HANDLE hFile,
         if (Status == STATUS_END_OF_FILE)
         {
             /*
-             * lpNumberOfBytesRead must not be NULL here, in fact Win doesn't
-             * check that case either and crashes (only after the operation
-             * completed).
+             * Windows 2003 and Vista do not check for lpNumberOfBytesRead == NULL,
+             * but Windows 8+ does. Avoid crashing.
              */
-            *lpNumberOfBytesRead = 0;
+            if (lpNumberOfBytesRead != NULL)
+                *lpNumberOfBytesRead = 0;
             return TRUE;
         }
 
         /*
-         * lpNumberOfBytesRead must not be NULL here, in fact Win doesn't
-         * check that case either and crashes (only after the operation
-         * completed).
+         * Windows 2003 and Vista do not check for lpNumberOfBytesRead == NULL,
+         * but Windows 8+ does. Avoid crashing.
          */
-        *lpNumberOfBytesRead = Iosb.Information;
+        if (lpNumberOfBytesRead != NULL)
+            *lpNumberOfBytesRead = Iosb.Information;
 
         if (!NT_SUCCESS(Status))
         {

--- a/modules/rostests/apitests/kernel32/CMakeLists.txt
+++ b/modules/rostests/apitests/kernel32/CMakeLists.txt
@@ -37,6 +37,7 @@ list(APPEND SOURCE
     Pipes.c
     PrivMoveFileIdentityW.c
     QueueUserAPC.c
+    ReadFile.c
     SetComputerNameExW.c
     SetConsoleWindowInfo.c
     SetCurrentDirectory.c
@@ -45,7 +46,9 @@ list(APPEND SOURCE
     TerminateProcess.c
     TunnelCache.c
     UEFIFirmware.c
-    WideCharToMultiByte.c)
+    WideCharToMultiByte.c
+    WriteFile.c
+)
 
 list(APPEND PCH_SKIP_SOURCE
     testlist.c)

--- a/modules/rostests/apitests/kernel32/DeviceIoControl.c
+++ b/modules/rostests/apitests/kernel32/DeviceIoControl.c
@@ -17,6 +17,42 @@ UINT DriveType;
 #define ok_type(condition, format, ...) ok(condition, "(%d): " format, DriveType,  ##__VA_ARGS__)
 #define skip_type(format, ...) skip("(%d): " format, DriveType, ##__VA_ARGS__)
 
+#define IOCTL_KSEC_RANDOM_FILL_BUFFER \
+    CTL_CODE(FILE_DEVICE_KSEC, 0x02, METHOD_BUFFERED, FILE_ANY_ACCESS)
+
+static void Test_DeviceIoControl_Parameters(void)
+{
+    static const PWSTR KsecDevicePath = L"\\\\.\\Global\\GLOBALROOT\\Device\\KsecDD";
+    UCHAR Buffer[16];
+    HANDLE hDevice;
+    BOOL ret;
+
+    /* Open ksecdd device */
+    hDevice = CreateFileW(KsecDevicePath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
+    if (hDevice == INVALID_HANDLE_VALUE)
+    {
+        skip("CreateFile failed: %lu\n", GetLastError());
+        return;
+    }
+
+    /* Test NULL lpBytesReturned (used by wine's wbemprox) */
+    SetLastError(0xDEADBEEF);
+    StartSeh()
+        ret = DeviceIoControl(hDevice,
+                              IOCTL_KSEC_RANDOM_FILL_BUFFER,
+                              NULL,
+                              0,
+                              Buffer,
+                              sizeof(Buffer),
+                              NULL, /* lpBytesReturned */
+                              NULL);
+        ok_eq_bool(ret, TRUE);
+        ok_eq_ulong(GetLastError(), 0xDEADBEEF);
+    EndSeh((GetNTVersion() >= _WIN32_WINNT_WIN8) ? STATUS_SUCCESS : STATUS_INVALID_PARAMETER);
+
+    CloseHandle(hDevice);
+}
+
 static
 BOOL
 GetDiskGeometry(VOID)
@@ -224,6 +260,8 @@ START_TEST(DeviceIoControl)
     WCHAR Path[MAX_PATH];
     DWORD DriveMap, Current;
     BOOL DiskDone, CdRomDone;
+
+    Test_DeviceIoControl_Parameters();
 
     DiskDone = FALSE;
     CdRomDone = FALSE;

--- a/modules/rostests/apitests/kernel32/DeviceIoControl.c
+++ b/modules/rostests/apitests/kernel32/DeviceIoControl.c
@@ -48,7 +48,7 @@ static void Test_DeviceIoControl_Parameters(void)
                               NULL);
         ok_eq_bool(ret, TRUE);
         ok_eq_ulong(GetLastError(), 0xDEADBEEF);
-    EndSeh((GetNTVersion() >= _WIN32_WINNT_WIN8) ? STATUS_SUCCESS : STATUS_INVALID_PARAMETER);
+    EndSeh(is_reactos() || (GetNTVersion() >= _WIN32_WINNT_WIN8) ? STATUS_SUCCESS : STATUS_INVALID_PARAMETER);
 
     CloseHandle(hDevice);
 }

--- a/modules/rostests/apitests/kernel32/ReadFile.c
+++ b/modules/rostests/apitests/kernel32/ReadFile.c
@@ -82,7 +82,7 @@ static void Test_ReadFile_sync(HANDLE hFile)
         bResult = ReadFile(hFile, Buffer, sizeof(Buffer), NULL, NULL);
         ok_eq_bool(bResult, TRUE);
         ok_eq_ulong(GetLastError(), 0xdeadbeef);
-    EndSeh((GetNTVersion() >= _WIN32_WINNT_WIN8) ? STATUS_SUCCESS : EXCEPTION_ACCESS_VIOLATION);
+    EndSeh(is_reactos() || (GetNTVersion() >= _WIN32_WINNT_WIN8) ? STATUS_SUCCESS : EXCEPTION_ACCESS_VIOLATION);
 
     /* Test with NULL lpNumberOfBytesRead at end of file */
     ok(SetFilePointer(hFile, 0, NULL, FILE_END) > 0, "SetFilePointer failed\n");
@@ -91,7 +91,7 @@ static void Test_ReadFile_sync(HANDLE hFile)
         bResult = ReadFile(hFile, Buffer, sizeof(Buffer), NULL, NULL);
         ok_eq_bool(bResult, TRUE);
         ok_eq_ulong(GetLastError(), 0xdeadbeef);
-    EndSeh((GetNTVersion() >= _WIN32_WINNT_WIN8) ? STATUS_SUCCESS : EXCEPTION_ACCESS_VIOLATION);
+    EndSeh(is_reactos() || (GetNTVersion() >= _WIN32_WINNT_WIN8) ? STATUS_SUCCESS : EXCEPTION_ACCESS_VIOLATION);
 }
 
 static void Test_ReadFile_async(HANDLE hFile)

--- a/modules/rostests/apitests/kernel32/ReadFile.c
+++ b/modules/rostests/apitests/kernel32/ReadFile.c
@@ -1,0 +1,223 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Test for ReadFile
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include "precomp.h"
+
+static void Test_ReadFile_sync(HANDLE hFile)
+{
+    UCHAR Buffer[128];
+    DWORD dwBytesRead;
+    BOOL bResult;
+
+    SetFilePointer(hFile, 0, NULL, FILE_BEGIN);
+
+    /* Test NULL File */
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    bResult = ReadFile(NULL, Buffer, sizeof(Buffer), &dwBytesRead, NULL);
+    ok_eq_bool(bResult, FALSE);
+    ok_eq_ulong(dwBytesRead, 0);
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_HANDLE);
+
+    /* Test INVALID_HANDLE_VALUE */
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    bResult = ReadFile(INVALID_HANDLE_VALUE, Buffer, sizeof(Buffer), &dwBytesRead, NULL);
+    ok_eq_bool(bResult, FALSE);
+    ok_eq_ulong(dwBytesRead, 0);
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_HANDLE);
+
+    /* Read some bytes */
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    bResult = ReadFile(hFile, Buffer, sizeof(Buffer), &dwBytesRead, NULL);
+    ok_eq_bool(bResult, TRUE);
+    ok_eq_ulong(dwBytesRead, sizeof(Buffer));
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+
+    /* Try to read at end of file */
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    ok(SetFilePointer(hFile, 0, NULL, FILE_END) > 0, "SetFilePointer failed\n");
+    bResult = ReadFile(hFile, Buffer, sizeof(Buffer), &dwBytesRead, NULL);
+    ok_eq_bool(bResult, TRUE);
+    ok_eq_ulong(dwBytesRead, 0);
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+
+    /* Try to read 0 bytes at end of file */
+    SetLastError(0xdeadbeef);
+    bResult = ReadFile(hFile, Buffer, 0, &dwBytesRead, NULL);
+    ok_eq_bool(bResult, TRUE);
+    ok_eq_ulong(dwBytesRead, 0);
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+    SetFilePointer(hFile, 0, NULL, FILE_BEGIN);
+
+    /* Test with NULL lpBuffer */
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    StartSeh()
+        bResult = ReadFile(hFile, NULL, sizeof(Buffer), &dwBytesRead, NULL);
+        ok_eq_bool(bResult, FALSE);
+        ok_eq_ulong(dwBytesRead, 0);
+        ok_eq_ulong(GetLastError(), ERROR_NOACCESS);
+    EndSeh(STATUS_SUCCESS);
+
+    /* Test with NULL lpBuffer and 0 nNumberOfBytesToRead */
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    StartSeh()
+        bResult = ReadFile(hFile, NULL, 0, &dwBytesRead, NULL);
+        ok_eq_bool(bResult, TRUE);
+        ok_eq_ulong(dwBytesRead, 0);
+        ok_eq_ulong(GetLastError(), 0xdeadbeef);
+    EndSeh(STATUS_SUCCESS);
+
+    /* Test with NULL lpNumberOfBytesRead */
+    SetLastError(0xdeadbeef);
+    StartSeh()
+        bResult = ReadFile(hFile, Buffer, sizeof(Buffer), NULL, NULL);
+        ok_eq_bool(bResult, TRUE);
+        ok_eq_ulong(GetLastError(), 0xdeadbeef);
+    EndSeh((GetNTVersion() >= _WIN32_WINNT_WIN8) ? STATUS_SUCCESS : EXCEPTION_ACCESS_VIOLATION);
+
+    /* Test with NULL lpNumberOfBytesRead at end of file */
+    ok(SetFilePointer(hFile, 0, NULL, FILE_END) > 0, "SetFilePointer failed\n");
+    SetLastError(0xdeadbeef);
+    StartSeh()
+        bResult = ReadFile(hFile, Buffer, sizeof(Buffer), NULL, NULL);
+        ok_eq_bool(bResult, TRUE);
+        ok_eq_ulong(GetLastError(), 0xdeadbeef);
+    EndSeh((GetNTVersion() >= _WIN32_WINNT_WIN8) ? STATUS_SUCCESS : EXCEPTION_ACCESS_VIOLATION);
+}
+
+static void Test_ReadFile_async(HANDLE hFile)
+{
+    BOOL bResult;
+    UCHAR Buffer[128];
+    DWORD dwBytesRead;
+    OVERLAPPED ol = { 0 };
+
+    SetFilePointer(hFile, 0, NULL, FILE_BEGIN);
+
+    /* Test NULL File */
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    bResult = ReadFile(NULL, Buffer, sizeof(Buffer), &dwBytesRead, &ol);
+    ok_eq_bool(bResult, FALSE);
+    ok_eq_ulong(dwBytesRead, 0);
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_HANDLE);
+
+    /* Test INVALID_HANDLE_VALUE */
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    bResult = ReadFile(INVALID_HANDLE_VALUE, Buffer, sizeof(Buffer), &dwBytesRead, &ol);
+    ok_eq_bool(bResult, FALSE);
+    ok_eq_ulong(dwBytesRead, 0);
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_HANDLE);
+
+    /* Read some bytes */
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    bResult = ReadFile(hFile, Buffer, sizeof(Buffer), &dwBytesRead, &ol);
+    ok_eq_bool(bResult, TRUE);
+    dwBytesRead = 0xdeadbeef;
+    bResult = GetOverlappedResult(hFile, &ol, &dwBytesRead, TRUE);
+    ok_eq_bool(bResult, TRUE);
+    ok_eq_ulong(dwBytesRead, sizeof(Buffer));
+    ok_eq_ulong(GetLastError(), (GetNTVersion() >= _WIN32_WINNT_WIN10) ? 0 : 0xdeadbeef);
+
+    /* Try to read at end of file */
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    ol.Offset = GetFileSize(hFile, NULL);
+    ok(ol.Offset > 0, "GetFileSize failed\n");
+    bResult = ReadFile(hFile, Buffer, sizeof(Buffer), &dwBytesRead, &ol);
+    ok_eq_bool(bResult, FALSE);
+    ok_eq_ulong(dwBytesRead, 0);
+    ok_eq_ulong(GetLastError(), ERROR_HANDLE_EOF);
+
+    /* Try to read 0 bytes at end of file */
+    SetLastError(0xdeadbeef);
+    bResult = ReadFile(hFile, Buffer, 0, &dwBytesRead, &ol);
+    ok_eq_bool(bResult, TRUE);
+    ok_eq_ulong(dwBytesRead, 0);
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+    ol.Offset = 0;
+
+    /* Test with NULL lpBuffer */
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    StartSeh()
+        bResult = ReadFile(hFile, NULL, sizeof(Buffer), &dwBytesRead, &ol);
+        ok_eq_bool(bResult, FALSE);
+        ok_eq_ulong(GetLastError(), ERROR_NOACCESS);
+    EndSeh(STATUS_SUCCESS);
+
+    /* Test with NULL lpBuffer and 0 nNumberOfBytesToRead */
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    StartSeh()
+        bResult = ReadFile(hFile, NULL, 0, &dwBytesRead, &ol);
+        ok_eq_bool(bResult, TRUE);
+        ok_eq_ulong(GetLastError(), 0xdeadbeef);
+        bResult = GetOverlappedResult(hFile, &ol, &dwBytesRead, TRUE);
+        ok_eq_bool(bResult, TRUE);
+        ok_eq_ulong(dwBytesRead, 0);
+        ok_eq_ulong(GetLastError(), (GetNTVersion() >= _WIN32_WINNT_WIN10) ? 0 : 0xdeadbeef);
+    EndSeh(STATUS_SUCCESS);
+
+    /* Test with NULL lpNumberOfBytesRead */
+    SetLastError(0xdeadbeef);
+    bResult = ReadFile(hFile, Buffer, sizeof(Buffer), NULL, &ol);
+    ok_eq_bool(bResult, TRUE);
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+    bResult = GetOverlappedResult(hFile, &ol, &dwBytesRead, TRUE);
+    ok_eq_bool(bResult, TRUE);
+    ok_eq_ulong(dwBytesRead, sizeof(Buffer));
+    ok_eq_ulong(GetLastError(), (GetNTVersion() >= _WIN32_WINNT_WIN10) ? 0 : 0xdeadbeef);
+
+    /* Test with NULL lpNumberOfBytesRead at end of file */
+    SetLastError(0xdeadbeef);
+    ol.Offset = GetFileSize(hFile, NULL);
+    ok(ol.Offset > 0, "GetFileSize failed\n");
+    bResult = ReadFile(hFile, Buffer, sizeof(Buffer), NULL, &ol);
+    ok_eq_bool(bResult, FALSE);
+    ok_eq_ulong(GetLastError(), ERROR_HANDLE_EOF);
+    SetLastError(0xdeadbeef);
+    dwBytesRead = 0xdeadbeef;
+    bResult = GetOverlappedResult(hFile, &ol, &dwBytesRead, TRUE);
+    ok_eq_bool(bResult, FALSE);
+    ok_eq_ulong(dwBytesRead, 0);
+    ok_eq_ulong(GetLastError(), ERROR_HANDLE_EOF);
+    ol.Offset = 0;
+}
+
+START_TEST(ReadFile)
+{
+    CHAR FileName[MAX_PATH];
+    HANDLE hFile;
+
+    /* Open the executable file */
+    GetModuleFileNameA(NULL, FileName, ARRAYSIZE(FileName));
+    hFile = CreateFileA(FileName,
+                        FILE_READ_ACCESS,
+                        FILE_SHARE_READ,
+                        NULL,
+                        OPEN_EXISTING,
+                        FILE_ATTRIBUTE_NORMAL,
+                        NULL);
+    if (hFile == INVALID_HANDLE_VALUE)
+    {
+        skip("CreateFileA failed with error %lu\n", GetLastError());
+        return;
+    }
+
+    Test_ReadFile_sync(hFile);
+    Test_ReadFile_async(hFile);
+
+    CloseHandle(hFile);
+}

--- a/modules/rostests/apitests/kernel32/WriteFile.c
+++ b/modules/rostests/apitests/kernel32/WriteFile.c
@@ -1,0 +1,170 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Test for WriteFile
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include "precomp.h"
+
+static void Test_WriteFile_sync(HANDLE hFile)
+{
+    UCHAR Buffer[128];
+    DWORD dwBytesWritten;
+    BOOL bResult;
+
+    SetFilePointer(hFile, 0, NULL, FILE_BEGIN);
+
+    /* Test NULL File */
+    SetLastError(0xdeadbeef);
+    dwBytesWritten = 0xdeadbeef;
+    bResult = WriteFile(NULL, Buffer, sizeof(Buffer), &dwBytesWritten, NULL);
+    ok_eq_bool(bResult, FALSE);
+    ok_eq_ulong(dwBytesWritten, 0);
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_HANDLE);
+
+    /* Test INVALID_HANDLE_VALUE */
+    SetLastError(0xdeadbeef);
+    dwBytesWritten = 0xdeadbeef;
+    bResult = WriteFile(INVALID_HANDLE_VALUE, Buffer, sizeof(Buffer), &dwBytesWritten, NULL);
+    ok_eq_bool(bResult, FALSE);
+    ok_eq_ulong(dwBytesWritten, 0);
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_HANDLE);
+
+    /* Write some bytes */
+    SetLastError(0xdeadbeef);
+    dwBytesWritten = 0xdeadbeef;
+    bResult = WriteFile(hFile, Buffer, sizeof(Buffer), &dwBytesWritten, NULL);
+    ok_eq_bool(bResult, TRUE);
+    ok_eq_ulong(dwBytesWritten, sizeof(Buffer));
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+
+    /* Test with NULL lpBuffer */
+    SetLastError(0xdeadbeef);
+    dwBytesWritten = 0xdeadbeef;
+    StartSeh()
+        bResult = WriteFile(hFile, NULL, sizeof(Buffer), &dwBytesWritten, NULL);
+        ok_eq_bool(bResult, FALSE);
+        ok_eq_ulong(dwBytesWritten, 0);
+        ok_eq_ulong(GetLastError(), ERROR_INVALID_USER_BUFFER);
+    EndSeh(STATUS_SUCCESS);
+
+    /* Test with NULL lpBuffer and 0 nNumberOfBytesToWrite */
+    SetLastError(0xdeadbeef);
+    dwBytesWritten = 0xdeadbeef;
+    StartSeh()
+        bResult = WriteFile(hFile, NULL, 0, &dwBytesWritten, NULL);
+        ok_eq_bool(bResult, TRUE);
+        ok_eq_ulong(dwBytesWritten, 0);
+        ok_eq_ulong(GetLastError(), 0xdeadbeef);
+    EndSeh(STATUS_SUCCESS);
+
+    /* Test with NULL lpNumberOfBytesWritten */
+    SetLastError(0xdeadbeef);
+    StartSeh()
+        bResult = WriteFile(hFile, Buffer, sizeof(Buffer), NULL, NULL);
+        ok_eq_bool(bResult, TRUE);
+        ok_eq_ulong(GetLastError(), 0xdeadbeef);
+    EndSeh((GetNTVersion() >= _WIN32_WINNT_WIN8) ? STATUS_SUCCESS : EXCEPTION_ACCESS_VIOLATION);
+}
+
+static void Test_WriteFile_async(HANDLE hFile)
+{
+    BOOL bResult;
+    UCHAR Buffer[128];
+    DWORD dwBytesWritten;
+    OVERLAPPED ol = { 0 };
+
+    SetFilePointer(hFile, 0, NULL, FILE_BEGIN);
+
+    /* Test NULL File */
+    SetLastError(0xdeadbeef);
+    dwBytesWritten = 0xdeadbeef;
+    bResult = WriteFile(NULL, Buffer, sizeof(Buffer), &dwBytesWritten, &ol);
+    ok_eq_bool(bResult, FALSE);
+    ok_eq_ulong(dwBytesWritten, 0);
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_HANDLE);
+
+    /* Test INVALID_HANDLE_VALUE */
+    SetLastError(0xdeadbeef);
+    dwBytesWritten = 0xdeadbeef;
+    bResult = WriteFile(INVALID_HANDLE_VALUE, Buffer, sizeof(Buffer), &dwBytesWritten, &ol);
+    ok_eq_bool(bResult, FALSE);
+    ok_eq_ulong(dwBytesWritten, 0);
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_HANDLE);
+
+    /* Write some bytes */
+    SetLastError(0xdeadbeef);
+    dwBytesWritten = 0xdeadbeef;
+    bResult = WriteFile(hFile, Buffer, sizeof(Buffer), &dwBytesWritten, &ol);
+    ok_eq_bool(bResult, TRUE);
+    dwBytesWritten = 0xdeadbeef;
+    bResult = GetOverlappedResult(hFile, &ol, &dwBytesWritten, TRUE);
+    ok_eq_bool(bResult, TRUE);
+    ok_eq_ulong(dwBytesWritten, sizeof(Buffer));
+    ok_eq_ulong(GetLastError(), (GetNTVersion() >= _WIN32_WINNT_WIN10) ? 0 : 0xdeadbeef);
+
+    /* Test with NULL lpBuffer */
+    SetLastError(0xdeadbeef);
+    dwBytesWritten = 0xdeadbeef;
+    StartSeh()
+        bResult = WriteFile(hFile, NULL, sizeof(Buffer), &dwBytesWritten, &ol);
+        ok_eq_bool(bResult, FALSE);
+        ok_eq_ulong(GetLastError(), ERROR_INVALID_USER_BUFFER);
+    EndSeh(STATUS_SUCCESS);
+
+    /* Test with NULL lpBuffer and 0 nNumberOfBytesToWrite */
+    SetLastError(0xdeadbeef);
+    dwBytesWritten = 0xdeadbeef;
+    StartSeh()
+        bResult = WriteFile(hFile, NULL, 0, &dwBytesWritten, &ol);
+        ok_eq_bool(bResult, TRUE);
+        ok_eq_ulong(GetLastError(), 0xdeadbeef);
+        bResult = GetOverlappedResult(hFile, &ol, &dwBytesWritten, TRUE);
+        ok_eq_bool(bResult, TRUE);
+        ok_eq_ulong(dwBytesWritten, 0);
+        ok_eq_ulong(GetLastError(), (GetNTVersion() >= _WIN32_WINNT_WIN10) ? 0 : 0xdeadbeef);
+    EndSeh(STATUS_SUCCESS);
+
+    /* Test with NULL lpNumberOfBytesWritten */
+    SetLastError(0xdeadbeef);
+    bResult = WriteFile(hFile, Buffer, sizeof(Buffer), NULL, &ol);
+    ok_eq_bool(bResult, TRUE);
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+    bResult = GetOverlappedResult(hFile, &ol, &dwBytesWritten, TRUE);
+    ok_eq_bool(bResult, TRUE);
+    ok_eq_ulong(dwBytesWritten, sizeof(Buffer));
+    ok_eq_ulong(GetLastError(), (GetNTVersion() >= _WIN32_WINNT_WIN10) ? 0 : 0xdeadbeef);
+}
+
+START_TEST(WriteFile)
+{
+    HANDLE hFile;
+
+    /* Create a temp file name */
+    CHAR tempFileName[MAX_PATH];
+    if (!GetTempFileNameA(".", "writetest", 0, tempFileName))
+    {
+        skip("GetTempFileNameA failed with error %lu\n", GetLastError());
+        return;
+    }
+
+    /* Create a temp file to write to */
+    hFile = CreateFileA(tempFileName,
+                        GENERIC_WRITE,
+                        0,
+                        NULL,
+                        CREATE_ALWAYS,
+                        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_DELETE_ON_CLOSE,
+                        NULL);
+    if (hFile == INVALID_HANDLE_VALUE)
+    {
+        skip("CreateFileA failed with error %lu\n", GetLastError());
+        return;
+    }
+
+    Test_WriteFile_sync(hFile);
+    Test_WriteFile_async(hFile);
+
+    CloseHandle(hFile);
+}

--- a/modules/rostests/apitests/kernel32/WriteFile.c
+++ b/modules/rostests/apitests/kernel32/WriteFile.c
@@ -65,7 +65,7 @@ static void Test_WriteFile_sync(HANDLE hFile)
         bResult = WriteFile(hFile, Buffer, sizeof(Buffer), NULL, NULL);
         ok_eq_bool(bResult, TRUE);
         ok_eq_ulong(GetLastError(), 0xdeadbeef);
-    EndSeh((GetNTVersion() >= _WIN32_WINNT_WIN8) ? STATUS_SUCCESS : EXCEPTION_ACCESS_VIOLATION);
+    EndSeh(is_reactos() || (GetNTVersion() >= _WIN32_WINNT_WIN8) ? STATUS_SUCCESS : EXCEPTION_ACCESS_VIOLATION);
 }
 
 static void Test_WriteFile_async(HANDLE hFile)


### PR DESCRIPTION
## Purpose

This adds some NULL checks that Windows 8+ has in ReadFile, WriteFile and DeviceIoControl and tests for that.
Wine code relies on this.

## Testbot runs (Filled in by Devs)

- [x] Vista x64: https://reactos.org/testman/compare.php?ids=107657,107659
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107654,107662
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107666,107667
