### PR TITLE
[GITHUB] Exclude build-msvc (windows-latest, 14, Release, 0x502)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,9 @@ jobs:
             toolset: 14.2
           - dllver: 0x600
             config: Release
+          - dllver: 0x502
+            toolset: 14
+            config: Release
       fail-fast: false
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,13 +90,13 @@ jobs:
         arch: [i386, amd64]
         config: [Debug, Release]
         dllver: ['0x502', '0x600']
-        exclude: # Build NT6 ISOs only with the latest toolset when compiled as a debug build
-          - dllver: 0x600
+        exclude:
+          - dllver: 0x502 # VS2026 fails to build with error C2169: 'wcsncmp': intrinsic function, cannot be defined
+            toolset: 14
+            config: Release
+          - dllver: 0x600 # Build NT6 ISOs only with the latest toolset when compiled as a debug build
             toolset: 14.2
           - dllver: 0x600
-            config: Release
-          - dllver: 0x502
-            toolset: 14
             config: Release
       fail-fast: false
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
## Purpose

Recently, this check target is moved to Visual Studio 2026 (e.g. #9147, #9148, #9150). Currently we cannot build the project for latest VS 2026. We will disable this check.

JIRA issue: N/A
See also: https://github.com/actions/runner-images/issues/14017

## Proposed changes

- Add exclusion of `build-msvc (windows-latest, 14, Release, 0x502)`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108283,108305
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108284,108306