### PR TITLE
[RSYM] Raise function name limit

### DIFF
--- a/sdk/tools/rsym/rsym.c
+++ b/sdk/tools/rsym/rsym.c
@@ -377,7 +377,7 @@ ConvertCoffs(ULONG *SymbolsCount, PROSSYM_ENTRY *SymbolsBase,
 {
     ULONG Count, i;
     PCOFF_SYMENT CoffEntry;
-    char FuncName[256], FileName[1024];
+    char FuncName[512], FileName[1024];
     char *p;
     PROSSYM_ENTRY Current;
     struct StringHashTable StringHash;


### PR DESCRIPTION
Required for importing milcore from WPF as it has symbols exceeding 256 characters.

## Purpose

Raise rsym function symbol limit to 512 by increasing the buffer size. This does not affect binary size, see FindOrAddString function. This is required for importing milcore because rsym would previously exit with "function name too long" when building it with GCC.

JIRA issue: None

## Proposed changes

- increase FuncName buffer to 512 bytes from 256 bytes.

## Testbot runs (Filled in by Devs)
Not required