### PR TITLE
[SHLWAPI][SHLWAPI_APITEST][SDK] Support NextPathA/W

### DIFF
--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -446,8 +446,8 @@
 446 stdcall -noname PathFileExistsAndAttributesW(wstr ptr)
 447 stub -noname FixSlashesAndColonA
 448 stdcall -noname FixSlashesAndColonW(wstr)
-449 stub -noname NextPathA
-450 stub -noname NextPathW
+449 stdcall -noname NextPathA(str ptr long)
+450 stdcall -noname NextPathW(wstr ptr long)
 451 stdcall -noname CharUpperNoDBCSA(str)
 452 stdcall -noname CharUpperNoDBCSW(wstr)
 453 stdcall -noname CharLowerNoDBCSA(str)

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -718,7 +718,7 @@ NextPathA(
     _Out_writes_(cchDest) LPSTR pszDest,
     _In_ UINT cchDest)
 {
-    if (!pszStart)
+    if (!pszStart || !cchDest)
         return NULL;
 
     PCSTR pchSegStart = pszStart;
@@ -733,12 +733,11 @@ NextPathA(
         pchSegEnd = (PSTR)(pchSegStart + strlen(pchSegStart));
 
     UINT segLen = (UINT)(pchSegEnd - pchSegStart);
-    UINT copyLen = segLen + 1;
-    if (cchDest < copyLen)
-        copyLen = cchDest;
+    UINT copyLen = min(segLen + 1, cchDest);
+    HRESULT hr = StringCchCopyA(pszDest, copyLen, pchSegStart);
+    if (FAILED(hr))
+        return NULL;
 
-    lstrcpynA(pszDest, pchSegStart, copyLen);
-    pszDest[segLen] = ANSI_NULL;
     PathRemoveBlanksA(pszDest);
 
     if (!*pszDest)
@@ -763,7 +762,7 @@ NextPathW(
     _Out_writes_(cchDest) PWSTR pszDest,
     _In_ UINT cchDest)
 {
-    if (!pszStart)
+    if (!pszStart || !cchDest)
         return NULL;
 
     PCWSTR pchSegStart = pszStart;
@@ -778,15 +777,15 @@ NextPathW(
         pchSegEnd = (PWSTR)(pchSegStart + wcslen(pchSegStart));
 
     UINT segLen = (UINT)(pchSegEnd - pchSegStart);
-    UINT copyLen = segLen + 1;
-    if (cchDest < copyLen)
-        copyLen = cchDest;
+    UINT copyLen = min(segLen + 1, cchDest);
+    HRESULT hr = StringCchCopyW(pszDest, copyLen, pchSegStart);
+    if (FAILED(hr))
+        return NULL;
 
-    lstrcpynW(pszDest, pchSegStart, copyLen);
-    pszDest[segLen] = UNICODE_NULL;
     PathRemoveBlanksW(pszDest);
 
     if (!*pszDest)
         return NULL;
+
     return (*pchSegEnd == L';') ? (pchSegEnd + 1) : pchSegEnd;
 }

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -710,7 +710,7 @@ SHDialogBox(
 EXTERN_C PSTR WINAPI
 NextPathA(
     _In_ PCSTR pszStart,
-    _Out_writes_(cchDest) LPSTR pszDest,
+    _Out_writes_(cchDest) PSTR pszDest,
     _In_ UINT cchDest)
 {
     if (!pszStart || !cchDest)

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -733,8 +733,7 @@ NextPathA(
         pchSegEnd = (PSTR)(pchSegStart + strlen(pchSegStart));
 
     UINT segLen = (UINT)(pchSegEnd - pchSegStart);
-    UINT copyLen = min(segLen + 1, cchDest);
-    HRESULT hr = StringCchCopyA(pszDest, copyLen, pchSegStart);
+    HRESULT hr = StringCchCopyNA(pszDest, cchDest, pchSegStart, segLen);
     if (FAILED(hr))
         return NULL;
 
@@ -777,8 +776,7 @@ NextPathW(
         pchSegEnd = (PWSTR)(pchSegStart + wcslen(pchSegStart));
 
     UINT segLen = (UINT)(pchSegEnd - pchSegStart);
-    UINT copyLen = min(segLen + 1, cchDest);
-    HRESULT hr = StringCchCopyW(pszDest, copyLen, pchSegStart);
+    HRESULT hr = StringCchCopyNW(pszDest, cchDest, pchSegStart, segLen);
     if (FAILED(hr))
         return NULL;
 

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -716,27 +716,27 @@ NextPathA(
     if (!pszStart)
         return NULL;
 
-    PCSTR pchSegStart = pszStart;
-    while (*pchSegStart == ';')
-        ++pchSegStart;
+    PCSTR pchStart = pszStart;
+    while (*pchStart == ';')
+        ++pchStart;
 
-    if (!*pchSegStart)
+    if (!*pchStart)
         return NULL;
 
-    PSTR pchSegEnd = StrChrA(pchSegStart, ';');
-    if (!pchSegEnd)
-        pchSegEnd = (PSTR)(pchSegStart + strlen(pchSegStart));
+    PSTR pchEnd = StrChrA(pchStart, ';');
+    if (!pchEnd)
+        pchEnd = (PSTR)(pchStart + strlen(pchStart));
 
-    HRESULT hr = StringCchCopyNA(pszDest, cchDest, pchSegStart, pchSegEnd - pchSegStart);
-    if (FAILED(hr))
-        return NULL;
+    const UINT cchSegment = (UINT)(pchEnd - pchStart);
+    const UINT cchToCopy = min(cchSegment + 1, cchDest);
+    lstrcpynA(pszDest, pchStart, cchToCopy);
+    pszDest[cchSegment] = ANSI_NULL;
 
     PathRemoveBlanksA(pszDest);
-
     if (!*pszDest)
         return NULL;
 
-    return (*pchSegEnd == ';') ? (pchSegEnd + 1) : pchSegEnd;
+    return (*pchEnd == ';') ? (pchEnd + 1) : pchEnd;
 }
 
 /*************************************************************************
@@ -758,25 +758,25 @@ NextPathW(
     if (!pszStart)
         return NULL;
 
-    PCWSTR pchSegStart = pszStart;
-    while (*pchSegStart == L';')
-        ++pchSegStart;
+    PCWSTR pchStart = pszStart;
+    while (*pchStart == L';')
+        ++pchStart;
 
-    if (!*pchSegStart)
+    if (!*pchStart)
         return NULL;
 
-    PWSTR pchSegEnd = StrChrW(pchSegStart, L';');
-    if (!pchSegEnd)
-        pchSegEnd = (PWSTR)(pchSegStart + wcslen(pchSegStart));
+    PWSTR pchEnd = StrChrW(pchStart, L';');
+    if (!pchEnd)
+        pchEnd = (PWSTR)(pchStart + wcslen(pchStart));
 
-    HRESULT hr = StringCchCopyNW(pszDest, cchDest, pchSegStart, pchSegEnd - pchSegStart);
-    if (FAILED(hr))
-        return NULL;
+    const UINT cchSegment = (UINT)(pchEnd - pchStart);
+    const UINT cchToCopy = min(cchSegment + 1, cchDest);
+    lstrcpynW(pszDest, pchStart, cchToCopy);
+    pszDest[cchSegment] = UNICODE_NULL;
 
     PathRemoveBlanksW(pszDest);
-
     if (!*pszDest)
         return NULL;
 
-    return (*pchSegEnd == L';') ? (pchSegEnd + 1) : pchSegEnd;
+    return (*pchEnd == L';') ? (pchEnd + 1) : pchEnd;
 }

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -725,7 +725,7 @@ NextPathA(
 
     PSTR pchEnd = StrChrA(pchStart, ';');
     if (!pchEnd)
-        pchEnd = (PSTR)(pchStart + strlen(pchStart));
+        pchEnd = (PSTR)(pchStart + lstrlenA(pchStart));
 
     const UINT cchSegment = (UINT)(pchEnd - pchStart);
     const UINT cchToCopy = min(cchSegment + 1, cchDest);
@@ -767,7 +767,7 @@ NextPathW(
 
     PWSTR pchEnd = StrChrW(pchStart, L';');
     if (!pchEnd)
-        pchEnd = (PWSTR)(pchStart + wcslen(pchStart));
+        pchEnd = (PWSTR)(pchStart + lstrlenW(pchStart));
 
     const UINT cchSegment = (UINT)(pchEnd - pchStart);
     const UINT cchToCopy = min(cchSegment + 1, cchDest);

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -705,12 +705,7 @@ SHDialogBox(
 /*************************************************************************
  * NextPathA [SHLWAPI.449]
  *
- * Extracts the next path from a semicolon-separated path string (ANSI version)
- *
- * @param pszStart Parsing start position (semicolon-separated path string)
- * @param pszDest Buffer to store the extracted path
- * @param cchDest Buffer size (number of characters)
- * @return Pointer to the beginning of the next path. NULL if there are no more paths.
+ * See NextPathW.
  */
 EXTERN_C PSTR WINAPI
 NextPathA(

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -713,7 +713,7 @@ NextPathA(
     _Out_writes_(cchDest) PSTR pszDest,
     _In_ UINT cchDest)
 {
-    if (!pszStart || !cchDest)
+    if (!pszStart)
         return NULL;
 
     PCSTR pchSegStart = pszStart;
@@ -755,7 +755,7 @@ NextPathW(
     _Out_writes_(cchDest) PWSTR pszDest,
     _In_ UINT cchDest)
 {
-    if (!pszStart || !cchDest)
+    if (!pszStart)
         return NULL;
 
     PCWSTR pchSegStart = pszStart;

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -701,3 +701,92 @@ SHDialogBox(
     SHDIALOG data = { fn, pThis };
     return DialogBoxParamA(hInstance, lpTemplateName, hWndParent, SHDialogProc, (LPARAM)&data);
 }
+
+/*************************************************************************
+ * NextPathA [SHLWAPI.449]
+ *
+ * Extracts the next path from a semicolon-separated path string (ANSI version)
+ *
+ * @param pszStart Parsing start position (semicolon-separated path string)
+ * @param pszDest Buffer to store the extracted path
+ * @param cchDest Buffer size (number of characters)
+ * @return Pointer to the beginning of the next path. NULL if there are no more paths.
+ */
+EXTERN_C PSTR WINAPI
+NextPathA(
+    _In_ PCSTR pszStart,
+    _Out_writes_(cchDest) LPSTR pszDest,
+    _In_ UINT cchDest)
+{
+    if (!pszStart)
+        return NULL;
+
+    PCSTR pchSegStart = pszStart;
+    while (*pchSegStart == ';')
+        ++pchSegStart;
+
+    if (!*pchSegStart)
+        return NULL;
+
+    PSTR pchSegEnd = StrChrA(pchSegStart, ';');
+    if (!pchSegEnd)
+        pchSegEnd = (PSTR)(pchSegStart + strlen(pchSegStart));
+
+    UINT segLen = (UINT)(pchSegEnd - pchSegStart);
+    UINT copyLen = segLen + 1;
+    if (cchDest < copyLen)
+        copyLen = cchDest;
+
+    lstrcpynA(pszDest, pchSegStart, copyLen);
+    pszDest[segLen] = ANSI_NULL;
+    PathRemoveBlanksA(pszDest);
+
+    if (!*pszDest)
+        return NULL;
+
+    return (*pchSegEnd == ';') ? (pchSegEnd + 1) : pchSegEnd;
+}
+
+/*************************************************************************
+ * NextPathW [SHLWAPI.450]
+ *
+ * Extracts the next path from a semicolon-separated path string (Unicode version)
+ *
+ * @param pszStart Parsing start position (semicolon-separated path string)
+ * @param pszDest Buffer to store the extracted path
+ * @param cchDest Buffer size (number of characters)
+ * @return Pointer to the beginning of the next path. NULL if there are no more paths.
+ */
+EXTERN_C PWSTR WINAPI
+NextPathW(
+    _In_ PCWSTR pszStart,
+    _Out_writes_(cchDest) PWSTR pszDest,
+    _In_ UINT cchDest)
+{
+    if (!pszStart)
+        return NULL;
+
+    PCWSTR pchSegStart = pszStart;
+    while (*pchSegStart == L';')
+        ++pchSegStart;
+
+    if (!*pchSegStart)
+        return NULL;
+
+    PWSTR pchSegEnd = StrChrW(pchSegStart, L';');
+    if (!pchSegEnd)
+        pchSegEnd = (PWSTR)(pchSegStart + wcslen(pchSegStart));
+
+    UINT segLen = (UINT)(pchSegEnd - pchSegStart);
+    UINT copyLen = segLen + 1;
+    if (cchDest < copyLen)
+        copyLen = cchDest;
+
+    lstrcpynW(pszDest, pchSegStart, copyLen);
+    pszDest[segLen] = UNICODE_NULL;
+    PathRemoveBlanksW(pszDest);
+
+    if (!*pszDest)
+        return NULL;
+    return (*pchSegEnd == L';') ? (pchSegEnd + 1) : pchSegEnd;
+}

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -727,8 +727,7 @@ NextPathA(
     if (!pchSegEnd)
         pchSegEnd = (PSTR)(pchSegStart + strlen(pchSegStart));
 
-    UINT segLen = (UINT)(pchSegEnd - pchSegStart);
-    HRESULT hr = StringCchCopyNA(pszDest, cchDest, pchSegStart, segLen);
+    HRESULT hr = StringCchCopyNA(pszDest, cchDest, pchSegStart, pchSegEnd - pchSegStart);
     if (FAILED(hr))
         return NULL;
 
@@ -770,8 +769,7 @@ NextPathW(
     if (!pchSegEnd)
         pchSegEnd = (PWSTR)(pchSegStart + wcslen(pchSegStart));
 
-    UINT segLen = (UINT)(pchSegEnd - pchSegStart);
-    HRESULT hr = StringCchCopyNW(pszDest, cchDest, pchSegStart, segLen);
+    HRESULT hr = StringCchCopyNW(pszDest, cchDest, pchSegStart, pchSegEnd - pchSegStart);
     if (FAILED(hr))
         return NULL;
 

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND SOURCE
     IShellFolderHelpers.cpp
     IsQSForward.cpp
     IStreamPidl.cpp
+    NextPath.c
     PathFileExistsDefExtAndAttributesW.c
     PathFindOnPath.c
     PathIsUNC.c

--- a/modules/rostests/apitests/shlwapi/NextPath.c
+++ b/modules/rostests/apitests/shlwapi/NextPath.c
@@ -16,15 +16,15 @@ static FN_NextPathW s_pNextPathW = NULL;
 
 static void TEST_NextPathA(void)
 {
-    PCSTR psz1 = "C:\\TEST1;C:\\TEST2;C:\\TEST3";
-    PCSTR psz2 = "C:\\TEST1;         ;C:\\TEST3";
     PSTR pch;
     CHAR sz[MAX_PATH];
 
+    /* NULL pszStart returns NULL */
     pch = s_pNextPathA(NULL, sz, _countof(sz));
     ok(pch == NULL, "pch was %p\n", pch);
 
-    pch = s_pNextPathA(psz1, sz, _countof(sz));
+    /* Basic semicolon-separated paths */
+    pch = s_pNextPathA("C:\\TEST1;C:\\TEST2;C:\\TEST3", sz, _countof(sz));
     ok_str(sz, "C:\\TEST1");
     pch = s_pNextPathA(pch, sz, _countof(sz));
     ok_str(sz, "C:\\TEST2");
@@ -33,24 +33,62 @@ static void TEST_NextPathA(void)
     pch = s_pNextPathA(pch, sz, _countof(sz));
     ok(pch == NULL, "pch was %p\n", pch);
 
-    pch = (PSTR)psz2;
-    pch = s_pNextPathA(pch, sz, _countof(sz));
+    /* Whitespace-only segment */
+    pch = s_pNextPathA("C:\\TEST1;   ;C:\\TEST3", sz, _countof(sz));
     ok_str(sz, "C:\\TEST1");
     pch = s_pNextPathA(pch, sz, _countof(sz));
     ok(pch == NULL, "pch was %p\n", pch);
+
+    /* Empty string: no paths at all */
+    pch = s_pNextPathA("", sz, _countof(sz));
+    ok(pch == NULL, "empty string: pch was %p\n", pch);
+
+    /* Leading semicolons are skipped */
+    pch = s_pNextPathA(";;;C:\\TEST1", sz, _countof(sz));
+    ok_str(sz, "C:\\TEST1");
+    ok(pch != NULL, "leading semicolons: pch should not be NULL\n");
+
+    /* Trailing semicolon */
+    pch = s_pNextPathA("C:\\TEST1;", sz, _countof(sz));
+    ok_str(sz, "C:\\TEST1");
+    pch = s_pNextPathA(pch, sz, _countof(sz));
+    ok(pch == NULL, "trailing semicolon: pch was %p\n", pch);
+
+    /* Only semicolons */
+    pch = s_pNextPathA(";;;", sz, _countof(sz));
+    ok(pch == NULL, "only semicolons: pch was %p\n", pch);
+
+    /* Path with surrounding spaces */
+    pch = s_pNextPathA("  C:\\TEST1  ;C:\\TEST2", sz, _countof(sz));
+    ok_str(sz, "C:\\TEST1");
+    pch = s_pNextPathA(pch, sz, _countof(sz));
+    ok_str(sz, "C:\\TEST2");
+
+    /* Single path, no semicolon */
+    pch = s_pNextPathA("C:\\SINGLE", sz, _countof(sz));
+    ok_str(sz, "C:\\SINGLE");
+    pch = s_pNextPathA(pch, sz, _countof(sz));
+    ok(pch == NULL, "single path: pch was %p\n", pch);
+
+    /* cchDest = 0 */
+    sz[0] = '*';
+    sz[1] = ANSI_NULL;
+    pch = s_pNextPathA("C:\\TEST1;C:\\TEST2;C:\\TEST3", sz, 0);
+    ok_str(pch, "C:\\TEST2;C:\\TEST3");
+    ok_str(sz, "*");
 }
 
 static void TEST_NextPathW(void)
 {
-    PCWSTR psz1 = L"C:\\TEST1;C:\\TEST2;C:\\TEST3";
-    PCWSTR psz2 = L"C:\\TEST1;         ;C:\\TEST3";
     PWSTR pch;
     WCHAR sz[MAX_PATH];
 
+    /* NULL pszStart returns NULL */
     pch = s_pNextPathW(NULL, sz, _countof(sz));
     ok(pch == NULL, "pch was %p\n", pch);
 
-    pch = s_pNextPathW(psz1, sz, _countof(sz));
+    /* Basic semicolon-separated paths */
+    pch = s_pNextPathW(L"C:\\TEST1;C:\\TEST2;C:\\TEST3", sz, _countof(sz));
     ok_wstr(sz, L"C:\\TEST1");
     pch = s_pNextPathW(pch, sz, _countof(sz));
     ok_wstr(sz, L"C:\\TEST2");
@@ -59,11 +97,49 @@ static void TEST_NextPathW(void)
     pch = s_pNextPathW(pch, sz, _countof(sz));
     ok(pch == NULL, "pch was %p\n", pch);
 
-    pch = (PWSTR)psz2;
-    pch = s_pNextPathW(pch, sz, _countof(sz));
+    /* Whitespace-only segment */
+    pch = s_pNextPathW(L"C:\\TEST1;   ;C:\\TEST3", sz, _countof(sz));
     ok_wstr(sz, L"C:\\TEST1");
     pch = s_pNextPathW(pch, sz, _countof(sz));
     ok(pch == NULL, "pch was %p\n", pch);
+
+    /* Empty string */
+    pch = s_pNextPathW(L"", sz, _countof(sz));
+    ok(pch == NULL, "empty string: pch was %p\n", pch);
+
+    /* Leading semicolons are skipped */
+    pch = s_pNextPathW(L";;;C:\\TEST1", sz, _countof(sz));
+    ok_wstr(sz, L"C:\\TEST1");
+    ok(pch != NULL, "leading semicolons: pch should not be NULL\n");
+
+    /* Trailing semicolon */
+    pch = s_pNextPathW(L"C:\\TEST1;", sz, _countof(sz));
+    ok_wstr(sz, L"C:\\TEST1");
+    pch = s_pNextPathW(pch, sz, _countof(sz));
+    ok(pch == NULL, "trailing semicolon: pch was %p\n", pch);
+
+    /* Only semicolons */
+    pch = s_pNextPathW(L";;;", sz, _countof(sz));
+    ok(pch == NULL, "only semicolons: pch was %p\n", pch);
+
+    /* Path with surrounding spaces */
+    pch = s_pNextPathW(L"  C:\\TEST1  ;C:\\TEST2", sz, _countof(sz));
+    ok_wstr(sz, L"C:\\TEST1");
+    pch = s_pNextPathW(pch, sz, _countof(sz));
+    ok_wstr(sz, L"C:\\TEST2");
+
+    /* Single path, no semicolon */
+    pch = s_pNextPathW(L"C:\\SINGLE", sz, _countof(sz));
+    ok_wstr(sz, L"C:\\SINGLE");
+    pch = s_pNextPathW(pch, sz, _countof(sz));
+    ok(pch == NULL, "single path: pch was %p\n", pch);
+
+    /* cchDest = 0 */
+    sz[0] = L'*';
+    sz[1] = UNICODE_NULL;
+    pch = s_pNextPathW(L"C:\\TEST1;C:\\TEST2;C:\\TEST3", sz, 0);
+    ok_wstr(pch, L"C:\\TEST2;C:\\TEST3");
+    ok_wstr(sz, L"*");
 }
 
 START_TEST(NextPath)

--- a/modules/rostests/apitests/shlwapi/NextPath.c
+++ b/modules/rostests/apitests/shlwapi/NextPath.c
@@ -17,33 +17,53 @@ static FN_NextPathW s_pNextPathW = NULL;
 static void TEST_NextPathA(void)
 {
     PCSTR psz1 = "C:\\TEST1;C:\\TEST2;C:\\TEST3";
-    PSTR pch = (PSTR)psz1;
+    PCSTR psz2 = "C:\\TEST1;         ;C:\\TEST3";
+    PSTR pch;
     CHAR sz[MAX_PATH];
 
-    pch = s_pNextPathA(pch, sz, _countof(sz));
+    pch = s_pNextPathA(NULL, sz, _countof(sz));
+    ok(pch == NULL, "pch was %p\n", pch);
+
+    pch = s_pNextPathA(psz1, sz, _countof(sz));
     ok_str(sz, "C:\\TEST1");
     pch = s_pNextPathA(pch, sz, _countof(sz));
     ok_str(sz, "C:\\TEST2");
     pch = s_pNextPathA(pch, sz, _countof(sz));
     ok_str(sz, "C:\\TEST3");
     pch = s_pNextPathA(pch, sz, _countof(sz));
-    ok(pch == NULL, "pch was %s\n", pch);
+    ok(pch == NULL, "pch was %p\n", pch);
+
+    pch = (PSTR)psz2;
+    pch = s_pNextPathA(pch, sz, _countof(sz));
+    ok_str(sz, "C:\\TEST1");
+    pch = s_pNextPathA(pch, sz, _countof(sz));
+    ok(pch == NULL, "pch was %p\n", pch);
 }
 
 static void TEST_NextPathW(void)
 {
     PCWSTR psz1 = L"C:\\TEST1;C:\\TEST2;C:\\TEST3";
-    PWSTR pch = (PWSTR)psz1;
+    PCWSTR psz2 = L"C:\\TEST1;         ;C:\\TEST3";
+    PWSTR pch;
     WCHAR sz[MAX_PATH];
 
-    pch = s_pNextPathW(pch, sz, _countof(sz));
+    pch = s_pNextPathW(NULL, sz, _countof(sz));
+    ok(pch == NULL, "pch was %p\n", pch);
+
+    pch = s_pNextPathW(psz1, sz, _countof(sz));
     ok_wstr(sz, L"C:\\TEST1");
     pch = s_pNextPathW(pch, sz, _countof(sz));
     ok_wstr(sz, L"C:\\TEST2");
     pch = s_pNextPathW(pch, sz, _countof(sz));
     ok_wstr(sz, L"C:\\TEST3");
     pch = s_pNextPathW(pch, sz, _countof(sz));
-    ok(pch == NULL, "pch was %S\n", pch);
+    ok(pch == NULL, "pch was %p\n", pch);
+
+    pch = (PWSTR)psz2;
+    pch = s_pNextPathW(pch, sz, _countof(sz));
+    ok_wstr(sz, L"C:\\TEST1");
+    pch = s_pNextPathW(pch, sz, _countof(sz));
+    ok(pch == NULL, "pch was %p\n", pch);
 }
 
 START_TEST(NextPath)

--- a/modules/rostests/apitests/shlwapi/NextPath.c
+++ b/modules/rostests/apitests/shlwapi/NextPath.c
@@ -1,0 +1,62 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for NextPathA/W
+ * COPYRIGHT:   Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <apitest.h>
+#include <shlwapi.h>
+
+typedef PSTR  (WINAPI *FN_NextPathA)(PCSTR, PSTR, UINT);
+typedef PWSTR (WINAPI *FN_NextPathW)(PCWSTR, PWSTR, UINT);
+
+static FN_NextPathA s_pNextPathA = NULL;
+static FN_NextPathW s_pNextPathW = NULL;
+
+static void TEST_NextPathA(void)
+{
+    PCSTR psz1 = "C:\\TEST1;C:\\TEST2;C:\\TEST3";
+    PSTR pch = (PSTR)psz1;
+    CHAR sz[MAX_PATH];
+
+    pch = s_pNextPathA(pch, sz, _countof(sz));
+    ok_str(sz, "C:\\TEST1");
+    pch = s_pNextPathA(pch, sz, _countof(sz));
+    ok_str(sz, "C:\\TEST2");
+    pch = s_pNextPathA(pch, sz, _countof(sz));
+    ok_str(sz, "C:\\TEST3");
+    pch = s_pNextPathA(pch, sz, _countof(sz));
+    ok(pch == NULL, "pch was %s\n", pch);
+}
+
+static void TEST_NextPathW(void)
+{
+    PCWSTR psz1 = L"C:\\TEST1;C:\\TEST2;C:\\TEST3";
+    PWSTR pch = (PWSTR)psz1;
+    WCHAR sz[MAX_PATH];
+
+    pch = s_pNextPathW(pch, sz, _countof(sz));
+    ok_wstr(sz, L"C:\\TEST1");
+    pch = s_pNextPathW(pch, sz, _countof(sz));
+    ok_wstr(sz, L"C:\\TEST2");
+    pch = s_pNextPathW(pch, sz, _countof(sz));
+    ok_wstr(sz, L"C:\\TEST3");
+    pch = s_pNextPathW(pch, sz, _countof(sz));
+    ok(pch == NULL, "pch was %S\n", pch);
+}
+
+START_TEST(NextPath)
+{
+    HINSTANCE hSHLWAPI = GetModuleHandleA("shlwapi");
+    s_pNextPathA = (FN_NextPathA)GetProcAddress(hSHLWAPI, MAKEINTRESOURCEA(449));
+    s_pNextPathW = (FN_NextPathW)GetProcAddress(hSHLWAPI, MAKEINTRESOURCEA(450));
+    if (!s_pNextPathA || !s_pNextPathW)
+    {
+        skip("NextPath not found\n");
+        return;
+    }
+
+    TEST_NextPathA();
+    TEST_NextPathW();
+}

--- a/modules/rostests/apitests/shlwapi/testlist.c
+++ b/modules/rostests/apitests/shlwapi/testlist.c
@@ -8,6 +8,7 @@ extern void func_PathFindOnPath(void);
 extern void func_IShellFolderHelpers(void);
 extern void func_IsQSForward(void);
 extern void func_IStreamPidl(void);
+extern void func_NextPath(void);
 extern void func_PathIsUNC(void);
 extern void func_PathIsUNCServer(void);
 extern void func_PathIsUNCServerShare(void);
@@ -32,6 +33,7 @@ const struct test winetest_testlist[] =
     { "IShellFolderHelpers", func_IShellFolderHelpers },
     { "IsQSForward", func_IsQSForward },
     { "IStreamPidl", func_IStreamPidl },
+    { "NextPath", func_NextPath },
     { "PathIsUNC", func_PathIsUNC },
     { "PathIsUNCServer", func_PathIsUNCServer },
     { "PathIsUNCServerShare", func_PathIsUNCServerShare },

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -80,10 +80,25 @@ SHRestrictionLookup(
 
 BOOL WINAPI SHAboutInfoA(LPSTR lpszDest, DWORD dwDestLen);
 BOOL WINAPI SHAboutInfoW(LPWSTR lpszDest, DWORD dwDestLen);
+
+PSTR WINAPI
+NextPathA(
+    _In_ PCSTR pszStart,
+    _Out_writes_(cchDest) LPSTR pszDest,
+    _In_ UINT cchDest);
+
+PWSTR WINAPI
+NextPathW(
+    _In_ PCWSTR pszStart,
+    _Out_writes_(cchDest) PWSTR pszDest,
+    _In_ UINT cchDest)
+
 #ifdef UNICODE
 #define SHAboutInfo SHAboutInfoW
+#define NextPath NextPathW
 #else
 #define SHAboutInfo SHAboutInfoA
+#define NextPath NextPathA
 #endif
 
 HRESULT WINAPI CLSIDFromStringWrap(_In_ LPCWSTR idstr, _Out_ CLSID *id);

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -84,7 +84,7 @@ BOOL WINAPI SHAboutInfoW(LPWSTR lpszDest, DWORD dwDestLen);
 PSTR WINAPI
 NextPathA(
     _In_ PCSTR pszStart,
-    _Out_writes_(cchDest) LPSTR pszDest,
+    _Out_writes_(cchDest) PSTR pszDest,
     _In_ UINT cchDest);
 
 PWSTR WINAPI

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -91,7 +91,7 @@ PWSTR WINAPI
 NextPathW(
     _In_ PCWSTR pszStart,
     _Out_writes_(cchDest) PWSTR pszDest,
-    _In_ UINT cchDest)
+    _In_ UINT cchDest);
 
 #ifdef UNICODE
 #define SHAboutInfo SHAboutInfoW


### PR DESCRIPTION
## Purpose
Implementing missing features...

JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Implement `NextPathA` and `NextPathW` functions.
- Modify `shlwapi.spec`.
- Add prototypes into `<shlwapi_undoc.h>`.
- Add `NextPath` testcase.

## Screenshots

WinXP:
<img width="640" height="480" alt="WinXP" src="https://github.com/user-attachments/assets/cc9d071e-39ad-40c0-9f4b-34c679fa483a" />

Win10:
<img width="579" height="382" alt="Win10" src="https://github.com/user-attachments/assets/287ba401-1a33-4e22-a44e-2505a14ee936" />

ReactOS (AFTER):
<img width="640" height="480" alt="after" src="https://github.com/user-attachments/assets/b6dd99b8-3e67-4894-abd0-310d2411f985" />

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107629,107834
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107632,107833
- [x] Win2003 x64: https://reactos.org/testman/compare.php?ids=107618,107951