### PR TITLE
[DHCPCSVC] Fix DHCP option stack overflow

### DIFF
--- a/base/services/dhcpcsvc/dhcp/dhclient.c
+++ b/base/services/dhcpcsvc/dhcp/dhclient.c
@@ -560,9 +560,11 @@ unset_domain(
 
 void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
     CHAR Buffer[200] = "SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces\\";
-    struct iaddr netmask;
+    CHAR AddressBuffer[32];
+    struct in_addr addr;
+    ULONG Netmask;
+    ULONG Router;
     HKEY hkey;
-    int i;
 
     strcat(Buffer, Adapter->DhclientInfo.name);
     if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, Buffer, 0, KEY_WRITE, &hkey) != ERROR_SUCCESS)
@@ -576,28 +578,23 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
     }
 
     /* Set up our default router if we got one from the DHCP server */
-    if( new_lease->options[DHO_SUBNET_MASK].len ) {
+    if( new_lease->options[DHO_SUBNET_MASK].len == (int)sizeof(ULONG) )
+    {
         NTSTATUS Status;
 
-        memcpy( netmask.iabuf,
-                new_lease->options[DHO_SUBNET_MASK].data,
-                new_lease->options[DHO_SUBNET_MASK].len );
+        memcpy( &Netmask, new_lease->options[DHO_SUBNET_MASK].data, sizeof(Netmask) );
         Status = AddIPAddress
             ( *((ULONG*)new_lease->address.iabuf),
-              *((ULONG*)netmask.iabuf),
+              Netmask,
               Adapter->IfMib.dwIndex,
               &Adapter->NteContext,
               &Adapter->NteInstance );
-        if (hkey) {
+        if (hkey)
+        {
             RegSetValueExA(hkey, "DhcpIPAddress", 0, REG_SZ, (LPBYTE)piaddr(new_lease->address), strlen(piaddr(new_lease->address))+1);
-            Buffer[0] = '\0';
-            for(i = 0; i < new_lease->options[DHO_SUBNET_MASK].len; i++)
-            {
-                sprintf(&Buffer[strlen(Buffer)], "%u", new_lease->options[DHO_SUBNET_MASK].data[i]);
-                if (i + 1 < new_lease->options[DHO_SUBNET_MASK].len)
-                    strcat(Buffer, ".");
-            }
-            RegSetValueExA(hkey, "DhcpSubnetMask", 0, REG_SZ, (LPBYTE)Buffer, strlen(Buffer)+1);
+            addr.S_un.S_addr = Netmask;
+            RtlIpv4AddressToStringA(&addr, AddressBuffer);
+            RegSetValueExA(hkey, "DhcpSubnetMask", 0, REG_SZ, (LPBYTE)AddressBuffer, strlen(AddressBuffer)+1);
             RegSetValueExA(hkey, "DhcpServer", 0, REG_SZ, (LPBYTE)piaddr(new_lease->serveraddress), strlen(piaddr(new_lease->serveraddress))+1);
 
             RegSetValueExA(hkey, "Lease", 0, REG_DWORD, (LPBYTE)&new_lease->lease, sizeof(DWORD));
@@ -612,8 +609,13 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
         if( !NT_SUCCESS(Status) )
             warning("AddIPAddress: %lx\n", Status);
     }
+    else if( new_lease->options[DHO_SUBNET_MASK].len )
+    {
+        warning("Invalid subnet mask option length: %d\n", new_lease->options[DHO_SUBNET_MASK].len);
+    }
 
-    if( new_lease->options[DHO_ROUTERS].len ) {
+    if( new_lease->options[DHO_ROUTERS].len >= (int)sizeof(ULONG) && new_lease->options[DHO_ROUTERS].len % (int)sizeof(ULONG) == 0 )
+    {
         NTSTATUS Status;
 
         Adapter->RouterMib.dwForwardDest = 0; /* Default route */
@@ -621,29 +623,30 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
         Adapter->RouterMib.dwForwardMetric1 = 1;
         Adapter->RouterMib.dwForwardIfIndex = Adapter->IfMib.dwIndex;
 
-        if( Adapter->RouterMib.dwForwardNextHop ) {
+        if( Adapter->RouterMib.dwForwardNextHop )
+        {
             /* If we set a default route before, delete it before continuing */
             DeleteIpForwardEntry( &Adapter->RouterMib );
         }
 
-        Adapter->RouterMib.dwForwardNextHop =
-            *((ULONG*)new_lease->options[DHO_ROUTERS].data);
+        memcpy( &Router, new_lease->options[DHO_ROUTERS].data, sizeof(Router) );
+        Adapter->RouterMib.dwForwardNextHop = Router;
 
         Status = CreateIpForwardEntry( &Adapter->RouterMib );
 
         if( !NT_SUCCESS(Status) )
             warning("CreateIpForwardEntry: %lx\n", Status);
 
-        if (hkey) {
-            Buffer[0] = '\0';
-            for(i = 0; i < new_lease->options[DHO_ROUTERS].len; i++)
-            {
-                sprintf(&Buffer[strlen(Buffer)], "%u", new_lease->options[DHO_ROUTERS].data[i]);
-                if (i + 1 < new_lease->options[DHO_ROUTERS].len)
-                    strcat(Buffer, ".");
-            }
-            RegSetValueExA(hkey, "DhcpDefaultGateway", 0, REG_SZ, (LPBYTE)Buffer, strlen(Buffer)+1);
+        if (hkey)
+        {
+            addr.S_un.S_addr = Router;
+            RtlIpv4AddressToStringA(&addr, AddressBuffer);
+            RegSetValueExA(hkey, "DhcpDefaultGateway", 0, REG_SZ, (LPBYTE)AddressBuffer, strlen(AddressBuffer)+1);
         }
+    }
+    else if( new_lease->options[DHO_ROUTERS].len )
+    {
+        warning("Invalid routers option length: %d\n", new_lease->options[DHO_ROUTERS].len);
     }
 
     if (hkey)
@@ -2209,9 +2212,31 @@ check_option(struct client_lease *l, int option)
 
 	switch (option) {
 	case DHO_SUBNET_MASK:
+		if (l->options[option].len != (int)sizeof(ULONG))
+		{
+			warning("Invalid IP address length in option(%d): %d", option, l->options[option].len);
+			return (0);
+		}
+		if (!ipv4addrs(opbuf))
+		{
+                        warning("Invalid IP address in option(%d): %s", option, opbuf);
+			return (0);
+		}
+		return (1)  ;
+	case DHO_ROUTERS:
+		if (l->options[option].len % (int)sizeof(ULONG))
+		{
+			warning("Invalid IP address list length in option(%d): %d", option, l->options[option].len);
+			return (0);
+		}
+		if (!ipv4addrs(opbuf))
+		{
+                        warning("Invalid IP address in option(%d): %s", option, opbuf);
+			return (0);
+		}
+		return (1)  ;
 	case DHO_TIME_SERVERS:
 	case DHO_NAME_SERVERS:
-	case DHO_ROUTERS:
 	case DHO_DOMAIN_NAME_SERVERS:
 	case DHO_LOG_SERVERS:
 	case DHO_COOKIE_SERVERS:

--- a/base/services/dhcpcsvc/dhcp/dhclient.c
+++ b/base/services/dhcpcsvc/dhcp/dhclient.c
@@ -562,8 +562,6 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
     CHAR Buffer[200] = "SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces\\";
     CHAR AddressBuffer[32];
     struct in_addr addr;
-    ULONG Netmask;
-    ULONG Router;
     HKEY hkey;
 
     strcat(Buffer, Adapter->DhclientInfo.name);
@@ -580,7 +578,8 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
     /* Set up our default router if we got one from the DHCP server */
     if( new_lease->options[DHO_SUBNET_MASK].len == (int)sizeof(ULONG) )
     {
-        NTSTATUS Status;
+        ULONG Netmask;
+        DWORD Status;
 
         memcpy( &Netmask, new_lease->options[DHO_SUBNET_MASK].data, sizeof(Netmask) );
         Status = AddIPAddress
@@ -589,7 +588,7 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
               Adapter->IfMib.dwIndex,
               &Adapter->NteContext,
               &Adapter->NteInstance );
-        if (hkey)
+        if (hkey && Status == ERROR_SUCCESS)
         {
             RegSetValueExA(hkey, "DhcpIPAddress", 0, REG_SZ, (LPBYTE)piaddr(new_lease->address), strlen(piaddr(new_lease->address))+1);
             addr.S_un.S_addr = Netmask;
@@ -606,7 +605,7 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
             RegSetValueExA(hkey, "AddressType", 0, REG_DWORD, (LPBYTE)&dwAddressType, sizeof(DWORD));
         }
 
-        if( !NT_SUCCESS(Status) )
+        if( Status != ERROR_SUCCESS )
             warning("AddIPAddress: %lx\n", Status);
     }
     else if( new_lease->options[DHO_SUBNET_MASK].len )
@@ -616,7 +615,8 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
 
     if( new_lease->options[DHO_ROUTERS].len >= (int)sizeof(ULONG) && new_lease->options[DHO_ROUTERS].len % (int)sizeof(ULONG) == 0 )
     {
-        NTSTATUS Status;
+        ULONG Router;
+        DWORD Status;
 
         Adapter->RouterMib.dwForwardDest = 0; /* Default route */
         Adapter->RouterMib.dwForwardMask = 0;
@@ -634,10 +634,10 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
 
         Status = CreateIpForwardEntry( &Adapter->RouterMib );
 
-        if( !NT_SUCCESS(Status) )
+        if( Status != ERROR_SUCCESS )
             warning("CreateIpForwardEntry: %lx\n", Status);
 
-        if (hkey)
+        if (hkey && Status == ERROR_SUCCESS)
         {
             addr.S_un.S_addr = Router;
             RtlIpv4AddressToStringA(&addr, AddressBuffer);
@@ -2219,10 +2219,10 @@ check_option(struct client_lease *l, int option)
 		}
 		if (!ipv4addrs(opbuf))
 		{
-                        warning("Invalid IP address in option(%d): %s", option, opbuf);
+			warning("Invalid IP address in option(%d): %s", option, opbuf);
 			return (0);
 		}
-		return (1)  ;
+		return (1);
 	case DHO_ROUTERS:
 		if (l->options[option].len % (int)sizeof(ULONG))
 		{
@@ -2231,10 +2231,10 @@ check_option(struct client_lease *l, int option)
 		}
 		if (!ipv4addrs(opbuf))
 		{
-                        warning("Invalid IP address in option(%d): %s", option, opbuf);
+			warning("Invalid IP address in option(%d): %s", option, opbuf);
 			return (0);
 		}
-		return (1)  ;
+		return (1);
 	case DHO_TIME_SERVERS:
 	case DHO_NAME_SERVERS:
 	case DHO_DOMAIN_NAME_SERVERS:

--- a/base/services/dhcpcsvc/dhcp/dhclient.c
+++ b/base/services/dhcpcsvc/dhcp/dhclient.c
@@ -578,20 +578,18 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
     /* Set up our default router if we got one from the DHCP server */
     if( new_lease->options[DHO_SUBNET_MASK].len == (int)sizeof(ULONG) )
     {
-        ULONG Netmask;
-        DWORD Status;
+        DWORD err;
 
-        memcpy( &Netmask, new_lease->options[DHO_SUBNET_MASK].data, sizeof(Netmask) );
-        Status = AddIPAddress
+        err = AddIPAddress
             ( *((ULONG*)new_lease->address.iabuf),
-              Netmask,
+              *((ULONG*)new_lease->options[DHO_SUBNET_MASK].data),
               Adapter->IfMib.dwIndex,
               &Adapter->NteContext,
               &Adapter->NteInstance );
-        if (hkey && Status == ERROR_SUCCESS)
+        if (hkey && err == NO_ERROR)
         {
             RegSetValueExA(hkey, "DhcpIPAddress", 0, REG_SZ, (LPBYTE)piaddr(new_lease->address), strlen(piaddr(new_lease->address))+1);
-            addr.S_un.S_addr = Netmask;
+            addr.S_un.S_addr = *((ULONG*)new_lease->options[DHO_SUBNET_MASK].data);
             RtlIpv4AddressToStringA(&addr, AddressBuffer);
             RegSetValueExA(hkey, "DhcpSubnetMask", 0, REG_SZ, (LPBYTE)AddressBuffer, strlen(AddressBuffer)+1);
             RegSetValueExA(hkey, "DhcpServer", 0, REG_SZ, (LPBYTE)piaddr(new_lease->serveraddress), strlen(piaddr(new_lease->serveraddress))+1);
@@ -605,41 +603,38 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
             RegSetValueExA(hkey, "AddressType", 0, REG_DWORD, (LPBYTE)&dwAddressType, sizeof(DWORD));
         }
 
-        if( Status != ERROR_SUCCESS )
-            warning("AddIPAddress: %lx\n", Status);
+        if( err != NO_ERROR )
+            warning("AddIPAddress: %d\n", err);
     }
     else if( new_lease->options[DHO_SUBNET_MASK].len )
     {
         warning("Invalid subnet mask option length: %d\n", new_lease->options[DHO_SUBNET_MASK].len);
     }
 
-    if( new_lease->options[DHO_ROUTERS].len >= (int)sizeof(ULONG) && new_lease->options[DHO_ROUTERS].len % (int)sizeof(ULONG) == 0 )
+    if( new_lease->options[DHO_ROUTERS].len > (int)0 && new_lease->options[DHO_ROUTERS].len % (int)sizeof(ULONG) == 0 )
     {
-        ULONG Router;
-        DWORD Status;
+        DWORD err;
 
         Adapter->RouterMib.dwForwardDest = 0; /* Default route */
         Adapter->RouterMib.dwForwardMask = 0;
         Adapter->RouterMib.dwForwardMetric1 = 1;
         Adapter->RouterMib.dwForwardIfIndex = Adapter->IfMib.dwIndex;
 
-        if( Adapter->RouterMib.dwForwardNextHop )
-        {
+        if( Adapter->RouterMib.dwForwardNextHop ) {
             /* If we set a default route before, delete it before continuing */
             DeleteIpForwardEntry( &Adapter->RouterMib );
         }
 
-        memcpy( &Router, new_lease->options[DHO_ROUTERS].data, sizeof(Router) );
-        Adapter->RouterMib.dwForwardNextHop = Router;
+        Adapter->RouterMib.dwForwardNextHop = *((ULONG*)new_lease->options[DHO_ROUTERS].data);
 
-        Status = CreateIpForwardEntry( &Adapter->RouterMib );
+        err = CreateIpForwardEntry( &Adapter->RouterMib );
 
-        if( Status != ERROR_SUCCESS )
-            warning("CreateIpForwardEntry: %lx\n", Status);
+        if( err != NO_ERROR )
+            warning("CreateIpForwardEntry: %d\n", err);
 
-        if (hkey && Status == ERROR_SUCCESS)
+        if (hkey && err == NO_ERROR)
         {
-            addr.S_un.S_addr = Router;
+            addr.S_un.S_addr = *((ULONG*)new_lease->options[DHO_ROUTERS].data);
             RtlIpv4AddressToStringA(&addr, AddressBuffer);
             RegSetValueExA(hkey, "DhcpDefaultGateway", 0, REG_SZ, (LPBYTE)AddressBuffer, strlen(AddressBuffer)+1);
         }

--- a/base/services/dhcpcsvc/dhcp/dhclient.c
+++ b/base/services/dhcpcsvc/dhcp/dhclient.c
@@ -576,8 +576,7 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
     }
 
     /* Set up our default router if we got one from the DHCP server */
-    if( new_lease->options[DHO_SUBNET_MASK].len == (int)sizeof(ULONG) )
-    {
+    if( new_lease->options[DHO_SUBNET_MASK].len == (int)sizeof(ULONG) ) {
         DWORD err;
 
         err = AddIPAddress
@@ -586,8 +585,7 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
               Adapter->IfMib.dwIndex,
               &Adapter->NteContext,
               &Adapter->NteInstance );
-        if (hkey && err == NO_ERROR)
-        {
+        if (hkey && err == NO_ERROR) {
             RegSetValueExA(hkey, "DhcpIPAddress", 0, REG_SZ, (LPBYTE)piaddr(new_lease->address), strlen(piaddr(new_lease->address))+1);
             addr.S_un.S_addr = *((ULONG*)new_lease->options[DHO_SUBNET_MASK].data);
             RtlIpv4AddressToStringA(&addr, AddressBuffer);
@@ -606,13 +604,11 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
         if( err != NO_ERROR )
             warning("AddIPAddress: %d\n", err);
     }
-    else if( new_lease->options[DHO_SUBNET_MASK].len )
-    {
+    else if( new_lease->options[DHO_SUBNET_MASK].len ) {
         warning("Invalid subnet mask option length: %d\n", new_lease->options[DHO_SUBNET_MASK].len);
     }
 
-    if( new_lease->options[DHO_ROUTERS].len > (int)0 && new_lease->options[DHO_ROUTERS].len % (int)sizeof(ULONG) == 0 )
-    {
+    if( new_lease->options[DHO_ROUTERS].len > (int)0 && new_lease->options[DHO_ROUTERS].len % (int)sizeof(ULONG) == 0 ) {
         DWORD err;
 
         Adapter->RouterMib.dwForwardDest = 0; /* Default route */
@@ -625,22 +621,21 @@ void setup_adapter( PDHCP_ADAPTER Adapter, struct client_lease *new_lease ) {
             DeleteIpForwardEntry( &Adapter->RouterMib );
         }
 
-        Adapter->RouterMib.dwForwardNextHop = *((ULONG*)new_lease->options[DHO_ROUTERS].data);
+        Adapter->RouterMib.dwForwardNextHop =
+            *((ULONG*)new_lease->options[DHO_ROUTERS].data);
 
         err = CreateIpForwardEntry( &Adapter->RouterMib );
 
         if( err != NO_ERROR )
             warning("CreateIpForwardEntry: %d\n", err);
 
-        if (hkey && err == NO_ERROR)
-        {
+        if (hkey && err == NO_ERROR) {
             addr.S_un.S_addr = *((ULONG*)new_lease->options[DHO_ROUTERS].data);
             RtlIpv4AddressToStringA(&addr, AddressBuffer);
             RegSetValueExA(hkey, "DhcpDefaultGateway", 0, REG_SZ, (LPBYTE)AddressBuffer, strlen(AddressBuffer)+1);
         }
     }
-    else if( new_lease->options[DHO_ROUTERS].len )
-    {
+    else if( new_lease->options[DHO_ROUTERS].len ) {
         warning("Invalid routers option length: %d\n", new_lease->options[DHO_ROUTERS].len);
     }
 


### PR DESCRIPTION
Reject malformed DHCP subnet mask and router option lengths before setup_adapter() consumes them.

This prevents attacker-controlled option lengths from expanding DHCP option bytes into a fixed stack buffer while preserving valid router address lists.

Validate the option lengths before use, keep router lists limited to complete IPv4 addresses, and format registry IPv4 strings with RtlIpv4AddressToStringA.

Booted amd64 QEMU image: no DHCP/client networking regression observed.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: