### PR TITLE
[SHLWAPI][SDK] Support PathUnExpandEnvStringsForUserA/W

### DIFF
--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -462,8 +462,8 @@
 462 stdcall -noname UrlFixupW(wstr wstr long)
 463 stdcall -noname SHExpandEnvironmentStringsForUserA(ptr str ptr long) userenv.ExpandEnvironmentStringsForUserA
 464 stdcall -noname SHExpandEnvironmentStringsForUserW(ptr wstr ptr long) userenv.ExpandEnvironmentStringsForUserW
-465 stub -noname PathUnExpandEnvStringsForUserA
-466 stdcall -stub -noname PathUnExpandEnvStringsForUserW(ptr wstr ptr long)
+465 stdcall -noname PathUnExpandEnvStringsForUserA(ptr str ptr long)
+466 stdcall -noname PathUnExpandEnvStringsForUserW(ptr wstr ptr long)
 467 stdcall -ordinal SHRunIndirectRegClientCommand(ptr wstr) # Exported by name in Vista+
 468 stdcall -noname RunIndirectRegCommand(ptr ptr wstr wstr)
 469 stdcall -noname RunRegCommand(ptr ptr wstr)

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -42,95 +42,6 @@ GetVersionMajorMinor()
     return MAKEWORD(HIBYTE(version), LOBYTE(version));
 }
 
-static UINT SHTruncateString(PSTR pszStr, UINT cchMax)
-{
-    if (!pszStr || cchMax <= 0)
-        return 0;
-
-    INT cchTrunc = cchMax - 1;
-    PSTR pchSafeTail = pszStr;
-
-    for (PSTR pch = pszStr; *pch && (pch - pszStr) < cchTrunc;)
-    {
-        PSTR pchNext = CharNextA(pch);
-        if (pchNext - pszStr > cchTrunc)
-            break;
-        pchSafeTail = pchNext;
-        pch = pchNext;
-    }
-
-    *pchSafeTail = ANSI_NULL;
-    return (UINT)(pchSafeTail - pszStr);
-}
-
-static DWORD
-SHExpandEnvironmentStringsForUserA(
-    HANDLE hUserToken,
-    PCSTR  lpSrc,
-    PSTR   pszBuff,
-    UINT   cchBuff)
-{
-    DWORD cchResult;
-
-    if (hUserToken)
-    {
-        if (ExpandEnvironmentStringsForUserA(hUserToken, lpSrc, pszBuff, cchBuff))
-            cchResult = lstrlenA(pszBuff) + 1;
-        else
-            cchResult = 0;
-    }
-    else
-    {
-        cchResult = ExpandEnvironmentStringsA(lpSrc, pszBuff, cchBuff);
-    }
-
-    if (cchResult > cchBuff)
-    {
-        SHTruncateString(pszBuff, cchBuff);
-        return 0;
-    }
-
-    if (!cchResult)
-    {
-        lstrcpynA(pszBuff, lpSrc, cchBuff);
-    }
-
-    return cchResult;
-}
-
-DWORD SHExpandEnvironmentStringsForUserW(
-    HANDLE hUserToken,
-    PCWSTR lpSrc,
-    PWSTR  pszBuff,
-    UINT   cchBuff)
-{
-    DWORD cchResult;
-
-    if (hUserToken)
-    {
-        if (ExpandEnvironmentStringsForUserW(hUserToken, lpSrc, pszBuff, cchBuff))
-            cchResult = lstrlenW(pszBuff) + 1;
-        else
-            cchResult = 0;
-    }
-    else
-    {
-        cchResult = ExpandEnvironmentStringsW(lpSrc, pszBuff, cchBuff);
-    }
-
-    if (cchResult > cchBuff)
-    {
-        if (cchBuff)
-            pszBuff[cchBuff - 1] = UNICODE_NULL;
-        return 0;
-    }
-
-    if (!cchResult)
-        lstrcpynW(pszBuff, lpSrc, cchBuff);
-
-    return cchResult;
-}
-
 static BOOL
 UnExpandEnvironmentStringForUserA(
     HANDLE hUserToken,
@@ -140,10 +51,21 @@ UnExpandEnvironmentStringForUserA(
     UINT   cchBuff)
 {
     CHAR szBuff[MAX_PATH];
+    UINT cchExpanded;
 
-    DWORD cchExpanded = SHExpandEnvironmentStringsForUserA(hUserToken, lpSrc, szBuff,
-                                                           _countof(szBuff));
-    if (cchExpanded == 0)
+    if (hUserToken)
+    {
+        if (ExpandEnvironmentStringsForUserA(hUserToken, lpSrc, szBuff, _countof(szBuff)))
+            cchExpanded = lstrlenA(pszBuff) + 1;
+        else
+            cchExpanded = 0;
+    }
+    else
+    {
+        cchExpanded = ExpandEnvironmentStringsA(lpSrc, szBuff, _countof(szBuff));
+    }
+
+    if (cchExpanded > cchBuff || !cchExpanded)
         return FALSE;
 
     INT cchEnvPath = cchExpanded - 1;
@@ -171,10 +93,21 @@ UnExpandEnvironmentStringForUserW(
     UINT   cchBuff)
 {
     WCHAR szBuff[MAX_PATH];
+    UINT cchExpanded;
 
-    DWORD cchExpanded = SHExpandEnvironmentStringsForUserW(hUserToken, lpSrc, szBuff,
-                                                           _countof(szBuff));
-    if (cchExpanded == 0)
+    if (hUserToken)
+    {
+        if (ExpandEnvironmentStringsForUserW(hUserToken, lpSrc, szBuff, _countof(szBuff)))
+            cchExpanded = lstrlenW(pszBuff) + 1;
+        else
+            cchExpanded = 0;
+    }
+    else
+    {
+        cchExpanded = ExpandEnvironmentStringsW(lpSrc, szBuff, _countof(szBuff));
+    }
+
+    if (cchExpanded > cchBuff || !cchExpanded)
         return FALSE;
 
     INT cchEnvPath = cchExpanded - 1;

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -68,7 +68,7 @@ UnExpandEnvironmentStringForUserA(
     if (!cchExpanded || cchExpanded > cchDest)
         return FALSE;
 
-    INT cchEnvPath = (INT)(cchExpanded - 1);
+    INT cchEnvPath = cchExpanded - 1;
     if (CompareStringA(LOCALE_SYSTEM_DEFAULT, NORM_IGNORECASE,
                        szBuff, cchEnvPath, lpString, cchEnvPath) != CSTR_EQUAL)
     {
@@ -110,7 +110,7 @@ UnExpandEnvironmentStringForUserW(
     if (!cchExpanded || cchExpanded > cchDest)
         return FALSE;
 
-    INT cchEnvPath = (INT)(cchExpanded - 1);
+    INT cchEnvPath = cchExpanded - 1;
     if (CompareStringW(LOCALE_SYSTEM_DEFAULT, NORM_IGNORECASE,
                        szBuff, cchEnvPath, lpString, cchEnvPath) != CSTR_EQUAL)
     {

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -19,6 +19,7 @@
 #include <shlwapi.h>
 #include <shlobj_undoc.h>
 #include <shlguid_undoc.h>
+#include <userenv.h>
 #include <atlstr.h>
 
 #include <shlwapi_undoc.h>
@@ -39,6 +40,246 @@ GetVersionMajorMinor()
 {
     DWORD version = GetVersion();
     return MAKEWORD(HIBYTE(version), LOBYTE(version));
+}
+
+static UINT SHTruncateString(PSTR pszStr, UINT cchMax)
+{
+    if (!pszStr || cchMax <= 0)
+        return 0;
+
+    INT cchTrunc = cchMax - 1;
+    PSTR pchSafeTail = pszStr;
+
+    for (PSTR pch = pszStr; *pch && (pch - pszStr) < cchTrunc;)
+    {
+        PSTR pchNext = CharNextA(pch);
+        if (pchNext - pszStr > cchTrunc)
+            break;
+        pchSafeTail = pchNext;
+        pch = pchNext;
+    }
+
+    *pchSafeTail = ANSI_NULL;
+    return (UINT)(pchSafeTail - pszStr);
+}
+
+static DWORD
+SHExpandEnvironmentStringsForUserA(
+    HANDLE hUserToken,
+    PCSTR  lpSrc,
+    PSTR   pszBuff,
+    UINT   cchBuff)
+{
+    DWORD cchResult;
+
+    if (hUserToken)
+    {
+        if (ExpandEnvironmentStringsForUserA(hUserToken, lpSrc, pszBuff, cchBuff))
+            cchResult = lstrlenA(pszBuff) + 1;
+        else
+            cchResult = 0;
+    }
+    else
+    {
+        cchResult = ExpandEnvironmentStringsA(lpSrc, pszBuff, cchBuff);
+    }
+
+    if (cchResult > cchBuff)
+    {
+        SHTruncateString(pszBuff, cchBuff);
+        return 0;
+    }
+
+    if (!cchResult)
+    {
+        lstrcpynA(pszBuff, lpSrc, cchBuff);
+    }
+
+    return cchResult;
+}
+
+DWORD SHExpandEnvironmentStringsForUserW(
+    HANDLE hUserToken,
+    PCWSTR lpSrc,
+    PWSTR  pszBuff,
+    UINT   cchBuff)
+{
+    DWORD cchResult;
+
+    if (hUserToken)
+    {
+        if (ExpandEnvironmentStringsForUserW(hUserToken, lpSrc, pszBuff, cchBuff))
+            cchResult = lstrlenW(pszBuff) + 1;
+        else
+            cchResult = 0;
+    }
+    else
+    {
+        cchResult = ExpandEnvironmentStringsW(lpSrc, pszBuff, cchBuff);
+    }
+
+    if (cchResult > cchBuff)
+    {
+        if (cchBuff)
+            pszBuff[cchBuff - 1] = UNICODE_NULL;
+        return 0;
+    }
+
+    if (!cchResult)
+        lstrcpynW(pszBuff, lpSrc, cchBuff);
+
+    return cchResult;
+}
+
+static BOOL
+UnExpandEnvironmentStringForUserA(
+    HANDLE hUserToken,
+    PCSTR  lpString,
+    PCSTR  lpSrc,
+    PSTR   pszBuff,
+    UINT   cchBuff)
+{
+    CHAR szBuff[MAX_PATH];
+
+    DWORD cchExpanded = SHExpandEnvironmentStringsForUserA(hUserToken, lpSrc, szBuff,
+                                                           _countof(szBuff));
+    if (cchExpanded == 0)
+        return FALSE;
+
+    INT cchEnvPath = cchExpanded - 1;
+    if (CompareStringA(LOCALE_SYSTEM_DEFAULT, NORM_IGNORECASE,
+                       szBuff, cchEnvPath, lpString, cchEnvPath) != CSTR_EQUAL)
+    {
+        return FALSE;
+    }
+
+    INT cchSuffix = lstrlenA(lpString) - cchEnvPath;
+    if (lstrlenA(lpSrc) + cchSuffix >= (INT)cchBuff)
+        return FALSE;
+
+    StringCchCopyA(pszBuff, cchBuff, lpSrc);
+    StringCchCatA(pszBuff, cchBuff, &lpString[cchEnvPath]);
+    return TRUE;
+}
+
+static BOOL
+UnExpandEnvironmentStringForUserW(
+    HANDLE hUserToken,
+    PCWSTR lpString,
+    PCWSTR lpSrc,
+    PWSTR  pszBuff,
+    UINT   cchBuff)
+{
+    WCHAR szBuff[MAX_PATH];
+
+    DWORD cchExpanded = SHExpandEnvironmentStringsForUserW(hUserToken, lpSrc, szBuff,
+                                                           _countof(szBuff));
+    if (cchExpanded == 0)
+        return FALSE;
+
+    INT cchEnvPath = cchExpanded - 1;
+    if (CompareStringW(LOCALE_SYSTEM_DEFAULT, NORM_IGNORECASE,
+                       szBuff, cchEnvPath, lpString, cchEnvPath) != CSTR_EQUAL)
+    {
+        return FALSE;
+    }
+
+    INT cchSuffix = lstrlenW(lpString) - cchEnvPath;
+    if (lstrlenW(lpSrc) + cchSuffix >= (INT)cchBuff)
+        return FALSE;
+
+    StringCchCopyW(pszBuff, cchBuff, lpSrc);
+    StringCchCatW(pszBuff, cchBuff, &lpString[cchEnvPath]);
+    return TRUE;
+}
+
+/*************************************************************************
+ * PathUnExpandEnvStringsForUserA [SHLWAPI.465]
+ *
+ * See PathUnExpandEnvStringsForUserW.
+ */
+EXTERN_C
+BOOL WINAPI
+PathUnExpandEnvStringsForUserA(
+    _In_ HANDLE hUserToken,
+    _In_ PCSTR pwszPath,
+    _Out_writes_(cchBuff) PSTR pszBuff,
+    _In_ INT cchBuff)
+{
+    if (!pwszPath)
+    {
+        if (pszBuff && cchBuff)
+            *pszBuff = ANSI_NULL;
+        return FALSE;
+    }
+    if (!pszBuff)
+        return FALSE;
+
+    static const PCSTR c_varsA[] =
+    {
+        "%APPDATA%",
+        "%USERPROFILE%",
+        "%ALLUSERSPROFILE%",
+        "%ProgramFiles%",
+        "%SystemRoot%",
+        "%SystemDrive%",
+    };
+
+    for (size_t iVar = 0; iVar < _countof(c_varsA); ++iVar)
+    {
+        if (UnExpandEnvironmentStringForUserA(hUserToken, pwszPath, c_varsA[iVar],
+                                              pszBuff, cchBuff))
+        {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+/*************************************************************************
+ * PathUnExpandEnvStringsForUserW [SHLWAPI.466]
+ *
+ * https://undoc.airesoft.co.uk/shlwapi.dll/PathUnExpandEnvStringsForUserW.php
+ */
+EXTERN_C
+BOOL WINAPI
+PathUnExpandEnvStringsForUserW(
+    _In_ HANDLE hUserToken,
+    _In_ PCWSTR pwszPath,
+    _Out_writes_(cchBuff) PWSTR pszBuff,
+    _In_ INT cchBuff)
+{
+    if (!pwszPath)
+    {
+        if (pszBuff && cchBuff)
+            *pszBuff = UNICODE_NULL;
+        return FALSE;
+    }
+
+    if (!pszBuff)
+        return FALSE;
+
+    static const PCWSTR c_varsW[] =
+    {
+        L"%APPDATA%",
+        L"%USERPROFILE%",
+        L"%ALLUSERSPROFILE%",
+        L"%ProgramFiles%",
+        L"%SystemRoot%",
+        L"%SystemDrive%",
+    };
+
+    for (size_t iVar = 0; iVar < _countof(c_varsW); ++iVar)
+    {
+        if (UnExpandEnvironmentStringForUserW(hUserToken, pwszPath, c_varsW[iVar],
+                                              pszBuff, cchBuff))
+        {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
 }
 
 static BOOL CharLowerNoDBCSAWorker(PSTR lpString, INT cchMax, BOOL bUppercase)

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -51,12 +51,12 @@ UnExpandEnvironmentStringForUserA(
     _In_ UINT cchDest)
 {
     CHAR szBuff[MAX_PATH];
-    UINT cchExpanded;
+    UINT cchExpanded = 0;
 
     if (hUserToken)
     {
         if (ExpandEnvironmentStringsForUserA(hUserToken, lpSrc, szBuff, _countof(szBuff)))
-            cchExpanded = lstrlenA(pszDest) + 1;
+            cchExpanded = lstrlenA(szBuff) + 1;
         else
             cchExpanded = 0;
     }
@@ -75,8 +75,8 @@ UnExpandEnvironmentStringForUserA(
         return FALSE;
     }
 
-    INT cchSuffix = lstrlenA(lpString) - cchEnvPath;
-    if (lstrlenA(lpSrc) + cchSuffix >= (INT)cchDest)
+    size_t cchSuffix = lstrlenA(lpString) - cchEnvPath;
+    if (strlen(lpSrc) + cchSuffix >= cchDest)
         return FALSE;
 
     StringCchCopyA(pszDest, cchDest, lpSrc);
@@ -98,7 +98,7 @@ UnExpandEnvironmentStringForUserW(
     if (hUserToken)
     {
         if (ExpandEnvironmentStringsForUserW(hUserToken, lpSrc, szBuff, _countof(szBuff)))
-            cchExpanded = lstrlenW(pszDest) + 1;
+            cchExpanded = lstrlenW(szBuff) + 1;
         else
             cchExpanded = 0;
     }
@@ -117,8 +117,8 @@ UnExpandEnvironmentStringForUserW(
         return FALSE;
     }
 
-    INT cchSuffix = lstrlenW(lpString) - cchEnvPath;
-    if (lstrlenW(lpSrc) + cchSuffix >= (INT)cchDest)
+    size_t cchSuffix = wcslen(lpString) - cchEnvPath;
+    if (lstrlenW(lpSrc) + cchSuffix >= cchDest)
         return FALSE;
 
     StringCchCopyW(pszDest, cchDest, lpSrc);

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -50,7 +50,7 @@ UnExpandEnvironmentStringForUserA(
     _Out_ PSTR pszDest,
     _In_ INT cchDest)
 {
-    CHAR ch, szBuff[MAX_PATH];
+    CHAR szBuff[MAX_PATH];
     INT cchExpanded;
 
     if (hUserToken)
@@ -75,11 +75,6 @@ UnExpandEnvironmentStringForUserA(
         return FALSE;
     }
 
-    // ReactOS only: Check separator or NUL
-    ch = lpString[cchEnvPath];
-    if (ch != ANSI_NULL && ch != '\\' && ch != '/')
-        return FALSE;
-
     INT cchSuffix = lstrlenA(lpString) - cchEnvPath;
     if (lstrlenA(lpSrc) + cchSuffix >= cchDest)
         return FALSE;
@@ -97,7 +92,7 @@ UnExpandEnvironmentStringForUserW(
     _Out_ PWSTR pszDest,
     _In_ INT cchDest)
 {
-    WCHAR ch, szBuff[MAX_PATH];
+    WCHAR szBuff[MAX_PATH];
     INT cchExpanded;
 
     if (hUserToken)
@@ -121,11 +116,6 @@ UnExpandEnvironmentStringForUserW(
     {
         return FALSE;
     }
-
-    // ReactOS only: Check separator or NUL
-    ch = lpString[cchEnvPath];
-    if (ch != UNICODE_NULL && ch != L'\\' && ch != L'/')
-        return FALSE;
 
     INT cchSuffix = lstrlenW(lpString) - cchEnvPath;
     if (lstrlenW(lpSrc) + cchSuffix >= cchDest)

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -48,15 +48,15 @@ UnExpandEnvironmentStringForUserA(
     _In_ PCSTR lpString,
     _In_ PCSTR lpSrc,
     _Out_ PSTR pszDest,
-    _In_ UINT cchDest)
+    _In_ INT cchDest)
 {
-    CHAR szBuff[MAX_PATH];
-    size_t cchExpanded;
+    CHAR ch, szBuff[MAX_PATH];
+    INT cchExpanded;
 
     if (hUserToken)
     {
         if (ExpandEnvironmentStringsForUserA(hUserToken, lpSrc, szBuff, _countof(szBuff)))
-            cchExpanded = strlen(szBuff) + 1;
+            cchExpanded = lstrlenA(szBuff) + 1;
         else
             cchExpanded = 0;
     }
@@ -65,21 +65,23 @@ UnExpandEnvironmentStringForUserA(
         cchExpanded = ExpandEnvironmentStringsA(lpSrc, szBuff, _countof(szBuff));
     }
 
-    if (cchExpanded > cchDest || !cchExpanded || cchExpanded >= MAXLONG)
+    if (!cchExpanded || cchExpanded > cchDest)
         return FALSE;
 
     INT cchEnvPath = (INT)(cchExpanded - 1);
     if (CompareStringA(LOCALE_SYSTEM_DEFAULT, NORM_IGNORECASE,
-                       szBuff, cchEnvPath, lpString, cchEnvPath) != CSTR_EQUAL ||
-        // ReactOS only: Check separator or NUL
-        (lpString[cchEnvPath] != ANSI_NULL && lpString[cchEnvPath] != '\\' &&
-         lpString[cchEnvPath] != '/'))
+                       szBuff, cchEnvPath, lpString, cchEnvPath) != CSTR_EQUAL)
     {
         return FALSE;
     }
 
-    size_t cchSuffix = strlen(lpString) - cchEnvPath;
-    if (strlen(lpSrc) + cchSuffix >= cchDest)
+    // ReactOS only: Check separator or NUL
+    ch = lpString[cchEnvPath];
+    if (ch != ANSI_NULL && ch != '\\' && ch != '/')
+        return FALSE;
+
+    INT cchSuffix = lstrlenA(lpString) - cchEnvPath;
+    if (lstrlenA(lpSrc) + cchSuffix >= cchDest)
         return FALSE;
 
     StringCchCopyA(pszDest, cchDest, lpSrc);
@@ -93,15 +95,15 @@ UnExpandEnvironmentStringForUserW(
     _In_ PCWSTR lpString,
     _In_ PCWSTR lpSrc,
     _Out_ PWSTR pszDest,
-    _In_ UINT cchDest)
+    _In_ INT cchDest)
 {
-    WCHAR szBuff[MAX_PATH];
-    UINT cchExpanded;
+    WCHAR ch, szBuff[MAX_PATH];
+    INT cchExpanded;
 
     if (hUserToken)
     {
         if (ExpandEnvironmentStringsForUserW(hUserToken, lpSrc, szBuff, _countof(szBuff)))
-            cchExpanded = wcslen(szBuff) + 1;
+            cchExpanded = lstrlenW(szBuff) + 1;
         else
             cchExpanded = 0;
     }
@@ -110,21 +112,23 @@ UnExpandEnvironmentStringForUserW(
         cchExpanded = ExpandEnvironmentStringsW(lpSrc, szBuff, _countof(szBuff));
     }
 
-    if (cchExpanded > cchDest || !cchExpanded || cchExpanded >= MAXLONG)
+    if (!cchExpanded || cchExpanded > cchDest)
         return FALSE;
 
     INT cchEnvPath = (INT)(cchExpanded - 1);
     if (CompareStringW(LOCALE_SYSTEM_DEFAULT, NORM_IGNORECASE,
-                       szBuff, cchEnvPath, lpString, cchEnvPath) != CSTR_EQUAL ||
-        // ReactOS only: Check separator or NUL
-        (lpString[cchEnvPath] != UNICODE_NULL && lpString[cchEnvPath] != L'\\' &&
-         lpString[cchEnvPath] != L'/'))
+                       szBuff, cchEnvPath, lpString, cchEnvPath) != CSTR_EQUAL)
     {
         return FALSE;
     }
 
-    size_t cchSuffix = wcslen(lpString) - cchEnvPath;
-    if (wcslen(lpSrc) + cchSuffix >= cchDest)
+    // ReactOS only: Check separator or NUL
+    ch = lpString[cchEnvPath];
+    if (ch != UNICODE_NULL && ch != L'\\' && ch != L'/')
+        return FALSE;
+
+    INT cchSuffix = lstrlenW(lpString) - cchEnvPath;
+    if (lstrlenW(lpSrc) + cchSuffix >= cchDest)
         return FALSE;
 
     StringCchCopyW(pszDest, cchDest, lpSrc);
@@ -141,7 +145,7 @@ EXTERN_C
 BOOL WINAPI
 PathUnExpandEnvStringsForUserA(
     _In_ HANDLE hUserToken,
-    _In_ PCSTR pwszPath,
+    _In_ PCSTR pszPath,
     _Out_writes_(cchBuff) PSTR pszBuff,
     _In_ INT cchBuff)
 {
@@ -155,7 +159,7 @@ PathUnExpandEnvStringsForUserA(
         "%SystemDrive%",
     };
 
-    if (!pwszPath)
+    if (!pszPath)
     {
         if (pszBuff && cchBuff)
             *pszBuff = ANSI_NULL;
@@ -168,7 +172,7 @@ PathUnExpandEnvStringsForUserA(
 
     for (size_t iVar = 0; iVar < _countof(c_varsA); ++iVar)
     {
-        if (UnExpandEnvironmentStringForUserA(hUserToken, pwszPath, c_varsA[iVar],
+        if (UnExpandEnvironmentStringForUserA(hUserToken, pszPath, c_varsA[iVar],
                                               pszBuff, cchBuff))
         {
             return TRUE;

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -44,11 +44,11 @@ GetVersionMajorMinor()
 
 static BOOL
 UnExpandEnvironmentStringForUserA(
-    HANDLE hUserToken,
-    PCSTR  lpString,
-    PCSTR  lpSrc,
-    PSTR   pszBuff,
-    UINT   cchBuff)
+    _In_ HANDLE hUserToken,
+    _In_ PCSTR lpString,
+    _In_ PCSTR lpSrc,
+    _Out_ PSTR pszDest,
+    _In_ UINT cchDest)
 {
     CHAR szBuff[MAX_PATH];
     UINT cchExpanded;
@@ -56,7 +56,7 @@ UnExpandEnvironmentStringForUserA(
     if (hUserToken)
     {
         if (ExpandEnvironmentStringsForUserA(hUserToken, lpSrc, szBuff, _countof(szBuff)))
-            cchExpanded = lstrlenA(pszBuff) + 1;
+            cchExpanded = lstrlenA(pszDest) + 1;
         else
             cchExpanded = 0;
     }
@@ -65,7 +65,7 @@ UnExpandEnvironmentStringForUserA(
         cchExpanded = ExpandEnvironmentStringsA(lpSrc, szBuff, _countof(szBuff));
     }
 
-    if (cchExpanded > cchBuff || !cchExpanded)
+    if (cchExpanded > cchDest || !cchExpanded)
         return FALSE;
 
     INT cchEnvPath = cchExpanded - 1;
@@ -76,21 +76,21 @@ UnExpandEnvironmentStringForUserA(
     }
 
     INT cchSuffix = lstrlenA(lpString) - cchEnvPath;
-    if (lstrlenA(lpSrc) + cchSuffix >= (INT)cchBuff)
+    if (lstrlenA(lpSrc) + cchSuffix >= (INT)cchDest)
         return FALSE;
 
-    StringCchCopyA(pszBuff, cchBuff, lpSrc);
-    StringCchCatA(pszBuff, cchBuff, &lpString[cchEnvPath]);
+    StringCchCopyA(pszDest, cchDest, lpSrc);
+    StringCchCatA(pszDest, cchDest, &lpString[cchEnvPath]);
     return TRUE;
 }
 
 static BOOL
 UnExpandEnvironmentStringForUserW(
-    HANDLE hUserToken,
-    PCWSTR lpString,
-    PCWSTR lpSrc,
-    PWSTR  pszBuff,
-    UINT   cchBuff)
+    _In_ HANDLE hUserToken,
+    _In_ PCWSTR lpString,
+    _In_ PCWSTR lpSrc,
+    _Out_ PWSTR pszDest,
+    _In_ UINT cchDest)
 {
     WCHAR szBuff[MAX_PATH];
     UINT cchExpanded;
@@ -98,7 +98,7 @@ UnExpandEnvironmentStringForUserW(
     if (hUserToken)
     {
         if (ExpandEnvironmentStringsForUserW(hUserToken, lpSrc, szBuff, _countof(szBuff)))
-            cchExpanded = lstrlenW(pszBuff) + 1;
+            cchExpanded = lstrlenW(pszDest) + 1;
         else
             cchExpanded = 0;
     }
@@ -107,7 +107,7 @@ UnExpandEnvironmentStringForUserW(
         cchExpanded = ExpandEnvironmentStringsW(lpSrc, szBuff, _countof(szBuff));
     }
 
-    if (cchExpanded > cchBuff || !cchExpanded)
+    if (cchExpanded > cchDest || !cchExpanded)
         return FALSE;
 
     INT cchEnvPath = cchExpanded - 1;
@@ -118,11 +118,11 @@ UnExpandEnvironmentStringForUserW(
     }
 
     INT cchSuffix = lstrlenW(lpString) - cchEnvPath;
-    if (lstrlenW(lpSrc) + cchSuffix >= (INT)cchBuff)
+    if (lstrlenW(lpSrc) + cchSuffix >= (INT)cchDest)
         return FALSE;
 
-    StringCchCopyW(pszBuff, cchBuff, lpSrc);
-    StringCchCatW(pszBuff, cchBuff, &lpString[cchEnvPath]);
+    StringCchCopyW(pszDest, cchDest, lpSrc);
+    StringCchCatW(pszDest, cchDest, &lpString[cchEnvPath]);
     return TRUE;
 }
 
@@ -139,15 +139,6 @@ PathUnExpandEnvStringsForUserA(
     _Out_writes_(cchBuff) PSTR pszBuff,
     _In_ INT cchBuff)
 {
-    if (!pwszPath)
-    {
-        if (pszBuff && cchBuff)
-            *pszBuff = ANSI_NULL;
-        return FALSE;
-    }
-    if (!pszBuff)
-        return FALSE;
-
     static const PCSTR c_varsA[] =
     {
         "%APPDATA%",
@@ -157,6 +148,17 @@ PathUnExpandEnvStringsForUserA(
         "%SystemRoot%",
         "%SystemDrive%",
     };
+
+    if (!pwszPath)
+    {
+        if (pszBuff && cchBuff)
+            *pszBuff = ANSI_NULL;
+
+        return FALSE;
+    }
+
+    if (!pszBuff)
+        return FALSE;
 
     for (size_t iVar = 0; iVar < _countof(c_varsA); ++iVar)
     {
@@ -183,16 +185,6 @@ PathUnExpandEnvStringsForUserW(
     _Out_writes_(cchBuff) PWSTR pszBuff,
     _In_ INT cchBuff)
 {
-    if (!pwszPath)
-    {
-        if (pszBuff && cchBuff)
-            *pszBuff = UNICODE_NULL;
-        return FALSE;
-    }
-
-    if (!pszBuff)
-        return FALSE;
-
     static const PCWSTR c_varsW[] =
     {
         L"%APPDATA%",
@@ -202,6 +194,17 @@ PathUnExpandEnvStringsForUserW(
         L"%SystemRoot%",
         L"%SystemDrive%",
     };
+
+    if (!pwszPath)
+    {
+        if (pszBuff && cchBuff)
+            *pszBuff = UNICODE_NULL;
+
+        return FALSE;
+    }
+
+    if (!pszBuff)
+        return FALSE;
 
     for (size_t iVar = 0; iVar < _countof(c_varsW); ++iVar)
     {

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -51,12 +51,12 @@ UnExpandEnvironmentStringForUserA(
     _In_ UINT cchDest)
 {
     CHAR szBuff[MAX_PATH];
-    UINT cchExpanded = 0;
+    size_t cchExpanded;
 
     if (hUserToken)
     {
         if (ExpandEnvironmentStringsForUserA(hUserToken, lpSrc, szBuff, _countof(szBuff)))
-            cchExpanded = lstrlenA(szBuff) + 1;
+            cchExpanded = strlen(szBuff) + 1;
         else
             cchExpanded = 0;
     }
@@ -65,17 +65,20 @@ UnExpandEnvironmentStringForUserA(
         cchExpanded = ExpandEnvironmentStringsA(lpSrc, szBuff, _countof(szBuff));
     }
 
-    if (cchExpanded > cchDest || !cchExpanded)
+    if (cchExpanded > cchDest || !cchExpanded || cchExpanded >= MAXLONG)
         return FALSE;
 
-    INT cchEnvPath = cchExpanded - 1;
+    INT cchEnvPath = (INT)(cchExpanded - 1);
     if (CompareStringA(LOCALE_SYSTEM_DEFAULT, NORM_IGNORECASE,
-                       szBuff, cchEnvPath, lpString, cchEnvPath) != CSTR_EQUAL)
+                       szBuff, cchEnvPath, lpString, cchEnvPath) != CSTR_EQUAL ||
+        // ReactOS only: Check separator or NUL
+        (lpString[cchEnvPath] != ANSI_NULL && lpString[cchEnvPath] != '\\' &&
+         lpString[cchEnvPath] != '/'))
     {
         return FALSE;
     }
 
-    size_t cchSuffix = lstrlenA(lpString) - cchEnvPath;
+    size_t cchSuffix = strlen(lpString) - cchEnvPath;
     if (strlen(lpSrc) + cchSuffix >= cchDest)
         return FALSE;
 
@@ -98,7 +101,7 @@ UnExpandEnvironmentStringForUserW(
     if (hUserToken)
     {
         if (ExpandEnvironmentStringsForUserW(hUserToken, lpSrc, szBuff, _countof(szBuff)))
-            cchExpanded = lstrlenW(szBuff) + 1;
+            cchExpanded = wcslen(szBuff) + 1;
         else
             cchExpanded = 0;
     }
@@ -107,18 +110,21 @@ UnExpandEnvironmentStringForUserW(
         cchExpanded = ExpandEnvironmentStringsW(lpSrc, szBuff, _countof(szBuff));
     }
 
-    if (cchExpanded > cchDest || !cchExpanded)
+    if (cchExpanded > cchDest || !cchExpanded || cchExpanded >= MAXLONG)
         return FALSE;
 
-    INT cchEnvPath = cchExpanded - 1;
+    INT cchEnvPath = (INT)(cchExpanded - 1);
     if (CompareStringW(LOCALE_SYSTEM_DEFAULT, NORM_IGNORECASE,
-                       szBuff, cchEnvPath, lpString, cchEnvPath) != CSTR_EQUAL)
+                       szBuff, cchEnvPath, lpString, cchEnvPath) != CSTR_EQUAL ||
+        // ReactOS only: Check separator or NUL
+        (lpString[cchEnvPath] != UNICODE_NULL && lpString[cchEnvPath] != L'\\' &&
+         lpString[cchEnvPath] != L'/'))
     {
         return FALSE;
     }
 
     size_t cchSuffix = wcslen(lpString) - cchEnvPath;
-    if (lstrlenW(lpSrc) + cchSuffix >= cchDest)
+    if (wcslen(lpSrc) + cchSuffix >= cchDest)
         return FALSE;
 
     StringCchCopyW(pszDest, cchDest, lpSrc);

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -388,6 +388,20 @@ PathFileExistsDefExtAndAttributesW(
     _In_ DWORD dwWhich,
     _Out_opt_ LPDWORD pdwFileAttributes);
 
+BOOL WINAPI
+PathUnExpandEnvStringsForUserA(
+    _In_ HANDLE hUserToken,
+    _In_ PCSTR pwszPath,
+    _Out_writes_(cchBuff) PSTR pszBuff,
+    _In_ INT cchBuff);
+
+BOOL WINAPI
+PathUnExpandEnvStringsForUserW(
+    _In_ HANDLE hUserToken,
+    _In_ PCWSTR pwszPath,
+    _Out_writes_(cchBuff) PWSTR pszBuff,
+    _In_ INT cchBuff);
+
 BOOL WINAPI PathFindOnPathExW(LPWSTR lpszFile, LPCWSTR *lppszOtherDirs, DWORD dwWhich);
 VOID WINAPI FixSlashesAndColonW(LPWSTR);
 BOOL WINAPI PathIsValidCharA(char c, DWORD dwClass);

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -391,7 +391,7 @@ PathFileExistsDefExtAndAttributesW(
 BOOL WINAPI
 PathUnExpandEnvStringsForUserA(
     _In_ HANDLE hUserToken,
-    _In_ PCSTR pwszPath,
+    _In_ PCSTR pszPath,
     _Out_writes_(cchBuff) PSTR pszBuff,
     _In_ INT cchBuff);
 


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Implement `PathUnExpandEnvStringsForUserA` and `PathUnExpandEnvStringsForUserW` functions.
- Modify `shlwapi.spec`.
- Add prototypes into `<shlwapi_undoc.h>`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107629,107792
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107632,107791