### PR TITLE
[WS2_32_WINETEST] Avoid inet_ntop call when unavailable

### DIFF
--- a/modules/rostests/winetests/ws2_32/sock.c
+++ b/modules/rostests/winetests/ws2_32/sock.c
@@ -7912,6 +7912,12 @@ static void verify_ipv6_addrinfo(ADDRINFOA *result, const char *expectedIp)
     char ipBuffer[256];
     const char *ret;
 
+    if (!result)
+    {
+        ok(0, "getaddrinfo returned NULL\n");
+        return;
+    }
+
     ok(result->ai_family == AF_INET6, "ai_family == %d\n", result->ai_family);
     ok(result->ai_addrlen >= sizeof(struct sockaddr_in6), "ai_addrlen == %d\n", (int)result->ai_addrlen);
     ok(result->ai_addr != NULL, "ai_addr == NULL\n");
@@ -7923,6 +7929,12 @@ static void verify_ipv6_addrinfo(ADDRINFOA *result, const char *expectedIp)
         ok(sockaddr6->sin6_port == 0, "ai_addr->sin6_port == %d\n", sockaddr6->sin6_port);
 
         ZeroMemory(ipBuffer, sizeof(ipBuffer));
+        if (!p_inet_ntop)
+        {
+            win_skip("inet_ntop is not available\n");
+            return;
+        }
+
         ret = p_inet_ntop(AF_INET6, &sockaddr6->sin6_addr, ipBuffer, sizeof(ipBuffer));
         ok(ret != NULL, "inet_ntop failed (%d)\n", WSAGetLastError());
         ok(strcmp(ipBuffer, expectedIp) == 0, "ai_addr->sin6_addr == '%s' (expected '%s')\n", ipBuffer, expectedIp);
@@ -8104,6 +8116,12 @@ static void test_getaddrinfo(void)
     ok(result == NULL, "expected NULL, got %p\n", result);
 
     /* Test IPv6 address conversion */
+    if (!p_inet_ntop)
+    {
+        win_skip("inet_ntop is not available\n");
+        goto test_hints;
+    }
+
     result = NULL;
     SetLastError(0xdeadbeef);
     ret = pgetaddrinfo("2a00:2039:dead:beef:cafe::6666", NULL, NULL, &result);
@@ -8119,7 +8137,8 @@ static void test_getaddrinfo(void)
         ret = pgetaddrinfo("[beef::cafe]", NULL, NULL, &result);
         ok(!ret, "getaddrinfo failed with %d\n", ret);
         verify_ipv6_addrinfo(result, "beef::cafe");
-        pfreeaddrinfo(result);
+        if (result)
+            pfreeaddrinfo(result);
 
         /* Test IPv6 address conversion with brackets and hints */
         memset(&hint, 0, sizeof(ADDRINFOA));
@@ -8129,7 +8148,8 @@ static void test_getaddrinfo(void)
         ret = pgetaddrinfo("[beef::cafe]", NULL, &hint, &result);
         ok(!ret, "getaddrinfo failed with %d\n", ret);
         verify_ipv6_addrinfo(result, "beef::cafe");
-        pfreeaddrinfo(result);
+        if (result)
+            pfreeaddrinfo(result);
 
         memset(&hint, 0, sizeof(ADDRINFOA));
         hint.ai_flags = AI_NUMERICHOST;
@@ -8143,7 +8163,8 @@ static void test_getaddrinfo(void)
         ret = pgetaddrinfo("[beef::cafe]:10239", NULL, NULL, &result);
         ok(!ret, "getaddrinfo failed with %d\n", ret);
         verify_ipv6_addrinfo(result, "beef::cafe");
-        pfreeaddrinfo(result);
+        if (result)
+            pfreeaddrinfo(result);
 
         /* Test IPv6 address conversion with unmatched brackets */
         result = NULL;
@@ -8162,6 +8183,7 @@ static void test_getaddrinfo(void)
 
     hint.ai_flags = 0;
 
+test_hints:
     for (i = 0;i < (sizeof(hinttests) / sizeof(hinttests[0]));i++)
     {
         hint.ai_family = hinttests[i].family;

--- a/modules/rostests/winetests/ws2_32/sock.c
+++ b/modules/rostests/winetests/ws2_32/sock.c
@@ -7912,11 +7912,13 @@ static void verify_ipv6_addrinfo(ADDRINFOA *result, const char *expectedIp)
     char ipBuffer[256];
     const char *ret;
 
+#ifdef __REACTOS__
     if (!result)
     {
         ok(0, "getaddrinfo returned NULL\n");
         return;
     }
+#endif
 
     ok(result->ai_family == AF_INET6, "ai_family == %d\n", result->ai_family);
     ok(result->ai_addrlen >= sizeof(struct sockaddr_in6), "ai_addrlen == %d\n", (int)result->ai_addrlen);
@@ -7929,11 +7931,13 @@ static void verify_ipv6_addrinfo(ADDRINFOA *result, const char *expectedIp)
         ok(sockaddr6->sin6_port == 0, "ai_addr->sin6_port == %d\n", sockaddr6->sin6_port);
 
         ZeroMemory(ipBuffer, sizeof(ipBuffer));
+#ifdef __REACTOS__
         if (!p_inet_ntop)
         {
             win_skip("inet_ntop is not available\n");
             return;
         }
+#endif
 
         ret = p_inet_ntop(AF_INET6, &sockaddr6->sin6_addr, ipBuffer, sizeof(ipBuffer));
         ok(ret != NULL, "inet_ntop failed (%d)\n", WSAGetLastError());
@@ -8116,11 +8120,13 @@ static void test_getaddrinfo(void)
     ok(result == NULL, "expected NULL, got %p\n", result);
 
     /* Test IPv6 address conversion */
+#ifdef __REACTOS__
     if (!p_inet_ntop)
     {
         win_skip("inet_ntop is not available\n");
         goto test_hints;
     }
+#endif
 
     result = NULL;
     SetLastError(0xdeadbeef);
@@ -8137,8 +8143,12 @@ static void test_getaddrinfo(void)
         ret = pgetaddrinfo("[beef::cafe]", NULL, NULL, &result);
         ok(!ret, "getaddrinfo failed with %d\n", ret);
         verify_ipv6_addrinfo(result, "beef::cafe");
+#ifdef __REACTOS__
         if (result)
             pfreeaddrinfo(result);
+#else
+        pfreeaddrinfo(result);
+#endif
 
         /* Test IPv6 address conversion with brackets and hints */
         memset(&hint, 0, sizeof(ADDRINFOA));
@@ -8148,8 +8158,12 @@ static void test_getaddrinfo(void)
         ret = pgetaddrinfo("[beef::cafe]", NULL, &hint, &result);
         ok(!ret, "getaddrinfo failed with %d\n", ret);
         verify_ipv6_addrinfo(result, "beef::cafe");
+#ifdef __REACTOS__
         if (result)
             pfreeaddrinfo(result);
+#else
+        pfreeaddrinfo(result);
+#endif
 
         memset(&hint, 0, sizeof(ADDRINFOA));
         hint.ai_flags = AI_NUMERICHOST;
@@ -8163,8 +8177,12 @@ static void test_getaddrinfo(void)
         ret = pgetaddrinfo("[beef::cafe]:10239", NULL, NULL, &result);
         ok(!ret, "getaddrinfo failed with %d\n", ret);
         verify_ipv6_addrinfo(result, "beef::cafe");
+#ifdef __REACTOS__
         if (result)
             pfreeaddrinfo(result);
+#else
+        pfreeaddrinfo(result);
+#endif
 
         /* Test IPv6 address conversion with unmatched brackets */
         result = NULL;
@@ -8183,7 +8201,9 @@ static void test_getaddrinfo(void)
 
     hint.ai_flags = 0;
 
+#ifdef __REACTOS__
 test_hints:
+#endif
     for (i = 0;i < (sizeof(hinttests) / sizeof(hinttests[0]));i++)
     {
         hint.ai_family = hinttests[i].family;


### PR DESCRIPTION
## Purpose

Fix [ROSTESTS-391](https://jira.reactos.org/browse/ROSTESTS-391). XP and Server 2003 do not export `inet_ntop` from `ws2_32.dll`, so the IPv6 `getaddrinfo` test crashed through a NULL function pointer.

## Proposed changes

- Skip the IPv6 address conversion checks when `inet_ntop` is unavailable, jumping to `test_hints:` so the remaining hint tests still run.
- Guard `verify_ipv6_addrinfo()` against NULL results so a failed `getaddrinfo` call is reported instead of dereferenced.
- Guard conditional `pfreeaddrinfo` calls in the IPv6 block so partial failures don't cause additional crashes.
- Wrap all ReactOS-specific changes in `#ifdef __REACTOS__` per winetest convention.

## Validation

Tested `ws2_32_winetest.exe sock` on:

- **Windows XP SP3** (IPv6 not installed): no crash; `sock.c:8126: Tests skipped: inet_ntop is not available` printed cleanly; all remaining `getaddrinfo` hint tests ran; 2 pre-existing unrelated failures only.
- **Windows XP SP2** (IPv6 not installed): same result; `sock.c:8126: Tests skipped: inet_ntop is not available`; no crash.

Both runs confirm the fix skips the IPv6 conversion block cleanly and continues execution normally.