### PR TITLE
[REACTOS] Add WS_TABSTOP to IDD_SUMMARYPAGE IDC_CONFIRM_INSTALL

### DIFF
--- a/base/setup/reactos/lang/bg-BG.rc
+++ b/base/setup/reactos/lang/bg-BG.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/cs-CZ.rc
+++ b/base/setup/reactos/lang/cs-CZ.rc
@@ -145,7 +145,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/de-DE.rc
+++ b/base/setup/reactos/lang/de-DE.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/el-GR.rc
+++ b/base/setup/reactos/lang/el-GR.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/en-US.rc
+++ b/base/setup/reactos/lang/en-US.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/es-ES.rc
+++ b/base/setup/reactos/lang/es-ES.rc
@@ -148,7 +148,7 @@ BEGIN
     LTEXT "Directorio de destino:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "Confirmo que las configuraciones de instalación son correctas. También conozco\nque ReactOS está en un fase de software Alpha y podría romper mi ordenador y corromper mis datos.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Por favor, confirme que todas las configuraciones son correctas,\nluego haga clic en Instalar para empezar el Proceso de Instalación.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/et-EE.rc
+++ b/base/setup/reactos/lang/et-EE.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/eu-ES.rc
+++ b/base/setup/reactos/lang/eu-ES.rc
@@ -146,7 +146,7 @@ BEGIN
     LTEXT "Directorio de destino:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "Confirmo que las configuraciones de instalación son correctas. También conozco\nque ReactOS está en un fase de software Alpha y podría romper mi ordenador y corromper mis datos.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Por favor, confirme que todas las configuraciones son correctas,\nluego haga clic en Instalar para empezar el Proceso de Instalación.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/fi-FI.rc
+++ b/base/setup/reactos/lang/fi-FI.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/fr-FR.rc
+++ b/base/setup/reactos/lang/fr-FR.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Dossier de destination :", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "Je confirme que tous les paramètres sont corrects. Je reconnais également que\nReactOS est un logiciel dans un état de qualité Alpha et peut endommager mon ordinateur ou corrompre mes données.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Merci de confirmer que tous les paramètres d'installation sont corrects,\npuis appuyer sur Installer pour démarrer le processus d'installation.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/he-IL.rc
+++ b/base/setup/reactos/lang/he-IL.rc
@@ -141,7 +141,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/hi-IN.rc
+++ b/base/setup/reactos/lang/hi-IN.rc
@@ -146,7 +146,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/hu-HU.rc
+++ b/base/setup/reactos/lang/hu-HU.rc
@@ -141,7 +141,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/id-ID.rc
+++ b/base/setup/reactos/lang/id-ID.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Direktori tujuan:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "Saya mengonfirmasikan bahwa seluruh penyetelan pemasangan ini adalah benar. Saya juga mengerti bahwa\nReactOS adalah perangkat lunak kualitas alpha dan mungkin saja merusak komputer maupun data saya.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Mohon konfirmasi bahwa seluruh penyetelan pemasangan adalah benar,\nkemudian klik Pasang untuk memulai proses pemasangan.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/it-IT.rc
+++ b/base/setup/reactos/lang/it-IT.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/ja-JP.rc
+++ b/base/setup/reactos/lang/ja-JP.rc
@@ -135,7 +135,7 @@ BEGIN
     LTEXT "インストール先フォルダ:", IDC_STATIC, 6, 89, 88, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "すべてのインストール設定が正しいことを確認しました。また、ReactOS がまだアルファ版であり、あなたのコンピュータやデータを壊す恐れがあることを理解しています。",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "すべてのインストール設定が正しいことを確認し、インストール プロセスを開始するために、インストールをクリックしてください。", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/ms-MY.rc
+++ b/base/setup/reactos/lang/ms-MY.rc
@@ -141,7 +141,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/no-NO.rc
+++ b/base/setup/reactos/lang/no-NO.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/pl-PL.rc
+++ b/base/setup/reactos/lang/pl-PL.rc
@@ -150,7 +150,7 @@ BEGIN
     LTEXT "Katalog docelowy:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "Potwierdzam, że wszystkie ustawienia instalacji są poprawne. Przyjmuję równierz, że system ReactOS to oprogramowanie w fazie Alpha i może w każdej chwili przestać działać lub nieodwracalnie uszkodzić moje dane na dysku.",
-        IDC_CONFIRM_INSTALL, 7, 100, 303, 24, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 100, 303, 24, BS_MULTILINE | WS_TABSTOP
     LTEXT "Potwierdź, że wszystkie ustawienia instalacji są poprawne, a następnie kliknij na Instaluj, aby rozpocząć proces instalacji.", IDC_STATIC, 7, 127, 303, 18
 END
 

--- a/base/setup/reactos/lang/pt-BR.rc
+++ b/base/setup/reactos/lang/pt-BR.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/pt-PT.rc
+++ b/base/setup/reactos/lang/pt-PT.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Directório de destino:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "Confirmo que todas as definições de  instalação estão correctas. Também reconheço que\no ReactOS é um software de qualidade Alpha e pode parar o meu computador ou corromper os meus dados.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Por favor confirme que todas as definições de  instalação estão correctas,\nde seguida clique em Instalar para iniciar o processo de instalação.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/ro-RO.rc
+++ b/base/setup/reactos/lang/ro-RO.rc
@@ -148,7 +148,7 @@ BEGIN
     LTEXT "Director de destinație:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "Confirm că toate setările de instalare sunt corecte. Recunosc, de asemenea, că\nReactOS este un software de calitate alfa și se poate deteriora pe computerul meu sau îmi poate deteriora datele.",
-        IDC_CONFIRM_INSTALL, 7, 104, 310, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 310, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Vă rugăm să confirmați că toate setările de instalare sunt corecte,\nfaceți clic pe Instalare pentru a începe procesul de instalare.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/ru-RU.rc
+++ b/base/setup/reactos/lang/ru-RU.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/sk-SK.rc
+++ b/base/setup/reactos/lang/sk-SK.rc
@@ -144,7 +144,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/sq-AL.rc
+++ b/base/setup/reactos/lang/sq-AL.rc
@@ -141,7 +141,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/tr-TR.rc
+++ b/base/setup/reactos/lang/tr-TR.rc
@@ -146,7 +146,7 @@ BEGIN
     LTEXT "Hedef dizin:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "Bütün kurulum ayarlarının doğru olduğunu onaylıyorum. Ayrıca, ReactOS'un alfa durumunda yazılım olduğunu ve bilgisayarımı bozacağını veya verilerimi bozacağını kabul ediyorum.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Lütfen bütün kurulum ayarlarının doğru olduğundan emin olunuz,\nardından kurulum işlemine başlamak için Kur'a tıklayınız.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/uk-UA.rc
+++ b/base/setup/reactos/lang/uk-UA.rc
@@ -147,7 +147,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/vi-VN.rc
+++ b/base/setup/reactos/lang/vi-VN.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/zh-CN.rc
+++ b/base/setup/reactos/lang/zh-CN.rc
@@ -139,7 +139,7 @@ BEGIN
     LTEXT "目标目录：", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "我确认我的操作是无误的。我同样了解 ReactOS\n 是一款 alpha 级软件，可能会损害我的计算机或破坏我的数据。",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "请确认所有安装设置正确，\n然后点击安装开始安装。", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/zh-HK.rc
+++ b/base/setup/reactos/lang/zh-HK.rc
@@ -147,7 +147,7 @@ BEGIN
     LTEXT "目的地路徑：", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "我確定所有的安裝設定正確。\n我亦明白 ReactOS 目前處於 Alpha 測試階段，有可能損壞電腦或導致我的資料損毀。",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "請確定所有的安裝設定正確，\n然後按［安裝］，開始安裝程序。", IDC_STATIC, 7, 124, 303, 18
 END
 

--- a/base/setup/reactos/lang/zh-TW.rc
+++ b/base/setup/reactos/lang/zh-TW.rc
@@ -147,7 +147,7 @@ BEGIN
     LTEXT "目的地路徑：", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "我確定所有的安裝設定是正確的。\n我亦明白 ReactOS 目前處於 Alpha 測試階段，有可能損壞電腦或導致我的資料損毀。",
-        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
+        IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE | WS_TABSTOP
     LTEXT "請確定所有的安裝設定是正確的，\n然後按［安裝］，開始安裝程序。", IDC_STATIC, 7, 124, 303, 18
 END
 


### PR DESCRIPTION
## Purpose
Due to resource compiler (`windres`)'s bug, `WS_TABSTOP` style wasn't added to `IDC_CONFIRM_INSTALL` checkbox (I've confirmed `WS_TABSTOP` lackness on `reactos.exe` with Resource Hacker and RisohEditor). This PR will improve keyboard usability.

JIRA issue: N/A

## Proposed changes

- Add `WS_TABSTOP` style to `IDC_CONFIRM_INSTALL` checkbox in `IDD_SUMMARYPAGE` resource dialog.

## Screenshots

BEFORE:
<img width="800" height="600" alt="before" src="https://github.com/user-attachments/assets/477c8bcf-8f63-4133-a819-916cdf57e48e" />

AFTER:
<img width="800" height="600" alt="after" src="https://github.com/user-attachments/assets/857a7d6b-3fbf-4d18-a20d-5f6890879191" />

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107629,107650
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107632,107651