### PR TITLE
[KERNEL32_VISTA] Don't delay-import from ntdll_vista

### DIFF
--- a/dll/win32/kernel32/kernel32_vista/CMakeLists.txt
+++ b/dll/win32/kernel32/kernel32_vista/CMakeLists.txt
@@ -42,6 +42,5 @@ add_library(kernel32_vista MODULE
 set_module_type(kernel32_vista win32dll ENTRYPOINT DllMain 12)
 target_link_libraries(kernel32_vista kernel32_vista_static kernel32_shared)
 add_importlibs(kernel32_vista kernel32 ntdll_vista ntdll)
-add_delay_importlibs(kernel32_vista ntdll_vista)
 add_dependencies(kernel32_vista psdk)
 add_cd_file(TARGET kernel32_vista DESTINATION reactos/system32 FOR all)


### PR DESCRIPTION
## Purpose

Fix potential heap corruption during msvcrt init.

kernel32 functions can be called during process-attach. The same must be true for kernel32_vista. Wine's msvcrt calls GetUserDefaultLocaleName in kernel32_vista during process attach, which calls RtlLcidToLocaleName in ntdll_vista. If that function is delay-loaded (which is probably not allowed anyway during process-attach), the dll will not be initialized, the default user locale is 0 and RtlLcidToLocaleName fails. Wine code doesn't check for failure and instead continues copying an uninitialized string buffer into the heap, causing heap corruption.

After removing the (redundant) add_delay_importlibs entry, this doesn't happen any longer.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107591,107595,107601
- [x] KVM x64:  https://reactos.org/testman/compare.php?ids=107619,107611
