### PR TITLE
[SHELL32] CPrinterFolder: Support IQueryAssociations

### DIFF
--- a/dll/win32/shell32/folders/CPrinterFolder.cpp
+++ b/dll/win32/shell32/folders/CPrinterFolder.cpp
@@ -323,6 +323,21 @@ HRESULT WINAPI CPrinterFolder::GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY 
     return hr;
 }
 
+HRESULT CPrinterFolder::_AssocCreate(REFIID riid, PVOID *ppvObj)
+{
+    IQueryAssociations *pAssoc;
+    HRESULT hr = ::AssocCreate(CLSID_QueryAssociations, IID_PPV_ARG(IQueryAssociations, &pAssoc));
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+
+    hr = pAssoc->Init(NULL, L"Printers", NULL, NULL);
+    if (SUCCEEDED(hr))
+        hr = pAssoc->QueryInterface(riid, ppvObj);
+
+    pAssoc->Release();
+    return hr;
+}
+
 /**************************************************************************
  *    CPrinterFolder::GetUIObjectOf
  *
@@ -351,6 +366,8 @@ HRESULT WINAPI CPrinterFolder::GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMI
 
     if ((IsEqualIID (riid, IID_IExtractIconA) || IsEqualIID(riid, IID_IExtractIconW)) && cidl == 1)
         hr = CPrintersExtractIconW_CreateInstane(apidl[0], riid, &pObj);
+    else if (IsEqualIID(riid, IID_IQueryAssociations))
+        hr = _AssocCreate(riid, &pObj);
     else
         hr = E_NOINTERFACE;
 

--- a/dll/win32/shell32/folders/CPrinterFolder.cpp
+++ b/dll/win32/shell32/folders/CPrinterFolder.cpp
@@ -330,7 +330,7 @@ HRESULT CPrinterFolder::_AssocCreate(REFIID riid, PVOID *ppvObj)
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
-    hr = pAssoc->Init(NULL, L"Printers", NULL, NULL);
+    hr = pAssoc->Init(ASSOCF_NONE, L"Printers", NULL, NULL);
     if (SUCCEEDED(hr))
         hr = pAssoc->QueryInterface(riid, ppvObj);
 

--- a/dll/win32/shell32/folders/CPrinterFolder.h
+++ b/dll/win32/shell32/folders/CPrinterFolder.h
@@ -32,10 +32,11 @@ class CPrinterFolder :
 {
     private:
         CLSID *pclsid;
-
         LPITEMIDLIST pidlRoot;  /* absolute pidl */
-
         int dwAttributes;        /* attributes returned by GetAttributesOf FIXME: use it */
+
+        HRESULT _AssocCreate(REFIID riid, PVOID *ppvObj);
+
     public:
         CPrinterFolder();
         ~CPrinterFolder();


### PR DESCRIPTION
## Purpose

`ShellExecute` implementation requires a valid `IQueryAssociations` interface.

https://learn.microsoft.com/en-us/windows/win32/shell/nse-implement

JIRA issue: [CORE-20467](https://jira.reactos.org/browse/CORE-20467)

## Proposed changes

- Enhance `CPrinterFolder::GetUIObjectOf` for `IQueryAssociations`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107871,107874
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107872,107875