### PR TITLE
[SHLWAPI] Use <new> std::nothrow

### DIFF
--- a/dll/win32/shlwapi/CMakeLists.txt
+++ b/dll/win32/shlwapi/CMakeLists.txt
@@ -58,7 +58,7 @@ target_compile_options(shlwapi_autocomp PRIVATE $<TARGET_PROPERTY:shlwapi,COMPIL
 add_dependencies(shlwapi_autocomp psdk)
 
 set_module_type(shlwapi win32dll UNICODE)
-target_link_libraries(shlwapi uuid wine cpprt)
+target_link_libraries(shlwapi uuid wine stlport)
 add_delay_importlibs(shlwapi userenv oleaut32 ole32 comctl32 comdlg32 mpr mlang urlmon shell32 winmm version)
 add_importlibs(shlwapi user32 gdi32 advapi32 wininet msvcrt kernel32 ntdll)
 add_pch(shlwapi precomp.h "${PCH_SKIP_SOURCE}")

--- a/dll/win32/shlwapi/CMakeLists.txt
+++ b/dll/win32/shlwapi/CMakeLists.txt
@@ -58,7 +58,7 @@ target_compile_options(shlwapi_autocomp PRIVATE $<TARGET_PROPERTY:shlwapi,COMPIL
 add_dependencies(shlwapi_autocomp psdk)
 
 set_module_type(shlwapi win32dll UNICODE)
-target_link_libraries(shlwapi uuid wine stlport)
+target_link_libraries(shlwapi uuid wine cppstl)
 add_delay_importlibs(shlwapi userenv oleaut32 ole32 comctl32 comdlg32 mpr mlang urlmon shell32 winmm version)
 add_importlibs(shlwapi user32 gdi32 advapi32 wininet msvcrt kernel32 ntdll)
 add_pch(shlwapi precomp.h "${PCH_SKIP_SOURCE}")

--- a/dll/win32/shlwapi/policy.cpp
+++ b/dll/win32/shlwapi/policy.cpp
@@ -13,6 +13,7 @@
 #include <shlguid_undoc.h>
 #include <atlstr.h>
 #include <strsafe.h>
+#include <new>
 #include <wine/debug.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(policy);
@@ -82,17 +83,6 @@ public:
 
         if (m_hGlobalCounter)
             CloseHandle(m_hGlobalCounter);
-    }
-
-    static void* operator new(size_t size)
-    {
-        // Returns NULL on failure; caller must check before use.
-        // NOTE: C++ UB if constructor runs on NULL, but ReactOS convention.
-        return LocalAlloc(LPTR, size);
-    }
-    static void operator delete(void *ptr)
-    {
-        LocalFree(ptr);
     }
 
     BOOL Initialize(const SHPOLICY_ITEM *pItems, UINT cItems)
@@ -257,7 +247,7 @@ static BOOL SHPolicyCache_Create(VOID)
     if (g_pPolicyCache)
         return TRUE;
 
-    CPolicyCache *pCache = new CPolicyCache;
+    CPolicyCache* pCache = new(std::nothrow) CPolicyCache;
     if (!pCache)
         return FALSE;
 

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -16,8 +16,8 @@
 #include <atlcomcli.h>      // for CComVariant
 #include <atlconv.h>        // for CA2W and CW2A
 #include <strsafe.h>        // for StringC... functions
-#include <new>
-#include <algorithm>        // for std::min
+#include <cstdlib>          // __min
+#include <new>              // std::nothrow
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
@@ -842,7 +842,7 @@ CIniPropertyBag::_GetSectionAndName(
     if (pchSep)
     {
         UINT cchSep = (UINT)(pchSep - pszStart + 1);
-        StrCpyNW(pszSection, pszStart, (std::min)(cchSep, cchSectionMax));
+        StrCpyNW(pszSection, pszStart, __min(cchSep, cchSectionMax));
         StrCpyNW(pszName, pchSep + 1, cchNameMax);
         return S_OK;
     }

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -6,7 +6,6 @@
  */
 
 #define _ATL_NO_EXCEPTIONS
-#define NOMINMAX
 #include "precomp.h"
 #include <shlwapi.h>
 #include <shlwapi_undoc.h>
@@ -18,7 +17,7 @@
 #include <atlconv.h>        // for CA2W and CW2A
 #include <strsafe.h>        // for StringC... functions
 #include <new>
-#include <algorithm>
+#include <algorithm>        // for std::min
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
@@ -843,7 +842,7 @@ CIniPropertyBag::_GetSectionAndName(
     if (pchSep)
     {
         UINT cchSep = (UINT)(pchSep - pszStart + 1);
-        StrCpyNW(pszSection, pszStart, std::min(cchSep, cchSectionMax));
+        StrCpyNW(pszSection, pszStart, (std::min)(cchSep, cchSectionMax));
         StrCpyNW(pszName, pchSep + 1, cchNameMax);
         return S_OK;
     }

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -6,6 +6,7 @@
  */
 
 #define _ATL_NO_EXCEPTIONS
+#define NOMINMAX
 #include "precomp.h"
 #include <shlwapi.h>
 #include <shlwapi_undoc.h>
@@ -17,6 +18,7 @@
 #include <atlconv.h>        // for CA2W and CW2A
 #include <strsafe.h>        // for StringC... functions
 #include <new>
+#include <algorithm>
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
@@ -841,7 +843,7 @@ CIniPropertyBag::_GetSectionAndName(
     if (pchSep)
     {
         UINT cchSep = (UINT)(pchSep - pszStart + 1);
-        StrCpyNW(pszSection, pszStart, min(cchSep, cchSectionMax));
+        StrCpyNW(pszSection, pszStart, std::min(cchSep, cchSectionMax));
         StrCpyNW(pszName, pchSep + 1, cchNameMax);
         return S_OK;
     }

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -16,6 +16,7 @@
 #include <atlcomcli.h>      // for CComVariant
 #include <atlconv.h>        // for CA2W and CW2A
 #include <strsafe.h>        // for StringC... functions
+#include <new>
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
@@ -257,7 +258,9 @@ SHCreatePropertyBagOnMemory(_In_ DWORD dwMode, _In_ REFIID riid, _Out_ void **pp
 
     *ppvObj = NULL;
 
-    CComPtr<CMemPropertyBag> pMemBag(new CMemPropertyBag(dwMode));
+    CComPtr<CMemPropertyBag> pMemBag(new(std::nothrow) CMemPropertyBag(dwMode));
+    if (!pMemBag)
+        return E_OUTOFMEMORY;
 
     return pMemBag->QueryInterface(riid, ppvObj);
 }
@@ -584,7 +587,9 @@ SHCreatePropertyBagOnRegKey(
 
     *ppvObj = NULL;
 
-    CComPtr<CRegPropertyBag> pRegBag(new CRegPropertyBag(dwMode));
+    CComPtr<CRegPropertyBag> pRegBag(new(std::nothrow) CRegPropertyBag(dwMode));
+    if (!pRegBag)
+        return E_OUTOFMEMORY;
 
     HRESULT hr = pRegBag->Init(hKey, pszSubKey);
     if (FAILED(hr))
@@ -995,7 +1000,9 @@ SHCreatePropertyBagOnProfileSection(
     if (!PathFileExistsW(lpFileName))
         return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
 
-    CComPtr<CIniPropertyBag> pIniPB(new CIniPropertyBag(dwMode));
+    CComPtr<CIniPropertyBag> pIniPB(new(std::nothrow) CIniPropertyBag(dwMode));
+    if (!pIniPB)
+        return E_OUTOFMEMORY;
 
     HRESULT hr = pIniPB->Init(lpFileName, pszSection);
     if (FAILED(hr))
@@ -1197,7 +1204,9 @@ CDesktopUpgradePropertyBag::Read(
 HRESULT SHGetDesktopUpgradePropertyBag(REFIID riid, void **ppvObj)
 {
     *ppvObj = NULL;
-    CComPtr<CDesktopUpgradePropertyBag> pPropBag(new CDesktopUpgradePropertyBag());
+    CComPtr<CDesktopUpgradePropertyBag> pPropBag(new(std::nothrow) CDesktopUpgradePropertyBag());
+    if (!pPropBag)
+        return E_OUTOFMEMORY;
     return pPropBag->QueryInterface(riid, ppvObj);
 }
 
@@ -1908,7 +1917,12 @@ SHGetViewStatePropertyBag(
         return E_FAIL;
     }
 
-    CComPtr<CViewStatePropertyBag> pBag(new CViewStatePropertyBag());
+    CComPtr<CViewStatePropertyBag> pBag(new(std::nothrow) CViewStatePropertyBag());
+    if (!pBag)
+    {
+        ::LeaveCriticalSection(&g_csBagCacheLock);
+        return E_OUTOFMEMORY;
+    }
 
     hr = pBag->Init(pidl, bag_name, flags);
     if (FAILED(hr))

--- a/dll/win32/shlwapi/querysrc.cpp
+++ b/dll/win32/shlwapi/querysrc.cpp
@@ -10,6 +10,7 @@
 #include <shlwapi_undoc.h>
 #include <shlobj_undoc.h>
 #include <shlguid_undoc.h>
+#include <new>
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
@@ -305,7 +306,9 @@ STDMETHODIMP_(ULONG) CRegistrySource::Release()
 
 STDMETHODIMP CRegistrySource::EnumValues(IEnumString **ppEnum)
 {
-    CRegistryEnumValues* pEnum = new CRegistryEnumValues();
+    CRegistryEnumValues* pEnum = new(std::nothrow) CRegistryEnumValues();
+    if (!pEnum)
+        return E_OUTOFMEMORY;
     HRESULT hr = pEnum->Init(m_hKey, this);
     if (FAILED(hr))
     {
@@ -318,7 +321,9 @@ STDMETHODIMP CRegistrySource::EnumValues(IEnumString **ppEnum)
 
 STDMETHODIMP CRegistrySource::EnumSources(IEnumString **ppEnum)
 {
-    CRegistryEnumKeys* pEnum = new CRegistryEnumKeys();
+    CRegistryEnumKeys* pEnum = new(std::nothrow) CRegistryEnumKeys();
+    if (!pEnum)
+        return E_OUTOFMEMORY;
     HRESULT hr = pEnum->Init(m_hKey, this);
     if (FAILED(hr))
     {
@@ -500,7 +505,9 @@ QuerySourceCreateFromKey(
 {
     *ppv = NULL;
 
-    CRegistrySource* pRS = new CRegistrySource();
+    CRegistrySource* pRS = new(std::nothrow) CRegistrySource();
+    if (!pRS)
+        return E_OUTOFMEMORY;
 
     HRESULT hr = pRS->Init(hKey, lpSubKey, bCreate);
     if (SUCCEEDED(hr))

--- a/sdk/lib/cpprt/CMakeLists.txt
+++ b/sdk/lib/cpprt/CMakeLists.txt
@@ -24,7 +24,9 @@ endif()
 
 add_library(cpprt ${SOURCE} ${cpprt_asm})
 set_target_cpp_properties(cpprt WITH_EXCEPTIONS)
-target_include_directories(cpprt INTERFACE ${REACTOS_SOURCE_DIR}/sdk/include/c++)
+target_include_directories(cpprt INTERFACE
+    ${REACTOS_SOURCE_DIR}/sdk/include/c++
+    ${REACTOS_SOURCE_DIR}/sdk/include/c++/stlport)
 add_dependencies(cpprt xdk)
 
 # On GCC builds, we need to link against libsupc++

--- a/sdk/lib/cpprt/CMakeLists.txt
+++ b/sdk/lib/cpprt/CMakeLists.txt
@@ -1,4 +1,8 @@
 
+include_directories(
+    ${REACTOS_SOURCE_DIR}/sdk/lib/crt/include
+    ${REACTOS_SOURCE_DIR}/sdk/include/c++)
+
 # We need different things, depending on the compiler
 if(MSVC)
     list(APPEND SOURCE

--- a/sdk/lib/cpprt/CMakeLists.txt
+++ b/sdk/lib/cpprt/CMakeLists.txt
@@ -24,8 +24,6 @@ endif()
 
 add_library(cpprt ${SOURCE} ${cpprt_asm})
 set_target_cpp_properties(cpprt WITH_EXCEPTIONS)
-target_include_directories(cpprt AFTER INTERFACE
-    ${REACTOS_SOURCE_DIR}/sdk/include/c++/stlport)
 add_dependencies(cpprt xdk)
 
 # On GCC builds, we need to link against libsupc++

--- a/sdk/lib/cpprt/CMakeLists.txt
+++ b/sdk/lib/cpprt/CMakeLists.txt
@@ -1,8 +1,4 @@
 
-include_directories(
-    ${REACTOS_SOURCE_DIR}/sdk/lib/crt/include
-    ${REACTOS_SOURCE_DIR}/sdk/include/c++)
-
 # We need different things, depending on the compiler
 if(MSVC)
     list(APPEND SOURCE
@@ -24,6 +20,9 @@ endif()
 
 add_library(cpprt ${SOURCE} ${cpprt_asm})
 set_target_cpp_properties(cpprt WITH_EXCEPTIONS)
+target_include_directories(cpprt INTERFACE
+    ${REACTOS_SOURCE_DIR}/sdk/lib/crt/include
+    ${REACTOS_SOURCE_DIR}/sdk/include/c++)
 add_dependencies(cpprt xdk)
 
 # On GCC builds, we need to link against libsupc++

--- a/sdk/lib/cpprt/CMakeLists.txt
+++ b/sdk/lib/cpprt/CMakeLists.txt
@@ -25,7 +25,6 @@ endif()
 add_library(cpprt ${SOURCE} ${cpprt_asm})
 set_target_cpp_properties(cpprt WITH_EXCEPTIONS)
 target_include_directories(cpprt AFTER INTERFACE
-    ${REACTOS_SOURCE_DIR}/sdk/include/c++
     ${REACTOS_SOURCE_DIR}/sdk/include/c++/stlport)
 add_dependencies(cpprt xdk)
 

--- a/sdk/lib/cpprt/CMakeLists.txt
+++ b/sdk/lib/cpprt/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 add_library(cpprt ${SOURCE} ${cpprt_asm})
 set_target_cpp_properties(cpprt WITH_EXCEPTIONS)
-target_include_directories(cpprt INTERFACE
+target_include_directories(cpprt AFTER INTERFACE
     ${REACTOS_SOURCE_DIR}/sdk/include/c++
     ${REACTOS_SOURCE_DIR}/sdk/include/c++/stlport)
 add_dependencies(cpprt xdk)

--- a/sdk/lib/cpprt/CMakeLists.txt
+++ b/sdk/lib/cpprt/CMakeLists.txt
@@ -24,9 +24,7 @@ endif()
 
 add_library(cpprt ${SOURCE} ${cpprt_asm})
 set_target_cpp_properties(cpprt WITH_EXCEPTIONS)
-target_include_directories(cpprt INTERFACE
-    ${REACTOS_SOURCE_DIR}/sdk/lib/crt/include
-    ${REACTOS_SOURCE_DIR}/sdk/include/c++)
+target_include_directories(cpprt INTERFACE ${REACTOS_SOURCE_DIR}/sdk/include/c++)
 add_dependencies(cpprt xdk)
 
 # On GCC builds, we need to link against libsupc++


### PR DESCRIPTION
## Purpose
Use preferred memory handling on memory shortage.
JIRA issue: N/A

## Proposed changes

- Link `cppstl` instead of `cpprt`.
- Use `<new>` `new(std::throw)` for memory allocation.
- Return `E_OUTOFMEMORY` on allocation failure.
- Don't use `<stdlib.h>` `min` macro but use `<cstdlib>` `__min`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108283,108302
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108284,108303