### PR TITLE
[FASTFAT] FatProcessException: validate irp before completion

### DIFF
--- a/drivers/filesystems/fastfat/fatdata.c
+++ b/drivers/filesystems/fastfat/fatdata.c
@@ -719,12 +719,15 @@ Return Value:
                 NOTHING;
             } _SEH2_END;
 
-            FatReleaseVcb( IrpContext, Vcb);
+            FatReleaseVcb( IrpContext, Vcb );
         }
     }
-
+    
+    if (Irp == NULL || Irp->Type != IO_TYPE_IRP) {
+        return ExceptionCode;
+    }
+    
     FatCompleteRequest( IrpContext, Irp, ExceptionCode );
-
     return ExceptionCode;
 }
 


### PR DESCRIPTION
FatProcessException called FatCompleteRequest unconditionally without checking the irp's validity. 

before, if FAT hits an exception, it would still try to do FatCompleteRequest on invalid data causing a BSOD.
 this was discovered while doing ntdll_apitest NtWriteFile.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: