### PR TITLE
[GDIPLUS] Fix a parameter check

### DIFF
--- a/dll/win32/gdiplus/imageattributes.c
+++ b/dll/win32/gdiplus/imageattributes.c
@@ -117,7 +117,11 @@ GpStatus WINGDIPAPI GdipGetImageAttributesAdjustedPalette(GpImageAttributes *ima
     TRACE("(%p,%p,%u)\n", imageattr, palette, type);
 
     if (!imageattr || !palette || !palette->Count ||
+#ifdef __REACTOS__
+        type >= ColorAdjustTypeCount || type <= ColorAdjustTypeDefault)
+#else
         type >= ColorAdjustTypeCount || type == ColorAdjustTypeDefault)
+#endif
         return InvalidParameter;
 
     apply_image_attributes(imageattr, (LPBYTE)palette->Entries, palette->Count, 1, 0,


### PR DESCRIPTION

## Purpose

Fix a parameter check.
This prevents a possible crash.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107935,107937,107939
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107929,107934,107936