### PR TITLE
[SHELL32][SDK] Add DisconnectWindowsDialog stub

### DIFF
--- a/dll/win32/shell32/dialogs/dialogs.cpp
+++ b/dll/win32/shell32/dialogs/dialogs.cpp
@@ -1687,3 +1687,13 @@ void WINAPI ExitWindowsDialog(HWND hWndOwner)
 
     FreeLibrary(msginaDll);
 }
+
+/*************************************************************************
+ * DisconnectWindowsDialog  [SHELL32.254]
+ *
+ * https://undoc.airesoft.co.uk/shell32.dll/DisconnectWindowsDialog.php
+ */
+EXTERN_C void WINAPI DisconnectWindowsDialog(_In_opt_ HWND hwndUnused)
+{
+    FIXME("stub\n");
+}

--- a/dll/win32/shell32/shell32.spec
+++ b/dll/win32/shell32/shell32.spec
@@ -250,7 +250,7 @@
 251 stdcall -noname PathRemoveArgs(wstr) PathRemoveArgsW
 252 stdcall -noname PathIsURL(wstr) shlwapi.PathIsURLW
 253 stub -noname SHIsCurrentProcessConsoleSession
-254 stub -noname DisconnectWindowsDialog
+254 stdcall -noname DisconnectWindowsDialog(ptr)
 255 stdcall Options_RunDLL(ptr ptr str long)
 256 stdcall SHCreateShellFolderView(ptr ptr)
 257 stdcall -noname SHGetShellFolderViewCB(ptr)

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -247,6 +247,7 @@ void WINAPI RunFileDlg(
 
 int WINAPI LogoffWindowsDialog(HWND hWndOwner);
 void WINAPI ExitWindowsDialog(HWND hWndOwner);
+void WINAPI DisconnectWindowsDialog(_In_opt_ HWND hwndUnused);
 
 BOOL WINAPI SHFindComputer(
     LPCITEMIDLIST pidlRoot,


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Add `DisconnectWindowsDialog` stub to `dialogs.cpp`.
- Modify `shell32.spec`.
- Add prototype to `<undocshell.h>`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107629,107711
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107632,107712