### PR TITLE
[WIN32SS:ENG] Fix Y coordinate of the software pointer exclude rectangle

### DIFF
--- a/win32ss/gdi/eng/mouse.c
+++ b/win32ss/gdi/eng/mouse.c
@@ -543,7 +543,7 @@ EngSetPointerShape(
         if (prcl != NULL)
         {
             prcl->left = x - pgp->HotSpot.x;
-            prcl->top = y - pgp->HotSpot.x;
+            prcl->top = y - pgp->HotSpot.y;
             prcl->right = prcl->left + pgp->Size.cx;
             prcl->bottom = prcl->top + pgp->Size.cy;
         }


### PR DESCRIPTION
crazy that this typo survived two decades, but here we are, that maybe should fix some gdi test 


## Testbot runs (Filled in by Devs)

- [ ] KVM x86: https://reactos.org/testman/compare.php?ids=108138,108141,108143
- [ ] KVM x64: https://reactos.org/testman/compare.php?ids=108139,108142,108144