### PR TITLE
[NTUSER] Return the correct value for SPI_GETLOWPOWERACTIVE

### DIFF
--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -1442,7 +1442,7 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             return SpiSetInt(&gspv.iPwrOffTimeout, uiParam, KEY_DESKTOP, L"PowerOffTimeOut", fl);
 
         case SPI_GETLOWPOWERACTIVE:
-            return SpiGetInt(pvParam, &gspv.iPwrOffTimeout, fl);
+            return SpiGetInt(pvParam, &gspv.bLowPwrActive, fl);
 
         case SPI_GETPOWEROFFACTIVE:
             return SpiGetInt(pvParam, &gspv.bPwrOffActive, fl);


### PR DESCRIPTION
wrong value used here 

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: