### PR TITLE
[EXPLORER][SHELL32] Avoid SHRunControlPanel to be Vista compatible

### DIFF
--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -66,9 +66,6 @@ extern HANDLE hProcessHeap;
 extern HKEY hkExplorer;
 extern BOOL bExplorerIsShell;
 
-#define SHELL_ExecuteControlPanelCPL(hwnd, cpl) ShellExecuteW((hwnd), NULL, (cpl), NULL, NULL, SW_NORMAL) // Note: Only supports .cpl files with no parameters
-#define SHRunControlPanel(command, hwnd) SHELL_ExecuteControlPanelCPL((hwnd), (command)) // Note: SHRunControlPanel does not work on Vista+
-
 /*
  * explorer.c
  */

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -66,6 +66,9 @@ extern HANDLE hProcessHeap;
 extern HKEY hkExplorer;
 extern BOOL bExplorerIsShell;
 
+#define SHELL_ExecuteControlPanelCPL(hwnd, cpl) ShellExecuteW((hwnd), NULL, (cpl), NULL, NULL, SW_NORMAL) // Note: Only supports .cpl files with no parameters
+#define SHRunControlPanel(command, hwnd) SHELL_ExecuteControlPanelCPL((hwnd), (command)) // Note: SHRunControlPanel does not work on Vista+
+
 /*
  * explorer.c
  */

--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -754,7 +754,7 @@ LRESULT CTrayClockWnd::OnLButtonDblClick(UINT uMsg, WPARAM wParam, LPARAM lParam
 {
     if (IsWindowVisible())
     {
-        SHELL_ExecuteControlPanelCPL(m_hWnd, L"timedate.cpl");
+        ShellExecuteW(m_hWnd, NULL, L"timedate.cpl", NULL, NULL, SW_NORMAL);
     }
     return TRUE;
 }

--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -754,8 +754,7 @@ LRESULT CTrayClockWnd::OnLButtonDblClick(UINT uMsg, WPARAM wParam, LPARAM lParam
 {
     if (IsWindowVisible())
     {
-        //FIXME: use SHRunControlPanel
-        ShellExecuteW(m_hWnd, NULL, L"timedate.cpl", NULL, NULL, SW_NORMAL);
+        SHELL_ExecuteControlPanelCPL(m_hWnd, L"timedate.cpl");
     }
     return TRUE;
 }

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -711,7 +711,7 @@ public:
             break;
 
         case ID_SHELL_CMD_ADJUST_DAT:
-            SHELL_ExecuteControlPanelCPL(m_hWnd, L"timedate.cpl");
+            ShellExecuteW(m_hWnd, NULL, L"timedate.cpl", NULL, NULL, SW_NORMAL);
             break;
 
         case ID_SHELL_CMD_RESTORE_ALL:
@@ -766,7 +766,7 @@ public:
             SHFindComputer(NULL, NULL);
             break;
         case IDHK_SYS_PROPERTIES:
-            SHELL_ExecuteControlPanelCPL(m_hWnd, L"sysdm.cpl");
+            ShellExecuteW(m_hWnd, NULL, L"sysdm.cpl", NULL, NULL, SW_NORMAL);
             break;
         case IDHK_NEXT_TASK:
             break;
@@ -828,7 +828,7 @@ public:
                 ToggleDesktop();
                 break;
             case TRAYCMD_DATE_AND_TIME:
-                SHELL_ExecuteControlPanelCPL(m_hWnd, L"timedate.cpl");
+                ShellExecuteW(m_hWnd, NULL, L"timedate.cpl", NULL, NULL, SW_NORMAL);
                 break;
             case TRAYCMD_EJECT:
                 SHCreateThread(EjectThreadProc, NULL, CTF_INSIST, NULL);

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -711,8 +711,7 @@ public:
             break;
 
         case ID_SHELL_CMD_ADJUST_DAT:
-            //FIXME: Use SHRunControlPanel
-            ShellExecuteW(m_hWnd, NULL, L"timedate.cpl", NULL, NULL, SW_NORMAL);
+            SHELL_ExecuteControlPanelCPL(m_hWnd, L"timedate.cpl");
             break;
 
         case ID_SHELL_CMD_RESTORE_ALL:
@@ -767,8 +766,7 @@ public:
             SHFindComputer(NULL, NULL);
             break;
         case IDHK_SYS_PROPERTIES:
-            //FIXME: Use SHRunControlPanel
-            ShellExecuteW(m_hWnd, NULL, L"sysdm.cpl", NULL, NULL, SW_NORMAL);
+            SHELL_ExecuteControlPanelCPL(m_hWnd, L"sysdm.cpl");
             break;
         case IDHK_NEXT_TASK:
             break;
@@ -830,7 +828,7 @@ public:
                 ToggleDesktop();
                 break;
             case TRAYCMD_DATE_AND_TIME:
-                ShellExecuteW(m_hWnd, NULL, L"timedate.cpl", NULL, NULL, SW_NORMAL);
+                SHELL_ExecuteControlPanelCPL(m_hWnd, L"timedate.cpl");
                 break;
             case TRAYCMD_EJECT:
                 SHCreateThread(EjectThreadProc, NULL, CTF_INSIST, NULL);

--- a/dll/win32/shell32/CShellDispatch.cpp
+++ b/dll/win32/shell32/CShellDispatch.cpp
@@ -264,7 +264,13 @@ HRESULT STDMETHODCALLTYPE CShellDispatch::RefreshMenu()
 HRESULT STDMETHODCALLTYPE CShellDispatch::ControlPanelItem(BSTR szDir)
 {
     TRACE("(%p, %ls)\n", this, szDir);
-    return SHRunControlPanel(szDir, NULL) ? S_OK : S_FALSE;
+    if (LOBYTE(GetVersion()) < 6)
+        SHELL32_RunControlPanel(szDir, NULL);
+    else if (!szDir)
+        return E_INVALIDARG; // NT5 does not check, just silently fails
+    else
+        ShellExecuteW(NULL, NULL, szDir, NULL, NULL, SW_SHOWNORMAL);
+    return S_OK;
 }
 
 // *** IShellDispatch2 methods ***

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -213,6 +213,7 @@ UINT
 MapVerbToDfmCmd(_In_ LPCSTR verba);
 UINT
 GetDfmCmd(_In_ IContextMenu *pCM, _In_ LPCSTR verba);
+
 EXTERN_C BOOL WINAPI
 SHELL32_RunControlPanel(_In_ PCWSTR commandLine, _In_opt_ HWND parent);
 #define SHELL_ExecuteControlPanelCPL(hwnd, cpl) SHELL32_RunControlPanel((cpl), (hwnd))

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -213,7 +213,9 @@ UINT
 MapVerbToDfmCmd(_In_ LPCSTR verba);
 UINT
 GetDfmCmd(_In_ IContextMenu *pCM, _In_ LPCSTR verba);
-#define SHELL_ExecuteControlPanelCPL(hwnd, cpl) SHRunControlPanel((cpl), (hwnd))
+EXTERN_C BOOL WINAPI
+SHELL32_RunControlPanel(_In_ PCWSTR commandLine, _In_ HWND parent);
+#define SHELL_ExecuteControlPanelCPL(hwnd, cpl) SHELL32_RunControlPanel((cpl), (hwnd))
 
 
 // CStubWindow32 --- The owner window of file property sheets.

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -214,7 +214,7 @@ MapVerbToDfmCmd(_In_ LPCSTR verba);
 UINT
 GetDfmCmd(_In_ IContextMenu *pCM, _In_ LPCSTR verba);
 EXTERN_C BOOL WINAPI
-SHELL32_RunControlPanel(_In_ PCWSTR commandLine, _In_ HWND parent);
+SHELL32_RunControlPanel(_In_ PCWSTR commandLine, _In_opt_ HWND parent);
 #define SHELL_ExecuteControlPanelCPL(hwnd, cpl) SHELL32_RunControlPanel((cpl), (hwnd))
 
 

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -1663,9 +1663,10 @@ HRESULT WINAPI SHWinHelp(HWND hwnd, LPCWSTR pszHelp, UINT uCommand, ULONG_PTR dw
  *  SHRunControlPanel [SHELL32.161]
  *
  */
-BOOL WINAPI SHRunControlPanel (_In_ LPCWSTR commandLine, _In_opt_ HWND parent)
-{
 #ifdef __REACTOS__
+EXTERN_C BOOL WINAPI
+SHELL32_RunControlPanel(_In_ PCWSTR commandLine, _In_ HWND parent)
+{
     /*
      * TODO: Run in-process when possible, using
      * HKLM\Software\Microsoft\Windows\CurrentVersion\Explorer\ControlPanel\InProcCPLs
@@ -1678,10 +1679,22 @@ BOOL WINAPI SHRunControlPanel (_In_ LPCWSTR commandLine, _In_opt_ HWND parent)
      * in order to keep control panel elements launch commands.
      */
     WCHAR parameters[MAX_PATH] = L"shell32.dll,Control_RunDLL ";
-    TRACE("(%s, %p)n", debugstr_w(commandLine), parent);
+    if (!commandLine)
+        return FALSE;
     wcscat(parameters, commandLine);
-
     return ((INT_PTR)ShellExecuteW(parent, L"open", L"rundll32.exe", parameters, NULL, SW_SHOWNORMAL) > 32);
+}
+#endif
+
+BOOL WINAPI SHRunControlPanel(_In_ LPCWSTR commandLine, _In_opt_ HWND parent)
+{
+#ifdef __REACTOS__
+    TRACE("(%s, %p)n", debugstr_w(commandLine), parent);
+    /* MSDN indicates that ROS should have a version check here but Vista+ just forwards to SHUNIMPL
+    if (LOBYTE(GetVersion()) >= 6)
+        return FALSE;
+    */
+    return SHELL32_RunControlPanel(commandLine, parent);
 #else
 	FIXME("(%s, %p): stub\n", debugstr_w(commandLine), parent);
 	return FALSE;

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -1665,7 +1665,7 @@ HRESULT WINAPI SHWinHelp(HWND hwnd, LPCWSTR pszHelp, UINT uCommand, ULONG_PTR dw
  */
 #ifdef __REACTOS__
 EXTERN_C BOOL WINAPI
-SHELL32_RunControlPanel(_In_ PCWSTR commandLine, _In_ HWND parent)
+SHELL32_RunControlPanel(_In_ PCWSTR commandLine, _In_opt_ HWND parent)
 {
     /*
      * TODO: Run in-process when possible, using


### PR DESCRIPTION
Our own code should not call `SHRunControlPanel` directly because it was nuked in Vista. `CShellDispatch::ControlPanelItem` matches Windows where Vista+ is just a pure `ShellExecute`.

JIRA issue: [CORE-9215](https://jira.reactos.org/browse/CORE-9215)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: