### PR TITLE
[DHCPCSVC] Fix stop_selecting truncated from time_t to int on 64-bit

### DIFF
--- a/base/services/dhcpcsvc/dhcp/dhclient.c
+++ b/base/services/dhcpcsvc/dhcp/dhclient.c
@@ -861,7 +861,8 @@ dhcpoffer(struct packet *packet)
 	struct interface_info *ip = packet->interface;
 	struct client_lease *lease, *lp;
 	int i;
-	int arp_timeout_needed = 0, stop_selecting;
+	int arp_timeout_needed = 0;
+	time_t stop_selecting;
 	char *name = packet->options[DHO_DHCP_MESSAGE_TYPE].len ?
 	    "DHCPOFFER" : "BOOTREPLY";
         time_t cur_time;


### PR DESCRIPTION
## Purpose

This fixes a bug noticed during ARM64 bringup where DHCP never completed. In dhcpoffer, `stop_selecting` is declared int (32-bit) but assigned two time_t operands of 64-bit. 

The truncated value breaks the timeout, leaving DHCP stuck in S_SELECTING. This is masked on AMD64 because the RTC is implemented there and `time()` returns values that fit in 32 bits. On ARM64 the RTC isn't implemented yet, exposing the truncation.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: