### PR TITLE
[DELAYIMP_APITEST] Fix crash on Vista x64

### DIFF
--- a/modules/rostests/apitests/sdk/delayimp.cpp
+++ b/modules/rostests/apitests/sdk/delayimp.cpp
@@ -489,7 +489,16 @@ START_TEST(delayimp_runtimehook)
     SetExpectedDli(g_winmm_midi_out_close);
     g_ExpectedDll = WINMM_DLLNAME;
     g_ExpectedName = "midiOutClose";
-    DWORD err = midiOutClose((HMIDIOUT)(ULONG_PTR)0xdeadbeef);
+    DWORD err;
+    _SEH2_TRY
+    {
+        err = midiOutClose((HMIDIOUT)INVALID_HANDLE_VALUE);
+    }
+    _SEH2_EXCEPT(ExceptionFilter(_SEH2_GetExceptionInformation(), _SEH2_GetExceptionCode()))
+    {
+        err = _SEH2_GetExceptionCode();
+    }
+    _SEH2_END;
     ok(err == MMSYSERR_INVALHANDLE, "Expected err to be MMSYSERR_INVALHANDLE, was 0x%lx\n", err);
     CheckDliDone();
 
@@ -500,7 +509,7 @@ START_TEST(delayimp_runtimehook)
     g_BreakFunctionName = true;
     _SEH2_TRY
     {
-        err = mixerClose((HMIXER)(ULONG_PTR)0xdeadbeef);
+        err = mixerClose((HMIXER)INVALID_HANDLE_VALUE);
     }
     _SEH2_EXCEPT(ExceptionFilter(_SEH2_GetExceptionInformation(), _SEH2_GetExceptionCode()))
     {


### PR DESCRIPTION
## Purpose

Stop the test from crashing on Vista x64.
For some reason on Vista x64 0xdeadbeef isn't detected as an invalid handle and the whole thing crashes. INVALID_HANDLE_VALUE on the other hand is detected as an invalid handle, so use that.

## Testbot runs (Filled in by Devs)

- [x] WHS x86: https://reactos.org/testman/compare.php?ids=107550,107582
- [x] Vista x64: https://reactos.org/testman/compare.php?ids=107571,107583
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107572,107576,107584
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107575,107577,107586
