### PR TITLE
[KERNEL32] Check `lpNumberOfBytes(Read/Written)` not null before writing like the latest Windows

### DIFF
--- a/dll/win32/kernel32/client/file/rw.c
+++ b/dll/win32/kernel32/client/file/rw.c
@@ -96,11 +96,13 @@ WriteFile(IN HANDLE hFile,
         }
 
         /*
-         * lpNumberOfBytesWritten must not be NULL here, in fact Win doesn't
-         * check that case either and crashes (only after the operation
-         * completed).
+         * The new version of Windows checks lpNumberOfBytesWritten to avoid crashes,
+         * and here we also perform the check as an improvement.
          */
-        *lpNumberOfBytesWritten = Iosb.Information;
+        if (lpNumberOfBytesWritten != NULL)
+        {
+            *lpNumberOfBytesWritten = Iosb.Information;
+        }
 
         if (!NT_SUCCESS(Status))
         {
@@ -218,11 +220,13 @@ ReadFile(IN HANDLE hFile,
         }
 
         /*
-         * lpNumberOfBytesRead must not be NULL here, in fact Win doesn't
-         * check that case either and crashes (only after the operation
-         * completed).
+         * The new version of Windows checks lpNumberOfBytesRead to avoid crashes,
+         * and here we also perform the check as an improvement.
          */
-        *lpNumberOfBytesRead = Iosb.Information;
+        if (lpNumberOfBytesRead != NULL)
+        {
+            *lpNumberOfBytesRead = Iosb.Information;
+        }
 
         if (!NT_SUCCESS(Status))
         {


### PR DESCRIPTION
## Purpose

In the latest Windows, `ReadFile` and `WriteFile` will check `lpNumberOfBytes(Read/Written)` is not `NULL` before writing, even if the document [ReadFile](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile) and [WriteFile](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile) said:
> This parameter can be NULL only when the lpOverlapped parameter is not NULL.
> Windows 7: This parameter can not be NULL.

In my Windows 11, system will check it before writing, unlike old Windows, the following code will success without crash:
```C
ReadFile(hFile, buff, sizeof(buff), NULL, NULL);
WriteFile(hFile, buff, sizeof(buff), NULL, NULL);
```

I didn't guard this modification by macro like `_WIN32_WINNT`, because this looks like an improvement that is consistent with Windows behavior, let me know if you want a guard.

JIRA issue: None

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: