### PR TITLE
[NTUSER] Return NO_SELECTED_ITEM from NtUserMenuItemFromPoint when no item is hit

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6348,7 +6348,7 @@ NtUserMenuItemFromPoint(
       }
    }
 
-   Ret = (mi ? i : NO_SELECTED_ITEM);
+   Ret = (i < Menu->cItems ? i : NO_SELECTED_ITEM);
 
 Exit:
    UserLeave();


### PR DESCRIPTION
NtUserMenuItemFromPoint returns cItems instead of NO_SELECTED_ITEM when no item is under the point (mi is never null on a miss), so MenuItemFromPoint callers can index one past the menu array.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: