### PR TITLE
[SYSDM] performance.c: #include <shlwapi_undoc.h>

### DIFF
--- a/dll/cpl/sysdm/performance.c
+++ b/dll/cpl/sysdm/performance.c
@@ -10,6 +10,7 @@
 #include "precomp.h"
 #include <shlguid_undoc.h> // CLSID_CRegTreeOptions
 #include <shlobj_undoc.h> // IRegTreeOptions
+#include <shlwapi_undoc.h> // SHSendMessageBroadcastW
 
 static VOID
 RegTreeOpt_OnDestroy(IRegTreeOptions *pRTO)


### PR DESCRIPTION
## Purpose

`SHSendMessageBroadcastW` needs `<shlwapi_undoc.h>`.
JIRA issue: N/A

```txt
/srv/buildbot/worker_data/Build_GCCLin_x86/build/dll/cpl/sysdm/performance.c: In function 'VisualEffectsDlgProc':
/srv/buildbot/worker_data/Build_GCCLin_x86/build/dll/cpl/sysdm/performance.c:104:21: error: implicit declaration of function 'SHSendMessageBroadcastW'; did you mean 'SendMessageTimeoutW'? [-Werror=implicit-function-declaration]
                     SHSendMessageBroadcastW(WM_SETTINGCHANGE, 0, 0); // For the ListviewShadow setting
                     ^~~~~~~~~~~~~~~~~~~~~~~
                     SendMessageTimeoutW
```

## Proposed changes

- `#include <shlwapi_undoc.h>` in `performance.c`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107888,107891
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107889,107892