### PR TITLE
[CRT] Disable intrinsic functions on MSVC

### DIFF
--- a/sdk/lib/crt/libcntpr.cmake
+++ b/sdk/lib/crt/libcntpr.cmake
@@ -31,4 +31,7 @@ target_compile_definitions(libcntpr
     _LIBCNT_
     __CRT__NO_INLINE
     CRTDLL)
+if(MSVC)
+    target_compile_definitions(libcntpr PRIVATE /Oi-)
+endif()
 add_dependencies(libcntpr psdk asm)


### PR DESCRIPTION
## Purpose
#9147 and #9148 got errors due to intrinsic functions.
JIRA issue: N/A

## Proposed changes

- Use `/Oi-` compiler option on MSVC in `sdk/lib/crt/libcntpr.cmake`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: