### PR TITLE
[RAPPS] Use the package name if REGNAME is not set when uninstalling

### DIFF
--- a/base/applications/rapps/appdb.cpp
+++ b/base/applications/rapps/appdb.cpp
@@ -50,9 +50,14 @@ public:
                                                         UNINSTALL_SUBKEY, KEY_WOW64_32KEY);
     }
 
-    HKEY GetNext(REGSAM &RegSam)
+    HKEY Get(REGSAM &RegSam)
     {
-        return m_Index < m_Count ? GetRootKeyInfo(m_Index++, RegSam) : NULL;
+        return m_Index < m_Count ? GetRootKeyInfo(m_Index, RegSam) : NULL;
+    }
+
+    void Next()
+    {
+        m_Index++;
     }
 
     UINT GetKeyIndex() const
@@ -235,7 +240,7 @@ CAppDB::EnumerateRegistry(CAtlList<CAppInfo *> *List, LPCWSTR SearchOnly)
     ATLASSERT(List || SearchOnly);
     REGSAM wowsam;
     HKEY hRootKey;
-    for (CEnumInstalledRootKey RootEnum; (hRootKey = RootEnum.GetNext(wowsam)) != NULL;)
+    for (CEnumInstalledRootKey RootEnum; (hRootKey = RootEnum.Get(wowsam)) != NULL; RootEnum.Next())
     {
         CRegKey hKey;
         if (hKey.Open(hRootKey, UNINSTALL_SUBKEY, KEY_READ | wowsam) != ERROR_SUCCESS)

--- a/base/applications/rapps/appinfo.cpp
+++ b/base/applications/rapps/appinfo.cpp
@@ -121,11 +121,19 @@ CompareVersion(const CStringW &left, const CStringW &right)
 }
 
 bool
-CAvailableApplicationInfo::IsInstalled() const
+CAvailableApplicationInfo::IsInstalled(CStringW *pOutKeyName) const
 {
+    LPCWSTR pszKeyName = NULL;
     CStringW szRegName;
     m_Parser->GetString(DB_REGNAME, szRegName);
-    return ::GetInstalledVersion(NULL, szRegName) || ::GetInstalledVersion(NULL, szDisplayName);
+    if (::GetInstalledVersion(NULL, szRegName))
+        pszKeyName = szRegName.GetString();
+    else if (::GetInstalledVersion(NULL, szDisplayName))
+        pszKeyName = szDisplayName.GetString();
+
+    if (pszKeyName && pOutKeyName)
+        *pOutKeyName = pszKeyName;
+    return pszKeyName != NULL;
 }
 
 VOID

--- a/base/applications/rapps/geninst.cpp
+++ b/base/applications/rapps/geninst.cpp
@@ -805,7 +805,7 @@ UninstallThread(LPVOID Parameter)
                     if (!DeleteFile(str))
                     {
                         err = GetLastError();
-                        if (err != ERROR_FILE_NOT_FOUND)
+                        if (err != ERROR_FILE_NOT_FOUND && err != ERROR_PATH_NOT_FOUND)
                         {
                             return ErrorBox(err);
                         }

--- a/base/applications/rapps/include/appinfo.h
+++ b/base/applications/rapps/include/appinfo.h
@@ -180,7 +180,7 @@ class CAvailableApplicationInfo : public CAppInfo
     bool
     IsCompatible() const;
     bool
-    IsInstalled() const;
+    IsInstalled(CStringW *pOutKeyName = NULL) const;
 
     virtual BOOL
     Valid() const override;

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -166,14 +166,10 @@ HandleUninstallCommand(CAppDB &db, UINT argcLeft, LPWSTR *argvLeft)
         if (!pInfo)
         {
             CAvailableApplicationInfo *p = db.FindAvailableByPackageName(name);
-            if (p)
+            if (p && p->IsInstalled(&buf))
             {
-                CConfigParser *cp = p->GetConfigParser();
-                if (cp && cp->GetString(DB_REGNAME, buf) && !buf.IsEmpty())
-                {
-                    name = buf.GetString();
-                    byregkeyname = TRUE;
-                }
+                name = buf.GetString();
+                byregkeyname = TRUE;
             }
         }
     }


### PR DESCRIPTION
Use the same logic to detect and to find the uninstall sub key. Fixes a command line only bug where manifests without a RegName value are not found (`rapps.exe /uninstall foo`).

Notes:
- ERROR_PATH_NOT_FOUND is ignored to handle the case where the user has unexpectedly deleted parts of the installed directory tree.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: