### PR TITLE
[WIN32SS:ENG] Use shared locks for display list lookups

### DIFF
--- a/win32ss/gdi/eng/device.c
+++ b/win32ss/gdi/eng/device.c
@@ -803,7 +803,7 @@ EngpFindGraphicsDevice(
            pustrDevice, iDevNum);
 
     /* Lock list */
-    EngAcquireSemaphore(ghsemGraphicsDeviceList);
+    EngAcquireSemaphoreShared(ghsemGraphicsDeviceList);
 
     if (pustrDevice && pustrDevice->Buffer)
     {

--- a/win32ss/gdi/eng/pdevobj.c
+++ b/win32ss/gdi/eng/pdevobj.c
@@ -805,7 +805,7 @@ EngpGetPDEV(
     ULONG i;
 
     /* Acquire PDEV lock */
-    EngAcquireSemaphore(ghsemPDEV);
+    EngAcquireSemaphoreShared(ghsemPDEV);
 
     /* Did the caller pass a device name? */
     if (pustrDeviceName)

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6315,7 +6315,7 @@ NtUserMenuItemFromPoint(
    int Ret = -1;
 
    TRACE("Enter NtUserMenuItemFromPoint\n");
-   UserEnterExclusive();
+   UserEnterShared();
 
    if (!(Menu = UserGetMenuObject(hMenu)))
    {

--- a/win32ss/user/ntuser/simplecall.c
+++ b/win32ss/user/ntuser/simplecall.c
@@ -61,7 +61,19 @@ NtUserCallNoParam(DWORD Routine)
     DWORD_PTR Result = 0;
 
     TRACE("Enter NtUserCallNoParam\n");
-    UserEnterExclusive();
+
+    /* Read-only routines only need a shared lock; the rest stay exclusive */
+    switch (Routine)
+    {
+        case NOPARAM_ROUTINE_GETMSESSAGEPOS:
+        case NOPARAM_ROUTINE_GETIMESHOWSTATUS:
+        case NOPARAM_ROUTINE_ISCONSOLEMODE:
+            UserEnterShared();
+            break;
+        default:
+            UserEnterExclusive();
+            break;
+    }
 
     switch (Routine)
     {
@@ -158,7 +170,22 @@ NtUserCallOneParam(
 
     TRACE("Enter NtUserCallOneParam\n");
 
-    UserEnterExclusive();
+    /* Read-only routines only need a shared lock; the rest stay exclusive */
+    switch (Routine)
+    {
+        case ONEPARAM_ROUTINE_GETDESKTOPMAPPING:
+        case ONEPARAM_ROUTINE_WINDOWFROMDC:
+        case ONEPARAM_ROUTINE_GETKEYBOARDTYPE:
+        case ONEPARAM_ROUTINE_GETKEYBOARDLAYOUT:
+        case ONEPARAM_ROUTINE_ENUMCLIPBOARDFORMATS:
+        case ONEPARAM_ROUTINE_GETCURSORPOS:
+        case ONEPARAM_ROUTINE_GETPROCDEFLAYOUT:
+            UserEnterShared();
+            break;
+        default:
+            UserEnterExclusive();
+            break;
+    }
 
     switch (Routine)
     {
@@ -319,7 +346,6 @@ NtUserCallOneParam(
         }
 
         case ONEPARAM_ROUTINE_ENUMCLIPBOARDFORMATS:
-            /* FIXME: Should use UserEnterShared */
             Result = UserEnumClipboardFormats(Param);
             break;
 

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1527,7 +1527,7 @@ NtUserBuildHwndList(
    if (pcHwndNeeded == NULL)
        return STATUS_INVALID_PARAMETER;
 
-   UserEnterExclusive();
+   UserEnterShared();
 
    if (hwndParent || !dwThreadId)
    {

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3283,7 +3283,7 @@ NtUserChildWindowFromPointEx(HWND hwndParent,
 {
    PWND pwndParent;
    TRACE("Enter NtUserChildWindowFromPointEx\n");
-   UserEnterExclusive();
+   UserEnterShared();
    if ((pwndParent = UserGetWindowObject(hwndParent)))
    {
       pwndParent = IntChildWindowFromPointEx(pwndParent, x, y, uiFlags);


### PR DESCRIPTION
Use shared acquisition for the display device and PDEV lookup paths. These functions only walk existing lists and take references, while list updates and mode-switch paths still use exclusive locking. 

This avoids serializing read-only display queries unnecessarily

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108688,108693
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108689,108692

No changes except for the usual flukes.