### PR TITLE
[SHLWAPI][SHLWAPI_APITEST][SDK] Support MapWin32ErrorToSTG

### DIFF
--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -482,7 +482,7 @@
 482 stub -noname SHMessageBoxHelpA
 483 stub -noname SHMessageBoxHelpW
 484 stdcall -noname IUnknown_QueryServiceExec(ptr ptr ptr long long long ptr)
-485 stub -noname MapWin32ErrorToSTG
+485 stdcall -noname MapWin32ErrorToSTG(long)
 486 stub -noname ModeToCreateFileFlags
 487 stdcall -ordinal SHLoadIndirectString(wstr ptr long ptr)
 488 stub -noname SHConvertGraphicsFile

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -219,6 +219,28 @@ PathUnExpandEnvStringsForUserW(
     return FALSE;
 }
 
+/*************************************************************************
+ *      MapWin32ErrorToSTG [SHLWAPI.485]
+ *
+ * https://undoc.airesoft.co.uk/shlwapi.dll/MapWin32ErrorToSTG.php
+ */
+HRESULT WINAPI MapWin32ErrorToSTG(_In_ HRESULT hr)
+{
+    switch (hr)
+    {
+        case HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED):
+            return STG_E_ACCESSDENIED;
+        case HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND):
+        case HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND):
+            return STG_E_FILENOTFOUND;
+        case HRESULT_FROM_WIN32(ERROR_FILE_EXISTS):
+        case HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS):
+            return STG_E_FILEALREADYEXISTS;
+        default:
+            return hr;
+    }
+}
+
 static BOOL CharLowerNoDBCSAWorker(PSTR lpString, INT cchMax, BOOL bUppercase)
 {
     CHAR szBuff[MAX_PATH];

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -224,7 +224,8 @@ PathUnExpandEnvStringsForUserW(
  *
  * https://undoc.airesoft.co.uk/shlwapi.dll/MapWin32ErrorToSTG.php
  */
-HRESULT WINAPI MapWin32ErrorToSTG(_In_ HRESULT hr)
+EXTERN_C HRESULT WINAPI
+MapWin32ErrorToSTG(_In_ HRESULT hr)
 {
     switch (hr)
     {

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND SOURCE
     IShellFolderHelpers.cpp
     IsQSForward.cpp
     IStreamPidl.cpp
+    MapWin32ErrorToSTG.c
     NextPath.c
     PathFileExistsDefExtAndAttributesW.c
     PathFindOnPath.c

--- a/modules/rostests/apitests/shlwapi/MapWin32ErrorToSTG.c
+++ b/modules/rostests/apitests/shlwapi/MapWin32ErrorToSTG.c
@@ -1,0 +1,45 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for MapWin32ErrorToSTG
+ * COPYRIGHT:   Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <apitest.h>
+#include <shlwapi.h>
+
+typedef HRESULT (WINAPI *FN_MapWin32ErrorToSTG)(HRESULT);
+static FN_MapWin32ErrorToSTG s_fnMapWin32ErrorToSTG = NULL;
+
+START_TEST(MapWin32ErrorToSTG)
+{
+    HRESULT hr;
+    HINSTANCE hSHLWAPI;
+
+    hSHLWAPI = GetModuleHandleA("shlwapi");
+    s_fnMapWin32ErrorToSTG = (FN_MapWin32ErrorToSTG)
+        GetProcAddress(hSHLWAPI, MAKEINTRESOURCEA(485));
+    if (!s_fnMapWin32ErrorToSTG)
+    {
+        skip("MapWin32ErrorToSTG not found\n");
+        return;
+    }
+
+    hr = s_fnMapWin32ErrorToSTG(HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED));
+    ok_long(hr, STG_E_ACCESSDENIED);
+
+    hr = s_fnMapWin32ErrorToSTG(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
+    ok_long(hr, STG_E_FILENOTFOUND);
+
+    hr = s_fnMapWin32ErrorToSTG(HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND));
+    ok_long(hr, STG_E_FILENOTFOUND);
+
+    hr = s_fnMapWin32ErrorToSTG(HRESULT_FROM_WIN32(ERROR_FILE_EXISTS));
+    ok_long(hr, STG_E_FILEALREADYEXISTS);
+
+    hr = s_fnMapWin32ErrorToSTG(HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS));
+    ok_long(hr, STG_E_FILEALREADYEXISTS);
+
+    hr = s_fnMapWin32ErrorToSTG(HRESULT_FROM_WIN32(ERROR_INVALID_PARAMETER));
+    ok_long(hr, HRESULT_FROM_WIN32(ERROR_INVALID_PARAMETER));
+}

--- a/modules/rostests/apitests/shlwapi/testlist.c
+++ b/modules/rostests/apitests/shlwapi/testlist.c
@@ -9,6 +9,7 @@ extern void func_PathFindOnPath(void);
 extern void func_IShellFolderHelpers(void);
 extern void func_IsQSForward(void);
 extern void func_IStreamPidl(void);
+extern void func_MapWin32ErrorToSTG(void); 
 extern void func_NextPath(void);
 extern void func_PathIsUNC(void);
 extern void func_PathIsUNCServer(void);
@@ -37,6 +38,7 @@ const struct test winetest_testlist[] =
     { "IShellFolderHelpers", func_IShellFolderHelpers },
     { "IsQSForward", func_IsQSForward },
     { "IStreamPidl", func_IStreamPidl },
+    { "MapWin32ErrorToSTG", func_MapWin32ErrorToSTG },
     { "NextPath", func_NextPath },
     { "PathIsUNC", func_PathIsUNC },
     { "PathIsUNCServer", func_PathIsUNCServer },

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -513,6 +513,8 @@ SHDialogBox(
     _In_opt_ SHDIALOGPROC fn,
     _In_opt_ PVOID pThis);
 
+HRESULT WINAPI MapWin32ErrorToSTG(_In_ HRESULT hr);
+
 PSTR WINAPI CharLowerNoDBCSA(_Inout_ PSTR lpString);
 PWSTR WINAPI CharLowerNoDBCSW(_Inout_ PWSTR lpString);
 PSTR WINAPI CharUpperNoDBCSA(_Inout_ PSTR lpString);


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Implement `MapWin32ErrorToSTG` function.
- Modify `shlwapi.spec`.
- Add prototype to `<shlwapi_undoc.h>`.
- Add `MapWin32ErrorToSTG` testcase.

## Screenshots

Win2k3:
<img width="640" height="480" alt="Win2k3" src="https://github.com/user-attachments/assets/009aee1a-9ccb-4c2d-bb2e-f03e045fe419" />
Successful.

Win10 x64:
<img width="579" height="382" alt="Win10" src="https://github.com/user-attachments/assets/f3155b37-838e-445c-a6f9-b42c10024647" />
Successful.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108283,108295
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108284,108294