### PR TITLE
[NTOS:MM] Map PPEs and PDEs in MmCreateVirtualMappingUnsafe

### DIFF
--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -1814,6 +1814,13 @@ VOID
 NTAPI
 MiInitializeWorkingSetList(_Inout_ PMMSUPPORT WorkingSet);
 
+/* pagfault.c ***************************************************************/
+
+NTSTATUS
+NTAPI
+MiMakeKernelPageTableValid(
+    _In_ PVOID Address);
+
 #ifdef __cplusplus
 } // extern "C"
 

--- a/ntoskrnl/mm/ARM3/pagfault.c
+++ b/ntoskrnl/mm/ARM3/pagfault.c
@@ -769,6 +769,64 @@ MiResolveDemandZeroFault(IN PVOID Address,
     return STATUS_PAGE_FAULT_DEMAND_ZERO;
 }
 
+NTSTATUS
+NTAPI
+MiMakeKernelPageTableValid(
+    _In_ PVOID Address)
+{
+    PEPROCESS CurrentProcess = PsGetCurrentProcess();
+    PMMPTE PointerPte = MiAddressToPte(Address);
+    PMMPDE PointerPde = MiAddressToPde(Address);
+    NTSTATUS Status;
+
+#if (_MI_PAGING_LEVELS >= 3)
+    /* Check if the PPE is valid */
+    PMMPPE PointerPpe = MiAddressToPpe(Address);
+    if (PointerPpe->u.Hard.Valid == 0)
+    {
+        /* Right now, we only handle scenarios where the PPE is totally empty */
+        ASSERT(PointerPpe->u.Long == 0);
+
+        /* Resolve a demand zero fault */
+        Status = MiResolveDemandZeroFault(PointerPde,
+                                          PointerPpe,
+                                          MM_EXECUTE_READWRITE,
+                                          CurrentProcess,
+                                          MM_NOIRQL);
+        if (!NT_SUCCESS(Status))
+        {
+            return Status;
+        }
+
+        /* We should come back with a valid PPE */
+        ASSERT(PointerPpe->u.Hard.Valid == 1);
+    }
+#endif
+
+    /* Check if the PDE is valid */
+    if (PointerPde->u.Hard.Valid == 0)
+    {
+        /* Right now, we only handle scenarios where the PDE is totally empty */
+        ASSERT(PointerPde->u.Long == 0);
+
+        /* Resolve a demand zero fault */
+        Status = MiResolveDemandZeroFault(PointerPte,
+                                          PointerPde,
+                                          MM_EXECUTE_READWRITE,
+                                          CurrentProcess,
+                                          MM_NOIRQL);
+        if (!NT_SUCCESS(Status))
+        {
+            return Status;
+        }
+
+        /* We should come back with a valid PDE */
+        ASSERT(PointerPde->u.Hard.Valid == 1);
+    }
+
+    return STATUS_SUCCESS;
+}
+
 static
 NTSTATUS
 NTAPI

--- a/ntoskrnl/mm/i386/page.c
+++ b/ntoskrnl/mm/i386/page.c
@@ -637,6 +637,7 @@ MmCreateVirtualMappingUnsafeEx(
     PMMPTE PointerPte;
     MMPTE TempPte;
     ULONG_PTR Pte;
+    NTSTATUS Status;
 
     DPRINT("MmCreateVirtualMappingUnsafe(%p, %p, %lu, %x)\n",
            Process, Address, flProtect, Page);
@@ -665,6 +666,17 @@ MmCreateVirtualMappingUnsafeEx(
         if (!MiSynchronizeSystemPde(MiAddressToPde(Address)))
             MiFillSystemPageDirectory(Address, PAGE_SIZE);
 #endif
+
+        /* Lock the system cache WS */
+        MiLockWorkingSet(PsGetCurrentThread(), &MmSystemCacheWs);
+
+        /* Make the page table valid */
+        Status = MiMakeKernelPageTableValid(Address);
+        if (!NT_SUCCESS(Status))
+        {
+            MiUnlockWorkingSet(PsGetCurrentThread(), &MmSystemCacheWs);
+            return Status;
+        }
     }
     else
     {
@@ -714,6 +726,10 @@ MmCreateVirtualMappingUnsafeEx(
         /* Add PDE reference */
         MiIncrementPageTableReferences(Address);
         MiUnlockProcessWorkingSetUnsafe(Process, PsGetCurrentThread());
+    }
+    else
+    {
+        MiUnlockWorkingSet(PsGetCurrentThread(), &MmSystemCacheWs);
     }
 
     return(STATUS_SUCCESS);


### PR DESCRIPTION
## Purpose

Map PPEs and PDEs in MmCreateVirtualMappingUnsafe

This is required for both x86 and x64. On x86 we only got away without, because the page fault handler is buggy and considers a fault on kernel PTE addresses as a user mode fault and makes the PDE valid for us. On x64 this is not enough, because it only works for invalid PDEs, not for invalid PPEs and we only got away with this, because RosMm sections are allocated from the first range available for memory areas, which happens to be the system cache WS following directly after the shared user page, which already has a PPE mapped. The bug in the fault handler needs to stay for now, since ARM3 also depends on it. Additionally also acquire the system cache working set lock while messing with the PTEs.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: https://reactos.org/testman/compare.php?ids=107994,107998,108002