### PR TITLE
[EXPLORER] Implement ShowUndockMenuItem

### DIFF
--- a/base/shell/explorer/startmnusite.cpp
+++ b/base/shell/explorer/startmnusite.cpp
@@ -99,12 +99,19 @@ public:
         return E_NOTIMPL;
     }
 
-    virtual BOOL
-        ShowUndockMenuItem(VOID)
+    BOOL IsEjectAllowed(VOID)
     {
-        TRACE("ShowUndockMenuItem() not implemented!\n");
-        /* FIXME: How do we detect this?! */
-        return FALSE;
+        BOOL bPresent;
+        CM_Is_Dock_Station_Present(&bPresent);
+        return bPresent;
+    }
+
+    virtual BOOL ShowUndockMenuItem(VOID)
+    {
+        return !SHRestricted(REST_NOSMEJECTPC) &&
+                SHTestTokenPrivilegeW(NULL, L"SeUndockPrivilege") &&
+                IsEjectAllowed() &&
+                !GetSystemMetrics(SM_REMOTESESSION);
     }
 
     virtual BOOL

--- a/base/shell/explorer/startmnusite.cpp
+++ b/base/shell/explorer/startmnusite.cpp
@@ -99,19 +99,19 @@ public:
         return E_NOTIMPL;
     }
 
-    BOOL IsEjectAllowed(VOID)
-    {
-        BOOL bPresent;
-        CM_Is_Dock_Station_Present(&bPresent);
-        return bPresent;
-    }
-
     virtual BOOL ShowUndockMenuItem(VOID)
     {
         return !SHRestricted(REST_NOSMEJECTPC) &&
                 SHTestTokenPrivilegeW(NULL, L"SeUndockPrivilege") &&
                 IsEjectAllowed() &&
                 !GetSystemMetrics(SM_REMOTESESSION);
+    }
+
+    BOOL IsEjectAllowed(VOID)
+    {
+        BOOL bPresent;
+        CM_Is_Dock_Station_Present(&bPresent);
+        return bPresent;
     }
 
     virtual BOOL

--- a/base/shell/explorer/startmnusite.cpp
+++ b/base/shell/explorer/startmnusite.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "precomp.h"
+#include <cfgmgr32.h>
 
 class CStartMenuSite :
     public CComCoClass<CStartMenuSite>,

--- a/base/shell/explorer/startmnusite.cpp
+++ b/base/shell/explorer/startmnusite.cpp
@@ -102,17 +102,13 @@ public:
 
     virtual BOOL ShowUndockMenuItem(VOID)
     {
-        return !SHRestricted(REST_NOSMEJECTPC) &&
-                SHTestTokenPrivilegeW(NULL, L"SeUndockPrivilege") &&
-                IsEjectAllowed() &&
-                !GetSystemMetrics(SM_REMOTESESSION);
-    }
-
-    BOOL IsEjectAllowed(VOID)
-    {
         BOOL bPresent;
         CM_Is_Dock_Station_Present(&bPresent);
-        return bPresent;
+
+        return bPresent &&
+               !SHRestricted(REST_NOSMEJECTPC) &&
+               SHTestTokenPrivilegeW(NULL, L"SeUndockPrivilege") &&
+               !GetSystemMetrics(SM_REMOTESESSION);
     }
 
     virtual BOOL


### PR DESCRIPTION
## Purpose
Follow-up of #9036. `ShowUndockMenuItem` function will detect system undocking ability.

JIRA issue: [CORE-10675](https://jira.reactos.org/browse/CORE-10675)

## Proposed changes

- Do `#include <cfgmgr32.h>` in `startmnusite.cpp`.
- Implement `ShowUndockMenuItem` by using `setupapi!CM_Is_Dock_Station_Present` function.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107922,107925
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107923,107926