### PR TITLE
[INCLUDE/WINE] Don't use DECLSPEC_IMPORT in shlwapi.h

### DIFF
--- a/sdk/include/wine/shlwapi.h
+++ b/sdk/include/wine/shlwapi.h
@@ -39,6 +39,16 @@ extern "C" {
 #endif
 #endif
 
+#ifdef __REACTOS__
+#if defined(__GNUC__) && !defined(_SHLWAPI_)
+#  undef WINSHLWAPI
+#  define WINSHLWAPI /* FIXME: HACK: CORE-6504 */
+#endif
+#ifndef __MSABI_LONG
+#  define __MSABI_LONG(x)  x ## l
+#endif
+#endif // __REACTOS__
+
 #ifndef NO_SHLWAPI_HTTP
 
 WINSHLWAPI HRESULT WINAPI GetAcceptLanguagesA(char *buffer, DWORD *buff_len);
@@ -47,11 +57,6 @@ WINSHLWAPI HRESULT WINAPI GetAcceptLanguagesW(WCHAR *buffer, DWORD *buff_len);
 
 #endif /* NO_SHLWAPI_HTTP */
 
-#ifdef __REACTOS__
-#ifndef __MSABI_LONG
-#  define __MSABI_LONG(x)  x ## l
-#endif
-#endif // __REACTOS__
 #ifndef NO_SHLWAPI_REG
 
 /* Registry functions */


### PR DESCRIPTION
This fixes wscript.exe crashing on .wsf files because of delay-loaded shlwapi, the bug was introduced in PR #8419.

Notes:
- I moved the `#ifdef __REACTOS__` fixes block above all the functions so we can hopefully keep all our specific hacks in one place (it was not located close to the thing it was fixing anyway!).

## Testbot runs (Filled in by Devs)

wscript:wsf was not broken on the KVM x64 build by the regression.

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107698,107706 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107699,107708 LGTM