### PR TITLE
[NTOS:EX] Fix wait mode in keyed event implementation

### DIFF
--- a/ntoskrnl/ex/keyedevt.c
+++ b/ntoskrnl/ex/keyedevt.c
@@ -123,6 +123,7 @@ ExpReleaseOrWaitForKeyedEvent(
     NTSTATUS Status;
     ULONG_PTR HashIndex;
     PVOID PreviousKeyedWaitValue;
+    KPROCESSOR_MODE PreviousMode;
 
     /* Get the current process */
     CurrentProcess = PsGetCurrentProcess();
@@ -203,9 +204,10 @@ ExpReleaseOrWaitForKeyedEvent(
     KeLeaveCriticalRegion();
 
     /* Wait for the keyed wait semaphore */
+    PreviousMode = KeGetPreviousMode();
     Status = KeWaitForSingleObject(&CurrentThread->KeyedWaitSemaphore,
                                    WrKeyedEvent,
-                                   KernelMode,
+                                   PreviousMode,
                                    Alertable,
                                    Timeout);
 


### PR DESCRIPTION
## Purpose

Use previous mode instead of KernelMode, to allow user mode threads to be terminated.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108163,108170,108179
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108164,108167

