### PR TITLE
[ZIPFLDR] Don't lock Zip Folder permanently

### DIFF
--- a/dll/shellext/zipfldr/CEnumZipContents.cpp
+++ b/dll/shellext/zipfldr/CEnumZipContents.cpp
@@ -101,9 +101,7 @@ public:
     END_COM_MAP()
 };
 
-
 HRESULT _CEnumZipContents_CreateInstance(IZip* zip, DWORD flags, PCWSTR prefix, REFIID riid, LPVOID * ppvOut)
 {
     return ShellObjectCreatorInit<CEnumZipContents>(zip, flags, prefix, riid, ppvOut);
 }
-

--- a/dll/shellext/zipfldr/CZipEnumerator.cpp
+++ b/dll/shellext/zipfldr/CZipEnumerator.cpp
@@ -15,6 +15,11 @@ CZipEnumerator::CZipEnumerator()
 {
 }
 
+CZipEnumerator::~CZipEnumerator()
+{
+    Close();
+}
+
 BOOL CZipEnumerator::Initialize(IZip* zip)
 {
     ATLASSERT(zip);
@@ -22,12 +27,26 @@ BOOL CZipEnumerator::Initialize(IZip* zip)
     return Reset();
 }
 
+void CZipEnumerator::Close()
+{
+    if (m_uf)
+    {
+        unzClose(m_uf);
+        m_uf = NULL;
+    }
+}
+
 BOOL CZipEnumerator::Reset()
 {
-    unzFile uf = m_Zip->getZip();
-    m_First = TRUE;
-    if (unzGoToFirstFile(uf) != UNZ_OK)
+    Close();
+    m_uf = unzOpen2_64(m_Zip->getZipFileName(), &g_FFunc);
+    if (!m_uf)
         return FALSE;
+
+    m_First = TRUE;
+    if (unzGoToFirstFile(m_uf) != UNZ_OK)
+        return FALSE;
+
     m_Returned.RemoveAll();
     return TRUE;
 }
@@ -94,17 +113,20 @@ CZipEnumerator::GetUtf8Name(
 BOOL CZipEnumerator::Next(CStringW& name, unz_file_info64& info)
 {
     INT err;
-    unzFile uf = m_Zip->getZip();
 
     if (!m_First)
     {
-        err = unzGoToNextFile(uf);
+        err = unzGoToNextFile(m_uf);
         if (err == UNZ_END_OF_LIST_OF_FILE)
+        {
+            unzClose(m_uf);
+            m_uf = NULL;
             return FALSE;
+        }
     }
     m_First = FALSE;
 
-    err = unzGetCurrentFileInfo64(uf, &info, NULL, 0, NULL, 0, NULL, 0);
+    err = unzGetCurrentFileInfo64(m_uf, &info, NULL, 0, NULL, 0, NULL, 0);
     if (err != UNZ_OK)
         return FALSE;
 
@@ -113,7 +135,7 @@ BOOL CZipEnumerator::Next(CStringW& name, unz_file_info64& info)
 
     CStringA nameA;
     PSTR buf = nameA.GetBuffer(info.size_filename);
-    err = unzGetCurrentFileInfo64(uf, NULL, buf, nameA.GetAllocLength(),
+    err = unzGetCurrentFileInfo64(m_uf, NULL, buf, nameA.GetAllocLength(),
         (info.size_file_extra > 0) ? extra.GetData() : NULL, info.size_file_extra,
         NULL, 0);
     nameA.ReleaseBuffer(info.size_filename);

--- a/dll/shellext/zipfldr/CZipEnumerator.hpp
+++ b/dll/shellext/zipfldr/CZipEnumerator.hpp
@@ -11,6 +11,7 @@
 struct CZipEnumerator
 {
     CComPtr<IZip> m_Zip;
+    unzFile m_uf = NULL;
     BOOL m_First = TRUE;
     CAtlList<CStringW> m_Returned; // for unique checking
     UINT m_nCodePage = GetZipCodePage(TRUE);
@@ -18,8 +19,11 @@ struct CZipEnumerator
     static DWORD CalculateCRC32(PCSTR filename);
     static CStringA GetUtf8Name(PCSTR originalName, const BYTE* extraField, DWORD extraFieldLen);
 
+    void Close();
+
 public:
     CZipEnumerator();
+    ~CZipEnumerator();
 
     BOOL Initialize(IZip* zip);
     BOOL Reset();

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -46,7 +46,7 @@ public:
     }
 
     // *** IZip methods ***
-    STDMETHODIMP QueryInterface(REFIID riid, void  **ppvObject)
+    STDMETHODIMP QueryInterface(REFIID riid, void **ppvObject) override
     {
         if (riid == IID_IUnknown)
         {
@@ -56,17 +56,17 @@ public:
         }
         return E_NOINTERFACE;
     }
-    STDMETHODIMP_(ULONG) AddRef(void)
+    STDMETHODIMP_(ULONG) AddRef() override
     {
         return 2;
     }
-    STDMETHODIMP_(ULONG) Release(void)
+    STDMETHODIMP_(ULONG) Release() override
     {
         return 1;
     }
-    STDMETHODIMP_(unzFile) getZip()
+    STDMETHODIMP_(PCWSTR) getZipFileName() override
     {
-        return uf;
+        return m_Filename;
     }
 
     class CExtractSettingsPage : public CPropertyPageImpl<CExtractSettingsPage>
@@ -714,10 +714,8 @@ public:
     }
 };
 
-
 void _CZipExtract_runWizard(PCWSTR Filename)
 {
     CZipExtract extractor(Filename);
     extractor.runWizard();
 }
-

--- a/dll/shellext/zipfldr/CZipFolder.cpp
+++ b/dll/shellext/zipfldr/CZipFolder.cpp
@@ -25,21 +25,11 @@ CZipFolder::CZipFolder()
 
 CZipFolder::~CZipFolder()
 {
-    Close();
 }
 
-void CZipFolder::Close()
+STDMETHODIMP_(PCWSTR) CZipFolder::getZipFileName()
 {
-    if (m_UnzipFile)
-        unzClose(m_UnzipFile);
-    m_UnzipFile = NULL;
-}
-
-STDMETHODIMP_(unzFile) CZipFolder::getZip()
-{
-    if (!m_UnzipFile)
-        m_UnzipFile = unzOpen2_64(m_ZipFile, &g_FFunc);
-    return m_UnzipFile;
+    return m_ZipFile;
 }
 
 HRESULT CZipFolder::Initialize(PCWSTR zipFile, PCWSTR zipDir, PCUIDLIST_ABSOLUTE curDir, PCUIDLIST_RELATIVE pidl)
@@ -110,7 +100,6 @@ HRESULT CZipFolder::DoDeleteItems(CComPtr<IDataObject> pDataObj)
 
 HRESULT CZipFolder::DeleteItems(CComPtr<IDataObject> pDataObj)
 {
-
     CDataObjectHIDA cida(pDataObj);
     if (!cida || cida->cidl <= 0)
         return E_FAIL;
@@ -135,9 +124,6 @@ HRESULT CZipFolder::DeleteItems(CComPtr<IDataObject> pDataObj)
     WCHAR szTempPath[MAX_PATH], szTempFile[MAX_PATH];
     GetTempPathW(MAX_PATH, szTempPath);
     GetTempFileNameW(szTempPath, L"ZIP", 0, szTempFile);
-
-    // Close the current handle to work with the ZIP file
-    Close();
 
     zlib_filefunc64_def ffunc = {};
     fill_win32_filefunc64W(&ffunc);
@@ -835,10 +821,6 @@ STDMETHODIMP CZipFolder::Drop(IDataObject* pDataObj, DWORD grfKeyState, POINTL p
     HDROP hDrop = (HDROP)GlobalLock(sm.hGlobal);
     if (hDrop)
     {
-        // Close the ZIP file before appending (it will be automatically
-        // reopened next time getZip() is called)
-        Close();
-
         // Create creator
         CZipCreator* pCreator = CZipCreator::DoCreate(m_ZipFile, m_ZipDir);
 

--- a/dll/shellext/zipfldr/CZipFolder.hpp
+++ b/dll/shellext/zipfldr/CZipFolder.hpp
@@ -62,7 +62,7 @@ public:
     void Close();
 
     // *** IZip methods ***
-    STDMETHODIMP_(unzFile) getZip();
+    STDMETHODIMP_(PCWSTR) getZipFileName() override;
 
     // *** IShellFolder2 methods ***
     STDMETHODIMP GetDefaultSearchGUID(GUID *pguid) override

--- a/dll/shellext/zipfldr/IZip.hpp
+++ b/dll/shellext/zipfldr/IZip.hpp
@@ -3,10 +3,10 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     IZip
  * COPYRIGHT:   Copyright 2017 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2026 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 struct IZip : public IUnknown
 {
-    virtual STDMETHODIMP_(unzFile) getZip() PURE;
+    STDMETHOD_(PCWSTR, getZipFileName)() PURE;
 };
-


### PR DESCRIPTION
## Purpose
While opening a Zip Folder, the user was unable to delete the ZIP file, due to the file share mode. Windows user can delete it.
JIRA issue: [CORE-20543](https://jira.reactos.org/browse/CORE-20543)

## Proposed changes

- Modify `IZip` interface in `IZip.hpp`.
- Don't keep opening the ZIP file.
- Add `CZipEnumerator::m_uf` to keep the UNZIP handle.
- Add `CZipEnumerator` destructor.

## Screenshots

BEFORE:
<img width="640" height="480" alt="before" src="https://github.com/user-attachments/assets/46ebbc43-a51f-4aab-ac4d-4426384d280e" />
Unable to delete the ZIP file.

AFTER:
<img width="640" height="480" alt="after" src="https://github.com/user-attachments/assets/d4d6e20d-a73f-482b-a49c-f30f32f090f9" />
Able to delete the ZIP file.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108147,108268
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108148,108269