### PR TITLE
[NTOS:MM] Release system image PTEs on unload

### DIFF
--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -992,9 +992,7 @@ MmUnloadSystemImage(IN PVOID ImageHandle)
                              NumberOfPages,
                              0,
                              NULL);
-    MiReleaseSystemPtes(MiAddressToPte(LdrEntry->DllBase),
-                        ROUND_TO_PAGES(LdrEntry->SizeOfImage) >> PAGE_SHIFT,
-                        SystemPteSpace);
+    MiReleaseSystemPtes(BasePte, NumberOfPages, SystemPteSpace);
 
     /* Check if we're linked in */
     if (LdrEntry->InLoadOrderLinks.Flink)

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -986,12 +986,9 @@ MmUnloadSystemImage(IN PVOID ImageHandle)
     }
 
     /* Delete the system image mapping and return its system PTEs. */
-    PPTE BasePte = MiAddressToPte(LdrEntry->DllBase);
+    PMMPTE BasePte = MiAddressToPte(LdrEntry->DllBase);
     PFN_COUNT NumberOfPages = BYTES_TO_PAGES(LdrEntry->SizeOfImage);
-    MiDeleteSystemPageableVm(BasePte,
-                             NumberOfPages,
-                             0,
-                             NULL);
+    MiDeleteSystemPageableVm(BasePte, NumberOfPages, 0, NULL);
     MiReleaseSystemPtes(BasePte, NumberOfPages, SystemPteSpace);
 
     /* Check if we're linked in */

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -985,9 +985,14 @@ MmUnloadSystemImage(IN PVOID ImageHandle)
         }
     }
 
-    /* FIXME: Free the driver */
-    DPRINT1("Leaking driver: %wZ\n", &LdrEntry->BaseDllName);
-    //MmFreeSection(LdrEntry->DllBase);
+    /* Delete the system image mapping and return its system PTEs. */
+    MiDeleteSystemPageableVm(MiAddressToPte(LdrEntry->DllBase),
+                             ROUND_TO_PAGES(LdrEntry->SizeOfImage) >> PAGE_SHIFT,
+                             0,
+                             NULL);
+    MiReleaseSystemPtes(MiAddressToPte(LdrEntry->DllBase),
+                        ROUND_TO_PAGES(LdrEntry->SizeOfImage) >> PAGE_SHIFT,
+                        SystemPteSpace);
 
     /* Check if we're linked in */
     if (LdrEntry->InLoadOrderLinks.Flink)

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -986,8 +986,10 @@ MmUnloadSystemImage(IN PVOID ImageHandle)
     }
 
     /* Delete the system image mapping and return its system PTEs. */
-    MiDeleteSystemPageableVm(MiAddressToPte(LdrEntry->DllBase),
-                             ROUND_TO_PAGES(LdrEntry->SizeOfImage) >> PAGE_SHIFT,
+    PPTE BasePte = MiAddressToPte(LdrEntry->DllBase);
+    PFN_COUNT NumberOfPages = BYTES_TO_PAGES(LdrEntry->SizeOfImage);
+    MiDeleteSystemPageableVm(BasePte,
+                             NumberOfPages,
                              0,
                              NULL);
     MiReleaseSystemPtes(MiAddressToPte(LdrEntry->DllBase),

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -214,6 +214,35 @@ MiLoadImageSection(_Inout_ PSECTION *SectionPtr,
     return Status;
 }
 
+/**
+ * @brief
+ * Undoes the mapping performed by MiLoadImageSection(): frees the pages
+ * backing the image, and returns the system PTEs it had reserved.
+ *
+ * @param[in]   ImageBase
+ * The base address of the image, as returned by MiLoadImageSection().
+ *
+ * @param[in]   ImageSize
+ * The size of the image, in bytes.
+ **/
+static
+VOID
+MiUnloadImageSection(
+    _In_ PVOID ImageBase,
+    _In_ ULONG ImageSize)
+{
+    PMMPTE BasePte = MiAddressToPte(ImageBase);
+    PFN_COUNT NumberOfPages = BYTES_TO_PAGES(ImageSize);
+
+    /* Large-page and session images are not supported */
+    NT_ASSERT(!MI_IS_PHYSICAL_ADDRESS(ImageBase));
+    NT_ASSERT(!MI_IS_SESSION_ADDRESS(ImageBase));
+
+    /* Free the pages, then give the reserved PTEs back */
+    MiDeleteSystemPageableVm(BasePte, NumberOfPages, 0, NULL);
+    MiReleaseSystemPtes(BasePte, NumberOfPages, SystemPteSpace);
+}
+
 #ifndef RVA
 #define RVA(m, b) ((PVOID)((ULONG_PTR)(b) + (ULONG_PTR)(m)))
 #endif
@@ -985,11 +1014,8 @@ MmUnloadSystemImage(IN PVOID ImageHandle)
         }
     }
 
-    /* Delete the system image mapping and return its system PTEs. */
-    PMMPTE BasePte = MiAddressToPte(LdrEntry->DllBase);
-    PFN_COUNT NumberOfPages = BYTES_TO_PAGES(LdrEntry->SizeOfImage);
-    MiDeleteSystemPageableVm(BasePte, NumberOfPages, 0, NULL);
-    MiReleaseSystemPtes(BasePte, NumberOfPages, SystemPteSpace);
+    /* Delete the image mapping and return its system PTEs */
+    MiUnloadImageSection(LdrEntry->DllBase, LdrEntry->SizeOfImage);
 
     /* Check if we're linked in */
     if (LdrEntry->InLoadOrderLinks.Flink)
@@ -2963,7 +2989,7 @@ MmLoadSystemImage(IN PUNICODE_STRING FileName,
     PIMAGE_NT_HEADERS NtHeader;
     UNICODE_STRING BaseName, BaseDirectory, PrefixName;
     PLDR_DATA_TABLE_ENTRY LdrEntry = NULL;
-    ULONG EntrySize, DriverSize;
+    ULONG EntrySize, DriverSize = 0;
     PLOAD_IMPORTS LoadedImports = MM_SYSLDR_NO_IMPORTS;
     PCHAR MissingApiName, Buffer;
     PWCHAR MissingDriverName, PrefixedBuffer = NULL;
@@ -3505,6 +3531,18 @@ LoaderScan:
     *ImageBaseAddress = LdrEntry->DllBase;
 
 Quickie:
+    /*
+     * If we failed after the image had been mapped, tear the mapping down.
+     * ModuleLoadBase is only set once MiLoadImageSection() has reserved the
+     * system PTEs for it, and the load lock is still held at that point.
+     */
+    if (!NT_SUCCESS(Status) && (ModuleLoadBase != NULL))
+    {
+        ASSERT(LockOwned);
+        MiUnloadImageSection(ModuleLoadBase, DriverSize);
+        ModuleLoadBase = NULL;
+    }
+
     /* Check if we have the lock acquired */
     if (LockOwned)
     {

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -220,7 +220,9 @@ MiLoadImageSection(_Inout_ PSECTION *SectionPtr,
  * backing the image, and returns the system PTEs it had reserved.
  *
  * @param[in]   ImageBase
- * The base address of the image, as returned by MiLoadImageSection().
+ * The base address of the image located in the system PTE space,
+ * as returned by MiLoadImageSection().
+ * Do not pass the original base addresses of the boot-start drivers here.
  *
  * @param[in]   ImageSize
  * The size of the image, in bytes.
@@ -1018,7 +1020,7 @@ MmUnloadSystemImage(IN PVOID ImageHandle)
      * Delete the image mapping and return its system PTEs. Only images that
      * MiLoadImageSection or MiReloadBootLoadedDrivers put into system PTE
      * space can be released this way; the boot drivers that the latter had
-     * to skip still sit wherever the boot loader placed them.
+     * to skip still sit wherever the bootloader placed them.
      */
     if (LdrEntry->Flags & LDRP_SYSTEM_MAPPED)
     {

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -1014,8 +1014,20 @@ MmUnloadSystemImage(IN PVOID ImageHandle)
         }
     }
 
-    /* Delete the image mapping and return its system PTEs */
-    MiUnloadImageSection(LdrEntry->DllBase, LdrEntry->SizeOfImage);
+    /*
+     * Delete the image mapping and return its system PTEs. Only images that
+     * MiLoadImageSection or MiReloadBootLoadedDrivers put into system PTE
+     * space can be released this way; the boot drivers that the latter had
+     * to skip still sit wherever the boot loader placed them.
+     */
+    if (LdrEntry->Flags & LDRP_SYSTEM_MAPPED)
+    {
+        MiUnloadImageSection(LdrEntry->DllBase, LdrEntry->SizeOfImage);
+    }
+    else
+    {
+        DPRINT1("Leaking non system-mapped image: %wZ\n", &LdrEntry->BaseDllName);
+    }
 
     /* Check if we're linked in */
     if (LdrEntry->InLoadOrderLinks.Flink)

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -229,14 +229,14 @@ MiLoadImageSection(_Inout_ PSECTION *SectionPtr,
  **/
 static
 VOID
-MiUnloadImageSection(
+MiUnmapSystemImage(
     _In_ PVOID ImageBase,
     _In_ ULONG ImageSize)
 {
     PMMPTE BasePte = MiAddressToPte(ImageBase);
     PFN_COUNT NumberOfPages = BYTES_TO_PAGES(ImageSize);
 
-    /* Large-page and session images are not supported */
+    /* TODO: Support large-page and session image mappings */
     NT_ASSERT(!MI_IS_PHYSICAL_ADDRESS(ImageBase));
     NT_ASSERT(!MI_IS_SESSION_ADDRESS(ImageBase));
 
@@ -1024,7 +1024,7 @@ MmUnloadSystemImage(IN PVOID ImageHandle)
      */
     if (LdrEntry->Flags & LDRP_SYSTEM_MAPPED)
     {
-        MiUnloadImageSection(LdrEntry->DllBase, LdrEntry->SizeOfImage);
+        MiUnmapSystemImage(LdrEntry->DllBase, LdrEntry->SizeOfImage);
     }
     else
     {
@@ -3553,7 +3553,7 @@ Quickie:
     if (!NT_SUCCESS(Status) && (ModuleLoadBase != NULL))
     {
         ASSERT(LockOwned);
-        MiUnloadImageSection(ModuleLoadBase, DriverSize);
+        MiUnmapSystemImage(ModuleLoadBase, DriverSize);
         ModuleLoadBase = NULL;
     }
 


### PR DESCRIPTION
release system image mappings on unload
MmUnloadSystemImage had an explicit leak placeholder for driver images. replace it with the matching teardown for the image mapping and return the reserved system PTE range

[CORE-8294](https://jira.reactos.org/browse/CORE-8294)

Note: Needs #9132 merged first.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109153,109157
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109155,109156