### PR TITLE
[NTUSER] Clip the non-client update region to the dirty region

### DIFF
--- a/win32ss/user/ntuser/painting.c
+++ b/win32ss/user/ntuser/painting.c
@@ -285,9 +285,25 @@ IntGetNCUpdateRgn(PWND Window, BOOL Validate)
          return HRGN_WINDOW;
       }
 
-      NcType = IntGdiGetRgnBox(hRgnNonClient, &update);
+      NcType = IntGdiGetRgnBox(Window->hrgnUpdate, &update);
 
       RgnType = NtGdiCombineRgn(hRgnNonClient, hRgnNonClient, hRgnWindow, RGN_DIFF);
+
+      if (RgnType == ERROR)
+      {
+         GreDeleteObject(hRgnWindow);
+         GreDeleteObject(hRgnNonClient);
+         return HRGN_WINDOW;
+      }
+      else if (RgnType == NULLREGION)
+      {
+         GreDeleteObject(hRgnWindow);
+         GreDeleteObject(hRgnNonClient);
+         Window->state &= ~WNDS_UPDATEDIRTY;
+         return NULL;
+      }
+
+      RgnType = NtGdiCombineRgn(hRgnNonClient, hRgnNonClient, Window->hrgnUpdate, RGN_AND);
 
       if (RgnType == ERROR)
       {

--- a/win32ss/user/ntuser/painting.c
+++ b/win32ss/user/ntuser/painting.c
@@ -288,22 +288,8 @@ IntGetNCUpdateRgn(PWND Window, BOOL Validate)
       NcType = IntGdiGetRgnBox(Window->hrgnUpdate, &update);
 
       RgnType = NtGdiCombineRgn(hRgnNonClient, hRgnNonClient, hRgnWindow, RGN_DIFF);
-
-      if (RgnType == ERROR)
-      {
-         GreDeleteObject(hRgnWindow);
-         GreDeleteObject(hRgnNonClient);
-         return HRGN_WINDOW;
-      }
-      else if (RgnType == NULLREGION)
-      {
-         GreDeleteObject(hRgnWindow);
-         GreDeleteObject(hRgnNonClient);
-         Window->state &= ~WNDS_UPDATEDIRTY;
-         return NULL;
-      }
-
-      RgnType = NtGdiCombineRgn(hRgnNonClient, hRgnNonClient, Window->hrgnUpdate, RGN_AND);
+      if ((RgnType != ERROR) && (RgnType != NULLREGION))
+         RgnType = NtGdiCombineRgn(hRgnNonClient, hRgnNonClient, Window->hrgnUpdate, RGN_AND);
 
       if (RgnType == ERROR)
       {

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -2184,7 +2184,6 @@ co_WinPosSetWindowPos(
                    IntInvalidateWindows( Parent, DirtyRgn, RDW_ERASE | RDW_INVALIDATE);
                    co_IntPaintWindows(Parent, RDW_NOCHILDREN, FALSE);
                 }
-                Window->state2 |= WNDS2_FORCEFULLNCPAINTCLIPRGN;
                 IntInvalidateWindows(Window, DirtyRgn, RDW_ERASE | RDW_FRAME | RDW_INVALIDATE | RDW_ALLCHILDREN);
              }
              else if (RgnType != ERROR && RgnType == NULLREGION) // Must be the same. See CORE-7166 & CORE-15934, NC HACK fix.

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -2184,6 +2184,7 @@ co_WinPosSetWindowPos(
                    IntInvalidateWindows( Parent, DirtyRgn, RDW_ERASE | RDW_INVALIDATE);
                    co_IntPaintWindows(Parent, RDW_NOCHILDREN, FALSE);
                 }
+                Window->state2 |= WNDS2_FORCEFULLNCPAINTCLIPRGN;
                 IntInvalidateWindows(Window, DirtyRgn, RDW_ERASE | RDW_FRAME | RDW_INVALIDATE | RDW_ALLCHILDREN);
              }
              else if (RgnType != ERROR && RgnType == NULLREGION) // Must be the same. See CORE-7166 & CORE-15934, NC HACK fix.


### PR DESCRIPTION
https://youtu.be/QfjjfMRvpZg

I was able to notice it while running my arm64 development on a qemu emulation with a low-end configuration.
This might affect some time based ros tests.

JIRA reports: [CORE-5877](https://jira.reactos.org/browse/CORE-5877), [CORE-16672](https://jira.reactos.org/browse/CORE-16672)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108688,108695
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108689,108694

No changes except for the usual flukes.