### PR TITLE
[NTUSER] Use MOUSEEVENTF_XDOWN/XUP in the X-button flush checks

### DIFF
--- a/win32ss/user/ntuser/mouse.c
+++ b/win32ss/user/ntuser/mouse.c
@@ -92,7 +92,7 @@ UserProcessMouseInput(PMOUSE_INPUT_DATA mid)
     }
 
     /* If mouseData is used by button 4, send input and clear mi */
-    if (mi.dwFlags & (MOUSE_BUTTON_4_DOWN | MOUSE_BUTTON_4_UP))
+    if (mi.dwFlags & (MOUSEEVENTF_XDOWN | MOUSEEVENTF_XUP))
     {
         UserSendMouseInput(&mi, FALSE);
         RtlZeroMemory(&mi, sizeof(mi));
@@ -111,7 +111,7 @@ UserProcessMouseInput(PMOUSE_INPUT_DATA mid)
     }
 
     /* If mouseData is used by button 5, send input and clear mi */
-    if (mi.dwFlags & (MOUSE_BUTTON_5_DOWN | MOUSE_BUTTON_5_UP))
+    if (mi.dwFlags & (MOUSEEVENTF_XDOWN | MOUSEEVENTF_XUP))
     {
         UserSendMouseInput(&mi, FALSE);
         RtlZeroMemory(&mi, sizeof(mi));


### PR DESCRIPTION
my last win32k fix worth doing: the flush checks test mi.dwFlags (MOUSEEVENTF_XDOWN/XUP) against raw MOUSE_BUTTON_4/5 bits, so combined button-4+5 events flush in the wrong block or get dropped

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: