### PR TITLE
[NTUSER] Use shared locks for read-only queries

### DIFF
--- a/win32ss/user/ntuser/class.c
+++ b/win32ss/user/ntuser/class.c
@@ -2956,7 +2956,7 @@ NtUserGetWOWClass(
         return FALSE;
     }
 
-    UserEnterExclusive();
+    UserEnterShared();
 
     pi = GetW32ProcessInfo();
 

--- a/win32ss/user/ntuser/focus.c
+++ b/win32ss/user/ntuser/focus.c
@@ -1645,7 +1645,7 @@ NtUserGetForegroundWindow(VOID)
    HWND Ret;
 
    TRACE("Enter NtUserGetForegroundWindow\n");
-   UserEnterExclusive();
+   UserEnterShared();
 
    Ret = UserGetForegroundWindow();
 

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -434,7 +434,7 @@ NtUserGetImeHotKey(
 {
     PIMEHOTKEY pNode = NULL;
 
-    UserEnterExclusive();
+    UserEnterShared();
 
     _SEH2_TRY
     {
@@ -1897,7 +1897,7 @@ NtUserQueryInputContext(HIMC hIMC, DWORD dwType)
     PTHREADINFO ptiIMC;
     DWORD_PTR ret = 0;
 
-    UserEnterExclusive();
+    UserEnterShared();
 
     if (!IS_IMM_MODE())
         goto Quit;

--- a/win32ss/user/ntuser/layered.c
+++ b/win32ss/user/ntuser/layered.c
@@ -249,7 +249,7 @@ NtUserGetLayeredWindowAttributes(
    BOOL Ret = FALSE;
 
    TRACE("Enter NtUserGetLayeredWindowAttributes\n");
-   UserEnterExclusive();
+   UserEnterShared();
 
    if (!(pWnd = UserGetWindowObject(hwnd)) ||
        !(pWnd->ExStyle & WS_EX_LAYERED) )

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -5765,7 +5765,7 @@ NtUserGetTitleBarInfo(
     BOOLEAN retValue = FALSE;
 
     TRACE("Enter NtUserGetTitleBarInfo\n");
-    UserEnterExclusive();
+    UserEnterShared();
 
     /* Validate the window handle */
     if (!(WindowObject = UserGetWindowObject(hwnd)))


### PR DESCRIPTION
Some win32k syscalls were still taking the exclusive user lock even though they only read existing state.

This switches a few simple query paths to the shared user lock instead: foreground window lookup, IME hotkey/context queries, layered window attributes, and title bar info.

The goal is to avoid taking the writer lock for read-only work while keeping the same behavior.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108688,108690
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108689,108691

No changes except for the usual flukes.