### PR TITLE
[NTOS:MM:AMD64] Pre-allocate PPEs for the system cache VA range

### DIFF
--- a/ntoskrnl/mm/amd64/init.c
+++ b/ntoskrnl/mm/amd64/init.c
@@ -264,6 +264,9 @@ MiInitializePageTable(VOID)
     /* Setup PPEs for system space view */
     MiMapPPEs(MiSystemViewStart, (PCHAR)MiSystemViewStart + MmSystemViewSize);
 
+    /* Setup PPEs for system cache views */
+    MiMapPPEs((PVOID)MI_SYSTEM_CACHE_START, (PVOID)MI_SYSTEM_CACHE_END);
+
     /* Setup the mapping PDEs */
     MiMapPDEs((PVOID)MI_MAPPING_RANGE_START, (PVOID)MI_MAPPING_RANGE_END);
 


### PR DESCRIPTION
pre-allocate the PPEs for the amd64 system cache area during early mm init

the cache VA range is already reserved for system cache views. setting up its PPEs upfront makes that area ready before cache mappings start using it

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: