### PR TITLE
[ACLAYERS] Add shim for GlobalMemoryStatus

### DIFF
--- a/dll/appcompat/shims/layer/CMakeLists.txt
+++ b/dll/appcompat/shims/layer/CMakeLists.txt
@@ -6,6 +6,7 @@ spec2def(aclayers.dll layer.spec)
 list(APPEND SOURCE
     dispmode.c
     forcedxsetupsuccess.c
+    globalmemorystatus.c
     ignoreloadlibrary.c
     versionlie.c
     vmhorizon.c

--- a/dll/appcompat/shims/layer/dispmode.c
+++ b/dll/appcompat/shims/layer/dispmode.c
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     ReactOS 'Layers' Shim library
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Display settings related shims
- * COPYRIGHT:   Copyright 2016,2017 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2016,2017 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #define WIN32_NO_STATUS

--- a/dll/appcompat/shims/layer/forcedxsetupsuccess.c
+++ b/dll/appcompat/shims/layer/forcedxsetupsuccess.c
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     ReactOS 'Layers' Shim library
- * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     ForceDxSetupSuccess shim
- * COPYRIGHT:   Copyright 2019 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2019 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #define WIN32_NO_STATUS

--- a/dll/appcompat/shims/layer/globalmemorystatus.c
+++ b/dll/appcompat/shims/layer/globalmemorystatus.c
@@ -1,0 +1,39 @@
+/*
+ * PROJECT:     ReactOS 'Layers' Shim library
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     GlobalMemoryStatus2GB shim
+ * COPYRIGHT:   Copyright 2026 Mark Jansen <mark.jansen@reactos.org>
+ */
+
+#define WIN32_NO_STATUS
+#include <windef.h>
+#include <winbase.h>
+#include <shimlib.h>
+
+typedef VOID(NTAPI *GLOBALMEMORYSTATUSPROC)(LPMEMORYSTATUS lpBuffer);
+
+#define SHIM_NS GlobalMemoryStatus2GB
+#include <setup_shim.inl>
+
+VOID NTAPI
+SHIM_OBJ_NAME(APIHook_GlobalMemoryStatus)(LPMEMORYSTATUS lpBuffer)
+{
+    CALL_SHIM(0, GLOBALMEMORYSTATUSPROC)(lpBuffer);
+
+    if (lpBuffer->dwTotalPhys > 0x3FFFFFFF)
+        lpBuffer->dwTotalPhys = 0x3FFFFFFF;
+
+    if (lpBuffer->dwAvailPhys > 0x3FFFFFFF)
+        lpBuffer->dwAvailPhys = 0x3FFFFFFF;
+
+    if (lpBuffer->dwTotalPageFile > 0x7FFFFFFF)
+        lpBuffer->dwTotalPageFile = 0x7FFFFFFF;
+
+    if (lpBuffer->dwAvailPageFile > 0x3FFFFFFF)
+        lpBuffer->dwAvailPageFile = 0x3FFFFFFF;
+}
+
+#define SHIM_NUM_HOOKS 1
+#define SHIM_SETUP_HOOKS SHIM_HOOK(0, "KERNEL32.DLL", "GlobalMemoryStatus", SHIM_OBJ_NAME(APIHook_GlobalMemoryStatus))
+
+#include <implement_shim.inl>

--- a/dll/appcompat/shims/layer/ignoreloadlibrary.c
+++ b/dll/appcompat/shims/layer/ignoreloadlibrary.c
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     ReactOS 'Layers' Shim library
- * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     IgnoreLoadLibrary shim
- * COPYRIGHT:   Copyright 2019 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2019 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #define WIN32_NO_STATUS

--- a/dll/appcompat/shims/layer/main.c
+++ b/dll/appcompat/shims/layer/main.c
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     ReactOS 'Layers' Shim library
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Shim entrypoint
- * COPYRIGHT:   Copyright 2016,2017 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2016,2017 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #define WIN32_NO_STATUS

--- a/dll/appcompat/shims/layer/versionlie.c
+++ b/dll/appcompat/shims/layer/versionlie.c
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     ReactOS 'Layers' Shim library
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Version lie shims
- * COPYRIGHT:   Copyright 2016,2017 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2016,2017 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #define WIN32_NO_STATUS

--- a/dll/appcompat/shims/layer/versionlie.inl
+++ b/dll/appcompat/shims/layer/versionlie.inl
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     ReactOS 'Layers' Shim library
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Version lie implementation helper
- * COPYRIGHT:   Copyright 2016,2017 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2016,2017 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #include <setup_shim.inl>

--- a/dll/appcompat/shims/layer/vmhorizon.c
+++ b/dll/appcompat/shims/layer/vmhorizon.c
@@ -1,9 +1,9 @@
 /*
  * PROJECT:     ReactOS 'Layers' Shim library
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Shim for VMWare Horizon setup
- * COPYRIGHT:   Copyright 2017 Thomas Faber (thomas.faber@reactos.org)
- *              Copyright 2017 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2017 Thomas Faber <thomas.faber@reactos.org>
+ *              Copyright 2017 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #define WIN32_NO_STATUS

--- a/media/sdb/sysmain.xml
+++ b/media/sdb/sysmain.xml
@@ -238,6 +238,9 @@
 
             <!-- misc shims -->
 
+            <SHIM NAME="GlobalMemoryStatus2GB">
+                <DLLFILE>aclayers.dll</DLLFILE>
+            </SHIM>
             <SHIM NAME="DisableThemes">
                 <DLLFILE>acgenral.dll</DLLFILE>
             </SHIM>
@@ -325,99 +328,119 @@
         </LAYER>
         <LAYER NAME="WINXP">
             <SHIM_REF NAME="WinXPVersionLie" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINXPSP1">
             <SHIM_REF NAME="WinXPSP1VersionLie" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINXPSP2">
             <SHIM_REF NAME="WinXPSP2VersionLie" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINXPSP3">
             <SHIM_REF NAME="WinXPSP3VersionLie" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINSRV03RTM">
             <SHIM_REF NAME="Win2k3RTMVersionLie" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINSRV03SP1">
             <SHIM_REF NAME="Win2k3SP1VersionLie" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINSRV03SP2">
             <SHIM_REF NAME="Win2k3SP2VersionLie" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="VISTARTM">
             <SHIM_REF NAME="VistaRTMVersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="600" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="VISTASP1">
             <SHIM_REF NAME="VistaSP1VersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="600" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="VISTASP2">
             <SHIM_REF NAME="VistaSP2VersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="600" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINSRV08">
             <SHIM_REF NAME="VistaRTMVersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="600" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINSRV08SP1">
             <SHIM_REF NAME="VistaSP1VersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="600" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINSRV08SP2">
             <SHIM_REF NAME="VistaSP2VersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="600" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WIN7RTM">
             <SHIM_REF NAME="Win7RTMVersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="601" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WIN7SP1">
             <!-- ReactOS specific. Windows does not have this version lie -->
             <SHIM_REF NAME="Win7SP1VersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="601" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WIN8RTM">
             <SHIM_REF NAME="Win8RTMVersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="602" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WIN81RTM">
             <SHIM_REF NAME="Win81RTMVersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="603" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WIN10RTM">
             <!-- ReactOS specific. Windows does not have this version lie -->
             <SHIM_REF NAME="Win10RTMVersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="1000" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINSRV16RTM">
             <!-- ReactOS specific. Windows does not have this version lie -->
             <SHIM_REF NAME="Win2k16RTMVersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="1000" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINSRV19RTM">
             <!-- ReactOS specific. Windows does not have this version lie -->
             <SHIM_REF NAME="Win2k19RTMVersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="1000" />
+            <SHIM_REF NAME="GlobalMemoryStatus2GB" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
 

--- a/modules/rostests/apitests/appshim/CMakeLists.txt
+++ b/modules/rostests/apitests/appshim/CMakeLists.txt
@@ -4,6 +4,7 @@ list(APPEND SOURCE
     dispmode.c
     forcedxsetup.c
     genral_hooks.c
+    globmemstatus.c
     ignorefreelib.c
     ignoreloadlib.c
     layer_hooks.c

--- a/modules/rostests/apitests/appshim/dispmode.c
+++ b/modules/rostests/apitests/appshim/dispmode.c
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     appshim_apitest
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Tests for display mode shims
- * COPYRIGHT:   Copyright 2016-2018 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2016-2018 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #include <ntstatus.h>

--- a/modules/rostests/apitests/appshim/forcedxsetup.c
+++ b/modules/rostests/apitests/appshim/forcedxsetup.c
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     appshim_apitest
- * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Tests for ForceDxSetupSuccess shim
- * COPYRIGHT:   Copyright 2019 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2019 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #include <ntstatus.h>

--- a/modules/rostests/apitests/appshim/genral_hooks.c
+++ b/modules/rostests/apitests/appshim/genral_hooks.c
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     appshim_apitest
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Test to document the hooks used by various shims in AcGenral
- * COPYRIGHT:   Copyright 2017-2018 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2017-2018 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #include <ntstatus.h>

--- a/modules/rostests/apitests/appshim/globmemstatus.c
+++ b/modules/rostests/apitests/appshim/globmemstatus.c
@@ -1,0 +1,93 @@
+/*
+ * PROJECT:     appshim_apitest
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for GlobalMemoryStatus2GB shim
+ * COPYRIGHT:   Copyright 2026 Mark Jansen <mark.jansen@reactos.org>
+ */
+
+#include <ntstatus.h>
+#define WIN32_NO_STATUS
+#include <windows.h>
+#include "wine/test.h"
+
+#include "appshim_apitest.h"
+
+static HMODULE g_hShimDll;
+static tGETHOOKAPIS pGetHookAPIs;
+
+typedef VOID(NTAPI *GLOBALMEMORYSTATUSPROC)(LPMEMORYSTATUS lpBuffer);
+
+
+VOID NTAPI
+my_GlobalMemoryStatus_Low(LPMEMORYSTATUS lpBuffer)
+{
+    memset(lpBuffer, 0, sizeof(MEMORYSTATUS));
+}
+
+VOID NTAPI
+my_GlobalMemoryStatus_High(LPMEMORYSTATUS lpBuffer)
+{
+    memset(lpBuffer, 0xff, sizeof(MEMORYSTATUS));
+}
+
+static void
+test_GlobalMemoryStatus(PHOOKAPI hook)
+{
+    GLOBALMEMORYSTATUSPROC proc;
+
+    ok_str(hook->LibraryName, "KERNEL32.DLL");
+    hook->OriginalFunction = my_GlobalMemoryStatus_Low;
+    proc = hook->ReplacementFunction;
+
+
+    MEMORYSTATUS ms;
+    memset(&ms, 0x33, sizeof(ms));
+    proc(&ms);
+
+    ok_hex(ms.dwLength, 0);
+    ok_hex(ms.dwMemoryLoad, 0);
+    ok_hex(ms.dwTotalPhys, 0);
+    ok_hex(ms.dwAvailPhys, 0);
+    ok_hex(ms.dwTotalPageFile, 0);
+    ok_hex(ms.dwAvailPageFile, 0);
+    ok_hex(ms.dwTotalVirtual, 0);
+    ok_hex(ms.dwAvailVirtual, 0);
+
+
+    hook->OriginalFunction = my_GlobalMemoryStatus_High;
+
+    memset(&ms, 0x33, sizeof(ms));
+    proc(&ms);
+    ok_hex(ms.dwLength, 0xffffffff);     // not touched
+    ok_hex(ms.dwMemoryLoad, 0xffffffff); // not touched
+    ok_hex(ms.dwTotalPhys, 0x3fffffff);
+    ok_hex(ms.dwAvailPhys, 0x3fffffff);
+    ok_hex(ms.dwTotalPageFile, 0x7fffffff);
+    ok_hex(ms.dwAvailPageFile, 0x3fffffff);
+    ok_hex(ms.dwTotalVirtual, 0xffffffff); // not touched
+    ok_hex(ms.dwAvailVirtual, 0xffffffff); // not touched
+}
+
+
+START_TEST(globalmemorystatus)
+{
+    DWORD num_shims = 0, n;
+    PHOOKAPI hook;
+
+    if (!LoadShimDLL(L"aclayers.dll", &g_hShimDll, &pGetHookAPIs))
+        return;
+
+    hook = pGetHookAPIs("", L"GlobalMemoryStatus2GB", &num_shims);
+
+    ok(hook != NULL, "Expected hook to be a valid pointer\n");
+    ok(num_shims == 1, "Expected num_shims to be 1, was: %u\n", num_shims);
+
+    if (!hook || !num_shims)
+        return;
+
+    for (n = 0; n < num_shims; ++n)
+    {
+        if (!_stricmp(hook[n].FunctionName, "GlobalMemoryStatus"))
+            test_GlobalMemoryStatus(hook + n);
+    }
+}

--- a/modules/rostests/apitests/appshim/ignorefreelib.c
+++ b/modules/rostests/apitests/appshim/ignorefreelib.c
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     appshim_apitest
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Tests for IgnoreFreeLibrary shim
- * COPYRIGHT:   Copyright 2018 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2018 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #include <ntstatus.h>

--- a/modules/rostests/apitests/appshim/ignoreloadlib.c
+++ b/modules/rostests/apitests/appshim/ignoreloadlib.c
@@ -1,9 +1,9 @@
 /*
-* PROJECT:     appshim_apitest
-* LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
-* PURPOSE:     Tests for IgnoreLoadLibrary shim
-* COPYRIGHT:   Copyright 2019 Mark Jansen (mark.jansen@reactos.org)
-*/
+ * PROJECT:     appshim_apitest
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for IgnoreLoadLibrary shim
+ * COPYRIGHT:   Copyright 2019 Mark Jansen <mark.jansen@reactos.org>
+ */
 
 #include <ntstatus.h>
 #define WIN32_NO_STATUS

--- a/modules/rostests/apitests/appshim/layer_hooks.c
+++ b/modules/rostests/apitests/appshim/layer_hooks.c
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     appshim_apitest
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Test to document the hooks used by various shims in AcLayers
- * COPYRIGHT:   Copyright 2018 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2018 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #include <ntstatus.h>

--- a/modules/rostests/apitests/appshim/testlist.c
+++ b/modules/rostests/apitests/appshim/testlist.c
@@ -6,6 +6,7 @@
 extern void func_dispmode(void);
 extern void func_forcedxsetup(void);
 extern void func_genral_hooks(void);
+extern void func_globalmemorystatus(void);
 extern void func_ignorefreelib(void);
 extern void func_ignoreloadlib(void);
 extern void func_layer_hooks(void);
@@ -16,6 +17,7 @@ const struct test winetest_testlist[] =
     { "dispmode", func_dispmode },
     { "forcedxsetup", func_forcedxsetup },
     { "genral_hooks", func_genral_hooks },
+    { "globalmemorystatus", func_globalmemorystatus },
     { "ignorefreelib", func_ignorefreelib },
     { "ignoreloadlib", func_ignoreloadlib },
     { "layer_hooks", func_layer_hooks },

--- a/modules/rostests/apitests/appshim/versionlie.c
+++ b/modules/rostests/apitests/appshim/versionlie.c
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     appshim_apitest
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Tests for versionlie shims
- * COPYRIGHT:   Copyright 2015-2018 Mark Jansen (mark.jansen@reactos.org)
+ * COPYRIGHT:   Copyright 2015-2018 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #include <ntstatus.h>


### PR DESCRIPTION
This is needed by games like Half-life that won't start without it:

<img width="241" height="128" alt="image" src="https://github.com/user-attachments/assets/8deb0f5c-5d18-4136-97f3-4f47f8fde2ac" />


## Purpose

Capture calls to `GlobalMemoryStatus`, and report numbers less than MAX_INT

## Details

For now the shim is only added on xp+ profiles,
we could add a shim for hl.exe and hldemo.exe
