### PR TITLE
[NTOS:IO] Check pool allocation success in IopDeviceFsIoControl

### DIFF
--- a/ntoskrnl/io/iomgr/iofunc.c
+++ b/ntoskrnl/io/iomgr/iofunc.c
@@ -530,6 +530,10 @@ IopDeviceFsIoControl(IN HANDLE DeviceHandle,
                         ExAllocatePoolWithQuotaTag(PoolType,
                                                    BufferLength,
                                                    TAG_IOBUF);
+                    if (Irp->AssociatedIrp.SystemBuffer == NULL)
+                    {
+                        RtlRaiseStatus(STATUS_INSUFFICIENT_RESOURCES);
+                    }
 
                     /* Check if we got a buffer */
                     if (InputBuffer)
@@ -577,6 +581,10 @@ IopDeviceFsIoControl(IN HANDLE DeviceHandle,
                         ExAllocatePoolWithQuotaTag(PoolType,
                                                    InputBufferLength,
                                                    TAG_IOBUF);
+                    if (Irp->AssociatedIrp.SystemBuffer == NULL)
+                    {
+                        RtlRaiseStatus(STATUS_INSUFFICIENT_RESOURCES);
+                    }
 
                     /* Copy into the System Buffer */
                     RtlCopyMemory(Irp->AssociatedIrp.SystemBuffer,


### PR DESCRIPTION
## Purpose

Check for NULL and raise STATUS_INSUFFICIENT_RESOURCES inside SEH.

Previously, if the allocation failed, the following RtlCopyMemory would trigger an access violation and cause the function to fail with STATUS_ACCESS_VIOLATION, which doesn't make sense. Also if the method was buffered and there was no input buffer, the IRP would be passed to the driver with a NULL buffer, potentially causing a crash later.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
