### PR TITLE
[RTL] Fix a 64 bit MSVC warning

### DIFF
--- a/sdk/lib/rtl/compress.c
+++ b/sdk/lib/rtl/compress.c
@@ -59,7 +59,7 @@ static PUCHAR lznt1_decompress_chunk(UCHAR *dst, ULONG dst_size, UCHAR *src, ULO
 
                 /* find length / displacement bits */
                 for (displacement_bits = 12; displacement_bits > 4; displacement_bits--)
-                    if ((1 << (displacement_bits - 1)) < dst_cur - dst) break;
+                    if ((1 << (displacement_bits - 1)) < (ULONG)(dst_cur - dst)) break;
                 length_bits       = 16 - displacement_bits;
                 code_length       = (code & ((1 << length_bits) - 1)) + 3;
                 code_displacement = (code >> length_bits) + 1;


### PR DESCRIPTION
## Purpose

Fix a 64 bit MSVC warning

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107969,107972,107975
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107971,107974,107976
