### PR TITLE
[NTUSER] Pass CHILDID_SELF in the caret show event

### DIFF
--- a/win32ss/user/ntuser/caret.c
+++ b/win32ss/user/ntuser/caret.c
@@ -285,7 +285,7 @@ BOOL FASTCALL co_UserShowCaret(PWND Window OPTIONAL)
       pWnd = ValidateHwndNoErr(ThreadQueue->CaretInfo.hWnd);
       if (!ThreadQueue->CaretInfo.Showing && pWnd)
       {
-         IntNotifyWinEvent(EVENT_OBJECT_SHOW, pWnd, OBJID_CARET, OBJID_CARET, 0);
+         IntNotifyWinEvent(EVENT_OBJECT_SHOW, pWnd, OBJID_CARET, CHILDID_SELF, 0);
       }
       if ((INT)gpsi->dtCaretBlink > 0)
       {


### PR DESCRIPTION
the caret EVENT_OBJECT_SHOW notification passed OBJID_CARET as idChild while the other four caret events in the file correctly pass CHILDID_SELF

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: