### PR TITLE
[WDMAUD]  WdmAudGetDeviceInterface: fix memory leak and protect the buffer

### DIFF
--- a/drivers/wdm/audio/legacy/wdmaud/CMakeLists.txt
+++ b/drivers/wdm/audio/legacy/wdmaud/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 add_definitions(-D_COMDDK_)
 
 include_directories(
@@ -15,7 +14,7 @@ list(APPEND SOURCE
 
 add_library(wdmaud MODULE ${SOURCE} wdmaud.rc)
 set_module_type(wdmaud kernelmodedriver)
-target_link_libraries(wdmaud mmixer libcntpr)
+target_link_libraries(wdmaud mmixer libcntpr seh)
 add_pch(wdmaud wdmaud.h SOURCE)
 add_importlibs(wdmaud ntoskrnl ks hal)
 add_cd_file(TARGET wdmaud DESTINATION reactos/system32/drivers FOR all)

--- a/drivers/wdm/audio/legacy/wdmaud/CMakeLists.txt
+++ b/drivers/wdm/audio/legacy/wdmaud/CMakeLists.txt
@@ -14,7 +14,7 @@ list(APPEND SOURCE
 
 add_library(wdmaud MODULE ${SOURCE} wdmaud.rc)
 set_module_type(wdmaud kernelmodedriver)
-target_link_libraries(wdmaud mmixer libcntpr seh)
+target_link_libraries(wdmaud mmixer libcntpr pseh)
 add_pch(wdmaud wdmaud.h SOURCE)
 add_importlibs(wdmaud ntoskrnl ks hal)
 add_cd_file(TARGET wdmaud DESTINATION reactos/system32/drivers FOR all)

--- a/drivers/wdm/audio/legacy/wdmaud/control.c
+++ b/drivers/wdm/audio/legacy/wdmaud/control.c
@@ -253,12 +253,21 @@ WdmAudGetDeviceInterface(
     {
         /* buffer too small */
         DeviceInfo->u.Interface.DeviceInterfaceStringSize = Length;
+        FreeItem(Device);
         return SetIrpIoStatus(Irp, STATUS_BUFFER_OVERFLOW, sizeof(WDMAUD_DEVICE_INFO));
     }
     else
     {
-        //FIXME SEH
-        RtlMoveMemory(DeviceInfo->u.Interface.DeviceInterfaceString, Device, Length);
+        __try
+        {
+            ProbeForWrite(DeviceInfo->u.Interface.DeviceInterfaceString, Length, sizeof(WCHAR));
+            RtlMoveMemory(DeviceInfo->u.Interface.DeviceInterfaceString, Device, Length);
+        }
+        __except(EXCEPTION_EXECUTE_HANDLER)
+        {
+            FreeItem(Device);
+            return SetIrpIoStatus(Irp, GetExceptionCode(), 0);
+        }
     }
 
     FreeItem(Device);

--- a/drivers/wdm/audio/legacy/wdmaud/control.c
+++ b/drivers/wdm/audio/legacy/wdmaud/control.c
@@ -258,16 +258,17 @@ WdmAudGetDeviceInterface(
     }
     else
     {
-        __try
+        _SEH2_TRY
         {
             ProbeForWrite(DeviceInfo->u.Interface.DeviceInterfaceString, Length, sizeof(WCHAR));
             RtlMoveMemory(DeviceInfo->u.Interface.DeviceInterfaceString, Device, Length);
         }
-        __except(EXCEPTION_EXECUTE_HANDLER)
+        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
             FreeItem(Device);
-            return SetIrpIoStatus(Irp, GetExceptionCode(), 0);
+            return SetIrpIoStatus(Irp, _SEH2_GetExceptionCode(), 0);
         }
+        _SEH2_END;
     }
 
     FreeItem(Device);

--- a/drivers/wdm/audio/legacy/wdmaud/wdmaud.h
+++ b/drivers/wdm/audio/legacy/wdmaud/wdmaud.h
@@ -3,6 +3,7 @@
 
 #include <portcls.h>
 #include <mmsystem.h>
+#include <pseh/pseh2.h>
 
 #include "interface.h"
 


### PR DESCRIPTION
## Purpose

Fix a memory leak and a (potential) kernel crash in `WdmAudGetDeviceInterface`
JIRA issue: None

## Proposed changes
- Fix memory leak in WdmAudGetDeviceInterface (FreeItem(Device) was not called on STATUS_BUFFER_OVERFLOW early return path)
- Wrap user-mode buffer write in ProbeForWrite + SEH

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: