### PR TITLE
[NTDLL] Unload DLLs on loader failure

### DIFF
--- a/dll/ntdll/ldr/ldrpe.c
+++ b/dll/ntdll/ldr/ldrpe.c
@@ -961,7 +961,7 @@ LdrpSnapThunk(IN PVOID ExportBase,
     UNICODE_STRING TempUString;
     ANSI_STRING ForwarderName;
     PANSI_STRING ForwardName;
-    PVOID ForwarderHandle;
+    PVOID ForwarderHandle = NULL;
     ULONG ForwardOrdinal;
 
     /* Check if the snap is by ordinal */
@@ -1012,6 +1012,13 @@ LdrpSnapThunk(IN PVOID ExportBase,
     if ((ULONG)Ordinal >= ExportDirectory->NumberOfFunctions)
     {
 FailurePath:
+        /* Check if we loeaded a forwarder DLL */
+        if (ForwarderHandle != NULL)
+        {
+            /* Unload the forwarder DLL */
+            LdrUnloadDll(ForwarderHandle);
+        }
+
         /* Is this a static snap? */
         if (Static)
         {

--- a/dll/ntdll/ldr/ldrutils.c
+++ b/dll/ntdll/ldr/ldrutils.c
@@ -2378,6 +2378,15 @@ LdrpGetProcedureAddress(
                     Status = _SEH2_GetExceptionCode();
                 }
                 _SEH2_END;
+
+                /* Check if it succeeded */
+                if (!NT_SUCCESS(Status))
+                {
+                    /* Failed, unload the entry */
+                    DPRINT1("Initialization routine failed with 0x%08x\n", Status);
+                    LdrUnloadDll(LdrEntry->DllBase);
+                    LdrEntry = NULL;
+                }
             }
         }
 


### PR DESCRIPTION
## Purpose

Unload DLLs on loader failure.
This is crucial, because otherwise they linger in the loader, waiting to run their init routine, which can cause failures later.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86: https://reactos.org/testman/compare.php?ids=107885,107888,107882
- [ ] KVM x64: https://reactos.org/testman/compare.php?ids=107886,107889,107883
