### PR TITLE
[NDK][RTL] Fix packing leak and ARM64 heap layouts

### DIFF
--- a/sdk/include/ndk/pstypes.h
+++ b/sdk/include/ndk/pstypes.h
@@ -1546,7 +1546,6 @@ typedef struct _EPROCESS
 //
 // Job Token Filter Data
 //
-#include <pshpack1.h>
 typedef struct _PS_JOB_TOKEN_FILTER
 {
     ULONG CapturedSidCount;
@@ -1617,7 +1616,6 @@ typedef struct _EJOB
     ULONG MemberLevel;
     ULONG JobFlags;
 } EJOB, *PEJOB;
-#include <poppack.h>
 
 //
 // Job Information Structures for NtQueryInformationJobObject

--- a/sdk/include/ndk/rtltypes.h
+++ b/sdk/include/ndk/rtltypes.h
@@ -1788,7 +1788,7 @@ typedef struct _STACK_TRACE_DATABASE
         PVOID Lock;
 
         /* Padding for ERESOURCE */
-#if defined(_M_AMD64)
+#ifdef _WIN64
         UCHAR Padding[0x68];
 #else
         UCHAR Padding[56];
@@ -1814,9 +1814,7 @@ typedef struct _STACK_TRACE_DATABASE
 
 // Validate that our padding is big enough:
 #ifndef NTOS_MODE_USER
-#if defined(_M_AMD64)
-C_ASSERT(sizeof(ERESOURCE) <= 0x68);
-#elif defined(_M_ARM64)
+#ifdef _WIN64
 C_ASSERT(sizeof(ERESOURCE) <= 0x68);
 #else
 C_ASSERT(sizeof(ERESOURCE) <= 56);

--- a/sdk/lib/rtl/heap.c
+++ b/sdk/lib/rtl/heap.c
@@ -196,12 +196,12 @@ RtlpInitializeHeap(OUT PHEAP Heap,
     /* Initialise the Heap alignment info */
     if (Flags & HEAP_CREATE_ALIGN_16)
     {
-        Heap->AlignMask = (ULONG) ~15;
+        Heap->AlignMask = ~(ULONG_PTR)15;
         Heap->AlignRound = 15 + sizeof(HEAP_ENTRY);
     }
     else
     {
-        Heap->AlignMask = (ULONG) ~(sizeof(HEAP_ENTRY) - 1);
+        Heap->AlignMask = ~(ULONG_PTR)(sizeof(HEAP_ENTRY) - 1);
         Heap->AlignRound = 2 * sizeof(HEAP_ENTRY) - 1;
     }
 

--- a/sdk/lib/rtl/heap.h
+++ b/sdk/lib/rtl/heap.h
@@ -77,7 +77,7 @@ RtlpHeapIsSpecial(ULONG Flags)
 /* Heap structures */
 struct _HEAP_COMMON_ENTRY
 {
-#ifdef _M_AMD64
+#ifdef _WIN64
     PVOID PreviousBlockPrivateData;
 #endif
     union
@@ -90,7 +90,7 @@ struct _HEAP_COMMON_ENTRY
         };
         struct
         {
-#ifndef _M_AMD64
+#ifndef _WIN64
             PVOID SubSegmentCode;
 #else
             ULONG SubSegmentCodeDummy;
@@ -139,8 +139,16 @@ typedef struct _HEAP_ENTRY
 
 #ifdef _WIN64
 C_ASSERT(sizeof(HEAP_ENTRY) == 16);
+C_ASSERT(FIELD_OFFSET(HEAP_ENTRY, Size) == 8);
+C_ASSERT(FIELD_OFFSET(HEAP_ENTRY, Flags) == 10);
+C_ASSERT(FIELD_OFFSET(HEAP_ENTRY, PreviousSize) == 12);
+C_ASSERT(FIELD_OFFSET(HEAP_ENTRY, UnusedBytes) == 15);
 #else
 C_ASSERT(sizeof(HEAP_ENTRY) == 8);
+C_ASSERT(FIELD_OFFSET(HEAP_ENTRY, Size) == 0);
+C_ASSERT(FIELD_OFFSET(HEAP_ENTRY, Flags) == 2);
+C_ASSERT(FIELD_OFFSET(HEAP_ENTRY, PreviousSize) == sizeof(PVOID));
+C_ASSERT(FIELD_OFFSET(HEAP_ENTRY, UnusedBytes) == sizeof(PVOID) + 3);
 #endif
 C_ASSERT((1 << HEAP_ENTRY_SHIFT) == sizeof(HEAP_ENTRY));
 C_ASSERT((2 << HEAP_ENTRY_SHIFT) == sizeof(HEAP_FREE_ENTRY));


### PR DESCRIPTION
This issue was exposed while bringing up ARM64, where the leaked pack(1) scope and incomplete Win64 heap layout assumptions caused visible alignment and heap metadata problems.

JIRA issue: [CORE-18200](https://jira.reactos.org/browse/CORE-18200)

The fix is not purely ARM64-specific:

- The PS_JOB_TOKEN_FILTER packing fix restores the intended packing scope
  before EJOB, avoiding accidental packed kernel fields on every target.
- The HEAP_ENTRY layout change makes ARM64 use the same Win64 heap metadata
  layout that AMD64 already used.
- The heap alignment mask fix affects shared 64-bit heap code, so AMD64 also
  benefits from keeping the mask pointer-sized instead of truncating it through
  ULONG.
- The STACK_TRACE_DATABASE padding change treats ARM64 like the other Win64
  target and keeps the ERESOURCE storage large enough.


## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: