### PR TITLE
[SHELL32] Initialize ShellState with defaults if it's not there

### DIFF
--- a/dll/win32/shell32/dialogs/general.cpp
+++ b/dll/win32/shell32/dialogs/general.cpp
@@ -81,7 +81,13 @@ SHELL32_ReadRegShellState(PREGSHELLSTATE prss)
     DWORD dwSize = sizeof(REGSHELLSTATE);
     LSTATUS err = SHGetValueW(HKEY_CURRENT_USER, s_pszExplorerKey,
                               L"ShellState", NULL, prss, &dwSize);
-    return err == ERROR_SUCCESS && prss->dwSize >= REGSHELLSTATE_SIZE;
+    if (err == ERROR_SUCCESS && prss->dwSize >= REGSHELLSTATE_SIZE)
+        return TRUE;
+
+    ZeroMemory(prss, sizeof(*prss));
+    SHELL32_GetDefaultShellState(&prss->ss);
+    SHELL32_WriteRegShellState(prss);
+    return TRUE;
 }
 
 // bUnderlineHover is TRUE if "Underline icon titles only when I point at them".


### PR DESCRIPTION
## Purpose

`SHELL32_ReadRegShellState` would return FALSE on a new install where ShellState doesn't exist yet, making `SHGetSetSettings` to fall back to in-memory defaults without persisting them. Since g_ShellState is zero-initialized, fDoubleClickInWebView would always be single-click mode

JIRA issue: [CORE-20585](https://jira.reactos.org/browse/CORE-20585)

This replaces the `HACKFIX` added in #9037

## Proposed changes
- Fix `SHELL32_ReadRegShellState` to write defaults when ShellState registry value is missing/corrupt
- Remove the HACKFIX from `SHGetSetSettings` added in #9037