### PR TITLE
[WIN32SS:ENG] Fix copy direction in overlapping EngTransparentBlt

### DIFF
--- a/win32ss/gdi/eng/transblt.c
+++ b/win32ss/gdi/eng/transblt.c
@@ -145,11 +145,11 @@ EngTransparentBlt(
             {
                 if (OutputRect.top < InputRect.top)
                 {
-                    Direction = OutputRect.left < (InputRect.left ? CD_RIGHTDOWN : CD_LEFTDOWN);
+                    Direction = OutputRect.left < InputRect.left ? CD_RIGHTDOWN : CD_LEFTDOWN;
                 }
                 else
                 {
-                    Direction = OutputRect.left < (InputRect.left ? CD_RIGHTUP : CD_LEFTUP);
+                    Direction = OutputRect.left < InputRect.left ? CD_RIGHTUP : CD_LEFTUP;
                 }
             }
             else


### PR DESCRIPTION
the brackets were around the wrong part, so the < checked the left edge against the picked direction instead of against the other left edge. 

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: