### PR TITLE
[DRIVERS][INF] Add Hardware IDs for Processors and update CD-ROM profiles

### DIFF
--- a/drivers/processor/processr/cpu.inf
+++ b/drivers/processor/processr/cpu.inf
@@ -78,6 +78,7 @@ HKR, , Icon,           0, "-28"
 %IntelCoreiXProcessor.DeviceDesc% = Processr_Inst,ACPI\GenuineIntel_-_x86_Family_6_Model_191
 %IntelP4Processor.DeviceDesc%     = Processr_Inst,ACPI\GenuineIntel_-_x86_Family_15
 %IntelProcessor.DeviceDesc%       = Processr_Inst,ACPI\GenuineIntel_-_x86
+%IntelCoreiXProcessor.DeviceDesc% = Processr_Inst,ACPI\GenuineIntel_-_EM64T_Family_6
 
 [Intel.NTAMD64]
 %IntelProcessor.DeviceDesc%       = Processr_Inst,ACPI\GenuineIntel_-_EM64T
@@ -92,6 +93,9 @@ HKR, , Icon,           0, "-28"
 %AMDK8Processor.DeviceDesc%   = Processr_Inst,ACPI\AuthenticAMD_-_x86_Family_15
 %AMDPHENProcessor.DeviceDesc% = Processr_Inst,ACPI\AuthenticAMD_-_x86_Family_16
 %AMDQProcessor.DeviceDesc%    = Processr_Inst,ACPI\AuthenticAMD_-_x86_Family_17
+%AMDProcessor.DeviceDesc%     = Processr_Inst,ACPI\AuthenticAMD_-_AMD64_Family_23
+%AMDProcessor.DeviceDesc%     = Processr_Inst,ACPI\AuthenticAMD_-_AMD64_Family_25
+%AMDProcessor.DeviceDesc%     = Processr_Inst,ACPI\AuthenticAMD_-_AMD64_Family_26
 %AMDProcessor.DeviceDesc%     = Processr_Inst,ACPI\AuthenticAMD_-_x86
 
 [AMD.NTAMD64]

--- a/drivers/processor/processr/pnp.c
+++ b/drivers/processor/processr/pnp.c
@@ -11,9 +11,9 @@
 #include "processr.h"
 
 #include <stdio.h>
+#include "ntstrsafe.h"
 #define NDEBUG
 #include <debug.h>
-#include "ntstrsafe.h"
 
 /* FUNCTIONS ******************************************************************/
 
@@ -111,9 +111,9 @@ ProcessorSetFriendlyName(
     WCHAR PathBuffer[128];
     NTSTATUS StringStatus;
 
-    /* Safely build the dynamic processor path using the bounded NT safe string API */
+    /* Build the dynamic processor path */
     StringStatus = RtlStringCchPrintfW(PathBuffer,
-                                    RTL_NUMBER_OF(PathBuffer), // Safe macro for sizeof(A)/sizeof(A[0])
+                                    RTL_NUMBER_OF(PathBuffer), 
                                     L"\\Registry\\Machine\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\%lu",
                                     KeGetCurrentProcessorNumber());
 
@@ -134,7 +134,6 @@ ProcessorSetFriendlyName(
     Status = ZwOpenKey(&KeyHandle,
                        KEY_READ,
                        &ObjectAttributes);
-
     if (!NT_SUCCESS(Status))
     {
         DPRINT1("ZwOpenKey() failed for CPU %lu (Status 0x%08lx)\n", KeGetCurrentProcessorNumber(), Status);
@@ -157,7 +156,7 @@ ProcessorSetFriendlyName(
 
     Buffer = ExAllocatePoolWithTag(PagedPool, 
                                DataLength + sizeof(KEY_VALUE_PARTIAL_INFORMATION), 
-                               'PnpC');
+                               'CpnP');
     if (Buffer == NULL)
     {
         DPRINT1("ExAllocatePool() failed\n");
@@ -205,7 +204,7 @@ ProcessorSetFriendlyName(
 
     BufferLength = wcslen(pszPrefix) + 1 + wcslen(DeviceId) + 1 + wcslen(InstanceId) + 1;
 
-    KeyNameBuffer = ExAllocatePoolWithTag(PagedPool, BufferLength * sizeof(WCHAR), 'KBuf');
+    KeyNameBuffer = ExAllocatePoolWithTag(PagedPool, BufferLength * sizeof(WCHAR), 'fuBK');
     if (KeyNameBuffer == NULL)
     {
         DPRINT1("ExAllocatePoolWithTag() failed\n");
@@ -248,7 +247,7 @@ done:
         ZwClose(KeyHandle);
 
     if (KeyNameBuffer != NULL)
-        ExFreePoolWithTag(KeyNameBuffer, 'KBuf');
+        ExFreePoolWithTag(KeyNameBuffer, 'fuBK');
 
     if (InstanceId != NULL)
         ExFreePool(InstanceId);
@@ -257,7 +256,7 @@ done:
         ExFreePool(DeviceId);
 
     if (Buffer != NULL)
-        ExFreePoolWithTag(Buffer, 'PnpC');
+        ExFreePoolWithTag(Buffer, 'CpnP');
 }
 
 

--- a/drivers/processor/processr/pnp.c
+++ b/drivers/processor/processr/pnp.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #define NDEBUG
 #include <debug.h>
+#include "ntstrsafe.h"
 
 /* FUNCTIONS ******************************************************************/
 
@@ -107,19 +108,36 @@ ProcessorSetFriendlyName(
     PWSTR InstanceId = NULL;
     PWSTR pszPrefix = L"\\Registry\\Machine\\System\\CurrentControlSet\\Enum";
 
-    RtlInitUnicodeString(&HardwareKeyName,
-                         L"\\Registry\\Machine\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0");
+    WCHAR PathBuffer[128];
+    NTSTATUS StringStatus;
+
+    /* Safely build the dynamic processor path using the bounded NT safe string API */
+    StringStatus = RtlStringCchPrintfW(PathBuffer,
+                                    RTL_NUMBER_OF(PathBuffer), // Safe macro for sizeof(A)/sizeof(A[0])
+                                    L"\\Registry\\Machine\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\%lu",
+                                    KeGetCurrentProcessorNumber());
+
+    if (!NT_SUCCESS(StringStatus))
+    {
+        DPRINT1("RtlStringCchPrintfW failed to format path (Status 0x%08lx)\n", StringStatus);
+        return; 
+    }
+
+    RtlInitUnicodeString(&HardwareKeyName, PathBuffer);
+
     InitializeObjectAttributes(&ObjectAttributes,
                                &HardwareKeyName,
                                OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
                                NULL,
                                NULL);
+
     Status = ZwOpenKey(&KeyHandle,
                        KEY_READ,
                        &ObjectAttributes);
+
     if (!NT_SUCCESS(Status))
     {
-        DPRINT1("ZwOpenKey() failed (Status 0x%08lx)\n", Status);
+        DPRINT1("ZwOpenKey() failed for CPU %lu (Status 0x%08lx)\n", KeGetCurrentProcessorNumber(), Status);
         return;
     }
 
@@ -137,8 +155,9 @@ ProcessorSetFriendlyName(
         goto done;
     }
 
-    Buffer = ExAllocatePool(PagedPool,
-                            DataLength + sizeof(KEY_VALUE_PARTIAL_INFORMATION));
+    Buffer = ExAllocatePoolWithTag(PagedPool, 
+                               DataLength + sizeof(KEY_VALUE_PARTIAL_INFORMATION), 
+                               'PnpC');
     if (Buffer == NULL)
     {
         DPRINT1("ExAllocatePool() failed\n");
@@ -186,10 +205,10 @@ ProcessorSetFriendlyName(
 
     BufferLength = wcslen(pszPrefix) + 1 + wcslen(DeviceId) + 1 + wcslen(InstanceId) + 1;
 
-    KeyNameBuffer = ExAllocatePool(PagedPool, BufferLength * sizeof(WCHAR));
+    KeyNameBuffer = ExAllocatePoolWithTag(PagedPool, BufferLength * sizeof(WCHAR), 'KBuf');
     if (KeyNameBuffer == NULL)
     {
-        DPRINT1("ExAllocatePool() failed\n");
+        DPRINT1("ExAllocatePoolWithTag() failed\n");
         goto done;
     }
 
@@ -229,7 +248,7 @@ done:
         ZwClose(KeyHandle);
 
     if (KeyNameBuffer != NULL)
-        ExFreePool(KeyNameBuffer);
+        ExFreePoolWithTag(KeyNameBuffer, 'KBuf');
 
     if (InstanceId != NULL)
         ExFreePool(InstanceId);
@@ -238,7 +257,7 @@ done:
         ExFreePool(DeviceId);
 
     if (Buffer != NULL)
-        ExFreePool(Buffer);
+        ExFreePoolWithTag(Buffer, 'PnpC');
 }
 
 

--- a/drivers/storage/class/cdrom/cdrom.inf
+++ b/drivers/storage/class/cdrom/cdrom.inf
@@ -81,8 +81,7 @@ HKR,,"FriendlyName",,%ISO_Generic_FriendlyName%
 ;;
 
 [autorun_addreg]
-HKR,,"AutoRun",0x00010003,1
-HKR,,"AutoRunAlwaysDisable", 0x00010008, "NEC     MBR-7   "
+HKR,,"AutoRunAlwaysDisable", 0x00010000, "NEC     MBR-7   "
 HKR,,"AutoRunAlwaysDisable", 0x00010008, "NEC     MBR-7.4 "
 HKR,,"AutoRunAlwaysDisable", 0x00010008, "PIONEER CHANGR DRM-1804X"
 HKR,,"AutoRunAlwaysDisable", 0x00010008, "PIONEER CD-ROM DRM-6324X"

--- a/drivers/storage/class/cdrom/data.c
+++ b/drivers/storage/class/cdrom/data.c
@@ -271,6 +271,7 @@ CDROM_SCAN_FOR_SPECIAL_INFO CdRomBadItems[] = {                     // Type (HH,
     { "", "PIONEER DVD-RW  DVR-106D"               , NULL  ,   0x10 }, // hh  , ?
     { "", "ASUS DVD-RW DRW-0402P"                  , NULL  ,   0x10 }, // hh  , ?
 
+#ifdef __REACTOS__ 
     { "", "TSSTcorp CDDVDW SH-S203B"               , NULL  ,   0x10 }, // hh  , 2007/06/15
     { "", "TSSTcorp CDDVDW SH-S223F"               , NULL  ,   0x10 }, // hh  , 2008/05/20
     { "", "TSSTcorp DVD-ROM SH-D162C"              , NULL  ,   0x10 }, // hh  , 2005/11/02
@@ -303,7 +304,7 @@ CDROM_SCAN_FOR_SPECIAL_INFO CdRomBadItems[] = {                     // Type (HH,
     { "", "BENQ DVD DD DW1620"                     , NULL  ,   0x10 }, // hh  , 2004/07/19
     { "", "BENQ DVD DD DW1640"                     , NULL  ,   0x10 }, // hh  , 2005/04/28
     { "", "PHILIPS DVDR1640K"                      , NULL  ,   0x10 }, // hh  , 2004/09/12
-
+#endif 
 
     // Sony sourced some drives from LG also....
 

--- a/drivers/storage/class/cdrom/data.c
+++ b/drivers/storage/class/cdrom/data.c
@@ -271,6 +271,39 @@ CDROM_SCAN_FOR_SPECIAL_INFO CdRomBadItems[] = {                     // Type (HH,
     { "", "PIONEER DVD-RW  DVR-106D"               , NULL  ,   0x10 }, // hh  , ?
     { "", "ASUS DVD-RW DRW-0402P"                  , NULL  ,   0x10 }, // hh  , ?
 
+    { "", "TSSTcorp CDDVDW SH-S203B"               , NULL  ,   0x10 }, // hh  , 2007/06/15
+    { "", "TSSTcorp CDDVDW SH-S223F"               , NULL  ,   0x10 }, // hh  , 2008/05/20
+    { "", "TSSTcorp DVD-ROM SH-D162C"              , NULL  ,   0x10 }, // hh  , 2005/11/02
+    { "", "TSSTcorp CDDVDW TS-L632D"               , NULL  ,   0x10 }, // slim, 2006/04/18
+    { "", "TSSTcorp CDDVDW TS-H653B"               , NULL  ,   0x10 }, // hh  , 2007/02/09
+
+    { "", "LITE-ON DVDRW SOHW-1673S"               , NULL  ,   0x10 }, // hh  , 2005/01/24
+    { "", "LITE-ON DVDRW LH-20A1P"                 , NULL  ,   0x10 }, // hh  , 2006/12/11
+    { "", "LITE-ON DVDRW SHM-165P6S"               , NULL  ,   0x10 }, // hh  , 2005/09/14
+    { "", "PLDS DVD+-RW DH-16A6S"                  , NULL  ,   0x10 }, // hh  , 2008/03/05
+
+    { "", "MATSHITA DVD-RAM UJ-840S"               , NULL  ,   0x10 }, // slim, 2005/04/12
+    { "", "MATSHITA DVD-RAM UJ-850S"               , NULL  ,   0x10 }, // slim, 2006/02/22
+    { "", "MATSHITA DVD+-RW UJ-875S"               , NULL  ,   0x10 }, // slim, 2008/01/15
+
+    { "", "_NEC DVD_RW ND-3520A"                   , NULL  ,   0x10 }, // hh  , 2004/12/10
+    { "", "_NEC DVD_RW ND-3540A"                   , NULL  ,   0x10 }, // hh  , 2005/04/04
+    { "", "_NEC DVD_RW ND-3550A"                   , NULL  ,   0x10 }, // hh  , 2005/10/18
+    { "", "_NEC DVD_RW ND-4550A"                   , NULL  ,   0x10 }, // hh  , 2005/09/20
+
+    { "", "SONY DVD RW DRU-810A"                   , NULL  ,   0x10 }, // hh  , 2005/08/11
+    { "", "SONY DVD RW DW-Q30A"                    , NULL  ,   0x10 }, // hh  , 2005/09/01
+    { "", "SONY DVD RW DRU-830A"                   , NULL  ,   0x10 }, // hh  , 2006/10/15
+    { "", "SONY CD-RW CRX230ED"                    , NULL  ,   0x10 }, // hh  , 2004/03/25
+
+    { "", "PIONEER DVD-RW  DVR-111D"               , NULL  ,   0x10 }, // hh  , 2006/02/14
+    { "", "PIONEER DVD-RW  DVR-112D"               , NULL  ,   0x10 }, // hh  , 2007/01/08
+    { "", "PIONEER DVD-RW  DVR-115D"               , NULL  ,   0x10 }, // hh  , 2008/01/11
+
+    { "", "BENQ DVD DD DW1620"                     , NULL  ,   0x10 }, // hh  , 2004/07/19
+    { "", "BENQ DVD DD DW1640"                     , NULL  ,   0x10 }, // hh  , 2005/04/28
+    { "", "PHILIPS DVDR1640K"                      , NULL  ,   0x10 }, // hh  , 2004/09/12
+
 
     // Sony sourced some drives from LG also....
 


### PR DESCRIPTION
## Purpose

This pull request updates device compatibility records for processor and optical storage hardware. It expands supported ACPI hardware IDs for modern x86/64 processor families to make sure driver matching is correct, cleans up legacy CD-ROM autorun quirks, and heavily updates the CD-ROM driver's device compatibility matrix with known hardware profiles.

JIRA issue: None

## Proposed changes

- Processor INF Updates: Added modern hardware IDs to `cpu.inf` for proper device matching, covering Intel Core iX (Family 6) and AMD Zen processor generations (Families 23, 25, and 26).

- CD-ROM Registry Fixes: Cleaned up overlapping autorun registry overrides in `cdrom.inf` specifically targeting older NEC MBR-7 devices.

- Hardware Profile: Added compatibility profiles to `data.c` mapping specific drive string profiles for various TSSTcorp, LITE-ON, PLDS, Matshita (Panasonic), NEC, Sony, Pioneer, BenQ, and Philips CD-ROM drives. 


## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: