### PR TITLE
[RTL][NTDLL] Implement RtlInterlockedPushListSListEx

### DIFF
--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -969,6 +969,8 @@
 @ stdcall RtlInterlockedPopEntrySList(ptr)
 @ stdcall RtlInterlockedPushEntrySList(ptr ptr)
 @ stdcall -arch=x86_64 RtlInterlockedPushListSList(ptr ptr ptr long)
+@ stdcall -version=0x602+ -arch=i386 RtlInterlockedPushListSListEx(ptr ptr ptr long)
+@ stdcall -version=0x602+ -arch=!i386 RtlInterlockedPushListSListEx(ptr ptr ptr long) RtlInterlockedPushListSList
 @ stdcall -stub -version=0x600+ RtlIoDecodeMemIoResource(ptr ptr ptr ptr)
 @ stdcall -stub -version=0x600+ RtlIoEncodeMemIoResource(ptr long long long long long)
 @ stdcall RtlIpv4AddressToStringA(ptr ptr)

--- a/dll/ntdll/nt_0600/ntdll_vista.spec
+++ b/dll/ntdll/nt_0600/ntdll_vista.spec
@@ -23,6 +23,8 @@
 @ stdcall RtlLcidToLocaleName(long ptr long long)
 @ stdcall RtlLocaleNameToLcid(wstr ptr long)
 @ stdcall RtlCompareUnicodeStrings(wstr long wstr long long)
+@ stdcall -arch=i386 RtlInterlockedPushListSListEx(ptr ptr ptr long)
+@ stdcall -arch=!i386 RtlInterlockedPushListSListEx(ptr ptr ptr long) ntdll.RtlInterlockedPushListSList
 
 @ stdcall TpAllocCleanupGroup(ptr)
 @ stdcall TpAllocIoCompletion(ptr ptr ptr ptr ptr)

--- a/sdk/lib/rtl/CMakeLists.txt
+++ b/sdk/lib/rtl/CMakeLists.txt
@@ -139,6 +139,7 @@ list(APPEND SOURCE_VISTA
     condvar.c
     locale.c
     runonce.c
+    slist.c
     srw.c
     threadpool.c
     unicode_vista.c

--- a/sdk/lib/rtl/slist.c
+++ b/sdk/lib/rtl/slist.c
@@ -207,6 +207,19 @@ RtlInterlockedPushListSList(
 #endif /* _WIN64 */
 }
 
+#ifdef _M_IX86
+PSLIST_ENTRY
+NTAPI
+RtlInterlockedPushListSListEx(
+    _Inout_ PSLIST_HEADER SListHead,
+    _Inout_ __drv_aliasesMem PSLIST_ENTRY List,
+    _Inout_ PSLIST_ENTRY ListEnd,
+    _In_ ULONG Count)
+{
+    /* Same function, different calling convention */
+    return RtlInterlockedPushListSList(SListHead, List, ListEnd, Count);
+}
+#endif
 
 #if !defined(_M_IX86) && !defined(_M_AMD64)
 


### PR DESCRIPTION

## Purpose

Implement RtlInterlockedPushListSListEx
It is the same function as RtlInterlockedPushListSList, but with stdcall calling convention instead of fastcall. On x86 this is a wrapper, on all other architectures it is simply a forwarder.

JIRA issue: [CORE-20630](https://jira.reactos.org/browse/CORE-20630)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86: https://reactos.org/testman/compare.php?ids=108060,108077
- [ ] KVM x64: https://reactos.org/testman/compare.php?ids=108072,108081