### PR TITLE
[SHELL32] Initialize ShellState registry entry

### DIFF
--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -379,6 +379,10 @@ VOID WINAPI SHGetSetSettings(LPSHELLSTATE lpss, DWORD dwMask, BOOL bSet)
                 SHELL32_GetDefaultShellState(gpss);
                 read = 0; // The advanced items we read are no longer valid in gpss
                 g_CachedSSF = SSF_STRUCTONLY;
+                /* HACKFIX: This should not be needed. Defaults should be used
+                 * until an override option is selected. See CORE-20585. */
+                rss.ss = *gpss;
+                SHELL32_WriteRegShellState(&rss);
             }
         }
         SHGSS_GetSetStruct(SHGSS_GetField); // Copy requested items from gpss to output


### PR DESCRIPTION
CORE-20585

## Purpose

_Initialize ShellState registry entry to start with default values._

JIRA issue: [CORE-20585](https://jira.reactos.org/browse/CORE-20585)

## Proposed changes

_When ShellState is needed and there is no registry key use defaults and save value to registry._

## Testbot runs (Filled in by Devs)

- [x] https://reactos.org/testman/compare.php?ids=107698,107715 LGTM
- [x] https://reactos.org/testman/compare.php?ids=107699,107714 LGTM