### PR TITLE
[NTUSER] Fix XBUTTON1 reported as XBUTTON2 on WM_XBUTTONUP

### DIFF
--- a/win32ss/user/ntuser/mouse.c
+++ b/win32ss/user/ntuser/mouse.c
@@ -326,7 +326,7 @@ UserSendMouseInput(MOUSEINPUT *pmi, BOOL bInjected)
             SET_KEY_DOWN(gafAsyncKeyState, VK_XBUTTON1, FALSE);
             pCurInfo->ButtonsDown &= ~MK_XBUTTON1;
             Msg.wParam &= ~MK_XBUTTON1;
-            Msg.wParam |= MAKEWPARAM(0, XBUTTON2);
+            Msg.wParam |= MAKEWPARAM(0, XBUTTON1);
             co_MsqInsertMouseMessage(&Msg, bInjected, pmi->dwExtraInfo, TRUE);
         }
         if (pmi->mouseData & XBUTTON2)


### PR DESCRIPTION
another typo

Bug was introduced in https://github.com/reactos/reactos/commit/9e2f17bd8e32da6c9c3bfd029927fb9d44971773 (r54227)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: