### PR TITLE
[WIN32SS:GDI] Fix an off-by-one in the StretchBlt mask bounds check

### DIFF
--- a/win32ss/gdi/dib/stretchblt.c
+++ b/win32ss/gdi/dib/stretchblt.c
@@ -174,7 +174,7 @@ BOOLEAN DIB_XXBPP_StretchBlt(SURFOBJ *DestSurf, SURFOBJ *SourceSurf, SURFOBJ *Ma
           sx = SourceRect->left+(DesX - DestRect->left) * SrcWidth / DstWidth;
         }
         if (sx < 0 || sy < 0 ||
-          MaskSurf->sizlBitmap.cx < sx || MaskCy < sy ||
+          MaskSurf->sizlBitmap.cx <= sx || MaskCy <= sy ||
           fnMask_GetPixel(MaskSurf, sx, sy) != 0)
         {
           CanDraw = FALSE;


### PR DESCRIPTION
The mask bounds check in DIB_XXBPP_StretchBlt allowed sx == cx, reading one pixel past the end of the mask bitmap, the source-surface check a few lines below already does it right.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108702,108706
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108703,108707
