### PR TITLE
[NTUSER] Report fresh scrollbar state in co_IntGetScrollBarInfo

### DIFF
--- a/win32ss/user/ntuser/scrollbar.c
+++ b/win32ss/user/ntuser/scrollbar.c
@@ -702,19 +702,19 @@ co_IntGetScrollBarInfo(PWND Window, LONG idObject, PSCROLLBARINFO psbi)
    IntCalculateThumb(Window, Bar, sbi, pSBData);
 
     // Scrollbar state
-    psbi->rgstate[0] = 0;
+    sbi->rgstate[0] = 0;
     if ((Bar == SB_HORZ && !(Window->style & WS_HSCROLL))
         || (Bar == SB_VERT && !(Window->style & WS_VSCROLL)))
-        psbi->rgstate[0] |= STATE_SYSTEM_INVISIBLE;
+        sbi->rgstate[0] |= STATE_SYSTEM_INVISIBLE;
     if (pSBData->posMin >= pSBData->posMax - max(pSBData->page - 1, 0))
     {
-        if (!(psbi->rgstate[0] & STATE_SYSTEM_INVISIBLE))
-            psbi->rgstate[0] |= STATE_SYSTEM_UNAVAILABLE;
+        if (!(sbi->rgstate[0] & STATE_SYSTEM_INVISIBLE))
+            sbi->rgstate[0] |= STATE_SYSTEM_UNAVAILABLE;
         else
-            psbi->rgstate[0] |= STATE_SYSTEM_OFFSCREEN;
+            sbi->rgstate[0] |= STATE_SYSTEM_OFFSCREEN;
     }
-    if (Bar == SB_CTL && !(Window->style & WS_DISABLED))
-        psbi->rgstate[0] |= STATE_SYSTEM_UNAVAILABLE;
+    if (Bar == SB_CTL && (Window->style & WS_DISABLED))
+        sbi->rgstate[0] |= STATE_SYSTEM_UNAVAILABLE;
 
    RtlCopyMemory(psbi, sbi, sizeof(SCROLLBARINFO));
 

--- a/win32ss/user/ntuser/scrollbar.c
+++ b/win32ss/user/ntuser/scrollbar.c
@@ -701,22 +701,22 @@ co_IntGetScrollBarInfo(PWND Window, LONG idObject, PSCROLLBARINFO psbi)
    IntGetScrollBarRect(Window, Bar, &(sbi->rcScrollBar));
    IntCalculateThumb(Window, Bar, sbi, pSBData);
 
+   RtlCopyMemory(psbi, sbi, sizeof(SCROLLBARINFO));
+
     // Scrollbar state
-    sbi->rgstate[0] = 0;
+    psbi->rgstate[0] = 0;
     if ((Bar == SB_HORZ && !(Window->style & WS_HSCROLL))
         || (Bar == SB_VERT && !(Window->style & WS_VSCROLL)))
-        sbi->rgstate[0] |= STATE_SYSTEM_INVISIBLE;
+        psbi->rgstate[0] |= STATE_SYSTEM_INVISIBLE;
     if (pSBData->posMin >= pSBData->posMax - max(pSBData->page - 1, 0))
     {
-        if (!(sbi->rgstate[0] & STATE_SYSTEM_INVISIBLE))
-            sbi->rgstate[0] |= STATE_SYSTEM_UNAVAILABLE;
+        if (!(psbi->rgstate[0] & STATE_SYSTEM_INVISIBLE))
+            psbi->rgstate[0] |= STATE_SYSTEM_UNAVAILABLE;
         else
-            sbi->rgstate[0] |= STATE_SYSTEM_OFFSCREEN;
+            psbi->rgstate[0] |= STATE_SYSTEM_OFFSCREEN;
     }
     if (Bar == SB_CTL && (Window->style & WS_DISABLED))
-        sbi->rgstate[0] |= STATE_SYSTEM_UNAVAILABLE;
-
-   RtlCopyMemory(psbi, sbi, sizeof(SCROLLBARINFO));
+        psbi->rgstate[0] |= STATE_SYSTEM_UNAVAILABLE;
 
    return TRUE;
 }

--- a/win32ss/user/ntuser/scrollbar.c
+++ b/win32ss/user/ntuser/scrollbar.c
@@ -701,7 +701,7 @@ co_IntGetScrollBarInfo(PWND Window, LONG idObject, PSCROLLBARINFO psbi)
    IntGetScrollBarRect(Window, Bar, &(sbi->rcScrollBar));
    IntCalculateThumb(Window, Bar, sbi, pSBData);
 
-   RtlCopyMemory(psbi, sbi, sizeof(SCROLLBARINFO));
+   RtlCopyMemory(psbi, sbi, sizeof(*psbi));
 
     // Scrollbar state
     psbi->rgstate[0] = 0;


### PR DESCRIPTION
this one is wild : co_IntGetScrollBarInfo computed the rgstate bits into the output buffer and then immediately overwrote them with the cached copy, 

so callers always got stale state; fixing that also exposed an inverted WS_DISABLED test (per wine, disabled SB_CTL should report UNAVAILABLE, not enabled ones)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: