### PR TITLE
[SDK][CMAKE] Link libgcc_eh into C++ targets when available 

### DIFF
--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -657,12 +657,19 @@ set_target_properties(libgcc PROPERTIES IMPORTED_LOCATION ${LIBGCC_LOCATION})
 # libgcc needs kernel32 and winpthread (an appropriate CRT must be linked manually)
 target_link_libraries(libgcc INTERFACE libwinpthread libkernel32)
 
+add_library(libgcc_eh INTERFACE)
+target_link_libraries(libgcc_eh INTERFACE libgcc)
+# only add libgcc_eh.a if it exists (SEH toolchains have it, SJLJ/DWARF do not)
+execute_process(COMMAND ${GXX_EXECUTABLE} -print-file-name=libgcc_eh.a OUTPUT_VARIABLE _LIBGCC_EH_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(EXISTS "${_LIBGCC_EH_PATH}")
+    target_link_libraries(libgcc_eh INTERFACE "${_LIBGCC_EH_PATH}")
+endif()
+
 add_library(libsupc++ STATIC IMPORTED GLOBAL)
 execute_process(COMMAND ${GXX_EXECUTABLE} -print-file-name=libsupc++.a OUTPUT_VARIABLE LIBSUPCXX_LOCATION)
 string(STRIP ${LIBSUPCXX_LOCATION} LIBSUPCXX_LOCATION)
 set_target_properties(libsupc++ PROPERTIES IMPORTED_LOCATION ${LIBSUPCXX_LOCATION})
-# libsupc++ requires libgcc and stdc++compat
-target_link_libraries(libsupc++ INTERFACE libgcc stdc++compat)
+target_link_libraries(libsupc++ INTERFACE libgcc_eh libgcc stdc++compat)
 
 add_library(libmingwex STATIC IMPORTED)
 execute_process(COMMAND ${GXX_EXECUTABLE} -print-file-name=libmingwex.a OUTPUT_VARIABLE LIBMINGWEX_LOCATION)


### PR DESCRIPTION
## Summary

This fixes building ReactOS with the native GCC toolchain shipped in Ubuntu 25.04 (and other modern distros), without requiring ROSBE to be installed.

## Problem

ReactOS uses `-nostdlib` which prevents GCC from auto-linking its runtime libraries. `libsupc++` was being linked but not `libgcc_eh`, which provides the SEH unwind symbols (`_Unwind_Resume`, `__emutls_get_address`, etc.) needed by C++ exception handling. Any C++ target using `-fexceptions` fails to link with undefined references on x86_64 SEH toolchains.

## Fix

Added a `libgcc_eh` INTERFACE target in `sdk/cmake/gcc.cmake` that:
- Conditionally pulls in `libgcc_eh.a` when the toolchain provides it (SEH x86_64)
- Falls back to a no-op when absent
- 
`libsupc++` now depends on it, so all C++ targets automatically get the unwind symbols they need.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: