### PR TITLE
[NTGDI][POLYTEST] Use newx1 as the lower bound in polyfill line-touch test

### DIFF
--- a/modules/rostests/tests/polytest/polytest.cpp
+++ b/modules/rostests/tests/polytest/polytest.cpp
@@ -612,7 +612,7 @@ POLYGONFILL_FillScanLineWinding(
       if ( (newx1 >= x1 && newx1 <= x2)
 	|| (newx2 >= x1 && newx2 <= x2)
 	|| (x1 >= newx1 && x1 <= newx2)
-	|| (x2 >= newx2 && x2 <= newx2)
+	|| (x2 >= newx1 && x2 <= newx2)
 	)
       {
 	// yup, just tack it on to our existing line

--- a/win32ss/gdi/ntgdi/polyfill.c
+++ b/win32ss/gdi/ntgdi/polyfill.c
@@ -475,7 +475,7 @@ POLYGONFILL_FillScanLineWinding(
             if ((newx1 >= x1 && newx1 <= x2) ||
                 (newx2 >= x1 && newx2 <= x2) ||
                 (x1 >= newx1 && x1 <= newx2) ||
-                (x2 >= newx2 && x2 <= newx2))
+                (x2 >= newx1 && x2 <= newx2))
             {
                 // Yup, just tack it on to our existing line
                 x1 = min(x1,newx1);


### PR DESCRIPTION
found another one, still hunting typos

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: