### PR TITLE
[EVTLIB] Do not preallocate event logs to MaxSize

### DIFF
--- a/sdk/lib/evtlib/evtlib.c
+++ b/sdk/lib/evtlib/evtlib.c
@@ -20,6 +20,7 @@
 // Once things become stabilized enough, replace all the EVTLTRACE1 by EVTLTRACE
 #define EVTLTRACE1(...)  DPRINT1("EvtLib: " __VA_ARGS__)
 
+#define EVENTLOG_FILE_GRANULARITY (64 * 1024)
 
 /* GLOBALS *******************************************************************/
 
@@ -304,6 +305,7 @@ ElfpInitNewFile(
     LARGE_INTEGER FileOffset;
     SIZE_T WrittenLength;
     EVENTLOGEOF EofRec;
+    ULONG InitialSize;
 
     /* Initialize the event log header */
     RtlZeroMemory(&LogFile->Header, sizeof(EVENTLOGHEADER));
@@ -322,13 +324,22 @@ ElfpInitNewFile(
     /* The event log is empty, there is no record so far */
     LogFile->Header.OldestRecordNumber = 0;
 
-    // FIXME: Windows' EventLog log file sizes are always multiple of 64kB
-    // but that does not mean the real log size is == file size.
+    /*
+     * Windows keeps the file size in 64 kB chunks. The used log area is tracked
+     * by the header offsets and the EOF record, not by the physical file EOF.
+     */
+    InitialSize = ROUND_UP(sizeof(EVENTLOGHEADER) + sizeof(EVENTLOGEOF),
+                           EVENTLOG_FILE_GRANULARITY);
 
-    /* Round MaxSize to be a multiple of ULONG (normally on Windows: multiple of 64 kB) */
-    LogFile->Header.MaxSize = ROUND_UP(MaxSize, sizeof(ULONG));
-    LogFile->CurrentSize = LogFile->Header.MaxSize; // or: FileSize ??
-    LogFile->FileSetSize(LogFile, LogFile->CurrentSize, 0);
+    LogFile->Header.MaxSize = ROUND_UP(max(MaxSize, InitialSize),
+                                       EVENTLOG_FILE_GRANULARITY);
+    LogFile->CurrentSize = InitialSize;
+    Status = LogFile->FileSetSize(LogFile, LogFile->CurrentSize, FileSize);
+    if (!NT_SUCCESS(Status))
+    {
+        EVTLTRACE1("FileSetSize() failed (Status 0x%08lx)\n", Status);
+        return Status;
+    }
 
     LogFile->Header.Flags = 0;
     LogFile->Header.Retention = Retention;
@@ -1488,11 +1499,24 @@ ElfWriteRecord(
      */
     if (LogFile->CurrentSize < LogFile->Header.MaxSize)
     {
-        EVTLTRACE1("Expanding the log file from %lu to %lu\n",
-                LogFile->CurrentSize, LogFile->Header.MaxSize);
+        ULONG NewSize = WriteOffset + BufSize + sizeof(EofRec);
 
-        LogFile->CurrentSize = LogFile->Header.MaxSize;
-        LogFile->FileSetSize(LogFile, LogFile->CurrentSize, 0);
+        if (WriteOffset < LogFile->Header.EndOffset || NewSize > LogFile->Header.MaxSize)
+            NewSize = LogFile->Header.MaxSize;
+        else
+            NewSize = ROUND_UP(NewSize, EVENTLOG_FILE_GRANULARITY);
+
+        if (NewSize > LogFile->CurrentSize)
+        {
+            Status = LogFile->FileSetSize(LogFile, NewSize, LogFile->CurrentSize);
+            if (!NT_SUCCESS(Status))
+            {
+                EVTLTRACE1("FileSetSize() failed (Status 0x%08lx)\n", Status);
+                return Status;
+            }
+
+            LogFile->CurrentSize = NewSize;
+        }
     }
 
     /* Since we can write events in the log, clear the log full flag */

--- a/sdk/lib/evtlib/evtlib.c
+++ b/sdk/lib/evtlib/evtlib.c
@@ -20,9 +20,10 @@
 // Once things become stabilized enough, replace all the EVTLTRACE1 by EVTLTRACE
 #define EVTLTRACE1(...)  DPRINT1("EvtLib: " __VA_ARGS__)
 
-#define EVENTLOG_FILE_GRANULARITY (64 * 1024)
 
 /* GLOBALS *******************************************************************/
+
+#define EVENTLOG_FILE_GRANULARITY   (64 * 1024)
 
 static const EVENTLOGEOF EOFRecord =
 {
@@ -330,9 +331,6 @@ ElfpInitNewFile(
      */
     InitialSize = sizeof(EVENTLOGHEADER) + sizeof(EVENTLOGEOF); // TODO: Consider FileSize as well.
     InitialSize = ROUND_UP(InitialSize, EVENTLOG_FILE_GRANULARITY);
-
-    LogFile->Header.MaxSize = ROUND_UP(max(MaxSize, InitialSize),
-                                       EVENTLOG_FILE_GRANULARITY);
     LogFile->CurrentSize = InitialSize;
     Status = LogFile->FileSetSize(LogFile, LogFile->CurrentSize, FileSize);
     if (!NT_SUCCESS(Status))
@@ -340,6 +338,10 @@ ElfpInitNewFile(
         EVTLTRACE1("FileSetSize() failed (Status 0x%08lx)\n", Status);
         return Status;
     }
+
+    /* Ensure that the log maximum size is greater than the initial file size */
+    MaxSize = max(MaxSize, InitialSize);
+    LogFile->Header.MaxSize = ROUND_UP(MaxSize, EVENTLOG_FILE_GRANULARITY);
 
     LogFile->Header.Flags = 0;
     LogFile->Header.Retention = Retention;

--- a/sdk/lib/evtlib/evtlib.c
+++ b/sdk/lib/evtlib/evtlib.c
@@ -328,8 +328,8 @@ ElfpInitNewFile(
      * Windows keeps the file size in 64 kB chunks. The used log area is tracked
      * by the header offsets and the EOF record, not by the physical file EOF.
      */
-    InitialSize = ROUND_UP(sizeof(EVENTLOGHEADER) + sizeof(EVENTLOGEOF),
-                           EVENTLOG_FILE_GRANULARITY);
+    InitialSize = sizeof(EVENTLOGHEADER) + sizeof(EVENTLOGEOF); // TODO: Consider FileSize as well.
+    InitialSize = ROUND_UP(InitialSize, EVENTLOG_FILE_GRANULARITY);
 
     LogFile->Header.MaxSize = ROUND_UP(max(MaxSize, InitialSize),
                                        EVENTLOG_FILE_GRANULARITY);

--- a/sdk/lib/evtlib/evtlib.c
+++ b/sdk/lib/evtlib/evtlib.c
@@ -1508,13 +1508,14 @@ ElfWriteRecord(
 
         if (NewSize > LogFile->CurrentSize)
         {
+            EVTLTRACE1("Expanding the log file from %lu to %lu\n",
+                    LogFile->CurrentSize, NewSize);
             Status = LogFile->FileSetSize(LogFile, NewSize, LogFile->CurrentSize);
             if (!NT_SUCCESS(Status))
             {
                 EVTLTRACE1("FileSetSize() failed (Status 0x%08lx)\n", Status);
                 return Status;
             }
-
             LogFile->CurrentSize = NewSize;
         }
     }


### PR DESCRIPTION
Keep the configured event log MaxSize as a capacity limit and track the physical file size separately. New logs now start at the Windows 64 KiB file-size granularity instead of growing synchronously to the full configured maximum.

Grow the file in 64 KiB chunks as records are written, while preserving the logical used area in the header offsets and EOF record.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: