### PR TITLE
[NTOS][KERNEL32][FREELDR] Expand amd64 physical memory support to 64GB

### DIFF
--- a/boot/freeldr/freeldr/include/mm.h
+++ b/boot/freeldr/freeldr/include/mm.h
@@ -70,7 +70,7 @@ typedef struct _FREELDR_MEMORY_DESCRIPTOR
 #define MM_PAGE_SHIFT    12
 //HACK: ReactOS AMD64 can't handle the full memory range yet CORE-20265
 //#define MM_MAX_PAGE        0xFFFFFFFFF /* 36 bits for the PFN */
-#define MM_MAX_PAGE        0x1FFFFF
+#define MM_MAX_PAGE        0xFFFFFF /* 64 GB */
 #define MM_MAX_PAGE_LOADER 0x3FFFF /* on x64 freeldr only maps 1 GB */
 
 #define MM_SIZE_TO_PAGES(a)  \

--- a/boot/freeldr/freeldr/ntldr/wlmemory.c
+++ b/boot/freeldr/freeldr/ntldr/wlmemory.c
@@ -63,8 +63,7 @@ MempAddMemoryBlock(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
     TRACE("MempAddMemoryBlock(BasePage=0x%lx, PageCount=0x%lx, Type=%ld)\n",
           BasePage, PageCount, Type);
 
-    /* Check for memory block after 4GB - we don't support it yet
-       Note: Even last page before 4GB limit is not supported */
+    /* Check for memory block beyond the supported range */
     if (BasePage >= MM_MAX_PAGE)
     {
         /* Just skip this, without even adding to MAD list */
@@ -312,13 +311,13 @@ WinLdrSetupMemoryLayout(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock)
     for (i = 0; i < BiosMemoryMapEntryCount; i++)
     {
         /* Check if its higher than the lookup table */
-        if (BiosMemoryMap->BasePage > MmGetHighestPhysicalPage())
+        if (BiosMemoryMap[i].BasePage > MmGetHighestPhysicalPage())
         {
             /* Copy this descriptor */
             MempAddMemoryBlock(LoaderBlock,
-                               BiosMemoryMap->BasePage,
-                               BiosMemoryMap->PageCount,
-                               BiosMemoryMap->MemoryType);
+                               BiosMemoryMap[i].BasePage,
+                               BiosMemoryMap[i].PageCount,
+                               BiosMemoryMap[i].MemoryType);
         }
     }
 

--- a/dll/win32/kernel32/client/heapmem.c
+++ b/dll/win32/kernel32/client/heapmem.c
@@ -1300,12 +1300,12 @@ GlobalMemoryStatusEx(LPMEMORYSTATUSEX lpBuffer)
                                       BaseStaticServerData->SysInfo.NumberOfPhysicalPages;
 
     /* Save physical memory */
-    PhysicalMemory = BaseStaticServerData->SysInfo.NumberOfPhysicalPages *
+    PhysicalMemory = (ULONGLONG)BaseStaticServerData->SysInfo.NumberOfPhysicalPages *
                      BaseStaticServerData->SysInfo.PageSize;
     lpBuffer->ullTotalPhys = PhysicalMemory;
 
     /* Now save available physical memory */
-    PhysicalMemory = PerformanceInfo.AvailablePages *
+    PhysicalMemory = (ULONGLONG)PerformanceInfo.AvailablePages *
                      BaseStaticServerData->SysInfo.PageSize;
     lpBuffer->ullAvailPhys = PhysicalMemory;
 

--- a/ntoskrnl/ex/init.c
+++ b/ntoskrnl/ex/init.c
@@ -1632,7 +1632,7 @@ Phase1InitializationDiscard(IN PVOID Context)
 
     /* Get total RAM size, in MiB */
     /* Round size up. Assumed to better match actual physical RAM size */
-    Size = ALIGN_UP_BY(MmNumberOfPhysicalPages * PAGE_SIZE, 1024 * 1024) / (1024 * 1024);
+    Size = ALIGN_UP_BY((SIZE_T)MmNumberOfPhysicalPages * PAGE_SIZE, 1024 * 1024) / (1024 * 1024);
 
     /* Create the string */
     StringBuffer = InitBuffer->VersionBuffer;

--- a/ntoskrnl/mm/amd64/init.c
+++ b/ntoskrnl/mm/amd64/init.c
@@ -308,8 +308,8 @@ MiBuildNonPagedPool(VOID)
     {
         /* Start with the minimum (256 KB) and add 32 KB for each MB above 4 */
         MmSizeOfNonPagedPoolInBytes = MmMinimumNonPagedPoolSize;
-        MmSizeOfNonPagedPoolInBytes += (MmNumberOfPhysicalPages - 1024) /
-                                       256 * MmMinAdditionNonPagedPoolPerMb;
+        MmSizeOfNonPagedPoolInBytes += (SIZE_T)((MmNumberOfPhysicalPages - 1024) /
+                                       256) * MmMinAdditionNonPagedPoolPerMb;
     }
 
     /* Check if the registy setting or our dynamic calculation was too high */
@@ -334,8 +334,8 @@ MiBuildNonPagedPool(VOID)
     {
         /* Start with the default (1MB) and add 400 KB for each MB above 4 */
         MmMaximumNonPagedPoolInBytes = MmDefaultMaximumNonPagedPool;
-        MmMaximumNonPagedPoolInBytes += (MmNumberOfPhysicalPages - 1024) /
-                                         256 * MmMaxAdditionNonPagedPoolPerMb;
+        MmMaximumNonPagedPoolInBytes += (SIZE_T)((MmNumberOfPhysicalPages - 1024) /
+                                         256) * MmMaxAdditionNonPagedPoolPerMb;
     }
 
     /* Don't let the maximum go too high */

--- a/ntoskrnl/mm/amd64/init.c
+++ b/ntoskrnl/mm/amd64/init.c
@@ -349,7 +349,7 @@ MiBuildNonPagedPool(VOID)
     MmMaximumNonPagedPoolInPages = MmMaximumNonPagedPoolInBytes >> PAGE_SHIFT;
 
     /* Non paged pool starts after the PFN database */
-    MmNonPagedPoolStart = MmPfnDatabase + MxPfnAllocation * PAGE_SIZE;
+    MmNonPagedPoolStart = (PUCHAR)MmPfnDatabase + MxPfnAllocation * PAGE_SIZE;
 
     /* Calculate the nonpaged pool expansion start region */
     MmNonPagedPoolExpansionStart = (PCHAR)MmNonPagedPoolStart +


### PR DESCRIPTION
## Purpose

with this PR reactos amd64 can use up to 64GB ram (0x1FFFFF -> 0xFFFFFF pages).

note MM_MAX_PAGE doesn't size anything in freeldr itself, the page lookup table is already sized from the real firmware memory map. the constant only clips what freeldr reports to the kernel, so it's just the guard rail for the Mm side (CORE-20265).

yes 64GB is not optimal, full 36-bit range would be a one-liner too, but it's a less disturbing change while the kernel high memory work is still in progress (#9086).
that's why i kept it 0xFFFFFF, once Mm handles the full range raising it further is trivial

also fixes the BiosMemoryMap loop in WinLdrSetupMemoryLayout that never advanced its index, and a PMMPFN pointer arithmetic scaling bug in the nonpaged pool start calculation.


[CORE-20265](https://jira.reactos.org/browse/CORE-20265)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: