### PR TITLE
[WINNLS] Fix incorrect behavior with grouping in GetCurrencyFormatW/GetNumberFormatW

### DIFF
--- a/dll/win32/kernel32/winnls/string/lcformat.c
+++ b/dll/win32/kernel32/winnls/string/lcformat.c
@@ -269,7 +269,7 @@ static const NLS_FORMAT_NODE *NLS_GetFormats(LCID lcid, DWORD dwFlags)
     new_node->cyfmt.NumDigits = new_node->fmt.NumDigits;
     new_node->cyfmt.LeadingZero = new_node->fmt.LeadingZero;
 
-    GET_LOCALE_NUMBER(new_node->cyfmt.Grouping, LOCALE_SGROUPING);
+    GET_LOCALE_NUMBER(new_node->cyfmt.Grouping, LOCALE_SMONGROUPING);
 
     if (new_node->cyfmt.Grouping > 9)
     {
@@ -1284,7 +1284,7 @@ INT WINAPI GetNumberFormatW(LCID lcid, DWORD dwFlags,
       *szOut-- = *lpszDec--; /* Write decimal separator */
   }
 
-  dwGroupCount = lpFormat->Grouping == 32 ? 3 : lpFormat->Grouping;
+  dwGroupCount = lpFormat->Grouping > 9 ? lpFormat->Grouping / 10 : lpFormat->Grouping;
 
   /* Write the remaining whole number digits, including grouping chars */
   while (szSrc >= lpszValue && *szSrc >= '0' && *szSrc <= '9')
@@ -1313,8 +1313,8 @@ INT WINAPI GetNumberFormatW(LCID lcid, DWORD dwFlags,
         *szOut-- = *lpszGrp--; /* Write grouping char */
 
       dwCurrentGroupCount = 0;
-      if (lpFormat->Grouping == 32)
-        dwGroupCount = 2; /* Indic grouping: 3 then 2 */
+      if (lpFormat->Grouping > 9)
+        dwGroupCount = lpFormat->Grouping % 10; /*first group 3, then repeat 2 */
     }
   }
   if (dwState & NF_ROUND)

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -38,8 +38,6 @@
 #include <winnetwk.h>
 #include <objsafe.h>
 #include <regstr.h>
-#include <set>
-#include <string>
 
 #include <comctl32_undoc.h>
 #include <shlguid_undoc.h>

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -38,6 +38,8 @@
 #include <winnetwk.h>
 #include <objsafe.h>
 #include <regstr.h>
+#include <set>
+#include <string>
 
 #include <comctl32_undoc.h>
 #include <shlguid_undoc.h>
@@ -352,31 +354,6 @@ typedef enum _FILEOPCALLBACKEVENT {
     FOCE_PRENEWITEM,
     FOCE_POSTNEWITEM
 } FILEOPCALLBACKEVENT;
-
-struct CStringElementTraitsIW : public CElementTraitsBase<CStringW>
-{
-    static ULONG Hash(INARGTYPE str)
-    {
-        ULONG nHash = 0;
-        LPCWSTR pch = str;
-        while (*pch)
-        {
-            nHash = (nHash << 5) + nHash + towupper(*pch);
-            pch++;
-        }
-        return nHash;
-    }
-
-    static bool CompareElements(INARGTYPE str1, INARGTYPE str2)
-    {
-        return _wcsicmp(str1, str2) == 0;
-    }
-
-    static int CompareElementsOrdered(INARGTYPE str1, INARGTYPE str2)
-    {
-        return _wcsicmp(str1, str2);
-    }
-};
 
 typedef HRESULT (CALLBACK *FILEOPCALLBACK)(FILEOPCALLBACKEVENT Event, LPCWSTR Source, LPCWSTR Destination,
                                            UINT Attributes, HRESULT hr, void *CallerData);

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -352,6 +352,32 @@ typedef enum _FILEOPCALLBACKEVENT {
     FOCE_PRENEWITEM,
     FOCE_POSTNEWITEM
 } FILEOPCALLBACKEVENT;
+
+struct CStringElementTraitsIW : public CElementTraitsBase<CStringW>
+{
+    static ULONG Hash(INARGTYPE str)
+    {
+        ULONG nHash = 0;
+        LPCWSTR pch = str;
+        while (*pch)
+        {
+            nHash = (nHash << 5) + nHash + towupper(*pch);
+            pch++;
+        }
+        return nHash;
+    }
+
+    static bool CompareElements(INARGTYPE str1, INARGTYPE str2)
+    {
+        return _wcsicmp(str1, str2) == 0;
+    }
+
+    static int CompareElementsOrdered(INARGTYPE str1, INARGTYPE str2)
+    {
+        return _wcsicmp(str1, str2);
+    }
+};
+
 typedef HRESULT (CALLBACK *FILEOPCALLBACK)(FILEOPCALLBACKEVENT Event, LPCWSTR Source, LPCWSTR Destination,
                                            UINT Attributes, HRESULT hr, void *CallerData);
 int SHELL32_FileOperation(LPSHFILEOPSTRUCTW lpFileOp, FILEOPCALLBACK Callback, void *CallerData);

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -352,7 +352,6 @@ typedef enum _FILEOPCALLBACKEVENT {
     FOCE_PRENEWITEM,
     FOCE_POSTNEWITEM
 } FILEOPCALLBACKEVENT;
-
 typedef HRESULT (CALLBACK *FILEOPCALLBACK)(FILEOPCALLBACKEVENT Event, LPCWSTR Source, LPCWSTR Destination,
                                            UINT Attributes, HRESULT hr, void *CallerData);
 int SHELL32_FileOperation(LPSHFILEOPSTRUCTW lpFileOp, FILEOPCALLBACK Callback, void *CallerData);

--- a/dll/win32/shell32/shell32.cpp
+++ b/dll/win32/shell32/shell32.cpp
@@ -95,7 +95,7 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
 
     if (bUpdateSelf)
     {
-        CAtlMap<CStringW, bool, CStringElementTraitsIW> newVarNames;
+        std::set<std::wstring> newVarNames;
 
         LPWSTR pszz = (LPWSTR)pEnv;
         while (pszz && *pszz)
@@ -106,9 +106,9 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
                 if (pchEqual)
                 {
                     *pchEqual = L'\0';
-                    newVarNames.SetAt(pszz, true);          /* record name */
+                    newVarNames.insert(pszz);
                     SetEnvironmentVariableW(pszz, pchEqual + 1);
-                    *pchEqual = L'=';                       /* restore */
+                    *pchEqual = L'=';
                 }
             }
             pszz += wcslen(pszz) + 1;
@@ -126,9 +126,9 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
                     if (pchEqual)
                     {
                         *pchEqual = L'\0';
-                        if (!newVarNames.Lookup(pCur))
-                            SetEnvironmentVariableW(pCur, NULL); /* delete */
-                        *pchEqual = L'=';                        /* restore */
+                        if (newVarNames.find(pCur) == newVarNames.end())
+                            SetEnvironmentVariableW(pCur, NULL);
+                        *pchEqual = L'=';
                     }
                 }
                 pCur += wcslen(pCur) + 1;

--- a/dll/win32/shell32/shell32.cpp
+++ b/dll/win32/shell32/shell32.cpp
@@ -95,7 +95,7 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
 
     if (bUpdateSelf)
     {
-        std::set<std::wstring> newVarNames;
+        CSimpleMap<CStringW, bool> newVarNames;
 
         LPWSTR pszz = (LPWSTR)pEnv;
         while (pszz && *pszz)
@@ -106,7 +106,7 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
                 if (pchEqual)
                 {
                     *pchEqual = L'\0';
-                    newVarNames.insert(pszz);
+                    newVarNames.Add(pszz, true);
                     SetEnvironmentVariableW(pszz, pchEqual + 1);
                     *pchEqual = L'=';
                 }
@@ -126,7 +126,7 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
                     if (pchEqual)
                     {
                         *pchEqual = L'\0';
-                        if (newVarNames.find(pCur) == newVarNames.end())
+                        if (newVarNames.FindKey(pCur) < 0)
                             SetEnvironmentVariableW(pCur, NULL);
                         *pchEqual = L'=';
                     }

--- a/dll/win32/shell32/shell32.cpp
+++ b/dll/win32/shell32/shell32.cpp
@@ -95,7 +95,7 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
 
     if (bUpdateSelf)
     {
-        CAtlMap<CStringW, bool, CStringElementTraitsI<CStringW>> newVarNames;
+        CAtlMap<CStringW, bool, CStringElementTraitsIW> newVarNames;
 
         LPWSTR pszz = (LPWSTR)pEnv;
         while (pszz && *pszz)
@@ -136,11 +136,12 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
             FreeEnvironmentStringsW(pCurEnv);
         }
 
-        /* We free the environment block now that we have applied it to the process.
+        /* We free the environment block now that we have applied it to the process;
          * the caller gets NULL back in *lpEnvironment in this case. */
         DestroyEnvironmentBlock(pEnv);
         *lpEnvironment = NULL;
     }
+
     CloseHandle(hUserToken);
     return bResult;
 }

--- a/dll/win32/shell32/shell32.cpp
+++ b/dll/win32/shell32/shell32.cpp
@@ -73,23 +73,30 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
     HANDLE hUserToken = NULL;
     LPVOID pEnv = NULL;
     BOOL bResult = FALSE;
+
     if (!lpEnvironment)
         return FALSE;
+
     if (!OpenProcessToken(GetCurrentProcess(),
                           TOKEN_QUERY | TOKEN_DUPLICATE | TOKEN_ASSIGN_PRIMARY,
                           &hUserToken))
     {
         return FALSE;
     }
+
     if (!CreateEnvironmentBlock(&pEnv, hUserToken, TRUE))
     {
         CloseHandle(hUserToken);
         return FALSE;
     }
+
     *lpEnvironment = pEnv;
     bResult = TRUE;
+
     if (bUpdateSelf)
     {
+        CAtlMap<CStringW, bool, CStringElementTraitsI<CStringW>> newVarNames;
+
         LPWSTR pszz = (LPWSTR)pEnv;
         while (pszz && *pszz)
         {
@@ -99,8 +106,9 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
                 if (pchEqual)
                 {
                     *pchEqual = L'\0';
+                    newVarNames.SetAt(pszz, true);          /* record name */
                     SetEnvironmentVariableW(pszz, pchEqual + 1);
-                    *pchEqual = L'='; /* restore */
+                    *pchEqual = L'=';                       /* restore */
                 }
             }
             pszz += wcslen(pszz) + 1;
@@ -112,46 +120,23 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
             LPWSTR pCur = (LPWSTR)pCurEnv;
             while (pCur && *pCur)
             {
-                /* skip special variables starting with = */
                 if (pCur[0] != L'=')
                 {
                     LPWSTR pchEqual = wcschr(pCur, L'=');
                     if (pchEqual)
                     {
                         *pchEqual = L'\0';
-
-                        /* check if this variable exists in the new block */
-                        BOOL bFound = FALSE;
-                        LPWSTR pNew = (LPWSTR)pEnv;
-                        while (pNew && *pNew)
-                        {
-                            if (pNew[0] != L'=')
-                            {
-                                LPWSTR pNewEqual = wcschr(pNew, L'=');
-                                if (pNewEqual)
-                                {
-                                    *pNewEqual = L'\0';
-                                    if (_wcsicmp(pCur, pNew) == 0)
-                                        bFound = TRUE;
-                                    *pNewEqual = L'='; /* restore */
-                                }
-                                if (bFound)
-                                    break;
-                            }
-                            pNew += wcslen(pNew) + 1;
-                        }
-
-                        if (!bFound)
+                        if (!newVarNames.Lookup(pCur))
                             SetEnvironmentVariableW(pCur, NULL); /* delete */
-
-                        *pchEqual = L'='; /* restore */
+                        *pchEqual = L'=';                        /* restore */
                     }
                 }
                 pCur += wcslen(pCur) + 1;
             }
             FreeEnvironmentStringsW(pCurEnv);
         }
-        /* We free the environment block now that we have applied it to the process
+
+        /* We free the environment block now that we have applied it to the process.
          * the caller gets NULL back in *lpEnvironment in this case. */
         DestroyEnvironmentBlock(pEnv);
         *lpEnvironment = NULL;

--- a/dll/win32/shell32/shell32.cpp
+++ b/dll/win32/shell32/shell32.cpp
@@ -23,6 +23,9 @@
 
 #include "shell32_version.h"
 
+#include <set>
+#include <string>
+
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
 /*

--- a/dll/win32/shell32/shell32.cpp
+++ b/dll/win32/shell32/shell32.cpp
@@ -23,9 +23,6 @@
 
 #include "shell32_version.h"
 
-#include <set>
-#include <string>
-
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
 /*
@@ -109,7 +106,9 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
                 if (pchEqual)
                 {
                     *pchEqual = L'\0';
-                    newVarNames.Add(pszz, true);
+                    CStringW key(pszz);
+                    key.MakeUpper();
+                    newVarNames.Add(key, true);
                     SetEnvironmentVariableW(pszz, pchEqual + 1);
                     *pchEqual = L'=';
                 }
@@ -129,7 +128,9 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
                     if (pchEqual)
                     {
                         *pchEqual = L'\0';
-                        if (newVarNames.FindKey(pCur) < 0)
+                        CStringW key(pCur);
+                        key.MakeUpper();
+                        if (newVarNames.FindKey(key) < 0)
                             SetEnvironmentVariableW(pCur, NULL);
                         *pchEqual = L'=';
                     }

--- a/dll/win32/shell32/shell32.cpp
+++ b/dll/win32/shell32/shell32.cpp
@@ -151,6 +151,9 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
             }
             FreeEnvironmentStringsW(pCurEnv);
         }
+
+        DestroyEnvironmentBlock(pEnv);
+        *lpEnvironment = NULL;
     }
     CloseHandle(hUserToken);
     return bResult;

--- a/dll/win32/shell32/shell32.cpp
+++ b/dll/win32/shell32/shell32.cpp
@@ -73,23 +73,30 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
     HANDLE hUserToken = NULL;
     LPVOID pEnv = NULL;
     BOOL bResult = FALSE;
+
     if (!lpEnvironment)
         return FALSE;
+
     if (!OpenProcessToken(GetCurrentProcess(),
                           TOKEN_QUERY | TOKEN_DUPLICATE | TOKEN_ASSIGN_PRIMARY,
                           &hUserToken))
     {
         return FALSE;
     }
+
     if (!CreateEnvironmentBlock(&pEnv, hUserToken, TRUE))
     {
         CloseHandle(hUserToken);
         return FALSE;
     }
+
     *lpEnvironment = pEnv;
     bResult = TRUE;
+
     if (bUpdateSelf)
     {
+        CSimpleMap<CStringW, bool> newVarNames;
+
         LPWSTR pszz = (LPWSTR)pEnv;
         while (pszz && *pszz)
         {
@@ -99,8 +106,11 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
                 if (pchEqual)
                 {
                     *pchEqual = L'\0';
+                    CStringW key(pszz);
+                    key.MakeUpper();
+                    newVarNames.Add(key, true);
                     SetEnvironmentVariableW(pszz, pchEqual + 1);
-                    *pchEqual = L'='; /* restore */
+                    *pchEqual = L'=';
                 }
             }
             pszz += wcslen(pszz) + 1;
@@ -112,50 +122,30 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
             LPWSTR pCur = (LPWSTR)pCurEnv;
             while (pCur && *pCur)
             {
-                /* skip special variables starting with = */
                 if (pCur[0] != L'=')
                 {
                     LPWSTR pchEqual = wcschr(pCur, L'=');
                     if (pchEqual)
                     {
                         *pchEqual = L'\0';
-
-                        /* check if this variable exists in the new block */
-                        BOOL bFound = FALSE;
-                        LPWSTR pNew = (LPWSTR)pEnv;
-                        while (pNew && *pNew)
-                        {
-                            if (pNew[0] != L'=')
-                            {
-                                LPWSTR pNewEqual = wcschr(pNew, L'=');
-                                if (pNewEqual)
-                                {
-                                    *pNewEqual = L'\0';
-                                    if (_wcsicmp(pCur, pNew) == 0)
-                                        bFound = TRUE;
-                                    *pNewEqual = L'='; /* restore */
-                                }
-                                if (bFound)
-                                    break;
-                            }
-                            pNew += wcslen(pNew) + 1;
-                        }
-
-                        if (!bFound)
-                            SetEnvironmentVariableW(pCur, NULL); /* delete */
-
-                        *pchEqual = L'='; /* restore */
+                        CStringW key(pCur);
+                        key.MakeUpper();
+                        if (newVarNames.FindKey(key) < 0)
+                            SetEnvironmentVariableW(pCur, NULL);
+                        *pchEqual = L'=';
                     }
                 }
                 pCur += wcslen(pCur) + 1;
             }
             FreeEnvironmentStringsW(pCurEnv);
         }
-        /* We free the environment block now that we have applied it to the process
+
+        /* We free the environment block now that we have applied it to the process;
          * the caller gets NULL back in *lpEnvironment in this case. */
         DestroyEnvironmentBlock(pEnv);
         *lpEnvironment = NULL;
     }
+
     CloseHandle(hUserToken);
     return bResult;
 }

--- a/dll/win32/shell32/shell32.cpp
+++ b/dll/win32/shell32/shell32.cpp
@@ -151,7 +151,8 @@ RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
             }
             FreeEnvironmentStringsW(pCurEnv);
         }
-
+        /* We free the environment block now that we have applied it to the process
+         * the caller gets NULL back in *lpEnvironment in this case. */
         DestroyEnvironmentBlock(pEnv);
         *lpEnvironment = NULL;
     }

--- a/dll/win32/shell32/shell32.cpp
+++ b/dll/win32/shell32/shell32.cpp
@@ -70,38 +70,89 @@ EXTERN_C BOOL
 WINAPI
 RegenerateUserEnvironment(LPVOID *lpEnvironment, BOOL bUpdateSelf)
 {
-    HANDLE hUserToken;
-    if (!OpenProcessToken(GetCurrentProcess(), TOKEN_READ | TOKEN_WRITE, &hUserToken))
+    HANDLE hUserToken = NULL;
+    LPVOID pEnv = NULL;
+    BOOL bResult = FALSE;
+    if (!lpEnvironment)
         return FALSE;
-
-    BOOL bResult = CreateEnvironmentBlock(lpEnvironment, hUserToken, TRUE);
-    if (!bResult || !lpEnvironment)
+    if (!OpenProcessToken(GetCurrentProcess(),
+                          TOKEN_QUERY | TOKEN_DUPLICATE | TOKEN_ASSIGN_PRIMARY,
+                          &hUserToken))
+    {
+        return FALSE;
+    }
+    if (!CreateEnvironmentBlock(&pEnv, hUserToken, TRUE))
     {
         CloseHandle(hUserToken);
         return FALSE;
     }
-
+    *lpEnvironment = pEnv;
+    bResult = TRUE;
     if (bUpdateSelf)
     {
-        LPWSTR pszz = (LPWSTR)*lpEnvironment;
-        if (!pszz)
-            return FALSE;
-
-        while (*pszz)
+        LPWSTR pszz = (LPWSTR)pEnv;
+        while (pszz && *pszz)
         {
-            size_t cch = wcslen(pszz);
-            LPWSTR pchEqual = wcschr(pszz, L'=');
-            if (pchEqual)
+            if (pszz[0] != L'=')
             {
-                CStringW strName(pszz, pchEqual - pszz);
-                SetEnvironmentVariableW(strName, pchEqual + 1);
+                LPWSTR pchEqual = wcschr(pszz, L'=');
+                if (pchEqual)
+                {
+                    *pchEqual = L'\0';
+                    SetEnvironmentVariableW(pszz, pchEqual + 1);
+                    *pchEqual = L'='; /* restore */
+                }
             }
-            pszz += cch + 1;
+            pszz += wcslen(pszz) + 1;
+        }
+
+        LPWCH pCurEnv = GetEnvironmentStringsW();
+        if (pCurEnv)
+        {
+            LPWSTR pCur = (LPWSTR)pCurEnv;
+            while (pCur && *pCur)
+            {
+                /* skip special variables starting with = */
+                if (pCur[0] != L'=')
+                {
+                    LPWSTR pchEqual = wcschr(pCur, L'=');
+                    if (pchEqual)
+                    {
+                        *pchEqual = L'\0';
+
+                        /* check if this variable exists in the new block */
+                        BOOL bFound = FALSE;
+                        LPWSTR pNew = (LPWSTR)pEnv;
+                        while (pNew && *pNew)
+                        {
+                            if (pNew[0] != L'=')
+                            {
+                                LPWSTR pNewEqual = wcschr(pNew, L'=');
+                                if (pNewEqual)
+                                {
+                                    *pNewEqual = L'\0';
+                                    if (_wcsicmp(pCur, pNew) == 0)
+                                        bFound = TRUE;
+                                    *pNewEqual = L'='; /* restore */
+                                }
+                                if (bFound)
+                                    break;
+                            }
+                            pNew += wcslen(pNew) + 1;
+                        }
+
+                        if (!bFound)
+                            SetEnvironmentVariableW(pCur, NULL); /* delete */
+
+                        *pchEqual = L'='; /* restore */
+                    }
+                }
+                pCur += wcslen(pCur) + 1;
+            }
+            FreeEnvironmentStringsW(pCurEnv);
         }
     }
-
     CloseHandle(hUserToken);
-
     return bResult;
 }
 

--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -27,6 +27,7 @@ list(APPEND SOURCE
     PathProcessCommand.cpp
     PathResolve.cpp
     RealShellExecuteEx.cpp
+    RegenerateUserEnvironment.cpp
     SHAppBarMessage.cpp
     SHChangeNotify.cpp
     SHCreateDataObject.cpp
@@ -72,7 +73,7 @@ set_target_properties(shell32_apitest
 target_link_libraries(shell32_apitest wine uuid ${PSEH_LIB} cpprt atl_classes)
 set_module_type(shell32_apitest win32cui)
 target_compile_definitions(shell32_apitest PRIVATE UNICODE _UNICODE)
-add_importlibs(shell32_apitest user32 gdi32 shell32 shlwapi ole32 oleaut32 advapi32 shlwapi msvcrt kernel32 ntdll)
+add_importlibs(shell32_apitest user32 gdi32 shell32 shlwapi ole32 oleaut32 advapi32 shlwapi msvcrt kernel32 ntdll userenv)
 add_pch(shell32_apitest shelltest.h "${PCH_SKIP_SOURCE}")
 add_rostests_file(TARGET shell32_apitest)
 
@@ -80,6 +81,6 @@ add_rostests_file(TARGET shell32_apitest)
 add_executable(shell32_apitest_sub shell32_apitest_sub.cpp)
 target_link_libraries(shell32_apitest_sub cpprt atl_classes)
 set_module_type(shell32_apitest_sub win32gui UNICODE)
-add_importlibs(shell32_apitest_sub msvcrt kernel32 user32 shell32 shlwapi ole32)
+add_importlibs(shell32_apitest_sub msvcrt kernel32 user32 shell32 shlwapi ole32 userenv)
 add_rostests_file(TARGET shell32_apitest_sub SUBDIR testdata)
 add_dependencies(shell32_apitest shell32_apitest_sub)

--- a/modules/rostests/apitests/shell32/RegenerateUserEnvironment.cpp
+++ b/modules/rostests/apitests/shell32/RegenerateUserEnvironment.cpp
@@ -1,0 +1,154 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for RegenerateUserEnvironment
+ * PROGRAMMER:  Alex Mendoza
+ */
+
+#include "shelltest.h"
+#include <userenv.h>
+
+#define NDEBUG
+#include <debug.h>
+
+typedef BOOL (WINAPI *PFN_REGENERATE_USER_ENVIRONMENT)(PVOID *pPrevEnv, BOOL bSetCurrentEnv);
+static PFN_REGENERATE_USER_ENVIRONMENT pRegenerateUserEnvironment = NULL;
+
+static BOOL IsValidEnvBlock(PVOID pEnv)
+{
+    LPWCH p = (LPWCH)pEnv;
+
+    if (!p || *p == L'\0')
+        return FALSE;
+
+    /* Walk the block but bail out early if it looks corrupted */
+    while (*p != L'\0')
+    {
+        SIZE_T len = wcslen(p);
+        if (len == 0)
+            return FALSE;
+        p += len + 1;
+    }
+
+    return TRUE;
+}
+
+static void Test_BasicCall(void)
+{
+    PVOID pEnv = NULL;
+    BOOL ret;
+
+    ret = pRegenerateUserEnvironment(&pEnv, TRUE);
+    ok(ret != FALSE,
+       "RegenerateUserEnvironment(&pEnv, TRUE) failed with last error %lu\n",
+       GetLastError());
+
+    pEnv = NULL;
+    ret = pRegenerateUserEnvironment(&pEnv, FALSE);
+    ok(ret != FALSE,
+       "RegenerateUserEnvironment(&pEnv, FALSE) failed with last error %lu\n",
+       GetLastError());
+    if (pEnv)
+        DestroyEnvironmentBlock(pEnv);
+}
+
+static void Test_PreviousEnvironmentReturned(void)
+{
+    PVOID pPrev = NULL;
+    BOOL ret;
+
+    ret = pRegenerateUserEnvironment(&pPrev, FALSE);
+    ok(ret != FALSE,
+       "RegenerateUserEnvironment(&pPrev, FALSE) failed with last error %lu\n",
+       GetLastError());
+
+    if (!ret)
+    {
+        skip("RegenerateUserEnvironment failed; skipping pPrev checks.\n");
+        return;
+    }
+
+    ok(pPrev != NULL,
+       "pPrev must not be NULL when bSetCurrentEnv is FALSE\n");
+
+    if (!pPrev)
+        return;
+
+    ok(IsValidEnvBlock(pPrev),
+       "pPrev does not point to a valid environment block\n");
+
+    DestroyEnvironmentBlock(pPrev);
+}
+
+static void Test_RegistryVariablePickedUp(void)
+{
+    static const WCHAR szKey[]     = L"Environment";
+    static const WCHAR szVarName[] = L"__REGEN_TEST_VAR__";
+    static const WCHAR szVarValue[]= L"ReactOS_RegenerateTest";
+
+    HKEY hKey;
+    LONG lRet;
+    BOOL ret;
+    WCHAR szBuf[64];
+
+    lRet = RegOpenKeyExW(HKEY_CURRENT_USER, szKey, 0, KEY_SET_VALUE, &hKey);
+    if (lRet != ERROR_SUCCESS)
+    {
+        skip("Cannot open HKCU\\Environment (error %ld); skipping registry test.\n", lRet);
+        return;
+    }
+
+    /* Write canary value */
+    lRet = RegSetValueExW(hKey, szVarName, 0, REG_SZ,
+                          (const BYTE *)szVarValue,
+                          (DWORD)((wcslen(szVarValue) + 1) * sizeof(WCHAR)));
+    ok(lRet == ERROR_SUCCESS,
+       "RegSetValueExW failed: %ld\n", lRet);
+
+    if (lRet != ERROR_SUCCESS)
+    {
+        RegCloseKey(hKey);
+        return;
+    }
+
+    /* Regenerate and apply to current process */
+    PVOID pEnv = NULL;
+    ret = pRegenerateUserEnvironment(&pEnv, TRUE);
+    ok(ret != FALSE,
+       "RegenerateUserEnvironment failed: %lu\n", GetLastError());
+
+    /* The canary should be visible with GetEnvironmentVariableW */
+    szBuf[0] = L'\0';
+    GetEnvironmentVariableW(szVarName, szBuf, _countof(szBuf));
+    ok(wcscmp(szBuf, szVarValue) == 0,
+       "Expected env var '%ls' = '%ls', got '%ls'\n",
+       szVarName, szVarValue, szBuf);
+
+    /* Remove canary from registry */
+    RegDeleteValueW(hKey, szVarName);
+    RegCloseKey(hKey);
+
+    PVOID pEnv2 = NULL;
+    pRegenerateUserEnvironment(&pEnv2, TRUE);
+}
+
+START_TEST(RegenerateUserEnvironment)
+{
+    HMODULE hShell32 = GetModuleHandleW(L"shell32.dll");
+
+    if (!hShell32)
+        hShell32 = LoadLibraryW(L"shell32.dll");
+
+    pRegenerateUserEnvironment =
+        (PFN_REGENERATE_USER_ENVIRONMENT)GetProcAddress(hShell32, "RegenerateUserEnvironment");
+
+    if (!pRegenerateUserEnvironment)
+    {
+        skip("RegenerateUserEnvironment not found in shell32.dll\n");
+        return;
+    }
+
+    Test_BasicCall();
+    Test_PreviousEnvironmentReturned();
+    Test_RegistryVariablePickedUp();
+}

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -30,6 +30,7 @@ extern void func_PathProcessCommand(void);
 extern void func_PathResolve(void);
 extern void func_PIDL(void);
 extern void func_RealShellExecuteEx(void);
+extern void func_RegenerateUserEnvironment(void);
 extern void func_SHAppBarMessage(void);
 extern void func_SHChangeNotify(void);
 extern void func_SHCreateDataObject(void);
@@ -88,6 +89,7 @@ const struct test winetest_testlist[] =
     { "PathResolve", func_PathResolve },
     { "PIDL", func_PIDL },
     { "RealShellExecuteEx", func_RealShellExecuteEx },
+    { "RegenerateUserEnvironment", func_RegenerateUserEnvironment },
     { "SHAppBarMessage", func_SHAppBarMessage },
     { "SHChangeNotify", func_SHChangeNotify },
     { "SHCreateDataObject", func_SHCreateDataObject },


### PR DESCRIPTION
## Purpose

Fix incorrect behavior with the grouping parameter in GetCurrencyFormatW/GetNumberFormatW, making it behave correctly with different groupings

JIRA issue: [CORE-18264](https://jira.reactos.org/browse/CORE-18264)

## Proposed changes
- Change a GET_LOCALE_NUMBER parameter from LOCALE_SGROUPING  -> LOCALE_SMONGROUPING
- Replace the hardcoded 32 special case with a two-field decode

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: