### PR TITLE
[NTDLL] Implement NT6 NtUserPfn functions

### DIFF
--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -950,7 +950,7 @@
 @ stdcall RtlInitializeGenericTable(ptr ptr ptr ptr ptr)
 @ stdcall RtlInitializeGenericTableAvl(ptr ptr ptr ptr ptr)
 @ stdcall RtlInitializeHandleTable(long long ptr)
-@ stdcall -stub -version=0x600+ RtlInitializeNtUserPfn(wstr long ptr long wstr ptr)
+@ stdcall -version=0x600+ RtlInitializeNtUserPfn(wstr long ptr long wstr ptr)
 @ stdcall RtlInitializeRXact(ptr long ptr)
 @ stdcall RtlInitializeResource(ptr)
 @ stdcall RtlInitializeSListHead(ptr)
@@ -1125,7 +1125,7 @@
 @ stdcall RtlResetRtlTranslations(ptr)
 @ stdcall -arch=x86_64 RtlRestoreContext(ptr ptr)
 @ stdcall RtlRestoreLastWin32Error(long) RtlSetLastWin32Error
-@ stdcall -stub -version=0x600+ RtlRetrieveNtUserPfn(ptr ptr ptr)
+@ stdcall -version=0x600+ RtlRetrieveNtUserPfn(ptr ptr ptr)
 @ stdcall RtlRevertMemoryStream(ptr)
 @ stdcall RtlRunDecodeUnicodeString(long ptr)
 @ stdcall RtlRunEncodeUnicodeString(long ptr)

--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -123,6 +123,7 @@ list(APPEND SOURCE
     RtlHandle.c
     RtlImageDirectoryEntryToData.c
     RtlImageRvaToVa.c
+    RtlInitializeNtUserPfn.c
     RtlIsNameLegalDOS8Dot3.c
     RtlLocale.c
     RtlMemoryStream.c
@@ -135,6 +136,7 @@ list(APPEND SOURCE
     RtlQueryTimeZoneInfo.c
     RtlReAllocateHeap.c
     RtlRemovePrivileges.c
+    RtlRetrieveNtUserPfn.c
     RtlUnhandledExceptionFilter.c
     RtlUnicodeStringToAnsiString.c
     RtlUnicodeStringToCountedOemString.c

--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -181,7 +181,8 @@ set_target_properties(ntdll_apitest
 
 target_link_libraries(ntdll_apitest ntdll_crt_test_lib rtl_test_lib wine uuid ${PSEH_LIB})
 set_module_type(ntdll_apitest win32cui)
-add_importlibs(ntdll_apitest msvcrt advapi32 kernel32 ntdll)
+add_delay_importlibs(ntdll_apitest advapi32)
+add_importlibs(ntdll_apitest msvcrt kernel32 ntdll)
 add_pch(ntdll_apitest precomp.h "${PCH_SKIP_SOURCE}")
 add_dependencies(ntdll_apitest load_notifications empty_dll)
 

--- a/modules/rostests/apitests/ntdll/RtlInitializeNtUserPfn.c
+++ b/modules/rostests/apitests/ntdll/RtlInitializeNtUserPfn.c
@@ -1,0 +1,82 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Test for RtlRetrieveNtUserPfn
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include "precomp.h"
+
+typedef
+NTSTATUS
+NTAPI
+FN_RtlInitializeNtUserPfn(
+    PVOID* ProcsA,
+    SIZE_T SizeOfProcsA,
+    PVOID* ProcsW,
+    SIZE_T SizeOfProcsW,
+    PVOID* OtherProcs,
+    SIZE_T SizeOfOtherProcs);
+
+FN_RtlInitializeNtUserPfn* pRtlInitializeNtUserPfn;
+
+START_TEST(RtlInitializeNtUserPfn)
+{
+    HINSTANCE hinstNtdll = GetModuleHandleW(L"ntdll.dll");
+    pRtlInitializeNtUserPfn = (FN_RtlInitializeNtUserPfn*)GetProcAddress(hinstNtdll, "RtlInitializeNtUserPfn");
+    if (pRtlInitializeNtUserPfn == NULL)
+    {
+        skip("RtlInitializeNtUserPfn is not available\n");
+        return;
+    }
+
+    NTSTATUS Status;
+    PVOID ProcsA[24] = { 0 };
+    PVOID ProcsW[24] = { 0 };
+    PVOID OtherProcs[11] = { 0 };
+    ULONG Count;
+
+    Status = pRtlInitializeNtUserPfn(NULL, 1, NULL, 0, NULL, 0);
+    ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+    Status = pRtlInitializeNtUserPfn(NULL, 0, NULL, 1, NULL, 0);
+    ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+    Status = pRtlInitializeNtUserPfn(NULL, 0, NULL, 0, NULL, 1);
+    ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+    Status = pRtlInitializeNtUserPfn(ProcsA, 0, ProcsW, 0, OtherProcs, 1);
+    ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+
+    Count = GetNTVersion() >= _WIN32_WINNT_WIN10 ? 24 : 23;
+
+    /* Try different variants of too large sizes */
+    Status = pRtlInitializeNtUserPfn(ProcsA, (Count + 1) * sizeof(PVOID), ProcsW, Count * sizeof(PVOID), OtherProcs, 11 * sizeof(PVOID));
+    ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+    Status = pRtlInitializeNtUserPfn(ProcsA, Count * sizeof(PVOID), ProcsW, (Count + 1) * sizeof(PVOID), OtherProcs, 11 * sizeof(PVOID));
+    ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+    Status = pRtlInitializeNtUserPfn(ProcsA, (Count + 1) * sizeof(PVOID), ProcsW, (Count + 1) * sizeof(PVOID), OtherProcs, 11 * sizeof(PVOID));
+    ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+    Status = pRtlInitializeNtUserPfn(ProcsA, Count * sizeof(PVOID), ProcsW, Count * sizeof(PVOID), OtherProcs, 12 * sizeof(PVOID));
+    ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+
+    if (GetNTVersion() < _WIN32_WINNT_WIN10)
+    {
+        /* Try different variants of too large sizes (these succeed on Windows 10) */
+        Status = pRtlInitializeNtUserPfn(ProcsA, (Count + 1) * sizeof(PVOID), ProcsW, Count * sizeof(PVOID), OtherProcs, 11 * sizeof(PVOID));
+        ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+        Status = pRtlInitializeNtUserPfn(ProcsA, Count * sizeof(PVOID), ProcsW, (Count + 1) * sizeof(PVOID), OtherProcs, 11 * sizeof(PVOID));
+        ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+        Status = pRtlInitializeNtUserPfn(ProcsA, (Count + 1) * sizeof(PVOID), ProcsW, (Count + 1) * sizeof(PVOID), OtherProcs, 11 * sizeof(PVOID));
+        ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+        Status = pRtlInitializeNtUserPfn(ProcsA, Count * sizeof(PVOID), ProcsW, Count * sizeof(PVOID), OtherProcs, 12 * sizeof(PVOID));
+        ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+    }
+
+    /* Pass the expected sizes */
+    Status = pRtlInitializeNtUserPfn(ProcsA, Count * sizeof(PVOID), ProcsW, Count * sizeof(PVOID), OtherProcs, 11 * sizeof(PVOID));
+    ok_ntstatus(Status, STATUS_SUCCESS);
+
+    /* Try to initialize again */
+    Status = pRtlInitializeNtUserPfn(ProcsA, Count * sizeof(PVOID), ProcsW, Count * sizeof(PVOID), OtherProcs, 11 * sizeof(PVOID));
+    ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+
+    return;
+}

--- a/modules/rostests/apitests/ntdll/RtlRetrieveNtUserPfn.c
+++ b/modules/rostests/apitests/ntdll/RtlRetrieveNtUserPfn.c
@@ -1,0 +1,173 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Test for RtlRetrieveNtUserPfn
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include "precomp.h"
+
+typedef
+NTSTATUS
+WINAPI
+FN_RtlRetrieveNtUserPfn(
+    _Out_ const PVOID**,
+    _Out_ const PVOID**,
+    _Out_ const PVOID**);
+
+FN_RtlRetrieveNtUserPfn* pRtlRetrieveNtUserPfn;
+
+START_TEST(RtlRetrieveNtUserPfn)
+{
+    HINSTANCE hinstNtdll = GetModuleHandleA("ntdll.dll");
+    pRtlRetrieveNtUserPfn = (void*)GetProcAddress(hinstNtdll, "RtlRetrieveNtUserPfn");
+    if (!pRtlRetrieveNtUserPfn)
+    {
+        win_skip("RtlRetrieveNtUserPfn not supported\n");
+        return;
+    }
+
+    // Get the start and end of the ".const" section in ntdll, and check that the retrieved pointers are within that range.
+    PVOID NtDllTextStart = NULL, NtDllTextEnd = NULL;
+    PVOID NtDllRdataStart = NULL, NtDllRdataEnd = NULL;
+    PIMAGE_NT_HEADERS NtHeaders = RtlImageNtHeader(hinstNtdll);
+    PIMAGE_SECTION_HEADER SectionHeaders = IMAGE_FIRST_SECTION(NtHeaders);
+
+    for (int i = 0; i < NtHeaders->FileHeader.NumberOfSections; i++)
+    {
+        PIMAGE_SECTION_HEADER Section = &SectionHeaders[i];
+        if (memcmp(Section->Name, ".text", 5) == 0)
+        {
+            NtDllTextStart = (PBYTE)hinstNtdll + Section->VirtualAddress;
+            NtDllTextEnd = (PBYTE)NtDllTextStart + Section->Misc.VirtualSize;
+        }
+        else if (memcmp(Section->Name, ".rdata", 6) == 0)
+        {
+            NtDllRdataStart = (PBYTE)hinstNtdll + Section->VirtualAddress;
+            NtDllRdataEnd = (PBYTE)NtDllRdataStart + Section->Misc.VirtualSize;
+        }
+    }
+
+    /* Some versions don't have a .rdata section */
+    if (NtDllRdataStart == NULL)
+    {
+        /* Use .text instead */
+        NtDllRdataStart = NtDllTextStart;
+        NtDllRdataEnd = NtDllTextEnd;
+    }
+
+    ok(NtDllTextStart != NULL, "Failed to find .text section in ntdll.dll\n");
+    ok(NtDllRdataStart != NULL, "Failed to find .rdata section in ntdll.dll\n");
+
+    NTSTATUS Status;
+    const PVOID *p1, *p2, *p3;
+
+    /* We expect the user PFNs not to have been set up by now */
+    Status = pRtlRetrieveNtUserPfn(&p1, &p2, &p3);
+    ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+
+    if (GetNTVersion() >= _WIN32_WINNT_WIN7)
+    {
+        /* Load win32u.dll, which should NOT register the PFNs */
+        HINSTANCE hinstWin32u = GetModuleHandleA("win32u.dll");
+        ok(hinstWin32u == NULL, "win32u.dll should not be loaded yet\n");
+        hinstWin32u = LoadLibraryA("win32u.dll");
+        ok(hinstWin32u != NULL, "Failed to load win32u.dll\n");
+
+        /* Try again (should still fail) */
+        Status = pRtlRetrieveNtUserPfn(&p1, &p2, &p3);
+        ok_ntstatus(Status, STATUS_INVALID_PARAMETER);
+    }
+
+    /* Load user32, which should register the PFNs */
+    HINSTANCE hinstUser32 = GetModuleHandleA("user32.dll");
+    ok(hinstUser32 == NULL, "user32.dll should not be loaded yet\n");
+    hinstUser32 = LoadLibraryA("user32.dll");
+    ok(hinstUser32 != NULL, "Failed to load user32.dll\n");
+
+    /* Try again */
+    Status = pRtlRetrieveNtUserPfn(&p1, &p2, &p3);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+
+    /* The function retrieves three pointers to internal ntdll pointer arrays.
+       All three arrays are located in the .rdata section of ntdll.dll,
+       so check that the retrieved pointers are within that range. */
+    ok((PVOID)p1 >= NtDllRdataStart && (PVOID)p1 < NtDllRdataEnd,
+       "p1 (%p) is not within .rdata section (%p-%p)\n", p1, NtDllRdataStart, NtDllRdataEnd);
+    ok((PVOID)p2 >= NtDllRdataStart && (PVOID)p2 < NtDllRdataEnd,
+       "p2 (%p) is not within .rdata section (%p-%p)\n", p2, NtDllRdataStart, NtDllRdataEnd);
+    ok((PVOID)p3 >= NtDllRdataStart && (PVOID)p3 < NtDllRdataEnd,
+       "p3 (%p) is not within .rdata section (%p-%p)\n", p3, NtDllRdataStart, NtDllRdataEnd);
+
+    // The arrays are expected to follow one after the other
+    ok(p2 > p1, "p2 (%p) is not greater than p1 (%p)\n", p2, p1);
+    ok(p3 > p2, "p3 (%p) is not greater than p2 (%p)\n", p3, p2);
+
+    /* Get the field size */
+    BOOL IsWow64;
+    IsWow64Process(GetCurrentProcess(), &IsWow64);
+    SIZE_T FieldSize = IsWow64 ? sizeof(ULONG64) : sizeof(PVOID);
+
+    SIZE_T Count1 = ((PUCHAR)p2 - (PUCHAR)p1) / FieldSize;
+    SIZE_T Count2 = ((PUCHAR)p3 - (PUCHAR)p2) / FieldSize;
+
+    ok_eq_size(Count1, Count2);
+    ok_eq_size(Count1, GetNTVersion() >= _WIN32_WINNT_WIN10 ? 24 : 23);
+
+    /* Iterate over all function pointers from arrays 1 and 2 in one run */
+    for (SIZE_T i = 0; i < (Count1 + Count2); i++)
+    {
+        PUCHAR pfn = *(PVOID*)((PUCHAR)p1 + i * FieldSize);
+        ok((PVOID)pfn >= NtDllTextStart && (PVOID)pfn < NtDllTextEnd,
+           "p1[%d] (%p) is not within .text section (%p-%p)\n", i, pfn, NtDllTextStart, NtDllTextEnd);
+
+        /* Check the dispatch code */
+        if (is_reactos() || GetNTVersion() >= _WIN32_WINNT_WIN10)
+        {
+#if defined(_M_IX86)
+            ok_eq_size((ULONG_PTR)pfn & 15, 0); // The functions should be 16-byte aligned
+            ok_eq_int(memcmp(&pfn[0], "\xFF\x25", 2), 0); // jmp dword ptr [x]
+            ok_eq_int(memcmp(&pfn[6], "\x8D\xA4\x24\x00\x00\x00\x00", 7), 0); // lea esp, [esp]
+            ok_eq_int(memcmp(&pfn[13], "\x8D\x49\x00", 3), 0); // lea ecx, [ecx]
+#elif defined(_M_AMD64)
+            ok_eq_size((ULONG_PTR)pfn & 15, 0); // The functions should be 16-byte aligned
+            ok_eq_int(memcmp(&pfn[0], "\xFF\x25", 2), 0); // jmp qword ptr [rip + x]
+            ok_eq_int(memcmp(&pfn[6], "\x66\x66\x0F\x1F\x84\x00\x00\x00\x00\x00", 10), 0); // nop word ptr [rax + rax]
+#endif
+        }
+        else
+        {
+#if defined(_M_IX86)
+            ok_eq_size((ULONG_PTR)pfn & 3, 0); // The functions should be 4-byte aligned
+            ok_eq_int(memcmp(&pfn[0], "\xFF\x25", 2), 0); // jmp dword ptr [x]
+            ok_eq_int(memcmp(&pfn[6], "\x90\x90\x90\x90\x90", 5), 0); // nop nop ...
+#elif defined(_M_AMD64)
+            ok_eq_size((ULONG_PTR)pfn & 3, 0); // The functions should be 4-byte aligned
+            ok_eq_int(memcmp(&pfn[0], "\x48\xFF\x25", 3), 0); // jmp qword ptr [rip + x]
+            //ok_eq_int(memcmp(&pfn[7], "\x90\x90\x90\x90\x90\x90\x90\x90\x90", 2), 0); // nop nop ...
+#endif
+        }
+    }
+
+    /* The 3rd array has only 11 entries, check those as well. */
+    for (SIZE_T i = 0; i < 11; i++)
+    {
+        PUCHAR pfn = *(PVOID*)((PUCHAR)p1 + i * FieldSize);
+        ok((PVOID)pfn >= NtDllTextStart && (PVOID)pfn < NtDllTextEnd,
+           "p3[%d] (%p) is not within .text section (%p-%p)\n", i, pfn, NtDllTextStart, NtDllTextEnd);
+    }
+
+    StartSeh()
+        Status = pRtlRetrieveNtUserPfn(NULL, &p2, &p3);
+    EndSeh(STATUS_ACCESS_VIOLATION)
+
+    StartSeh()
+        Status = pRtlRetrieveNtUserPfn(&p1, NULL, &p3);
+    EndSeh(STATUS_ACCESS_VIOLATION)
+
+    StartSeh()
+        Status = pRtlRetrieveNtUserPfn(&p1, &p2, NULL);
+    EndSeh(STATUS_ACCESS_VIOLATION)
+
+    return;
+}

--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -5091,6 +5091,30 @@ RtlRunOnceComplete(
     _In_ ULONG Flags,
     _In_opt_ PVOID Context);
 
+#if (NTDDI_VERSION >= NTDDI_WIN10)
+#define RTLP_NUMBER_OF_NTUSER_WNDPROCS 24
+#else
+#define RTLP_NUMBER_OF_NTUSER_WNDPROCS 23
+#endif
+#define RTLP_NUMBER_OF_NTUSER_WORKERPROCS 11
+
+NTSTATUS
+NTAPI
+RtlInitializeNtUserPfn(
+    _In_reads_bytes_(SizeOfProcsA) LPCVOID WndProcsA,
+    _In_ SIZE_T SizeOfProcsA,
+    _In_reads_bytes_(SizeOfProcsW) LPCVOID WndProcsW,
+    _In_ SIZE_T SizeOfProcsW,
+    _In_reads_bytes_(SizeOfProcsX) LPCVOID WorkerProcs,
+    _In_ SIZE_T SizeOfProcsX);
+
+NTSTATUS
+WINAPI
+RtlRetrieveNtUserPfn(
+    _Out_ LPCVOID* NtdllWndProcsA,
+    _Out_ LPCVOID* NtdllWndProcsW,
+    _Out_ LPCVOID* NtdllWorkerProcs);
+
 #endif
 
 #if (_WIN32_WINNT >= _WIN32_WINNT_VISTA) || (defined(__REACTOS__) && defined(_NTDLLBUILD_))

--- a/sdk/lib/rtl/CMakeLists.txt
+++ b/sdk/lib/rtl/CMakeLists.txt
@@ -1,4 +1,7 @@
 
+remove_definitions(-D_WIN32_WINNT=0x502)
+#add_definitions(-D_WIN32_WINNT=0x600)
+
 add_definitions(
     -D_NTOSKRNL_
     -DNO_RTL_INLINES
@@ -130,14 +133,18 @@ endif()
 
 add_asm_files(rtl_asm ${ASM_SOURCE})
 add_library(rtl ${SOURCE} ${rtl_asm})
+target_compile_definitions(rtl PRIVATE _WIN32_WINNT=0x502)
 target_link_libraries(rtl PRIVATE pseh)
 add_pch(rtl rtl.h SOURCE)
 add_dependencies(rtl psdk asm)
 
+add_asm_files(rtl_vista_asm ntuserdisp.s)
 list(APPEND SOURCE_VISTA
+    ${rtl_vista_asm}
     ${RTL_WINE_SOURCE_VISTA}
     condvar.c
     locale.c
+    ntuserpfn.c
     runonce.c
     srw.c
     threadpool.c
@@ -145,6 +152,7 @@ list(APPEND SOURCE_VISTA
     utf8.c)
 
 add_library(rtl_vista ${SOURCE_VISTA})
+target_compile_definitions(rtl_vista PRIVATE _WIN32_WINNT=0x600)
 add_pch(rtl_vista rtl_vista.h SOURCE_VISTA)
 add_dependencies(rtl_vista psdk)
 target_link_libraries(rtl_vista PRIVATE pseh)

--- a/sdk/lib/rtl/ntuserdisp.s
+++ b/sdk/lib/rtl/ntuserdisp.s
@@ -1,0 +1,128 @@
+/*
+ * PROJECT:     ReactOS Runtime Library (RTL)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     NtUserPfn dispatch code
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+/* INCLUDES ******************************************************************/
+
+#if defined(_M_IX86) || defined(_M_AMD64)
+
+#include <asm.inc>
+
+#if (NTDDI_VERSION >= NTDDI_WIN10)
+#define NUMBER_OF_NTUSER_AW_PFNS 24
+#else
+#define NUMBER_OF_NTUSER_AW_PFNS 23
+#endif
+#define NUMBER_OF_NTUSER_OTHER_PFNS 11
+#define RTL_NUMBER_OF_NTUSER_PFNS (2 * NUMBER_OF_NTUSER_AW_PFNS + NUMBER_OF_NTUSER_OTHER_PFNS)
+
+#if defined(_M_IX86)
+EXTERN _RtlpNtUserPfns:DWORD
+#else
+EXTERN RtlpNtUserPfns:QWORD
+#endif
+
+/* ARCH SPECIFIC MACROS ******************************************************/
+
+#if defined(_M_IX86)
+
+MACRO(DEFINE_NTUSER_PFN_THUNK, Index)
+    ALIGN 16
+    RtlpNtUserPfnDispatch&Index:
+        jmp dword ptr _RtlpNtUserPfns[Index * 4]
+ENDM
+
+#elif defined(_M_AMD64)
+
+MACRO(DEFINE_NTUSER_PFN_THUNK, Index)
+    ALIGN 16
+    RtlpNtUserPfnDispatch&Index:
+        jmp qword ptr RtlpNtUserPfns[rip + Index * 8]
+ENDM
+
+#elif defined(_M_ARM)
+
+    MACRO
+    DEFINE_NTUSER_PFN_THUNK $Index
+        LEAF_ENTRY RtlpNtUserPfnDispatch$Index
+            ldr r12, =RtlpNtUserPfns + (Index * 8)
+            ldr r12, [r12]
+            bx  r12
+        LEAF_END RtlpNtUserPfnDispatch$Index
+    MEND
+
+#elif defined(_M_ARM64)
+
+    MACRO(DEFINE_NTUSER_PFN_THUNK, Index)
+        LEAF_ENTRY RtlpNtUserPfnDispatch&Index
+            adrp x16, RtlpNtUserPfns + (Index * 8)
+            ldr  x16, [x16, #:lo12:RtlpNtUserPfns + (Index * 8)]
+            br   x16
+        LEAF_END RtlpNtUserPfnDispatch&Index
+    ENDM
+
+#else
+#error Unsupported architecture
+#endif
+
+
+/* DISPATCH THUNKS ***********************************************************/
+
+#ifdef _WIN64
+.code64
+#elif defined(_M_IX86)
+.code
+#endif
+
+/* Generate the thunk functions */
+#ifndef _M_ARM
+Index = 0
+REPEAT RTL_NUMBER_OF_NTUSER_PFNS
+    DEFINE_NTUSER_PFN_THUNK %Index
+    Index = Index + 1
+ENDR
+#endif
+
+/* DISPATCH POINTER TABLE ****************************************************/
+
+#if defined(_M_IX86) || defined(_M_AMD64)
+.const
+#else
+#endif
+
+#ifdef _WIN64
+MACRO(DEFINE_NTUSER_PFN_REF, Index)
+    .quad RtlpNtUserPfnDispatch&Index
+ENDM
+#else
+MACRO(DEFINE_NTUSER_PFN_REF, Index)
+    .long RtlpNtUserPfnDispatch&Index
+ENDM
+#endif
+
+#if defined(_M_IX86)
+ASSUME CS:NOTHING
+PUBLIC _NtDllUserStubs
+_NtDllUserStubs:
+#else
+PUBLIC NtDllUserStubs
+NtDllUserStubs:
+#endif
+
+Index = 0
+REPEAT RTL_NUMBER_OF_NTUSER_PFNS
+    DEFINE_NTUSER_PFN_REF %Index
+    Index = Index + 1
+ENDR
+
+
+#elif defined(_M_ARM) || defined(_M_ARM64)
+
+// TODO Implement this
+
+#endif
+
+    END

--- a/sdk/lib/rtl/ntuserpfn.c
+++ b/sdk/lib/rtl/ntuserpfn.c
@@ -1,0 +1,107 @@
+/*
+ * PROJECT:     ReactOS runtime library
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     NtUser PFN registration
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include <rtl.h>
+#include <ndk/rtlfuncs.h>
+
+#define NDEBUG
+#include <debug.h>
+
+typedef struct _NTUSER_PFN
+{
+    PVOID WndProcsA[RTLP_NUMBER_OF_NTUSER_WNDPROCS];
+    PVOID WndProcsW[RTLP_NUMBER_OF_NTUSER_WNDPROCS];
+    PVOID WorkerProcs[RTLP_NUMBER_OF_NTUSER_WORKERPROCS];
+} NTUSER_PFN, *PNTUSER_PFN;
+
+const NTUSER_PFN RtlpNtUserPfns = { 0 };
+
+extern const NTUSER_PFN NtDllUserStubs;
+
+static BOOLEAN NtUserPfnsInitialized;
+
+NTSTATUS
+NTAPI
+RtlInitializeNtUserPfn(
+    _In_reads_bytes_(SizeOfWndProcsA) LPCVOID WndProcsA,
+    _In_ SIZE_T SizeOfWndProcsA,
+    _In_reads_bytes_(SizeOfWndProcsW) LPCVOID WndProcsW,
+    _In_ SIZE_T SizeOfWndProcsW,
+    _In_reads_bytes_(SizeOfWorkerProcs) LPCVOID WorkerProcs,
+    _In_ SIZE_T SizeOfWorkerProcs)
+{
+    ULONG OldProtect;
+    PVOID BaseAddress;
+    SIZE_T RegionSize;
+    NTSTATUS Status;
+
+    /* Validate parameters */
+    if ((SizeOfWndProcsA != sizeof(RtlpNtUserPfns.WndProcsA)) ||
+        (SizeOfWndProcsW != sizeof(RtlpNtUserPfns.WndProcsW)) ||
+        (SizeOfWorkerProcs != sizeof(RtlpNtUserPfns.WorkerProcs)))
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    /* Check if already initialized */
+    if (NtUserPfnsInitialized != FALSE)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    /* Change page protection, so we can set up the PFNs */
+    BaseAddress = (PVOID)&RtlpNtUserPfns;
+    RegionSize = sizeof(RtlpNtUserPfns);
+    Status = NtProtectVirtualMemory(NtCurrentProcess(),
+                                    &BaseAddress,
+                                    &RegionSize,
+                                    PAGE_READWRITE,
+                                    &OldProtect);
+    if (!NT_SUCCESS(Status))
+    {
+        return Status;
+    }
+
+    RtlCopyMemory((PVOID)RtlpNtUserPfns.WndProcsA, WndProcsA, SizeOfWndProcsA);
+    RtlCopyMemory((PVOID)RtlpNtUserPfns.WndProcsW, WndProcsW, SizeOfWndProcsW);
+    RtlCopyMemory((PVOID)RtlpNtUserPfns.WorkerProcs, WorkerProcs, SizeOfWorkerProcs);
+
+    /* Restore original page protection */
+    Status = NtProtectVirtualMemory(NtCurrentProcess(),
+                                    &BaseAddress,
+                                    &RegionSize,
+                                    OldProtect,
+                                    &OldProtect);
+    if (!NT_SUCCESS(Status))
+    {
+        return Status;
+    }
+
+    NtUserPfnsInitialized = TRUE;
+
+    return STATUS_SUCCESS;
+}
+
+
+NTSTATUS
+WINAPI
+RtlRetrieveNtUserPfn(
+    _Out_ LPCVOID* NtdllWndProcsA,
+    _Out_ LPCVOID* NtdllWndProcsW,
+    _Out_ LPCVOID* NtdllWorkerProcs)
+{
+    if (NtUserPfnsInitialized == FALSE)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    *NtdllWndProcsA = NtDllUserStubs.WndProcsA;
+    *NtdllWndProcsW = NtDllUserStubs.WndProcsW;
+    *NtdllWorkerProcs = NtDllUserStubs.WorkerProcs;
+
+    return STATUS_SUCCESS;
+}

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -816,6 +816,9 @@ typedef struct _PFNCLIENT
     WNDPROC pfnDispatchDefWindowProc;
     WNDPROC pfnDispatchMessage;
     WNDPROC pfnMDIActivateDlgProc;
+#if (NTDDI_VERSION >= NTDDI_WIN10)
+    WNDPROC pfnFilteredProcessRedirectingWndProc;
+#endif
 } PFNCLIENT, *PPFNCLIENT;
 
 /*

--- a/win32ss/user/user32/controls/button.c
+++ b/win32ss/user/user32/controls/button.c
@@ -143,12 +143,8 @@ const struct builtin_class_descr BUTTON_builtin_class =
 {
     buttonW,             /* name */
     CS_DBLCLKS | CS_VREDRAW | CS_HREDRAW | CS_PARENTDC, /* style  */
-#ifdef __REACTOS__
-    ButtonWndProcA,      /* procA */
-    ButtonWndProcW,      /* procW */
-#else
-    WINPROC_BUTTON,      /* proc */
-#endif
+    &pfnClientA.pfnButtonWndProc, /* procA */
+    &pfnClientW.pfnButtonWndProc, /* procW */
     NB_EXTRA_BYTES,      /* extra */
     IDC_ARROW,           /* cursor */
     0                    /* brush */

--- a/win32ss/user/user32/controls/combo.c
+++ b/win32ss/user/user32/controls/combo.c
@@ -68,12 +68,8 @@ const struct builtin_class_descr COMBO_builtin_class =
 {
     comboboxW,            /* name */
     CS_PARENTDC | CS_DBLCLKS | CS_HREDRAW | CS_VREDRAW, /* style  */
-#ifdef __REACTOS__
-    ComboWndProcA,        /* procA */
-    ComboWndProcW,        /* procW */
-#else
-    WINPROC_COMBO,        /* proc */
-#endif
+    &pfnClientA.pfnComboBoxWndProc,        /* procA */
+    &pfnClientW.pfnComboBoxWndProc,        /* procW */
     sizeof(HEADCOMBO *),  /* extra */
     IDC_ARROW,            /* cursor */
     0                     /* brush */

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -5547,12 +5547,8 @@ const struct builtin_class_descr EDIT_builtin_class =
 {
     editW,                /* name */
     CS_DBLCLKS | CS_PARENTDC,   /* style */
-#ifdef __REACTOS__
-    EditWndProcA,         /* procA */
-    EditWndProcW,         /* procW */
-#else
-    WINPROC_EDIT,         /* proc */
-#endif
+    &pfnClientA.pfnEditWndProc, /* procA */
+    &pfnClientW.pfnEditWndProc, /* procW */
 #ifndef _WIN64
     sizeof(EDITSTATE *) + sizeof(WORD), /* extra */
 #else

--- a/win32ss/user/user32/controls/ghost.c
+++ b/win32ss/user/user32/controls/ghost.c
@@ -18,8 +18,8 @@ const struct builtin_class_descr GHOST_builtin_class =
 {
     L"Ghost",                   /* name */
     0,                          /* style  */
-    GhostWndProcA,              /* procA */
-    GhostWndProcW,              /* procW */
+    &pfnClientA.pfnGhostWndProc, /* procA */
+    &pfnClientW.pfnGhostWndProc, /* procW */
     0,                          /* extra */
     IDC_WAIT,                   /* cursor */
     NULL                        /* brush */

--- a/win32ss/user/user32/controls/icontitle.c
+++ b/win32ss/user/user32/controls/icontitle.c
@@ -30,8 +30,8 @@ const struct builtin_class_descr ICONTITLE_builtin_class =
 {
     WC_ICONTITLE,     /* name */
     0,                /* style */
-    NULL,             /* procA (winproc is Unicode only) */
-    IconTitleWndProc, /* procW */
+    &pfnClientA.pfnTitleWndProc, /* procA (winproc is Unicode only) */
+    &pfnClientW.pfnTitleWndProc, /* procW */
     0,                /* extra */
     IDC_ARROW,        /* cursor */
     0                 /* brush */

--- a/win32ss/user/user32/controls/listbox.c
+++ b/win32ss/user/user32/controls/listbox.c
@@ -127,8 +127,8 @@ const struct builtin_class_descr LISTBOX_builtin_class =
 {
     listboxW,             /* name */
     CS_DBLCLKS /*| CS_PARENTDC*/,  /* style */
-    ListBoxWndProcA,      /* procA */
-    ListBoxWndProcW,      /* procW */
+    &pfnClientA.pfnListBoxWndProc, /* procA */
+    &pfnClientW.pfnListBoxWndProc, /* procW */
     sizeof(LB_DESCR *),   /* extra */
     IDC_ARROW,            /* cursor */
     0                     /* brush */
@@ -143,8 +143,8 @@ const struct builtin_class_descr COMBOLBOX_builtin_class =
 {
     combolboxW,           /* name */
     CS_DBLCLKS | CS_SAVEBITS,  /* style */
-    ListBoxWndProcA,      /* procA */
-    ListBoxWndProcW,      /* procW */
+    &pfnClientA.pfnComboListBoxProc, /* procA */
+    &pfnClientW.pfnComboListBoxProc, /* procW */
     sizeof(LB_DESCR *),   /* extra */
     IDC_ARROW,            /* cursor */
     0                     /* brush */

--- a/win32ss/user/user32/controls/regcontrol.c
+++ b/win32ss/user/user32/controls/regcontrol.c
@@ -12,9 +12,9 @@
 
 DWORD RegisterDefaultClasses = FALSE;
 
-static PFNCLIENT pfnClientA;
-static PFNCLIENT pfnClientW;
-static PFNCLIENTWORKER pfnClientWorker;
+PFNCLIENT pfnClientA;
+PFNCLIENT pfnClientW;
+PFNCLIENTWORKER pfnClientWorker;
 
 
 /***********************************************************************
@@ -92,7 +92,7 @@ BOOL WINAPI RegisterSystemControls(VOID)
 
         // Set Global bit!
         WndClass.style = g_SysClasses[i].desc->style|CS_GLOBALCLASS;
-        WndClass.lpfnWndProc = g_SysClasses[i].desc->procW;
+        WndClass.lpfnWndProc = *g_SysClasses[i].desc->procW;
         WndClass.cbWndExtra = g_SysClasses[i].desc->extra;
         WndClass.hCursor = LoadCursorW(NULL, g_SysClasses[i].desc->cursor);
         WndClass.hbrBackground= g_SysClasses[i].desc->brush;
@@ -203,6 +203,37 @@ BOOL WINAPI RegisterClientPFN(VOID)
   pfnClientWorker.pfnImeWndProc       = ImeWndProc_common;
   pfnClientWorker.pfnGhostWndProc     = GhostWndProc_common;
   pfnClientWorker.pfnCtfHookProc      = User32DefWindowProc;
+
+#if (DLL_EXPORT_VERSION >= _WIN32_WINNT_VISTA)
+    /* Register the PFNs with ntdll */
+    Status = RtlInitializeNtUserPfn(&pfnClientA,
+                                    sizeof(pfnClientA),
+                                    &pfnClientW,
+                                    sizeof(pfnClientW),
+                                    &pfnClientWorker,
+                                    sizeof(pfnClientWorker));
+    if (!NT_SUCCESS(Status))
+    {
+        return FALSE;
+    }
+
+    /* Query the PFN thunks from ntdll */
+    PFNCLIENT* pfnNtdllClientA;
+    PFNCLIENT* pfnNtdllClientW;
+    PFNCLIENTWORKER* pfnNtdllClientWorker;
+    Status = RtlRetrieveNtUserPfn((LPCVOID*)&pfnNtdllClientA,
+                                  (LPCVOID*)&pfnNtdllClientW,
+                                  (LPCVOID*)&pfnNtdllClientWorker);
+    if (!NT_SUCCESS(Status))
+    {
+        return FALSE;
+    }
+
+    /* Now update the global PFNs */
+    pfnClientA = *pfnNtdllClientA;
+    pfnClientW = *pfnNtdllClientW;
+    pfnClientWorker = *pfnNtdllClientWorker;
+#endif
 
   Status = NtUserInitializeClientPfnArrays( &pfnClientA,
                                             &pfnClientW,

--- a/win32ss/user/user32/controls/scrollbar.c
+++ b/win32ss/user/user32/controls/scrollbar.c
@@ -77,8 +77,8 @@ const struct builtin_class_descr SCROLL_builtin_class =
 {
     L"ScrollBar",           /* name */
     CS_DBLCLKS | CS_VREDRAW | CS_HREDRAW | CS_PARENTDC, /* style */
-    ScrollBarWndProcA,      /* procA */
-    ScrollBarWndProcW,      /* procW */
+    &pfnClientA.pfnScrollBarWndProc, /* procA */
+    &pfnClientW.pfnScrollBarWndProc, /* procW */
     sizeof(SBWND)-sizeof(WND), /* extra */
     IDC_ARROW,              /* cursor */
     0                       /* brush */

--- a/win32ss/user/user32/controls/static.c
+++ b/win32ss/user/user32/controls/static.c
@@ -82,8 +82,8 @@ const struct builtin_class_descr STATIC_builtin_class =
 {
     staticW,             /* name */
     CS_DBLCLKS | CS_PARENTDC, /* style  */
-    StaticWndProcA,      /* procA */
-    StaticWndProcW,      /* procW */
+    &pfnClientA.pfnStaticWndProc, /* procA */
+    &pfnClientW.pfnStaticWndProc, /* procW */
     STATIC_EXTRA_BYTES,  /* extra */
     IDC_ARROW,           /* cursor */
     0                    /* brush */

--- a/win32ss/user/user32/include/regcontrol.h
+++ b/win32ss/user/user32/include/regcontrol.h
@@ -10,13 +10,17 @@
 
 #pragma once
 
+extern PFNCLIENT pfnClientA;
+extern PFNCLIENT pfnClientW;
+extern PFNCLIENTWORKER pfnClientWorker;
+
 /* Built-in class descriptor */
 struct builtin_class_descr
 {
     LPCWSTR name;    /* class name */
     UINT    style;   /* class style */
-    WNDPROC procA;   /* Ansi window procedure */
-    WNDPROC procW;   /* Unicode window procedure */
+    WNDPROC* procA;  /* Ansi window procedure */
+    WNDPROC* procW;  /* Unicode window procedure */
     INT     extra;   /* window extra bytes */
     LPCWSTR cursor;  /* cursor name */
     HBRUSH  brush;   /* brush or system color */

--- a/win32ss/user/user32/misc/imm.c
+++ b/win32ss/user/user32/misc/imm.c
@@ -1184,8 +1184,8 @@ const struct builtin_class_descr IME_builtin_class =
 {
     L"IME",                       /* name */
     CS_GLOBALCLASS,               /* style */
-    ImeWndProcA,                  /* procA */
-    ImeWndProcW,                  /* procW */
+    &pfnClientA.pfnImeWndProc,    /* procA */
+    &pfnClientW.pfnImeWndProc,    /* procW */
     sizeof(IMEWND) - sizeof(WND), /* extra */
     IDC_ARROW,                    /* cursor */
     NULL                          /* brush */

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -110,8 +110,8 @@ const struct builtin_class_descr DIALOG_builtin_class =
 {
     WC_DIALOG,       /* name */
     CS_SAVEBITS | CS_DBLCLKS, /* style  */
-    DefDlgProcA,              /* procA */
-    DefDlgProcW,              /* procW */
+    &pfnClientA.pfnDialogWndProc, /* procA */
+    &pfnClientW.pfnDialogWndProc, /* procW */
     DLGWINDOWEXTRA,           /* extra */
     (LPCWSTR) IDC_ARROW,      /* cursor */
     0                         /* brush */

--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -214,8 +214,8 @@ const struct builtin_class_descr MDICLIENT_builtin_class =
 {
     L"MDIClient",            /* name */
     0,                      /* style */
-    MDIClientWndProcA,      /* procA */
-    MDIClientWndProcW,      /* procW */
+    &pfnClientA.pfnMDIClientWndProc, /* procA */
+    &pfnClientW.pfnMDIClientWndProc, /* procW */
     sizeof(MDIWND),         /* extra */
     IDC_ARROW,              /* cursor */
     (HBRUSH)(COLOR_APPWORKSPACE+1)    /* brush */

--- a/win32ss/user/user32/windows/menu.c
+++ b/win32ss/user/user32/windows/menu.c
@@ -49,8 +49,8 @@ const struct builtin_class_descr POPUPMENU_builtin_class =
 {
     WC_MENU,                     /* name */
     CS_SAVEBITS | CS_DBLCLKS,                  /* style  */
-    NULL,                                      /* FIXME - procA */
-    PopupMenuWndProcW,                         /* FIXME - procW */
+    &pfnClientA.pfnMenuWndProc,                /* procA */
+    &pfnClientW.pfnMenuWndProc,                /* procW */
     sizeof(MENUINFO *),                        /* extra */
     (LPCWSTR) IDC_ARROW,                       /* cursor */
     (HBRUSH)(COLOR_MENU + 1)                   /* brush */


### PR DESCRIPTION
## Purpose

This implements NT6+ RtlInitializeNtUserPfn and RtlRetrieveNtUserPfn.
The implementations are not yet doing anything relevant, but they satisfy the tests.
This is tested by ntdll_winetest rtl.

## Proposed changes
* [NTDLL_APITEST] Implement tests for RTL NtUserPfn functions
* [RTL][NTDLL] Implement RTL NtUserPfn functions
* [USER32] Fake-register NtUser PFNs with ntdll

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: