### PR TITLE
Hide the Internet desktop icon on Live environment

### DIFF
--- a/boot/bootdata/hivedef.inf
+++ b/boot/bootdata/hivedef.inf
@@ -1893,9 +1893,6 @@ HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer","SelectExtOnRename",0x
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts",,0x00000012
-HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons",,0x00000012
-HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\ClassicStartMenu",,0x00000012
-HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\ClassicStartMenu","{208D2C60-3AEA-1069-A2D7-08002B30309D}",0x00010001,0x00000000
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CLSID\{20D04FE0-3AEA-1069-A2D8-08002B30309D}",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","ListviewShadow",0x00010003,0x00000001
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","HideFileExt",0x00010003,0x00000000

--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -570,12 +570,6 @@ HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\ShellServiceObjectDelayLoad",,0x
 ; FIXME - Setup doesn't handle extra paths
 HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnceEx\Finalize","1",,"||rundll32.exe setupapi.dll,InstallHinfSection Finalize 128 %systemroot%\inf\syssetup.inf"
 
-HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons",,0x00000012
-HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\ClassicStartMenu",,0x00000012
-HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\ClassicStartMenu","{208D2C60-3AEA-1069-A2D7-08002B30309D}",0x00010001,0x00000000
-HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\BitBucket",,0x00000012
-HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\BitBucket\Volume",,0x00000012
-
 ; CMD Settings
 HKLM,"SOFTWARE\Microsoft\Command Processor","AutoRun",0x00020000,""
 HKLM,"SOFTWARE\Microsoft\Command Processor","CompletionChar",0x00010001,0x40

--- a/boot/bootdata/livecd.inf
+++ b/boot/bootdata/livecd.inf
@@ -33,6 +33,10 @@ HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList","ProfilesDirecto
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList","AllUsersProfile",0x00000000,"All Users"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList","DefaultUserProfile",0x00000000,"Default User"
 
+; Hide the "Internet Browser" desktop icon
+HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\ClassicStartMenu","{871C5380-42A0-1069-A2EA-08002B30309D}",0x00010001,1
+HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel","{871C5380-42A0-1069-A2EA-08002B30309D}",0x00010001,1
+
 ; Shell Folders
 HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders","Common Documents",0x00020000,""
 HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders","Common Desktop",0x00020000,"%SystemDrive%\Profiles\All Users\Desktop"

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -186,14 +186,17 @@ bool SHELL_CanInvokeAutoRunOnDrive(PCWSTR DrvPath)
 }
 #endif
 
+/**
+ * @brief
+ * Returns true if the item should be hidden in DefView but not in the Explorer folder tree.
+ **/
 BOOL SHELL32_IsShellFolderNamespaceItemHidden(LPCWSTR SubKey, REFCLSID Clsid)
 {
-    // If this function returns true, the item should be hidden in DefView but not in the Explorer folder tree.
     WCHAR path[MAX_PATH], name[CHARS_IN_GUID];
     wsprintfW(path, L"%s\\%s", REGSTR_PATH_EXPLORER, SubKey);
     SHELL32_GUIDToStringW(Clsid, name);
-    DWORD data = 0, size = sizeof(data);
-    return !RegGetValueW(HKEY_CURRENT_USER, path, name, RRF_RT_DWORD, NULL, &data, &size) && data;
+    // Check the value in both HKEY_CURRENT_USER and HKEY_LOCAL_MACHINE
+    return SHRegGetBoolUSValue(path, name, FALSE, FALSE);
 }
 
 /***********************************************************************


### PR DESCRIPTION
## Purpose

Hide the Internet desktop icon on Live environment, because currently we cannot use any web-browser there:
the Wine IE would require a pre-installed Wine-Gecko, and otherwise, the Live environment is currently read-only.

JIRA issue: [CORE-19203](https://jira.reactos.org/browse/CORE-19203)

## Proposed changes

- ### `[SHELL32] Better determine whether to hide or show shell-folder namespace items`

  In `SHELL32_IsShellFolderNamespaceItemHidden()`, use `SHRegGetBoolUSValue()` to look at both `HKEY_CURRENT_USER` with fallback to `HKEY_LOCAL_MACHINE`, when searching for the registry value that determines whether a shell-folder namespace item is to be hidden or shown.

  Behaviour confirmed on Windows 2003.
  Addendum to commit 6ae11ba09d (PR #7189).

- ### `[BOOTDATA] Hide the Internet desktop icon in the Live environment`

- ### `[BOOTDATA] Cleanup BitBucket and useless redundant HideDesktopIcons registry entries`

  - The `HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons` entries were redundant between hivedef.inf and hivesft.inf.
    In addition, adding them were useless, because the "Network Places" (network location folder) icon they were specifying is already shown by default (like the others) on the desktop.

    This basically reverts commit 054c755d91 (r31545) -- originally added for the next commit 562c812846 (r31547).
    The "reason" given by this commit was also wrong: the registration of the network folder is done instead in its `HKCR\CLSID\<the_clsid>` registry key.

  - Similarly, the `HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Bitbucket` registry key doesn't need to be pre-created; the shell will create it on-demand at runtime.

    This reverts commit bab735cf05 (r35203).
