### PR TITLE
[NETAPI32] Fix NetLocalGroupAddMembers crash because return code was interpreted incorrectly

### DIFF
--- a/dll/win32/netapi32/local_group.c
+++ b/dll/win32/netapi32/local_group.c
@@ -524,7 +524,7 @@ NetLocalGroupAddMembers(
     LPBYTE buf,
     DWORD totalentries)
 {
-    UNICODE_STRING ServerName;
+    UNICODE_STRING ServerName, *pServerName = NULL;
     UNICODE_STRING AliasName;
     SAM_HANDLE ServerHandle = NULL;
     SAM_HANDLE DomainHandle = NULL;
@@ -538,7 +538,7 @@ NetLocalGroupAddMembers(
           debugstr_w(groupname), level, buf, totalentries);
 
     if (servername != NULL)
-        RtlInitUnicodeString(&ServerName, servername);
+        RtlInitUnicodeString(pServerName = &ServerName, servername);
 
     RtlInitUnicodeString(&AliasName, groupname);
 
@@ -549,14 +549,13 @@ NetLocalGroupAddMembers(
             break;
 
         case 3:
-            Status = BuildSidListFromDomainAndName((servername != NULL) ? &ServerName : NULL,
+            ApiStatus = BuildSidListFromDomainAndName(pServerName,
                                                    (PLOCALGROUP_MEMBERS_INFO_3)buf,
                                                    totalentries,
                                                    &MemberList);
-            if (!NT_SUCCESS(Status))
+            if (ApiStatus != NERR_Success)
             {
-                ERR("BuildSidListFromDomainAndName failed (Status %08lx)\n", Status);
-                ApiStatus = NetpNtStatusToApiStatus(Status);
+                ERR("BuildSidListFromDomainAndName failed (ApiStatus %lu)\n", ApiStatus);
                 goto done;
             }
             break;
@@ -567,7 +566,7 @@ NetLocalGroupAddMembers(
     }
 
     /* Connect to the SAM Server */
-    Status = SamConnect((servername != NULL) ? &ServerName : NULL,
+    Status = SamConnect(pServerName,
                         &ServerHandle,
                         SAM_SERVER_CONNECT | SAM_SERVER_LOOKUP_DOMAIN,
                         NULL);
@@ -607,7 +606,7 @@ NetLocalGroupAddMembers(
 
         /* Open the Acount Domain */
         Status = OpenAccountDomain(ServerHandle,
-                                   (servername != NULL) ? &ServerName : NULL,
+                                   pServerName,
                                    DOMAIN_LOOKUP,
                                    &DomainHandle);
         if (!NT_SUCCESS(Status))
@@ -846,14 +845,13 @@ NetLocalGroupDelMembers(
             break;
 
         case 3:
-            Status = BuildSidListFromDomainAndName((servername != NULL) ? &ServerName : NULL,
+            ApiStatus = BuildSidListFromDomainAndName((servername != NULL) ? &ServerName : NULL,
                                                    (PLOCALGROUP_MEMBERS_INFO_3)buf,
                                                    totalentries,
                                                    &MemberList);
-            if (!NT_SUCCESS(Status))
+            if (ApiStatus)
             {
-                ERR("BuildSidListFromDomainAndName failed (Status %08lx)\n", Status);
-                ApiStatus = NetpNtStatusToApiStatus(Status);
+                ERR("BuildSidListFromDomainAndName failed (ApiStatus %lu)\n", ApiStatus);
                 goto done;
             }
             break;

--- a/dll/win32/netapi32/local_group.c
+++ b/dll/win32/netapi32/local_group.c
@@ -538,7 +538,10 @@ NetLocalGroupAddMembers(
           debugstr_w(groupname), level, buf, totalentries);
 
     if (servername != NULL)
-        RtlInitUnicodeString(pServerName = &ServerName, servername);
+    {
+        RtlInitUnicodeString(&ServerName, servername);
+        pServerName = &ServerName;
+    }
 
     RtlInitUnicodeString(&AliasName, groupname);
 

--- a/dll/win32/netapi32/local_group.c
+++ b/dll/win32/netapi32/local_group.c
@@ -550,9 +550,9 @@ NetLocalGroupAddMembers(
 
         case 3:
             ApiStatus = BuildSidListFromDomainAndName(pServerName,
-                                                   (PLOCALGROUP_MEMBERS_INFO_3)buf,
-                                                   totalentries,
-                                                   &MemberList);
+                                                      (PLOCALGROUP_MEMBERS_INFO_3)buf,
+                                                      totalentries,
+                                                      &MemberList);
             if (ApiStatus != NERR_Success)
             {
                 ERR("BuildSidListFromDomainAndName failed (ApiStatus %lu)\n", ApiStatus);
@@ -846,9 +846,9 @@ NetLocalGroupDelMembers(
 
         case 3:
             ApiStatus = BuildSidListFromDomainAndName((servername != NULL) ? &ServerName : NULL,
-                                                   (PLOCALGROUP_MEMBERS_INFO_3)buf,
-                                                   totalentries,
-                                                   &MemberList);
+                                                      (PLOCALGROUP_MEMBERS_INFO_3)buf,
+                                                      totalentries,
+                                                      &MemberList);
             if (ApiStatus)
             {
                 ERR("BuildSidListFromDomainAndName failed (ApiStatus %lu)\n", ApiStatus);

--- a/dll/win32/netapi32/local_group.c
+++ b/dll/win32/netapi32/local_group.c
@@ -823,7 +823,7 @@ NetLocalGroupDelMembers(
     LPBYTE buf,
     DWORD totalentries)
 {
-    UNICODE_STRING ServerName;
+    UNICODE_STRING ServerName, *pServerName = NULL;
     UNICODE_STRING AliasName;
     SAM_HANDLE ServerHandle = NULL;
     SAM_HANDLE DomainHandle = NULL;
@@ -837,7 +837,10 @@ NetLocalGroupDelMembers(
           debugstr_w(groupname), level, buf, totalentries);
 
     if (servername != NULL)
+    {
         RtlInitUnicodeString(&ServerName, servername);
+        pServerName = &ServerName;
+    }
 
     RtlInitUnicodeString(&AliasName, groupname);
 
@@ -848,7 +851,7 @@ NetLocalGroupDelMembers(
             break;
 
         case 3:
-            ApiStatus = BuildSidListFromDomainAndName((servername != NULL) ? &ServerName : NULL,
+            ApiStatus = BuildSidListFromDomainAndName(pServerName,
                                                       (PLOCALGROUP_MEMBERS_INFO_3)buf,
                                                       totalentries,
                                                       &MemberList);
@@ -865,7 +868,7 @@ NetLocalGroupDelMembers(
     }
 
     /* Connect to the SAM Server */
-    Status = SamConnect((servername != NULL) ? &ServerName : NULL,
+    Status = SamConnect(pServerName,
                         &ServerHandle,
                         SAM_SERVER_CONNECT | SAM_SERVER_LOOKUP_DOMAIN,
                         NULL);
@@ -905,7 +908,7 @@ NetLocalGroupDelMembers(
 
         /* Open the Acount Domain */
         Status = OpenAccountDomain(ServerHandle,
-                                   (servername != NULL) ? &ServerName : NULL,
+                                   pServerName,
                                    DOMAIN_LOOKUP,
                                    &DomainHandle);
         if (!NT_SUCCESS(Status))


### PR DESCRIPTION
## Purpose

Fixes a crash when `net.exe localgroup Administrators UserNameThatDoesNotExist /Add` is called. The return value of `BuildSidListFromDomainAndName` was incorrectly interpreted as a `NTSTATUS`. When it returns a NETAPI error code, `NT_SUCCESS` evaluates it as a success (positive integer) and later on we access `MemberList[i]` which is not a valid array.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: