### PR TITLE
[CMAKE] Fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 
 cmake_minimum_required(VERSION 3.17.0)
 
-if(NOT CMAKE_VERSION MATCHES "ReactOS")
-    message(WARNING "Building with \"${CMAKE_COMMAND}\", which is not the custom CMake included in RosBE, might cause build issues...")
-endif()
-
 include(CMakeDependentOption)
 
 # CMAKE_CROSSCOMPILING and MSVC_IDE are not set until project() is called, so let's test this instead

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -592,7 +592,6 @@ function(add_linker_script _target _linker_script_file)
             # OUTPUT ${_generated_file}
             TARGET ${_target} PRE_LINK # PRE_BUILD
             COMMAND ${CMAKE_C_COMPILER} /nologo ${_no_std_includes_flag} /D__LINKER__ /EP /c "${_file_full_path}" > "${_generated_file}"
-            DEPENDS ${_file_full_path}
             VERBATIM)
         set_source_files_properties(${_generated_file} PROPERTIES GENERATED TRUE)
         # add_custom_target("${_target}_${_file_name}" ALL DEPENDS ${_generated_file})


### PR DESCRIPTION
## Purpose

Fixes these warnings:

- ```
    CMake Warning at CMakeLists.txt:5 (message):
    Building with "C:/CMake/bin/cmake.exe", which is not the custom CMake
    included in RosBE, might cause build issues..
    ```

  - Removed the warning as I don't see it as necessary
- ```
  CMake Warning (dev) at sdk/cmake/msvc.cmake:591 (add_custom_command):
  The following keywords are not supported when using
  add_custom_command(TARGET): DEPENDS.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
    ```

  - According to the help policy command, ```CMake 3.30 and earlier silently ignored unsupported keywords and missing or
invalid arguments for the different forms of the ``add_custom_command()``
command. CMake 3.31 implements more rigorous argument checking and will flag
invalid or missing arguments as errors.``` I removed the DEPENDS statement since previous versions of cmake ignored it without a warning.

JIRA issue: None

## Proposed changes

- Fix cmake warnings

## Testbot runs (Filled in by Devs)
Not applicable