### PR TITLE
[NTUSER] Preserve WM_QUIT in move/size modal loop

### DIFF
--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -187,13 +187,11 @@ DefWndStartSizeMove(PWND Wnd, WPARAM wParam, POINT *capturePoint)
        while (!hittest)
        {
           if (!co_IntGetPeekMessage(&msg, 0, 0, 0, PM_REMOVE, TRUE)) return 0;
-
           if (msg.message == WM_QUIT)
           {
              MsqPostQuitMessage(pti, (ULONG)msg.wParam);
              return 0;
           }
-
           if (IntCallMsgFilter( &msg, MSGF_SIZE )) continue;
 
 	  switch(msg.message)
@@ -415,13 +413,11 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
       int dx = 0, dy = 0;
 
       if (!co_IntGetPeekMessage(&msg, 0, 0, 0, PM_REMOVE, TRUE)) break;
-
       if (msg.message == WM_QUIT)
       {
          MsqPostQuitMessage(pti, (ULONG)msg.wParam);
          break;
       }
-
       if (IntCallMsgFilter( &msg, MSGF_SIZE )) continue;
 
       if (msg.message == WM_KEYDOWN && (msg.wParam == VK_RETURN || msg.wParam == VK_ESCAPE))

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -187,6 +187,13 @@ DefWndStartSizeMove(PWND Wnd, WPARAM wParam, POINT *capturePoint)
        while (!hittest)
        {
           if (!co_IntGetPeekMessage(&msg, 0, 0, 0, PM_REMOVE, TRUE)) return 0;
+
+          if (msg.message == WM_QUIT)
+          {
+             MsqPostQuitMessage(pti, (ULONG)msg.wParam);
+             return 0;
+          }
+
           if (IntCallMsgFilter( &msg, MSGF_SIZE )) continue;
 
 	  switch(msg.message)
@@ -408,6 +415,13 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
       int dx = 0, dy = 0;
 
       if (!co_IntGetPeekMessage(&msg, 0, 0, 0, PM_REMOVE, TRUE)) break;
+
+      if (msg.message == WM_QUIT)
+      {
+         MsqPostQuitMessage(pti, (ULONG)msg.wParam);
+         break;
+      }
+
       if (IntCallMsgFilter( &msg, MSGF_SIZE )) continue;
 
       if (msg.message == WM_KEYDOWN && (msg.wParam == VK_RETURN || msg.wParam == VK_ESCAPE))


### PR DESCRIPTION
I saw a bug where dragging the first-boot install/status window could make setup stall, and Explorer never started after that.

The problem is that the move/size modal loop can remove a posted WM_QUIT while setup is tearing the thread down. That quit message then does not reach the outer GetMessage loop, so the setup thread keeps waiting instead of exiting.

This keeps WM_QUIT alive by re-posting it and leaving the move/size loop.

**How to test:**
Boot to first-boot setup, drag the install/status window while it is finishing, and check that setup continues and Explorer starts instead of hanging.

[CORE-19060](https://jira.reactos.org/browse/CORE-19060) UI freezes during rapid clicking
[CORE-17877](https://jira.reactos.org/browse/CORE-17877) Thunderbird redraw glitches happen
[CORE-17353](https://jira.reactos.org/browse/CORE-17353) RAPPS freeze during theme change
[CORE-15994](https://jira.reactos.org/browse/CORE-15994) Winamp window dragging glitches happen
[CORE-14129](https://jira.reactos.org/browse/CORE-14129) Alt+Tab BSoD happens
[CORE-13962](https://jira.reactos.org/browse/CORE-13962) MPC-HC full-screen switch fails
[CORE-12247](https://jira.reactos.org/browse/CORE-12247) Program stops responding after dialog closure
[CORE-12277](https://jira.reactos.org/browse/CORE-12277) The UI deadlock happens
[CORE-10255](https://jira.reactos.org/browse/CORE-10255) Titlebar blinking happens

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108648,108662,108670
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108667,108669,108671