### PR TITLE
[WINLOGON] Optimize StartLsass and StartServicesManager

### DIFF
--- a/base/system/winlogon/winlogon.c
+++ b/base/system/winlogon/winlogon.c
@@ -54,12 +54,6 @@ StartServicesManager(VOID)
     /* Start the service control manager (services.exe) */
     ZeroMemory(&StartupInfo, sizeof(STARTUPINFOW));
     StartupInfo.cb = sizeof(StartupInfo);
-    StartupInfo.lpReserved = NULL;
-    StartupInfo.lpDesktop = NULL;
-    StartupInfo.lpTitle = NULL;
-    StartupInfo.dwFlags = 0;
-    StartupInfo.cbReserved2 = 0;
-    StartupInfo.lpReserved2 = 0;
 
     TRACE("WL: Creating new process - %S\n", ServiceString);
 
@@ -102,12 +96,6 @@ StartLsass(VOID)
     /* Start the local security authority subsystem (lsass.exe) */
     ZeroMemory(&StartupInfo, sizeof(STARTUPINFOW));
     StartupInfo.cb = sizeof(StartupInfo);
-    StartupInfo.lpReserved = NULL;
-    StartupInfo.lpDesktop = NULL;
-    StartupInfo.lpTitle = NULL;
-    StartupInfo.dwFlags = 0;
-    StartupInfo.cbReserved2 = 0;
-    StartupInfo.lpReserved2 = 0;
 
     TRACE("WL: Creating new process - %S\n", ServiceString);
 

--- a/base/system/winlogon/winlogon.c
+++ b/base/system/winlogon/winlogon.c
@@ -5,7 +5,7 @@
  * PURPOSE:         Logon
  * PROGRAMMERS:     Thomas Weidenmueller (w3seek@users.sourceforge.net)
  *                  Filip Navara
- *                  Hervé Poussineau (hpoussin@reactos.org)
+ *                  HervÃ© Poussineau (hpoussin@reactos.org)
  */
 
 /* INCLUDES *****************************************************************/
@@ -52,7 +52,6 @@ StartServicesManager(VOID)
     BOOL res;
 
     /* Start the service control manager (services.exe) */
-
     TRACE("WL: Creating new process - %S\n", ServiceString);
 
     res = CreateProcessW(ServiceString,

--- a/base/system/winlogon/winlogon.c
+++ b/base/system/winlogon/winlogon.c
@@ -46,14 +46,12 @@ static
 BOOL
 StartServicesManager(VOID)
 {
-    STARTUPINFOW StartupInfo;
+    STARTUPINFOW StartupInfo = { sizeof(StartupInfo) };
     PROCESS_INFORMATION ProcessInformation;
     LPCWSTR ServiceString = L"services.exe";
     BOOL res;
 
     /* Start the service control manager (services.exe) */
-    ZeroMemory(&StartupInfo, sizeof(STARTUPINFOW));
-    StartupInfo.cb = sizeof(StartupInfo);
 
     TRACE("WL: Creating new process - %S\n", ServiceString);
 
@@ -88,14 +86,12 @@ static
 BOOL
 StartLsass(VOID)
 {
-    STARTUPINFOW StartupInfo;
+    STARTUPINFOW StartupInfo = { sizeof(StartupInfo) };
     PROCESS_INFORMATION ProcessInformation;
     LPCWSTR ServiceString = L"lsass.exe";
     BOOL res;
 
     /* Start the local security authority subsystem (lsass.exe) */
-    ZeroMemory(&StartupInfo, sizeof(STARTUPINFOW));
-    StartupInfo.cb = sizeof(StartupInfo);
 
     TRACE("WL: Creating new process - %S\n", ServiceString);
 

--- a/base/system/winlogon/winlogon.c
+++ b/base/system/winlogon/winlogon.c
@@ -90,7 +90,6 @@ StartLsass(VOID)
     BOOL res;
 
     /* Start the local security authority subsystem (lsass.exe) */
-
     TRACE("WL: Creating new process - %S\n", ServiceString);
 
     res = CreateProcessW(ServiceString,

--- a/base/system/winlogon/winlogon.c
+++ b/base/system/winlogon/winlogon.c
@@ -53,7 +53,6 @@ StartServicesManager(VOID)
 
     /* Start the service control manager (services.exe) */
     TRACE("WL: Creating new process - %S\n", ServiceString);
-
     res = CreateProcessW(ServiceString,
                          NULL,
                          NULL,

--- a/base/system/winlogon/winlogon.c
+++ b/base/system/winlogon/winlogon.c
@@ -91,7 +91,6 @@ StartLsass(VOID)
 
     /* Start the local security authority subsystem (lsass.exe) */
     TRACE("WL: Creating new process - %S\n", ServiceString);
-
     res = CreateProcessW(ServiceString,
                          NULL,
                          NULL,


### PR DESCRIPTION
## Purpose

Optimize for speed.
JIRA issue: N/A

## Proposed changes

- Do not initialize the `STARTUPINFO` member, which is already filled with zeros, with zeros, in `StartLsass` and `StartServicesManager` functions.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107629,107678
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107632,107679