### PR TITLE
[WIN32K:NTGDI] Fix brush origin for pattern painting

### DIFF
--- a/win32ss/gdi/ntgdi/bitblt.c
+++ b/win32ss/gdi/ntgdi/bitblt.c
@@ -1274,7 +1274,7 @@ IntGdiFillRgn(
     bRet = IntEngPaint(&pdc->dclevel.pSurface->SurfObj,
                        (CLIPOBJ *)&xcoClip,
                        pbo,
-                       &pdc->pdcattr->ptlBrushOrigin,
+                       &pdc->ptlFillOrigin,
                        mix);
 
     DC_vFinishBlit(pdc, NULL);
@@ -1547,10 +1547,10 @@ NtGdiGetPixel(
     ptlSrc.x += pdc->ptlDCOrig.x;
     ptlSrc.y += pdc->ptlDCOrig.y;
 
-    rcDest.left = x;
-    rcDest.top = y;
-    rcDest.right = x + 1;
-    rcDest.bottom = y + 1;
+    rcDest.left = ptlSrc.x;
+    rcDest.top = ptlSrc.y;
+    rcDest.right = ptlSrc.x + 1;
+    rcDest.bottom = ptlSrc.y + 1;
 
     /* Prepare DC for blit */
     DC_vPrepareDCsForBlit(pdc, &rcDest, NULL, NULL);


### PR DESCRIPTION
## Purpose

Fix painting with pattern brush.
Use pdc->ptlFillOrigin (which is adjusted by the Window origin already) instead of pdc->pdcattr->ptlBrushOrigin. Fixes several gdiplus_winetest:brush tests

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107828,107836,107840
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107829,107837,107841