### PR TITLE
[RTL] Implement RtlCheckForOrphanedCriticalSections

### DIFF
--- a/sdk/lib/rtl/critical.c
+++ b/sdk/lib/rtl/critical.c
@@ -874,7 +874,7 @@ RtlTryEnterCriticalSection(PRTL_CRITICAL_SECTION CriticalSection)
  **/
 VOID
 NTAPI
-RtlCheckForOrphanedCriticalSections(HANDLE ThreadHandle)
+RtlCheckForOrphanedCriticalSections(_In_ HANDLE ThreadHandle)
 {
     THREAD_BASIC_INFORMATION ThreadInfo;
     NTSTATUS Status;

--- a/sdk/lib/rtl/critical.c
+++ b/sdk/lib/rtl/critical.c
@@ -858,22 +858,22 @@ RtlTryEnterCriticalSection(PRTL_CRITICAL_SECTION CriticalSection)
     return FALSE;
 }
 
-/*++
+/**
+ * @brief
  * RtlCheckForOrphanedCriticalSections
- * @implemented NT5
  *
- * Just calls RtlCheckHeldCriticalSections.
+ * Checks if the given thread owns any critical sections at the time
+ * of its exit, and emits a debug message for each orphaned section found.
  *
- * Params:
- *     ThreadHandle - Handle to the thread to check.
+ * @param[in] ThreadHandle
+ * Handle to the thread to check.
  *
- * Returns:
- *     Nothing
+ * @return
+ * Nothing
  *
- * Remarks:
- *     This function is typically called by the loader during thread exit.
- *
- *--*/
+ * @remarks
+ * This function is typically called by the loader during thread exit.
+ **/
 VOID
 NTAPI
 RtlCheckForOrphanedCriticalSections(_In_ HANDLE ThreadHandle)

--- a/sdk/lib/rtl/critical.c
+++ b/sdk/lib/rtl/critical.c
@@ -867,8 +867,6 @@ RtlCheckHeldCriticalSections(
     THREAD_BASIC_INFORMATION ThreadInfo;
     NTSTATUS Status;
     PLIST_ENTRY ListEntry;
-    PRTL_CRITICAL_SECTION_DEBUG DebugInfo;
-    PRTL_CRITICAL_SECTION CriticalSection;
     HANDLE CurrentThreadId;
 
     /* Early exit if verifier is not active */
@@ -905,6 +903,9 @@ RtlCheckHeldCriticalSections(
     ListEntry = RtlCriticalSectionList.Flink;
     while (ListEntry != &RtlCriticalSectionList)
     {
+        PRTL_CRITICAL_SECTION_DEBUG DebugInfo;
+        PRTL_CRITICAL_SECTION CriticalSection;
+        
         /* Get the debug info from the list entry */
         DebugInfo = CONTAINING_RECORD(
             ListEntry,

--- a/sdk/lib/rtl/critical.c
+++ b/sdk/lib/rtl/critical.c
@@ -13,6 +13,7 @@
 
 #define NDEBUG
 #include <debug.h>
+#include <reactos/verifier.h>
 
 #define MAX_STATIC_CS_DEBUG_OBJECTS 64
 
@@ -24,6 +25,7 @@ static BOOLEAN RtlpDebugInfoFreeList[MAX_STATIC_CS_DEBUG_OBJECTS];
 
 LARGE_INTEGER RtlpTimeout;
 BOOLEAN RtlpTimeoutDisable;
+BOOLEAN RtlpCriticalSectionVerifier = FALSE;
 
 extern BOOLEAN LdrpShutdownInProgress;
 extern HANDLE LdrpShutdownThreadId;
@@ -856,67 +858,108 @@ RtlTryEnterCriticalSection(PRTL_CRITICAL_SECTION CriticalSection)
     return FALSE;
 }
 
-/**
- * @brief
- * RtlCheckForOrphanedCriticalSections
- *
- * Checks if the given thread owns any critical sections at the time
- * of its exit, and emits a debug message for each orphaned section found.
- *
- * @param[in] ThreadHandle
- * Handle to the thread to check.
- *
- * @return
- * Nothing
- *
- * @remarks
- * This function is typically called by the loader during thread exit.
- **/
 VOID
 NTAPI
-RtlCheckForOrphanedCriticalSections(_In_ HANDLE ThreadHandle)
+RtlCheckHeldCriticalSections(
+    _In_ HANDLE ThreadHandle,
+    _In_opt_ PDWORD Reserved)
 {
     THREAD_BASIC_INFORMATION ThreadInfo;
     NTSTATUS Status;
     PLIST_ENTRY ListEntry;
     PRTL_CRITICAL_SECTION_DEBUG DebugInfo;
     PRTL_CRITICAL_SECTION CriticalSection;
+    HANDLE CurrentThreadId;
 
-    /* Get the thread ID from the handle */
-    Status = NtQueryInformationThread(ThreadHandle,
-                                      ThreadBasicInformation,
-                                      &ThreadInfo,
-                                      sizeof(ThreadInfo),
-                                      NULL);
-    if (!NT_SUCCESS(Status))
+    /* Early exit if verifier is not active */
+    if (!RtlpCriticalSectionVerifier)
         return;
+
+    /* Get current thread ID first */
+    CurrentThreadId = NtCurrentTeb()->ClientId.UniqueThread;
+
+    /* Handle the pseudo-handle for current thread */
+    if (ThreadHandle == (HANDLE)-1 || ThreadHandle == NULL)
+    {
+        /* Using current thread */
+        ThreadInfo.ClientId.UniqueThread = CurrentThreadId;
+    }
+    else
+    {
+        /* Query thread info from the handle */
+        Status = NtQueryInformationThread(
+            ThreadHandle,
+            ThreadBasicInformation,
+            &ThreadInfo,
+            sizeof(ThreadInfo),
+            NULL);
+        
+        if (!NT_SUCCESS(Status))
+            return;
+    }
 
     /* Lock the critical section list */
     RtlEnterCriticalSection(&RtlCriticalSectionLock);
 
-    /* Walk global list */
+    /* Walk the global critical section list */
     ListEntry = RtlCriticalSectionList.Flink;
     while (ListEntry != &RtlCriticalSectionList)
     {
-        DebugInfo = CONTAINING_RECORD(ListEntry,
-                                      RTL_CRITICAL_SECTION_DEBUG,
-                                      ProcessLocksList);
+        /* Get the debug info from the list entry */
+        DebugInfo = CONTAINING_RECORD(
+            ListEntry,
+            RTL_CRITICAL_SECTION_DEBUG,
+            ProcessLocksList);
+
         CriticalSection = DebugInfo->CriticalSection;
 
-        /* Check if this CS is owned by the target thread */
+        /* Check if this critical section is owned by the target thread */
         if (CriticalSection &&
             CriticalSection->OwningThread == ThreadInfo.ClientId.UniqueThread)
         {
-            DPRINT1("RtlCheckForOrphanedCriticalSections: "
-                    "Thread %p is exiting while owning critical section %p!\n",
-                    ThreadInfo.ClientId.UniqueThread,
-                    CriticalSection);
+            /* Thread is exiting while owning a critical section! */
+            VERIFIER_STOP(
+                APPLICATION_VERIFIER_EXIT_THREAD_OWNS_LOCK,
+                "Thread is exiting while owning a critical section",
+                CriticalSection,
+                "Critical section object",
+                ThreadInfo.ClientId.UniqueThread,
+                "Thread ID",
+                DebugInfo,
+                "Critical section debug info",
+                NULL,
+                NULL);
         }
 
+        /* Move to next entry */
         ListEntry = ListEntry->Flink;
     }
 
+    /* Release the lock */
     RtlLeaveCriticalSection(&RtlCriticalSectionLock);
+}
+
+/*++
+ * RtlCheckForOrphanedCriticalSections
+ * @implemented NT5
+ *
+ * Just calls RtlCheckHeldCriticalSections.
+ *
+ * Params:
+ *     ThreadHandle - Handle to the thread to check.
+ *
+ * Returns:
+ *     Nothing
+ *
+ * Remarks:
+ *     This function is typically called by the loader during thread exit.
+ *
+ *--*/
+VOID
+NTAPI
+RtlCheckForOrphanedCriticalSections(_In_ HANDLE ThreadHandle)
+{
+    RtlCheckHeldCriticalSections(ThreadHandle, NULL);
 }
 
 LOGICAL

--- a/sdk/lib/rtl/critical.c
+++ b/sdk/lib/rtl/critical.c
@@ -856,11 +856,68 @@ RtlTryEnterCriticalSection(PRTL_CRITICAL_SECTION CriticalSection)
     return FALSE;
 }
 
+/*++
+ * RtlCheckForOrphanedCriticalSections
+ * @implemented NT5
+ *
+ *     Checks if the given thread owns any critical sections at the time
+ *     of its exit, and emits a debug message for each orphaned section found.
+ *
+ * Params:
+ *     ThreadHandle - Handle to the thread to check.
+ *
+ * Returns:
+ *     Nothing
+ *
+ * Remarks:
+ *     This function is typically called by the loader during thread exit.
+ *
+ *--*/
 VOID
 NTAPI
 RtlCheckForOrphanedCriticalSections(HANDLE ThreadHandle)
 {
-    UNIMPLEMENTED;
+    THREAD_BASIC_INFORMATION ThreadInfo;
+    NTSTATUS Status;
+    PLIST_ENTRY ListEntry;
+    PRTL_CRITICAL_SECTION_DEBUG DebugInfo;
+    PRTL_CRITICAL_SECTION CriticalSection;
+
+    /* Get the thread ID from the handle */
+    Status = NtQueryInformationThread(ThreadHandle,
+                                      ThreadBasicInformation,
+                                      &ThreadInfo,
+                                      sizeof(ThreadInfo),
+                                      NULL);
+    if (!NT_SUCCESS(Status))
+        return;
+
+    /* Lock the critical section list */
+    RtlEnterCriticalSection(&RtlCriticalSectionLock);
+
+    /* Walk global list */
+    ListEntry = RtlCriticalSectionList.Flink;
+    while (ListEntry != &RtlCriticalSectionList)
+    {
+        DebugInfo = CONTAINING_RECORD(ListEntry,
+                                      RTL_CRITICAL_SECTION_DEBUG,
+                                      ProcessLocksList);
+        CriticalSection = DebugInfo->CriticalSection;
+
+        /* Check if this CS is owned by the target thread */
+        if (CriticalSection &&
+            CriticalSection->OwningThread == ThreadInfo.ClientId.UniqueThread)
+        {
+            DPRINT1("RtlCheckForOrphanedCriticalSections: "
+                    "Thread %p is exiting while owning critical section %p!\n",
+                    ThreadInfo.ClientId.UniqueThread,
+                    CriticalSection);
+        }
+
+        ListEntry = ListEntry->Flink;
+    }
+
+    RtlLeaveCriticalSection(&RtlCriticalSectionLock);
 }
 
 LOGICAL

--- a/sdk/lib/rtl/critical.c
+++ b/sdk/lib/rtl/critical.c
@@ -856,23 +856,22 @@ RtlTryEnterCriticalSection(PRTL_CRITICAL_SECTION CriticalSection)
     return FALSE;
 }
 
-/*++
+/**
+ * @brief
  * RtlCheckForOrphanedCriticalSections
- * @implemented NT5
  *
- *     Checks if the given thread owns any critical sections at the time
- *     of its exit, and emits a debug message for each orphaned section found.
+ * Checks if the given thread owns any critical sections at the time
+ * of its exit, and emits a debug message for each orphaned section found.
  *
- * Params:
- *     ThreadHandle - Handle to the thread to check.
+ * @param[in] ThreadHandle
+ * Handle to the thread to check.
  *
- * Returns:
- *     Nothing
+ * @return
+ * Nothing
  *
- * Remarks:
- *     This function is typically called by the loader during thread exit.
- *
- *--*/
+ * @remarks
+ * This function is typically called by the loader during thread exit.
+ **/
 VOID
 NTAPI
 RtlCheckForOrphanedCriticalSections(HANDLE ThreadHandle)

--- a/sdk/lib/rtl/critical.c
+++ b/sdk/lib/rtl/critical.c
@@ -858,29 +858,39 @@ RtlTryEnterCriticalSection(PRTL_CRITICAL_SECTION CriticalSection)
     return FALSE;
 }
 
+/*++
+ * RtlCheckForOrphanedCriticalSections
+ * @implemented NT5
+ *
+ * Just calls RtlCheckHeldCriticalSections.
+ *
+ * Params:
+ *     ThreadHandle - Handle to the thread to check.
+ *
+ * Returns:
+ *     Nothing
+ *
+ * Remarks:
+ *     This function is typically called by the loader during thread exit.
+ *
+ *--*/
 VOID
 NTAPI
-RtlCheckHeldCriticalSections(
-    _In_ HANDLE ThreadHandle,
-    _In_opt_ PDWORD Reserved)
+RtlCheckForOrphanedCriticalSections(_In_ HANDLE ThreadHandle)
 {
     THREAD_BASIC_INFORMATION ThreadInfo;
     NTSTATUS Status;
     PLIST_ENTRY ListEntry;
-    HANDLE CurrentThreadId;
 
     /* Early exit if verifier is not active */
     if (!RtlpCriticalSectionVerifier)
         return;
 
     /* Get current thread ID first */
-    CurrentThreadId = NtCurrentTeb()->ClientId.UniqueThread;
-
-    /* Handle the pseudo-handle for current thread */
-    if (ThreadHandle == (HANDLE)-1 || ThreadHandle == NULL)
+    if (ThreadHandle == NtCurrentThread())
     {
         /* Using current thread */
-        ThreadInfo.ClientId.UniqueThread = CurrentThreadId;
+        ThreadInfo.ClientId.UniqueThread = NtCurrentTeb()->ClientId.UniqueThread;
     }
     else
     {
@@ -905,7 +915,7 @@ RtlCheckHeldCriticalSections(
     {
         PRTL_CRITICAL_SECTION_DEBUG DebugInfo;
         PRTL_CRITICAL_SECTION CriticalSection;
-        
+
         /* Get the debug info from the list entry */
         DebugInfo = CONTAINING_RECORD(
             ListEntry,
@@ -930,37 +940,14 @@ RtlCheckHeldCriticalSections(
                 "Critical section debug info",
                 NULL,
                 NULL);
+            
+            /* TODO: Add stack trace information here (CORE-16870) */
         }
 
-        /* Move to next entry */
         ListEntry = ListEntry->Flink;
     }
 
-    /* Release the lock */
     RtlLeaveCriticalSection(&RtlCriticalSectionLock);
-}
-
-/*++
- * RtlCheckForOrphanedCriticalSections
- * @implemented NT5
- *
- * Just calls RtlCheckHeldCriticalSections.
- *
- * Params:
- *     ThreadHandle - Handle to the thread to check.
- *
- * Returns:
- *     Nothing
- *
- * Remarks:
- *     This function is typically called by the loader during thread exit.
- *
- *--*/
-VOID
-NTAPI
-RtlCheckForOrphanedCriticalSections(_In_ HANDLE ThreadHandle)
-{
-    RtlCheckHeldCriticalSections(ThreadHandle, NULL);
 }
 
 LOGICAL

--- a/sdk/lib/rtl/critical.c
+++ b/sdk/lib/rtl/critical.c
@@ -874,18 +874,6 @@ RtlTryEnterCriticalSection(PRTL_CRITICAL_SECTION CriticalSection)
  * @remarks
  * This function is typically called by the loader during thread exit.
  **/
-/*************************************************************************
- *                RtlCheckForOrphanedCriticalSections
- *
- * @param[in] ThreadHandle
- * Handle to the thread to check.
- *
- * @return
- * Nothing.
- *
- * @remarks
- * This function is typically called by the loader during thread exit.
- */
 VOID
 NTAPI
 RtlCheckForOrphanedCriticalSections(

--- a/sdk/lib/rtl/critical.c
+++ b/sdk/lib/rtl/critical.c
@@ -874,9 +874,22 @@ RtlTryEnterCriticalSection(PRTL_CRITICAL_SECTION CriticalSection)
  * @remarks
  * This function is typically called by the loader during thread exit.
  **/
+/*************************************************************************
+ *                RtlCheckForOrphanedCriticalSections
+ *
+ * @param[in] ThreadHandle
+ * Handle to the thread to check.
+ *
+ * @return
+ * Nothing.
+ *
+ * @remarks
+ * This function is typically called by the loader during thread exit.
+ */
 VOID
 NTAPI
-RtlCheckForOrphanedCriticalSections(_In_ HANDLE ThreadHandle)
+RtlCheckForOrphanedCriticalSections(
+    _In_ HANDLE ThreadHandle)
 {
     THREAD_BASIC_INFORMATION ThreadInfo;
     NTSTATUS Status;
@@ -901,7 +914,7 @@ RtlCheckForOrphanedCriticalSections(_In_ HANDLE ThreadHandle)
             &ThreadInfo,
             sizeof(ThreadInfo),
             NULL);
-        
+
         if (!NT_SUCCESS(Status))
             return;
     }
@@ -921,8 +934,14 @@ RtlCheckForOrphanedCriticalSections(_In_ HANDLE ThreadHandle)
             ListEntry,
             RTL_CRITICAL_SECTION_DEBUG,
             ProcessLocksList);
-
         CriticalSection = DebugInfo->CriticalSection;
+
+        /* Skip our own lock since we own it right now */
+        if (CriticalSection == &RtlCriticalSectionLock)
+        {
+            ListEntry = ListEntry->Flink;
+            continue;
+        }
 
         /* Check if this critical section is owned by the target thread */
         if (CriticalSection &&
@@ -940,7 +959,6 @@ RtlCheckForOrphanedCriticalSections(_In_ HANDLE ThreadHandle)
                 "Critical section debug info",
                 NULL,
                 NULL);
-            
             /* TODO: Add stack trace information here (CORE-16870) */
         }
 


### PR DESCRIPTION
## Purpose

Implement `RtlCheckForOrphanedCriticalSections`.

JIRA issue: [CORE-16870](https://jira.reactos.org/browse/CORE-16870)

## Proposed changes
- Implement `RtlCheckForOrphanedCriticalSections` in critical.c
- Change it's signature to use SAL2

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: