### PR TITLE
[KMTEST] Make ObType(s) tests run on Vista+

### DIFF
--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -104,8 +104,8 @@ list(APPEND KMTEST_DRV_SOURCE
     ntos_ob/ObReference.c
     ntos_ob/ObSecurity.c
     ntos_ob/ObSymbolicLink.c
-    ntos_ob/ObType.c
-    ntos_ob/ObTypes.c
+    ntos_ob/ObType.cpp
+    ntos_ob/ObTypes.cpp
     ntos_ob/ObWait.c
     ntos_ps/PsNotify.c
     ntos_ps/PsQuota.c

--- a/modules/rostests/kmtests/include/kmt_test.h
+++ b/modules/rostests/kmtests/include/kmt_test.h
@@ -18,6 +18,10 @@
 
 #include <kmt_platform.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define GetNTVersion() ((SharedUserData->NtMajorVersion << 8) | SharedUserData->NtMinorVersion)
 
 typedef VOID KMT_TESTFUNC(VOID);
@@ -213,7 +217,7 @@ extern PKMT_RESULTBUFFER ResultBuffer;
 #define KMT_FORMAT(type, fmt, first)
 #endif /* !defined __GNUC__ */
 
-#define START_TEST(name) VOID Test_##name(VOID)
+#define START_TEST(name) EXTERN_C VOID Test_##name(VOID)
 
 #ifndef KMT_STRINGIZE
 #define KMT_STRINGIZE(x) #x
@@ -526,5 +530,34 @@ VOID KmtFreeGuarded(PVOID Pointer)
 }
 
 #endif /* defined KMT_DEFINE_TEST_FUNCTIONS */
+
+#define is_reactos() \
+    (*(unsigned*)((size_t)0x7FFE0FFC) == 0x8EAC705)
+
+static inline ULONG GetNTDDIVersion(VOID)
+{
+    RTL_OSVERSIONINFOW OSVersion;
+    OSVersion.dwOSVersionInfoSize = sizeof(OSVersion);
+    RtlGetVersion(&OSVersion);
+    switch (OSVersion.dwBuildNumber)
+    {
+        case 3790: return NTDDI_WS03;
+        case 6000: return NTDDI_VISTA;
+        case 6001: return NTDDI_VISTASP1;
+        case 6002: return NTDDI_VISTASP2;
+        case 6003: return NTDDI_VISTASP3;
+        case 7600: return NTDDI_WIN7;
+        case 7601: return NTDDI_WIN7SP1;
+        case 9200: return NTDDI_WIN8;
+
+        default:
+            trace("Unknown build number: %lu\n", OSVersion.dwBuildNumber);
+            return NTDDI_WS03;
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !defined _KMTEST_TEST_H_ */

--- a/modules/rostests/kmtests/ntos_ob/ObType.cpp
+++ b/modules/rostests/kmtests/ntos_ob/ObType.cpp
@@ -9,6 +9,7 @@
 /* TODO: split this into multiple tests! ObLife, ObHandle, ObName, ... */
 
 #include <kmt_test.h>
+#include "ObTypes.hpp"
 
 #define NDEBUG
 #include <debug.h>
@@ -36,10 +37,9 @@ typedef struct _MY_OBJECT2
     ULONG SomeLong[10];
 } MY_OBJECT2, *PMY_OBJECT2;
 
-static POBJECT_TYPE            ObTypes[NUM_OBTYPES];
+static PVOID                   ObTypes_[NUM_OBTYPES];
 static UNICODE_STRING          ObTypeName[NUM_OBTYPES];
 static UNICODE_STRING          ObName[NUM_OBTYPES];
-static OBJECT_TYPE_INITIALIZER ObTypeInitializer[NUM_OBTYPES];
 static UNICODE_STRING          ObDirectoryName;
 static OBJECT_ATTRIBUTES       ObDirectoryAttributes;
 static OBJECT_ATTRIBUTES       ObAttributes[NUM_OBTYPES];
@@ -82,6 +82,23 @@ OpenProc(
 {
     DPRINT("OpenProc() 0x%p, OpenReason %d, HandleCount %lu, AccessMask 0x%lX\n",
         Object, OpenReason, HandleCount, GrantedAccess);
+    ++Counts.Open;
+    return STATUS_SUCCESS;
+}
+
+static
+NTSTATUS
+NTAPI
+OpenProc_NT6(
+    _In_ OB_OPEN_REASON OpenReason,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _In_opt_ PEPROCESS Process,
+    _In_ PVOID Object,
+    _In_ PACCESS_MASK GrantedAccess,
+    _In_ ULONG HandleCount)
+{
+    DPRINT("OpenProc() 0x%p, OpenReason %d, HandleCount %lu, AccessMask 0x%lX\n",
+        Object, OpenReason, HandleCount, *GrantedAccess);
     ++Counts.Open;
     return STATUS_SUCCESS;
 }
@@ -168,10 +185,14 @@ QueryNameProc(
     return STATUS_OBJECT_NAME_NOT_FOUND;
 }
 
+template<unsigned NtDdiVersion>
 static
 NTSTATUS
 ObtCreateObjectTypes(VOID)
 {
+    static TOBJECT_TYPE_INITIALIZER<NtDdiVersion> ObTypeInitializer[NUM_OBTYPES];
+    using OBJECT_TYPE = TOBJECT_TYPE<NtDdiVersion>;
+    OBJECT_TYPE** ObTypes = reinterpret_cast<OBJECT_TYPE**>(&ObTypes_);
     INT i;
     NTSTATUS Status;
     struct
@@ -182,9 +203,7 @@ ObtCreateObjectTypes(VOID)
     OBJECT_ATTRIBUTES ObjectAttributes;
     HANDLE ObjectTypeHandle;
     UNICODE_STRING ObjectPath;
-
-    if (skip(GetNTVersion() < _WIN32_WINNT_VISTA, "Custom object types are not supported on Vista+.\n"))
-        return STATUS_NOT_SUPPORTED;
+    BOOLEAN UseNT6Callbacks = (GetNTVersion() >= _WIN32_WINNT_VISTA);
 
     RtlCopyMemory(&Name.DirectoryName, L"\\ObjectTypes\\", sizeof Name.DirectoryName);
 
@@ -202,21 +221,25 @@ ObtCreateObjectTypes(VOID)
         ObTypeInitializer[i].ValidAccessMask = OBJECT_TYPE_ALL_ACCESS;
 
         // Test for invalid parameter
-        // FIXME: Make it more exact, to see which params Win2k3 checks
-        // existence of
-        Status = ObCreateObjectType(&ObTypeName[i], &ObTypeInitializer[i], NULL, &ObTypes[i]);
-        ok_eq_hex(Status, STATUS_INVALID_PARAMETER);
+        // FIXME: Make it more exact, to see which params Win2k3 checks existence of.
+        // Vista+: This triggers a DbgBreakPoint() in the kernel
+        if (NtDdiVersion <= NTDDI_WS03)
+        {
+            Status = ObCreateObjectType(&ObTypeName[i], (POBJECT_TYPE_INITIALIZER)&ObTypeInitializer[i], NULL, (POBJECT_TYPE*)&ObTypes[i]);
+            ok_eq_hex(Status, STATUS_INVALID_PARAMETER);
+        }
 
+        using OPEN_PROCEDURE = decltype(ObTypeInitializer[i].OpenProcedure);
         ObTypeInitializer[i].CloseProcedure = CloseProc;
         ObTypeInitializer[i].DeleteProcedure = DeleteProc;
         ObTypeInitializer[i].DumpProcedure = DumpProc;
-        ObTypeInitializer[i].OpenProcedure = OpenProc;
+        ObTypeInitializer[i].OpenProcedure = UseNT6Callbacks ? (OPEN_PROCEDURE)OpenProc_NT6 : (OPEN_PROCEDURE)OpenProc;
         ObTypeInitializer[i].ParseProcedure = ParseProc;
         ObTypeInitializer[i].OkayToCloseProcedure = OkayToCloseProc;
         ObTypeInitializer[i].QueryNameProcedure = QueryNameProc;
         //ObTypeInitializer[i].SecurityProcedure = SecurityProc;
 
-        Status = ObCreateObjectType(&ObTypeName[i], &ObTypeInitializer[i], NULL, &ObTypes[i]);
+        Status = ObCreateObjectType(&ObTypeName[i], (POBJECT_TYPE_INITIALIZER)&ObTypeInitializer[i], NULL, (POBJECT_TYPE*)&ObTypes[i]);
         if (Status == STATUS_OBJECT_NAME_COLLISION)
         {
             /* as we cannot delete the object types, get a pointer if they
@@ -228,14 +251,15 @@ ObtCreateObjectTypes(VOID)
             ok(ObjectTypeHandle != NULL, "ObjectTypeHandle = NULL\n");
             if (!skip(Status == STATUS_SUCCESS && ObjectTypeHandle, "No handle\n"))
             {
-                Status = ObReferenceObjectByHandle(ObjectTypeHandle, 0, NULL, KernelMode, (PVOID)&ObTypes[i], NULL);
+                Status = ObReferenceObjectByHandle(ObjectTypeHandle, 0, NULL, KernelMode, (PVOID*)&ObTypes[i], NULL);
                 ok_eq_hex(Status, STATUS_SUCCESS);
                 if (!skip(Status == STATUS_SUCCESS && ObTypes[i], "blah\n"))
                 {
+                    using OPEN_PROCEDURE = decltype(ObTypes[i]->TypeInfo.OpenProcedure);
                     ObTypes[i]->TypeInfo.CloseProcedure = CloseProc;
                     ObTypes[i]->TypeInfo.DeleteProcedure = DeleteProc;
                     ObTypes[i]->TypeInfo.DumpProcedure = DumpProc;
-                    ObTypes[i]->TypeInfo.OpenProcedure = OpenProc;
+                    ObTypes[i]->TypeInfo.OpenProcedure = UseNT6Callbacks ? (OPEN_PROCEDURE)OpenProc_NT6 : (OPEN_PROCEDURE)OpenProc;
                     ObTypes[i]->TypeInfo.ParseProcedure = ParseProc;
                     ObTypes[i]->TypeInfo.OkayToCloseProcedure = OkayToCloseProc;
                     ObTypes[i]->TypeInfo.QueryNameProcedure = QueryNameProc;
@@ -268,6 +292,7 @@ ObtCreateDirectory(VOID)
                         OkayToCloseCount, QueryNameCount) do        \
 {                                                                   \
     ok_eq_uint(Counts.Open, OpenCount);                             \
+    if (Counts.Open != OpenCount) __debugbreak(); \
     ok_eq_uint(Counts.Close, CloseCount);                           \
     ok_eq_uint(Counts.Delete, DeleteCount);                         \
     ok_eq_uint(Counts.Parse, ParseCount);                           \
@@ -279,6 +304,8 @@ ObtCreateDirectory(VOID)
 
 /* TODO: make this the same as NUM_OBTYPES */
 #define NUM_OBTYPES2 2
+
+template<unsigned NtDdiVersion>
 static
 VOID
 ObtCreateObjects(VOID)
@@ -303,7 +330,7 @@ ObtCreateObjects(VOID)
 
     for (i = 0; i < NUM_OBTYPES2; ++i)
     {
-        Status = ObCreateObject(KernelMode, ObTypes[i], &ObAttributes[i], KernelMode, NULL, ObjectSize[i], 0L, 0L, &ObBody[i]);
+        Status = ObCreateObject(KernelMode, (POBJECT_TYPE)ObTypes_[i], &ObAttributes[i], KernelMode, NULL, ObjectSize[i], 0L, 0L, &ObBody[i]);
         ok_eq_hex(Status, STATUS_SUCCESS);
     }
 
@@ -333,6 +360,7 @@ ObtClose(
     BOOLEAN Clean,
     BOOLEAN AlternativeMethod)
 {
+    PVOID* ObTypes = ObTypes_;
     NTSTATUS Status;
     LONG_PTR Ret;
     PVOID TypeObject;
@@ -378,6 +406,7 @@ ObtClose(
 
         Status = ZwClose(DirectoryHandle);
         ok_eq_hex(Status, STATUS_SUCCESS);
+        DirectoryHandle = NULL;
     }
 
     /* we don't delete the object types we created. It makes Windows unstable.
@@ -415,26 +444,57 @@ ObtClose(
     }
 }
 
+template<unsigned NtDdiVersion>
 static
 VOID
-TestObjectType(
+TestObjectType_(
     IN BOOLEAN Clean)
 {
+    PVOID* ObTypes = ObTypes_;
     NTSTATUS Status;
 
     RtlZeroMemory(&Counts, sizeof Counts);
 
-    Status = ObtCreateObjectTypes();
+    Status = ObtCreateObjectTypes<NtDdiVersion>();
     DPRINT("ObtCreateObjectTypes() %s\n", NT_SUCCESS(Status) ? "succeeded" : "failed");
 
     ObtCreateDirectory();
     DPRINT("ObtCreateDirectory() done\n");
 
     if (!skip(ObTypes[0] != NULL, "No object types!\n"))
-        ObtCreateObjects();
+        ObtCreateObjects<NtDdiVersion>();
     DPRINT("ObtCreateObjects() done\n");
 
     ObtClose(Clean, FALSE);
+}
+
+static
+VOID
+TestObjectType(
+    IN BOOLEAN Clean)
+{
+    ULONG NtDdiVersion = GetNTDDIVersion();
+
+    switch (NtDdiVersion)
+    {
+        case NTDDI_WS03:
+            TestObjectType_<NTDDI_WS03>(Clean);
+            return;
+        case NTDDI_VISTA:
+            TestObjectType_<NTDDI_VISTA>(Clean);
+            return;
+        case NTDDI_VISTASP1:
+        case NTDDI_VISTASP2:
+        case NTDDI_VISTASP3:
+            TestObjectType_<NTDDI_VISTASP1>(Clean);
+            return;
+        case NTDDI_WIN7:
+            TestObjectType_<NTDDI_WIN7>(Clean);
+            return;
+        default:
+            skip(FALSE, "Unsupported NTDDI version: 0x%lx\n", NtDdiVersion);
+            return;
+    }
 }
 
 START_TEST(ObType)

--- a/modules/rostests/kmtests/ntos_ob/ObTypes.cpp
+++ b/modules/rostests/kmtests/ntos_ob/ObTypes.cpp
@@ -6,9 +6,62 @@
  */
 
 #include <kmt_test.h>
+#include "ObTypes.hpp"
 
 #define NDEBUG
 #include <debug.h>
+
+const UCHAR TypeIndex_Type[] = { 1, 1 };
+const UCHAR TypeIndex_Directory[] = { 2, 2 };
+const UCHAR TypeIndex_SymbolicLink[] = { 3, 3 };
+const UCHAR TypeIndex_Token[] = { 4, 4 };
+const UCHAR TypeIndex_Process[] = { 5, 6 };
+const UCHAR TypeIndex_Thread[] = { 6, 7 };
+const UCHAR TypeIndex_Job[] = { 7, 5 };
+const UCHAR TypeIndex_DebugObject[] = { 8, 8 };
+const UCHAR TypeIndex_Event[] = { 9, 9 };
+const UCHAR TypeIndex_EventPair[] = { 10, 10 };
+const UCHAR TypeIndex_Mutant[] = { 11, 11 };
+const UCHAR TypeIndex_Callback[] = { 12, 12 };
+const UCHAR TypeIndex_Semaphore[] = { 13, 13 };
+const UCHAR TypeIndex_Timer[] = { 14, 14 };
+const UCHAR TypeIndex_Profile[] = { 15, 15 };
+const UCHAR TypeIndex_KeyedEvent[] = { 16, 16 };
+const UCHAR TypeIndex_WindowStation[] = { 17, 17 };
+const UCHAR TypeIndex_Desktop[] = { 18, 18 };
+const UCHAR TypeIndex_Section[] = { 19, 30 };
+const UCHAR TypeIndex_Key[] = { 20, 32 };
+const UCHAR TypeIndex_Port[] = { 21, 21 };
+const UCHAR TypeIndex_WaitablePort[] = { 22, 22 };
+const UCHAR TypeIndex_Adapter[] = { 23, 20 };
+const UCHAR TypeIndex_Controller[] = { 24, 21 };
+const UCHAR TypeIndex_Device[] = { 25, 22 };
+const UCHAR TypeIndex_Driver[] = { 26, 23 };
+const UCHAR TypeIndex_IoCompletion[] = { 27, 24 };
+const UCHAR TypeIndex_File[] = { 28, 25 };
+const UCHAR TypeIndex_WmiGuid[] = { 29, 34 };
+const UCHAR TypeIndex_FilterConnectionPort[] = { 30, 36 };
+const UCHAR TypeIndex_FilterCommunicationPort[] = { 31, 37 };
+
+static
+ULONG
+GetNtDdiIndex(ULONG NtDdiVersion)
+{
+    switch (NtDdiVersion)
+    {
+        case NTDDI_WS03: return 0;
+        case NTDDI_VISTA: return 1;
+        case NTDDI_VISTASP1: return 1;
+        case NTDDI_VISTASP2: return 1;
+        case NTDDI_VISTASP3: return 1;
+        default:
+            trace("Unsupported NTDDI version 0x%lx\n", NtDdiVersion);
+            return 0;
+    }
+}
+
+#define GetTypeIndex(TypeName, NtDdiVersion) \
+    (TypeIndex_ ## TypeName[GetNtDdiIndex(NtDdiVersion)])
 
 static
 POBJECT_TYPE
@@ -24,17 +77,17 @@ GetObjectType(
     RtlInitUnicodeString(&Name, TypeName);
     InitializeObjectAttributes(&ObjectAttributes, &Name, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
     Status = ObOpenObjectByName(&ObjectAttributes, NULL, KernelMode, NULL, 0, NULL, &Handle);
-    ok_eq_hex(Status, STATUS_SUCCESS);
+    ok(Status == STATUS_SUCCESS, "ObOpenObjectByName failed for '%wZ': %08x\n", &Name, Status);
     ok(Handle != NULL, "ObjectTypeHandle = NULL\n");
     if (!skip(Status == STATUS_SUCCESS && Handle, "No handle\n"))
     {
         Status = ObReferenceObjectByHandle(Handle, 0, NULL, KernelMode, &ObjectType, NULL);
-        ok_eq_hex(Status, STATUS_SUCCESS);
+        ok(Status == STATUS_SUCCESS, "ObReferenceObjectByHandle failed for '%wZ': %08x\n", &Name, Status);
         ok(ObjectType != NULL, "ObjectType = NULL\n");
         Status = ZwClose(Handle);
-        ok_eq_hex(Status, STATUS_SUCCESS);
+        ok(Status == STATUS_SUCCESS, "ZwClose failed for '%wZ': %08x\n", &Name, Status);
     }
-    return ObjectType;
+    return (POBJECT_TYPE)ObjectType;
 }
 
 #define ok_eq_ustr(value, expected) ok(RtlEqualUnicodeString(value, expected, FALSE), #value " = \"%wZ\", expected \"%%wZ\"\n", value, expected)
@@ -43,7 +96,7 @@ GetObjectType(
                         ReadMapping, WriteMapping, ExecMapping, AllMapping,         \
                         ValidMask) do                                               \
 {                                                                                   \
-    POBJECT_TYPE ObjectType;                                                        \
+    OBJECT_TYPE* ObjectType;                                                        \
     UNICODE_STRING Name;                                                            \
     ULONG Key;                                                                      \
     BOOLEAN UseDefault = ((Flags) & OBT_NO_DEFAULT) == 0;                           \
@@ -54,18 +107,18 @@ GetObjectType(
     BOOLEAN MaintainHandleCount = ((Flags) & OBT_MAINTAIN_HANDLE_COUNT) != 0;       \
     POOL_TYPE PoolType = ((Flags) & OBT_PAGED_POOL) ? PagedPool : NonPagedPool;     \
     BOOLEAN CustomKey = ((Flags) & OBT_CUSTOM_KEY) != 0;                            \
+    ULONG Index = GetTypeIndex(TypeName, NtDdiVersion);                             \
                                                                                     \
     trace(#TypeName "\n");                                                          \
-    ObjectType = GetObjectType(L"\\ObjectTypes\\" L ## #TypeName);                  \
+    ObjectType = (OBJECT_TYPE*)GetObjectType(L"\\ObjectTypes\\" L ## #TypeName);    \
     ok(ObjectType != NULL, "ObjectType = NULL\n");                                  \
     if (!skip(ObjectType != NULL, "No ObjectType\n"))                               \
     {                                                                               \
-        ok(!Variable || Variable == ObjectType,                                     \
+        ok(!Variable || (OBJECT_TYPE*)Variable == (OBJECT_TYPE*)ObjectType,         \
            #Variable "is %p, expected %p\n", Variable, ObjectType);                 \
         RtlInitUnicodeString(&Name, L ## #TypeName);                                \
         ok_eq_ustr(&ObjectType->Name, &Name);                                       \
         ok_eq_ulong(ObjectType->Index, Index);                                      \
-        Index = ObjectType->Index + 1;                                              \
         /* apparently, File and WaitablePort are evil and have other stuff          \
          * in DefaultObject. All others are NULL */                                 \
         if (UseDefault)                                                             \
@@ -119,7 +172,6 @@ GetObjectType(
     }                                                                               \
 } while (0)
 
-static POBJECT_TYPE ObpTypeObjectType;
 #define ObpDirectoryObjectType      NULL
 #define ObpSymbolicLinkObjectType   NULL
 #define DbgkDebugObjectType         NULL
@@ -135,9 +187,6 @@ static POBJECT_TYPE ObpTypeObjectType;
 #define IoCompletionObjectType      NULL
 #define WmipGuidObjectType          NULL
 
-static POBJECT_TYPE ObpDefaultObject;
-static OB_SECURITY_METHOD SeDefaultObjectMethod;
-
 #define OBT_NO_DEFAULT              0x01
 #define OBT_CUSTOM_SECURITY_PROC    0x02
 #define OBT_SECURITY_REQUIRED       0x04
@@ -149,17 +198,22 @@ static OB_SECURITY_METHOD SeDefaultObjectMethod;
 
 #define TAG(x) RtlUlongByteSwap(x)
 
+template<unsigned NtDdiVersion>
 static
 VOID
-TestWin2003ObjectTypes(VOID)
+TestObjectTypes(VOID)
 {
-    ULONG Index;
+    using OBJECT_TYPE = TOBJECT_TYPE<NtDdiVersion>;
+    static OBJECT_TYPE* ObpTypeObjectType;
+    static OBJECT_TYPE* ObpDefaultObject;
+    using OB_SECURITY_METHOD = decltype(ObpTypeObjectType->TypeInfo.SecurityProcedure);
+    static OB_SECURITY_METHOD SeDefaultObjectMethod;
 
-    ObpTypeObjectType = GetObjectType(L"\\ObjectTypes\\Type");
+    ObpTypeObjectType = (OBJECT_TYPE*)GetObjectType(L"\\ObjectTypes\\Type");
     if (skip(ObpTypeObjectType != NULL, "No Type object type\n"))
         return;
 
-    ObpDefaultObject = ObpTypeObjectType->DefaultObject;
+    ObpDefaultObject = (OBJECT_TYPE*)ObpTypeObjectType->DefaultObject;
     ok(ObpDefaultObject != NULL, "No ObpDefaultObject\n");
     SeDefaultObjectMethod = ObpTypeObjectType->TypeInfo.SecurityProcedure;
     ok(SeDefaultObjectMethod != NULL, "No SeDefaultObjectMethod\n");
@@ -190,15 +244,28 @@ TestWin2003ObjectTypes(VOID)
 #define WmipGuidObjectType *WmipGuidObjectType
 #endif
 
-    Index = 1;
+#define DIR_SEC_REQUIRED ((NtDdiVersion >= NTDDI_VISTA) ? OBT_SECURITY_REQUIRED : 0)
+#define TOKEN_GENERIC_READ ((NtDdiVersion >= NTDDI_VISTA) ? 0x02001a : 0x020008)
+#define TOKEN_GENERIC_WRITE ((NtDdiVersion >= NTDDI_VISTA) ? 0x0201e0 : 0x0200e0)
+#define TOKEN_GENERIC_EXECUTE ((NtDdiVersion >= NTDDI_VISTA) ? 0x020005 : 0x020000)
+#define PROCESS_GENERIC_WRITE ((NtDdiVersion >= NTDDI_VISTA) ? 0x020bea : 0x020beb)
+#define PROCESS_GENERIC_EXECUTE ((NtDdiVersion >= NTDDI_VISTA) ? 0x121001 : 0x120000)
+#define PROCESS_GENERIC_ALL ((NtDdiVersion >= NTDDI_VISTA) ? 0x001fffff : 0x1f0fff)
+#define THREAD_GENERIC_WRITE ((NtDdiVersion >= NTDDI_VISTA) ? 0x020437 : 0x020037)
+#define THREAD_GENERIC_EXECUTE ((NtDdiVersion >= NTDDI_VISTA) ? 0x120800 : 0x120000)
+#define THREAD_GENERIC_ALL ((NtDdiVersion >= NTDDI_VISTA) ? 0x1fffff : 0x1f03ff)
+#define JOB_GENERIC_ALL ((NtDdiVersion >= NTDDI_VISTA) ? 0x1f001f : 0x1f03ff)
+#define KEY_GENERIC_EXECUTE ((NtDdiVersion >= NTDDI_VISTA) ? 0x020039 : 0x020019)
+#define PROCESS_INDEX ((NtDdiVersion >= NTDDI_VISTA) ? 6 : 5)
+
     CheckObjectType(Type, ObpTypeObjectType,                    OBT_MAINTAIN_TYPE_LIST | OBT_CUSTOM_KEY,    0x100,  0x020000, 0x020000, 0x020000, 0x0f0001, 0x1f0001);
         ok_eq_hex(ObpTypeObjectType->Key, TAG('ObjT'));
-    CheckObjectType(Directory, ObpDirectoryObjectType,          OBT_CASE_INSENSITIVE | OBT_PAGED_POOL,      0x100,  0x020003, 0x02000c, 0x020003, 0x0f000f, 0x0f000f);
+    CheckObjectType(Directory, ObpDirectoryObjectType,          DIR_SEC_REQUIRED | OBT_CASE_INSENSITIVE | OBT_PAGED_POOL,      0x100,  0x020003, 0x02000c, 0x020003, 0x0f000f, 0x0f000f);
     CheckObjectType(SymbolicLink, ObpSymbolicLinkObjectType,    OBT_CASE_INSENSITIVE | OBT_PAGED_POOL,      0x100,  0x020001, 0x020000, 0x020001, 0x0f0001, 0x0f0001);
-    CheckObjectType(Token, *SeTokenObjectType,                   OBT_SECURITY_REQUIRED | OBT_PAGED_POOL,     0x100,  0x020008, 0x0200e0, 0x020000, 0x0f01ff, 0x1f01ff);
-    CheckObjectType(Process, *PsProcessType,                     OBT_NO_DEFAULT | OBT_SECURITY_REQUIRED,     0x0b0,  0x020410, 0x020beb, 0x120000, 0x1f0fff, 0x1f0fff);
-    CheckObjectType(Thread, *PsThreadType,                       OBT_NO_DEFAULT | OBT_SECURITY_REQUIRED,     0x0b0,  0x020048, 0x020037, 0x120000, 0x1f03ff, 0x1f03ff);
-    CheckObjectType(Job, PsJobType,                             OBT_NO_DEFAULT | OBT_SECURITY_REQUIRED,     0x000,  0x020004, 0x02000b, 0x120000, 0x1f03ff, 0x1f001f);
+    CheckObjectType(Token, *SeTokenObjectType,                   OBT_SECURITY_REQUIRED | OBT_PAGED_POOL,     0x100,  TOKEN_GENERIC_READ, TOKEN_GENERIC_WRITE, TOKEN_GENERIC_EXECUTE, 0x0f01ff, 0x1f01ff);
+    CheckObjectType(Process, *PsProcessType,                     OBT_NO_DEFAULT | OBT_SECURITY_REQUIRED,     0x0b0,  0x020410, PROCESS_GENERIC_WRITE, PROCESS_GENERIC_EXECUTE, PROCESS_GENERIC_ALL, PROCESS_GENERIC_ALL);
+    CheckObjectType(Thread, *PsThreadType,                       OBT_NO_DEFAULT | OBT_SECURITY_REQUIRED,     0x0b0,  0x020048, THREAD_GENERIC_WRITE, THREAD_GENERIC_EXECUTE, THREAD_GENERIC_ALL, THREAD_GENERIC_ALL);
+    CheckObjectType(Job, PsJobType,                             OBT_NO_DEFAULT | OBT_SECURITY_REQUIRED,     0x000,  0x020004, 0x02000b, 0x120000, JOB_GENERIC_ALL, 0x1f001f);
     CheckObjectType(DebugObject, DbgkDebugObjectType,           OBT_NO_DEFAULT | OBT_SECURITY_REQUIRED,     0x000,  0x020001, 0x020002, 0x120000, 0x1f000f, 0x1f000f);
     CheckObjectType(Event, *ExEventObjectType,                   OBT_NO_DEFAULT,                             0x100,  0x020001, 0x020002, 0x120000, 0x1f0003, 0x1f0003);
     CheckObjectType(EventPair, ExEventPairObjectType,           0,                                          0x100,  0x120000, 0x120000, 0x120000, 0x1f0000, 0x1f0000);
@@ -214,11 +281,14 @@ TestWin2003ObjectTypes(VOID)
                                                                                                             0x130,  0x020041, 0x0200be, 0x020100, 0x0f01ff, 0x0f01ff);
     CheckObjectType(Section, MmSectionObjectType,               OBT_PAGED_POOL,                             0x100,  0x020005, 0x020002, 0x020008, 0x0f001f, 0x1f001f);
     CheckObjectType(Key, CmpKeyObjectType,                      OBT_CUSTOM_SECURITY_PROC | OBT_SECURITY_REQUIRED | OBT_PAGED_POOL,
-                                                                                                            0x030,  0x020019, 0x020006, 0x020019, 0x0f003f, 0x1f003f);
-    // 0x7b2 is used for Server 2003 SP2 RTM, it seems it was changed to 0xfb2 in some patch level.
-    CheckObjectType(Port, LpcPortObjectType,                    OBT_PAGED_POOL,                             0xfb2,  0x020001, 0x010001, 0x000000, 0x1f0001, 0x1f0001);
-    // 0x7b2 is used for Server 2003 SP2 RTM, it seems it was changed to 0xfb2 in some patch level.
-    CheckObjectType(WaitablePort, LpcWaitablePortObjectType,    OBT_NO_DEFAULT,                             0xfb2,  0x020001, 0x010001, 0x000000, 0x1f0001, 0x1f0001);
+                                                                                                            0x030,  0x020019, 0x020006, KEY_GENERIC_EXECUTE, 0x0f003f, 0x1f003f);
+    if (NtDdiVersion <= NTDDI_WS03)
+    {
+        // 0x7b2 is used for Server 2003 SP2 RTM, it seems it was changed to 0xfb2 in some patch level.
+        CheckObjectType(Port, LpcPortObjectType,                    OBT_PAGED_POOL,                             0xfb2,  0x020001, 0x010001, 0x000000, 0x1f0001, 0x1f0001);
+        // 0x7b2 is used for Server 2003 SP2 RTM, it seems it was changed to 0xfb2 in some patch level.
+        CheckObjectType(WaitablePort, LpcWaitablePortObjectType,    OBT_NO_DEFAULT,                             0xfb2,  0x020001, 0x010001, 0x000000, 0x1f0001, 0x1f0001);
+    }
     CheckObjectType(Adapter, IoAdapterObjectType,               0,                                          0x100,  0x120089, 0x120116, 0x1200a0, 0x1f01ff, 0x1f01ff);
     CheckObjectType(Controller, IoControllerObjectType,         0,                                          0x100,  0x120089, 0x120116, 0x1200a0, 0x1f01ff, 0x1f01ff);
     CheckObjectType(Device, IoDeviceObjectType,                 OBT_CUSTOM_SECURITY_PROC | OBT_CASE_INSENSITIVE,
@@ -258,13 +328,26 @@ TestWin2003ObjectTypes(VOID)
 
 START_TEST(ObTypes)
 {
-    switch (GetNTVersion())
+    ULONG NtDdiVersion = GetNTDDIVersion();
+
+    switch (NtDdiVersion)
     {
-        case _WIN32_WINNT_WS03:
-            TestWin2003ObjectTypes();
-            break;
+        case NTDDI_WS03:
+            TestObjectTypes<NTDDI_WS03>();
+            return;
+        case NTDDI_VISTA:
+            TestObjectTypes<NTDDI_VISTA>();
+            return;
+        case NTDDI_VISTASP1:
+        case NTDDI_VISTASP2:
+        case NTDDI_VISTASP3:
+            TestObjectTypes<NTDDI_VISTASP1>();
+            return;
+        case NTDDI_WIN7:
+            TestObjectTypes<NTDDI_WIN7>();
+            return;
         default:
-            skip(FALSE, "FIXME: kmtest:ObTypes is invalid for this NT version (0x%X).\n", GetNTVersion());
-            break;
+            skip(FALSE, "Unsupported NTDDI version: 0x%lx\n", NtDdiVersion);
+            return;
     }
 }

--- a/modules/rostests/kmtests/ntos_ob/ObTypes.hpp
+++ b/modules/rostests/kmtests/ntos_ob/ObTypes.hpp
@@ -1,0 +1,203 @@
+/*
+ * PROJECT:     ReactOS kernel-mode tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Header for C++ Ob template type definitions
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+typedef NTSTATUS
+(NTAPI *OB_OPEN_METHOD_WS03)(
+    _In_ OB_OPEN_REASON Reason,
+    _In_opt_ PEPROCESS Process,
+    _In_ PVOID ObjectBody,
+    _In_ ACCESS_MASK GrantedAccess,
+    _In_ ULONG HandleCount
+);
+
+typedef NTSTATUS
+(NTAPI *OB_OPEN_METHOD_VISTA)(
+    _In_ OB_OPEN_REASON Reason,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _In_opt_ PEPROCESS Process,
+    _In_ PVOID ObjectBody,
+    _In_ PACCESS_MASK GrantedAccess,
+    _In_ ULONG HandleCount
+);
+
+typedef NTSTATUS
+(NTAPI *OB_SECURITY_METHOD_WS03)(
+    _In_ PVOID Object,
+    _In_ SECURITY_OPERATION_CODE OperationType,
+    _In_ PSECURITY_INFORMATION SecurityInformation,
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _Inout_ PULONG CapturedLength,
+    _Inout_ PSECURITY_DESCRIPTOR *ObjectSecurityDescriptor,
+    _In_ POOL_TYPE PoolType,
+    _In_ PGENERIC_MAPPING GenericMapping
+);
+
+typedef NTSTATUS
+(NTAPI *OB_SECURITY_METHOD_VISTA)(
+    _In_ PVOID Object,
+    _In_ SECURITY_OPERATION_CODE OperationType,
+    _In_ PSECURITY_INFORMATION SecurityInformation,
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _Inout_ PULONG CapturedLength,
+    _Inout_ PSECURITY_DESCRIPTOR *ObjectSecurityDescriptor,
+    _In_ POOL_TYPE PoolType,
+    _In_ PGENERIC_MAPPING GenericMapping,
+    _In_ KPROCESSOR_MODE AccessMode
+);
+
+struct OBJECT_TYPE_INITIALIZER_WS03
+{
+    USHORT Length;                                      // 0x00
+    UCHAR UseDefaultObject;                             // 0x02
+    UCHAR CaseInsensitive;                              // 0x03
+    ULONG InvalidAttributes;                            // 0x04
+    GENERIC_MAPPING GenericMapping;                     // 0x08
+    ULONG ValidAccessMask;                              // 0x18
+    UCHAR SecurityRequired;                             // 0x1c
+    UCHAR MaintainHandleCount;                          // 0x1d
+    UCHAR MaintainTypeList;                             // 0x1e
+    POOL_TYPE PoolType;                                 // 0x20
+    ULONG DefaultPagedPoolCharge;                       // 0x24
+    ULONG DefaultNonPagedPoolCharge;                    // 0x28
+    OB_DUMP_METHOD DumpProcedure;                       // 0x30
+    OB_OPEN_METHOD_WS03 OpenProcedure;                  // 0x38
+    OB_CLOSE_METHOD CloseProcedure;                     // 0x40
+    OB_DELETE_METHOD DeleteProcedure;                   // 0x48
+    OB_PARSE_METHOD ParseProcedure;                     // 0x50
+    OB_SECURITY_METHOD_WS03 SecurityProcedure;          // 0x58
+    OB_QUERYNAME_METHOD QueryNameProcedure;             // 0x60
+    OB_OKAYTOCLOSE_METHOD OkayToCloseProcedure;         // 0x68
+};
+struct OBJECT_TYPE_INITIALIZER_VISTA
+{
+    USHORT Length;                                      // 0x00
+    union
+    {
+        UCHAR ObjectTypeFlags;                          // 0x2
+        struct
+        {
+            UCHAR CaseInsensitive:1;                    // 0x2
+            UCHAR UnnamedObjectsOnly:1;                 // 0x2
+            UCHAR UseDefaultObject:1;                   // 0x2
+            UCHAR SecurityRequired:1;                   // 0x2
+            UCHAR MaintainHandleCount:1;                // 0x2
+            UCHAR MaintainTypeList:1;                   // 0x2
+        };
+    };
+    ULONG ObjectTypeCode;                               // 0x4
+    ULONG InvalidAttributes;                            // 0x8
+    GENERIC_MAPPING GenericMapping;                     // 0xc
+    ULONG ValidAccessMask;                              // 0x1c
+    POOL_TYPE PoolType;                                 // 0x20
+    ULONG DefaultPagedPoolCharge;                       // 0x24
+    ULONG DefaultNonPagedPoolCharge;                    // 0x28
+    OB_DUMP_METHOD DumpProcedure;                       // 0x30
+    OB_OPEN_METHOD_VISTA OpenProcedure;                 // 0x38
+    OB_CLOSE_METHOD CloseProcedure;                     // 0x40
+    OB_DELETE_METHOD DeleteProcedure;                   // 0x48
+    OB_PARSE_METHOD ParseProcedure;                     // 0x50
+    OB_SECURITY_METHOD_VISTA SecurityProcedure;         // 0x58
+    OB_QUERYNAME_METHOD QueryNameProcedure;             // 0x60
+    OB_OKAYTOCLOSE_METHOD OkayToCloseProcedure;         // 0x68
+};
+
+struct OBJECT_TYPE_INITIALIZER_VISTASP1
+{
+    USHORT Length;                                      // 0x00
+    union
+    {
+        UCHAR ObjectTypeFlags;                          // 0x02
+        struct
+        {
+            UCHAR CaseInsensitive:1;                    // 0x02
+            UCHAR UnnamedObjectsOnly:1;                 // 0x02
+            UCHAR UseDefaultObject:1;                   // 0x02
+            UCHAR SecurityRequired:1;                   // 0x02
+            UCHAR MaintainHandleCount:1;                // 0x02
+            UCHAR MaintainTypeList:1;                   // 0x02
+            UCHAR SupportsObjectCallbacks:1;            // 0x02
+        };
+    };
+    ULONG ObjectTypeCode;                               // 0x04
+    ULONG InvalidAttributes;                            // 0x08
+    GENERIC_MAPPING GenericMapping;                     // 0x0c
+    ULONG ValidAccessMask;                              // 0x1c
+    ULONG RetainAccess;                                 // 0x20
+    POOL_TYPE PoolType;                                 // 0x24
+    ULONG DefaultPagedPoolCharge;                       // 0x28
+    ULONG DefaultNonPagedPoolCharge;                    // 0x2c
+    OB_DUMP_METHOD DumpProcedure;                       // 0x30
+    OB_OPEN_METHOD_VISTA OpenProcedure;                 // 0x38
+    OB_CLOSE_METHOD CloseProcedure;                     // 0x40
+    OB_DELETE_METHOD DeleteProcedure;                   // 0x48
+    OB_PARSE_METHOD ParseProcedure;                     // 0x50
+    OB_SECURITY_METHOD_VISTA SecurityProcedure;         // 0x58
+    OB_QUERYNAME_METHOD QueryNameProcedure;             // 0x60
+    OB_OKAYTOCLOSE_METHOD OkayToCloseProcedure;         // 0x68
+};
+
+template<unsigned NtDdiVersion> struct TOBJECT_TYPE_INITIALIZER;
+template<> struct TOBJECT_TYPE_INITIALIZER<NTDDI_WS03> : public OBJECT_TYPE_INITIALIZER_WS03 {};
+template<> struct TOBJECT_TYPE_INITIALIZER<NTDDI_VISTA> : public OBJECT_TYPE_INITIALIZER_VISTA {};
+template<> struct TOBJECT_TYPE_INITIALIZER<NTDDI_VISTASP1> : public OBJECT_TYPE_INITIALIZER_VISTASP1 {};
+template<> struct TOBJECT_TYPE_INITIALIZER<NTDDI_WIN7> : public OBJECT_TYPE_INITIALIZER_VISTASP1 {};
+
+struct OBJECT_TYPE_WS03
+{
+    ERESOURCE Mutex;                                    // 0x00
+    LIST_ENTRY TypeList;                                // 0x68
+    UNICODE_STRING Name;                                // 0x78
+    VOID* DefaultObject;                                // 0x88
+    ULONG Index;                                        // 0x90
+    ULONG TotalNumberOfObjects;                         // 0x94
+    ULONG TotalNumberOfHandles;                         // 0x98
+    ULONG HighWaterNumberOfObjects;                     // 0x9c
+    ULONG HighWaterNumberOfHandles;                     // 0xa0
+    OBJECT_TYPE_INITIALIZER_WS03 TypeInfo;              // 0xa8
+    ULONG Key;                                          // 0x118
+    ERESOURCE ObjectLocks[4];                           // 0x120
+};
+
+struct OBJECT_TYPE_VISTASP1
+{
+    LIST_ENTRY TypeList;                                // 0x00
+    UNICODE_STRING Name;                                // 0x10
+    VOID* DefaultObject;                                // 0x20
+    ULONG Index;                                        // 0x28
+    ULONG TotalNumberOfObjects;                         // 0x2c
+    ULONG TotalNumberOfHandles;                         // 0x30
+    ULONG HighWaterNumberOfObjects;                     // 0x34
+    ULONG HighWaterNumberOfHandles;                     // 0x38
+    OBJECT_TYPE_INITIALIZER_VISTASP1 TypeInfo;          // 0x40
+    ERESOURCE Mutex;                                    // 0xb0
+    EX_PUSH_LOCK TypeLock;                              // 0x118
+    ULONG Key;                                          // 0x120
+    EX_PUSH_LOCK ObjectLocks[32];                       // 0x128
+    LIST_ENTRY CallbackList;                            // 0x228
+};
+
+struct OBJECT_TYPE_WIN7
+{
+    LIST_ENTRY TypeList;                                // 0x00
+    UNICODE_STRING Name;                                // 0x10
+    PVOID DefaultObject;                                // 0x20
+    UCHAR Index;                                        // 0x28
+    ULONG TotalNumberOfObjects;                         // 0x2c
+    ULONG TotalNumberOfHandles;                         // 0x30
+    ULONG HighWaterNumberOfObjects;                     // 0x34
+    ULONG HighWaterNumberOfHandles;                     // 0x38
+    OBJECT_TYPE_INITIALIZER_VISTASP1 TypeInfo;          // 0x40
+    EX_PUSH_LOCK TypeLock;                              // 0xb0
+    ULONG Key;                                          // 0xb8
+    LIST_ENTRY CallbackList;                            // 0xc0
+};
+
+template<unsigned NtDdiVersion> struct TOBJECT_TYPE;
+template<> struct TOBJECT_TYPE<NTDDI_WS03> : public OBJECT_TYPE_WS03 {};
+template<> struct TOBJECT_TYPE<NTDDI_VISTA> : public OBJECT_TYPE_WS03 {};
+template<> struct TOBJECT_TYPE<NTDDI_VISTASP1> : public OBJECT_TYPE_VISTASP1 {};
+template<> struct TOBJECT_TYPE<NTDDI_WIN7> : public OBJECT_TYPE_WIN7 {};

--- a/sdk/include/ndk/iotypes.h
+++ b/sdk/include/ndk/iotypes.h
@@ -25,6 +25,10 @@ Author:
 #include <ifssupp.h>
 #include <potypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //
 // I/O Completion Access Rights
 //
@@ -1273,5 +1277,9 @@ typedef struct _REPARSE_DATA_BUFFER {
 } REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
 
 #endif // NTOS_MODE_USER
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/sdk/include/ndk/kdfuncs.h
+++ b/sdk/include/ndk/kdfuncs.h
@@ -25,6 +25,10 @@ Author:
 #include <umtypes.h>
 #include <kdtypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef NTOS_MODE_USER
 
 //
@@ -110,4 +114,9 @@ ZwSystemDebugControl(
     _In_ ULONG OutputBufferLength,
     _Out_opt_ PULONG ReturnLength
 );
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
+
+#endif // _KDFUNCS_H

--- a/sdk/include/ndk/lpctypes.h
+++ b/sdk/include/ndk/lpctypes.h
@@ -25,6 +25,10 @@ Author:
 #include <umtypes.h>
 //#include <pstypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef NTOS_MODE_USER
 
 //
@@ -292,5 +296,9 @@ typedef struct _CLIENT_DIED_MSG
     (LPC_MAX_MESSAGE_LENGTH - \
     sizeof(PORT_MESSAGE) - \
     sizeof(LPCP_CONNECTION_MESSAGE))
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _LPCTYPES_H

--- a/sdk/include/ndk/mmfuncs.h
+++ b/sdk/include/ndk/mmfuncs.h
@@ -25,6 +25,10 @@ Author:
 #include <umtypes.h>
 #include <mmtypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef NTOS_MODE_USER
 
 //
@@ -495,4 +499,8 @@ ZwWriteVirtualMemory(
     _Out_opt_ PSIZE_T NumberOfBytesWritten
 );
 
+#ifdef __cplusplus
+} // extern "C"
 #endif
+
+#endif // _MMFUNCS_H


### PR DESCRIPTION
## Purpose

Makes the ObType and ObTypes test run on Vista+.
It's converted to C++ to use templates for different NTDDI_VERSIONs, which have different type layouts.

## Testbot runs (Filled in by Devs)

- [x] Test WHS: https://reactos.org/testman/compare.php?ids=108887,108892
- [x] Test Vista x64: https://reactos.org/testman/compare.php?ids=108889,108894
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108863,108869
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108864,108897