### PR TITLE
[BOOTVID] Optimize and fix VGA text rendering

### DIFF
--- a/drivers/base/bootvid/console.c
+++ b/drivers/base/bootvid/console.c
@@ -79,6 +79,8 @@ VidDisplayStringXY(
 {
     ULONG BackColor;
 
+    PrepareForSetPixel();
+
     /*
      * If the caller wanted transparent, then send the special value (16),
      * else use our default and call the helper routine.
@@ -98,6 +100,8 @@ NTAPI
 VidDisplayString(
     _In_ PCSTR String)
 {
+    BOOLEAN HwStateChanged = TRUE;
+
     /* Start looping the string */
     for (; *String; ++String)
     {
@@ -118,6 +122,7 @@ VidDisplayString(
                 /* Preserve the current row */
                 PreserveRow(VidpCurrentY, BOOTCHAR_HEIGHT + 1, FALSE);
             }
+            HwStateChanged = TRUE;
 
             /* Update current X */
             VidpCurrentX = VidpScrollRegion.Left;
@@ -141,9 +146,16 @@ VidDisplayString(
             {
                 PreserveRow(VidpCurrentY, BOOTCHAR_HEIGHT + 1, TRUE);
                 ClearRow = FALSE;
+
+                HwStateChanged = TRUE;
             }
 
             /* Display this character */
+            if (HwStateChanged)
+            {
+                HwStateChanged = FALSE;
+                PrepareForSetPixel();
+            }
             DisplayCharacter(*String, VidpCurrentX, VidpCurrentY, VidpTextColor, BV_COLOR_NONE);
             VidpCurrentX += BOOTCHAR_WIDTH;
 
@@ -164,6 +176,7 @@ VidDisplayString(
                     /* Preserve the current row */
                     PreserveRow(VidpCurrentY, BOOTCHAR_HEIGHT + 1, FALSE);
                 }
+                HwStateChanged = TRUE;
 
                 /* Update current X */
                 VidpCurrentX = VidpScrollRegion.Left;

--- a/drivers/base/bootvid/i386/pc/vga.c
+++ b/drivers/base/bootvid/i386/pc/vga.c
@@ -118,18 +118,17 @@ DisplayCharacter(
     _In_ ULONG BackColor)
 {
     const UCHAR* FontChar;
-    PUCHAR PixelPtr;
+    PUCHAR PixelPtr, PixelPosition;
     ULONG Height;
-    UCHAR Shift;
-
-    PrepareForSetPixel();
+    ULONG Shift;
 
     /* Calculate shift */
     Shift = Left & 7;
 
     /* Get the font and pixel pointer */
     FontChar = GetFontPtr(Character);
-    PixelPtr = (PUCHAR)(VgaBase + (Left >> 3) + (Top * (SCREEN_WIDTH / 8)));
+    PixelPosition = (PUCHAR)(VgaBase + (Left / 8) + (Top * (SCREEN_WIDTH / 8)));
+    PixelPtr = PixelPosition;
 
     /* Loop all pixel rows */
     for (Height = BOOTCHAR_HEIGHT; Height > 0; --Height)
@@ -147,7 +146,7 @@ DisplayCharacter(
 
         /* Get the font and pixel pointer (2nd byte) */
         FontChar = GetFontPtr(Character);
-        PixelPtr = (PUCHAR)(VgaBase + (Left >> 3) + (Top * (SCREEN_WIDTH / 8)) + 1);
+        PixelPtr = PixelPosition + 1;
 
         /* Loop all pixel rows */
         for (Height = BOOTCHAR_HEIGHT; Height > 0; --Height)
@@ -170,12 +169,12 @@ DisplayCharacter(
 
     /* Get the font and pixel pointer */
     FontChar = GetFontPtr(Character);
-    PixelPtr = (PUCHAR)(VgaBase + (Left >> 3) + (Top * (SCREEN_WIDTH / 8)));
+    PixelPtr = PixelPosition;
 
     /* Loop all pixel rows */
     for (Height = BOOTCHAR_HEIGHT; Height > 0; --Height)
     {
-        SET_PIXELS(PixelPtr, ~*FontChar >> Shift, BackColor);
+        SET_PIXELS(PixelPtr, (UCHAR)~*FontChar >> Shift, BackColor);
         PixelPtr += (SCREEN_WIDTH / 8);
         FontChar += FONT_PTR_DELTA;
     }
@@ -188,12 +187,12 @@ DisplayCharacter(
 
         /* Get the font and pixel pointer (2nd byte) */
         FontChar = GetFontPtr(Character);
-        PixelPtr = (PUCHAR)(VgaBase + (Left >> 3) + (Top * (SCREEN_WIDTH / 8)) + 1);
+        PixelPtr = PixelPosition + 1;
 
         /* Loop all pixel rows */
         for (Height = BOOTCHAR_HEIGHT; Height > 0; --Height)
         {
-            SET_PIXELS(PixelPtr, ~*FontChar << Shift, BackColor);
+            SET_PIXELS(PixelPtr, (UCHAR)~*FontChar << Shift, BackColor);
             PixelPtr += (SCREEN_WIDTH / 8);
             FontChar += FONT_PTR_DELTA;
         }


### PR DESCRIPTION
## Purpose

- Do not call `PrepareForSetPixel()` for each character in a string, instead do it once before iterating over the string. Also call that after executing the `PreserveRow()` and `DoScroll()` operations.
- Add a cast to `UCHAR` to fix displaying of characters with a solid background color.
- Cache the pixel offset.

Test results:
**BEFORE:**
<img width="640" height="480" alt="b" src="https://github.com/user-attachments/assets/f565c4ec-ad57-41a6-b3dd-73331c41bcb2" />

**AFTER:**
<img width="640" height="480" alt="a" src="https://github.com/user-attachments/assets/04ace442-1779-4c67-aee6-22af4e28aa3c" />

JIRA issue: none

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: