### PR TITLE
[GDI32][WIN32K] Fix GetDIBits a bit

### DIFF
--- a/modules/rostests/apitests/gdi32/GetDIBits.c
+++ b/modules/rostests/apitests/gdi32/GetDIBits.c
@@ -136,7 +136,28 @@ void Test_GetDIBits()
     ok(GetDIBits((HDC)2345, hbmp, 0, 15, NULL, pbi, 0) == 0, "\n");
     ok_err(ERROR_INVALID_PARAMETER);
 
-
+    /* Test partly "uninitialized" BITMAPINFO (from wine's gdiplus!GdipCreateBitmapFromHBITMAP) */
+    memset(pbi, 0xCC, bisize);
+    HBITMAP hbm = CreateBitmap(16, 16, 1, 32, NULL);
+    pbi->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    pbi->bmiHeader.biBitCount = 0;
+    ok_eq_int(GetDIBits(hdcScreen, hbm, 0, 0, NULL, pbi, DIB_RGB_COLORS), 1);
+    ok_eq_int(pbi->bmiHeader.biWidth, 16);
+    ok_eq_int(pbi->bmiHeader.biHeight, 16);
+    ok_eq_int(pbi->bmiHeader.biPlanes, 1);
+    ok_eq_int(pbi->bmiHeader.biBitCount, 32);
+    ok_eq_int(pbi->bmiHeader.biCompression, BI_BITFIELDS);
+    ok_eq_int(pbi->bmiHeader.biSizeImage, 0x400);
+    ok_eq_int(pbi->bmiHeader.biXPelsPerMeter, 0);
+    ok_eq_int(pbi->bmiHeader.biYPelsPerMeter, 0);
+    ok_eq_int(pbi->bmiHeader.biClrUsed, 0);
+    ok_eq_int(pbi->bmiHeader.biClrImportant, 0);
+    ok_eq_int(*(PULONG)&pbi->bmiColors[0], 0x00FF0000);
+    ok_eq_int(*(PULONG)&pbi->bmiColors[1], 0x0000FF00);
+    ok_eq_int(*(PULONG)&pbi->bmiColors[2], 0x000000FF);
+    ok_eq_int(*(PULONG)&pbi->bmiColors[3], 0xCCCCCCCC);
+    ok_eq_int(*(PULONG)&pbi->bmiColors[255], 0xCCCCCCCC);
+    DeleteObject(hbm);
 
     /* null hdc */
     SetLastError(ERROR_SUCCESS);

--- a/win32ss/gdi/gdi32/objects/bitmap.c
+++ b/win32ss/gdi/gdi32/objects/bitmap.c
@@ -73,6 +73,10 @@ FASTCALL DIB_BitmapInfoSize(
     {
         const BITMAPCOREHEADER *core = (const BITMAPCOREHEADER *) info;
         size = sizeof(BITMAPCOREHEADER);
+        if (core->bcBitCount == 0)
+        {
+            return size;
+        }
         if (core->bcBitCount <= 8)
         {
             colors = 1 << core->bcBitCount;
@@ -85,6 +89,10 @@ FASTCALL DIB_BitmapInfoSize(
     }
     else /* assume BITMAPINFOHEADER */
     {
+        if (info->bmiHeader.biBitCount == 0)
+        {
+            return info->bmiHeader.biSize;
+        }
         colors = max ? (1 << info->bmiHeader.biBitCount) : info->bmiHeader.biClrUsed;
         if (colors > 256)
             colors = 256;

--- a/win32ss/gdi/gdi32/objects/bitmap.c
+++ b/win32ss/gdi/gdi32/objects/bitmap.c
@@ -410,7 +410,7 @@ GetDIBits(
     LPBITMAPINFO lpbmi,
     UINT uUsage)
 {
-    UINT cjBmpScanSize;
+    UINT cjMaxBits;
     UINT cjInfoSize;
 
     if (!hDC || !GdiValidateHandle((HGDIOBJ) hDC) || !lpbmi)
@@ -419,7 +419,6 @@ GetDIBits(
         return 0;
     }
 
-    cjBmpScanSize = DIB_BitmapMaxBitsSize(lpbmi, cScanLines);
     /* Caller must provide maximum size possible */
     cjInfoSize = DIB_BitmapInfoSize(lpbmi, uUsage, TRUE);
 
@@ -434,10 +433,23 @@ GetDIBits(
                 return 0;
             }
         }
+
+        cjMaxBits = DIB_BitmapMaxBitsSize(lpbmi, cScanLines);
+    }
+    else
+    {
+        cjMaxBits = 0;
     }
 
-    return NtGdiGetDIBitsInternal(hDC, hbmp, uStartScan, cScanLines, lpvBits, lpbmi, uUsage,
-        cjBmpScanSize, cjInfoSize);
+    return NtGdiGetDIBitsInternal(hDC,
+                                  hbmp,
+                                  uStartScan,
+                                  cScanLines,
+                                  lpvBits,
+                                  lpbmi,
+                                  uUsage,
+                                  cjMaxBits,
+                                  cjInfoSize);
 }
 
 /*

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -2167,11 +2167,19 @@ INT FASTCALL DIB_BitmapInfoSize(const BITMAPINFO * info, WORD coloruse)
     if (info->bmiHeader.biSize == sizeof(BITMAPCOREHEADER))
     {
         const BITMAPCOREHEADER *core = (const BITMAPCOREHEADER *)info;
+        if (core->bcBitCount == 0)
+        {
+            return sizeof(BITMAPCOREHEADER);
+        }
         colors = (core->bcBitCount <= 8) ? 1 << core->bcBitCount : 0;
         return sizeof(BITMAPCOREHEADER) + colors * colorsize;
     }
     else  /* Assume BITMAPINFOHEADER */
     {
+        if (info->bmiHeader.biBitCount == 0)
+        {
+            return info->bmiHeader.biSize;
+        }
         colors = info->bmiHeader.biClrUsed;
         if (colors > 256) colors = 256;
         if (!colors && (info->bmiHeader.biBitCount <= 8))

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -781,13 +781,16 @@ GreGetDIBitsInternal(
     }
 
     /* Validate input:
-       - negative width is always an invalid value
+       - non-null Bits and negative width is an invalid combination
        - non-null Bits and zero bpp is an invalid combination
        - only check the rest of the input params if either bpp is non-zero or Bits are set */
-    if (width < 0 || (bpp == 0 && Bits))
+    if (Bits != NULL)
     {
-        ScanLines = 0;
-        goto done;
+        if ((width < 0) || (bpp == 0))
+        {
+            ScanLines = 0;
+            goto done;
+        }
     }
 
     if (Bits || bpp)
@@ -2317,13 +2320,13 @@ DIB_FreeConvertedBitmapInfo(BITMAPINFO* converted, BITMAPINFO* orig, DWORD usage
         if(!numColors) numColors = 1 << pbmci->bmciHeader.bcBitCount;
         if(usage == DIB_PAL_COLORS)
         {
-            RtlZeroMemory(pbmci->bmciColors, (1 << pbmci->bmciHeader.bcBitCount) * sizeof(WORD));
+            RtlZeroMemory(pbmci->bmciColors, ((SIZE_T)1 << pbmci->bmciHeader.bcBitCount) * sizeof(WORD));
             RtlCopyMemory(pbmci->bmciColors, converted->bmiColors, numColors * sizeof(WORD));
         }
         else
         {
             UINT i;
-            RtlZeroMemory(pbmci->bmciColors, (1 << pbmci->bmciHeader.bcBitCount) * sizeof(RGBTRIPLE));
+            RtlZeroMemory(pbmci->bmciColors, ((SIZE_T)1 << pbmci->bmciHeader.bcBitCount) * sizeof(RGBTRIPLE));
             for(i=0; i<numColors; i++)
             {
                 pbmci->bmciColors[i].rgbtRed = converted->bmiColors[i].rgbRed;


### PR DESCRIPTION
## Purpose

Fix handling of BITMAPINFO in (NtGdi)GetDIBits(Internal)

## Proposed changes
* [GDI32_APITEST] Test partly "uninitialized" BITMAPINFO
* [GDI32] Fix calculation of cjMaxBits in GetDIBits
* [WIN32K:NTGDI] Fix input validation in GreGetDIBitsInternal

## Testbot runs (Filled in by Devs)

- [ ] WHS x86:
- [x] Vista x64: https://reactos.org/testman/compare.php?ids=108146,108187
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109672,109675
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109673,109676