### PR TITLE
[SHELL32][SDK] Support CShellDispatch::EjectPC

### DIFF
--- a/dll/win32/shell32/CShellDispatch.cpp
+++ b/dll/win32/shell32/CShellDispatch.cpp
@@ -216,13 +216,13 @@ HRESULT STDMETHODCALLTYPE CShellDispatch::ShutdownWindows()
 HRESULT STDMETHODCALLTYPE CShellDispatch::Suspend()
 {
     TRACE("(%p)\n", this);
-    return E_NOTIMPL;
+    return PostTrayCommand(TRAYCMD_SUSPEND);
 }
 
 HRESULT STDMETHODCALLTYPE CShellDispatch::EjectPC()
 {
     TRACE("(%p)\n", this);
-    return E_NOTIMPL;
+    return PostTrayCommand(TRAYCMD_EJECT);
 }
 
 HRESULT STDMETHODCALLTYPE CShellDispatch::SetTime()
@@ -258,7 +258,7 @@ HRESULT STDMETHODCALLTYPE CShellDispatch::FindComputer()
 HRESULT STDMETHODCALLTYPE CShellDispatch::RefreshMenu()
 {
     TRACE("(%p)\n", this);
-    return E_NOTIMPL;
+    return PostTrayCommand(TRAYCMD_REFRESH_MENU);
 }
 
 HRESULT STDMETHODCALLTYPE CShellDispatch::ControlPanelItem(BSTR szDir)
@@ -266,7 +266,6 @@ HRESULT STDMETHODCALLTYPE CShellDispatch::ControlPanelItem(BSTR szDir)
     TRACE("(%p, %ls)\n", this, szDir);
     return SHRunControlPanel(szDir, NULL) ? S_OK : S_FALSE;
 }
-
 
 // *** IShellDispatch2 methods ***
 HRESULT STDMETHODCALLTYPE CShellDispatch::IsRestricted(BSTR group, BSTR restriction, LONG *value)

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -1000,6 +1000,7 @@ BOOL WINAPI LinkWindow_UnregisterClass(_In_ DWORD dwUnused);
 #define TRAYCMD_TILE_V              405
 #define TRAYCMD_TOGGLE_DESKTOP      407
 #define TRAYCMD_DATE_AND_TIME       408
+#define TRAYCMD_SUSPEND             409
 #define TRAYCMD_EJECT               410
 #define TRAYCMD_TASKBAR_PROPERTIES  413
 #define TRAYCMD_MINIMIZE_ALL        415
@@ -1016,6 +1017,7 @@ BOOL WINAPI LinkWindow_UnregisterClass(_In_ DWORD dwUnused);
 #define TRAYCMD_SWITCH_USER_DIALOG  5000
 #define TRAYCMD_SEARCH_FILES        41093
 #define TRAYCMD_SEARCH_COMPUTERS    41094
+#define TRAYCMD_REFRESH_MENU        41504
 
 // Explorer Tray Application Bar Data Message Commands
 #define TABDMC_APPBAR     0


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: N/A

## Proposed changes

- Implement `CShellDispatch::EjectPC` by using `TRAYCMD_EJECT` tray command.
- Add `TRAYCMD_SUSPEND` and `TRAYCMD_REFRESH_MENU` tray commands (they have no effect) into `<undocshell.h>`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108012,108068
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108013,108069