### PR TITLE
[NTOS:FSTUB] Clear the whole partition table in FstubCreateDiskRaw

### DIFF
--- a/ntoskrnl/fstub/fstubex.c
+++ b/ntoskrnl/fstub/fstubex.c
@@ -487,7 +487,7 @@ FstubCreateDiskRaw(IN PDEVICE_OBJECT DeviceObject)
     /* Only zero useful stuff */
     MasterBootRecord = (PMASTER_BOOT_RECORD)Disk->Buffer;
     MasterBootRecord->Signature = 0;
-    RtlZeroMemory(MasterBootRecord->PartitionTable, sizeof(PARTITION_TABLE_ENTRY));
+    RtlZeroMemory(MasterBootRecord->PartitionTable, sizeof(PARTITION_TABLE_ENTRY) * NUM_PARTITION_TABLE_ENTRIES);
     MasterBootRecord->MasterBootRecordMagic = 0;
 
     /* Write back that destroyed MBR */


### PR DESCRIPTION
FstubCreateDiskRaw is supposed to wipe the MBR when it makes a raw disk, but it only cleared the first of the 4 partition entries so one entry (16 bytes) instead of the whole table (64).

so the waped MBR that gets written back to disk still has entries 2, 3 and 4 sitting there with old data, and those come back as ghost/garbage partitions.



## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: