### PR TITLE
[WIN32K:DIB] Fix destination row stride in DIB_8BPP_BitBltSrcCopy

### DIFF
--- a/win32ss/gdi/dib/dib8bpp.c
+++ b/win32ss/gdi/dib/dib8bpp.c
@@ -323,6 +323,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             DPRINT("Flip is bTopToBottom.\n");
 
             DWORD  Index;
+            LONG   SrcDelta;
 
             /* Allocate enough pixels for a column in BYTE's */
             BYTE *store = ExAllocatePoolWithTag(NonPagedPool,
@@ -344,6 +345,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               SourceLine = (PBYTE)BltInfo->DestSurface->pvScan0 +
                 (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta) + BltInfo->DestRect.left  +
                 (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) * BltInfo->DestSurface->lDelta;
+              SrcDelta = BltInfo->DestSurface->lDelta;
             }
             else
             {
@@ -352,6 +354,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
                 ((BltInfo->SourcePoint.y + BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1)
                 * BltInfo->SourceSurface->lDelta) +
                 BltInfo->SourcePoint.x;
+              SrcDelta = BltInfo->SourceSurface->lDelta;
             }
 
             /* This set the DestLine to the top line */
@@ -371,9 +374,9 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               /* Read up the column and store the pixels */
               for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
               {
-                store[Index] = (BYTE)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, *SourceBits);
+                store[Index] = OneDone ? *SourceBits : (BYTE)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, *SourceBits);
                 /* Go up a line */
-                SourceBits -= BltInfo->SourceSurface->lDelta;
+                SourceBits -= SrcDelta;
                 Index++;
               }
 

--- a/win32ss/gdi/dib/dib8bpp.c
+++ b/win32ss/gdi/dib/dib8bpp.c
@@ -384,7 +384,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               {
                 *DestBits = store[Index];
                 /* Go down a line */
-                DestBits += BltInfo->SourceSurface->lDelta;
+                DestBits += BltInfo->DestSurface->lDelta;
                 Index++;
               }
               /* Index to next column */


### PR DESCRIPTION
the overlapping copy in DIB_8BPP_BitBltSrcCopy advances DestBits by the source stride instead of DestSurface , corrupting 8bpp blits when src/dst strides differ

[CORE-2965](https://jira.reactos.org/browse/CORE-2965)
## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: