### PR TITLE
[GITHUB] build-msbuild-i386: Upgrade to "Visual Studio 18 2026"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,7 +311,7 @@ jobs:
 
   build-msbuild-i386:
     name: MSBuild (i386)
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     steps:
     - name: Install Flex and Bison
       run: |
@@ -331,6 +331,6 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=i386 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{github.workspace}}\src
+        cmake -G "Visual Studio 18 2026" -A Win32 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=i386 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{github.workspace}}\src
     - name: Build
       run: cmake --build ${{github.workspace}}\build --target bootcd


### PR DESCRIPTION
from "Visual Studio 17 2022".

## Purpose

`windows-latest` builds will be affected by
https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners
> The migration to the new Visual Studio 2026 image will start on June 8, 2026.

## Proposed changes

- Upgrade to "Visual Studio 18 2026"

## TODO

To be committed after the migration actually starts/ends,
unless you prefer to temporarily switch to `runs-on: windows-2025-vs2026`.
Edit: Let's do the latter.