### PR TITLE
[MSVCRT][CRT][UCRT] Disable intrinsic string functions on MSVC

### DIFF
--- a/dll/win32/msvcrt/string.c
+++ b/dll/win32/msvcrt/string.c
@@ -37,7 +37,10 @@
 WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 
 #ifdef _MSC_VER
-#pragma function(_strset,memchr,memcmp,memcpy,memset,strcat,strcmp,strcpy,strlen,strncpy,strncmp)
+#pragma function(_strset,memchr,memcmp,memcpy,memset,strcat,strcmp,strcpy,strlen)
+#if _MSC_VER >= 1932 // VS2022 Version 17.2 and later
+#pragma function(strncpy,strncmp)
+#endif
 #endif
 
 /*********************************************************************

--- a/dll/win32/msvcrt/string.c
+++ b/dll/win32/msvcrt/string.c
@@ -38,8 +38,10 @@ WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 
 #ifdef _MSC_VER
 #pragma function(_strset,memchr,memcmp,memcpy,memset,strcat,strcmp,strcpy,strlen)
+#ifdef __REACTOS__
 #if defined(_M_ARM) || _MSC_VER >= 1932 // VS2022 version 17.2 and later
 #pragma function(strncpy,strncmp)
+#endif
 #endif
 #endif
 

--- a/dll/win32/msvcrt/string.c
+++ b/dll/win32/msvcrt/string.c
@@ -40,7 +40,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 #pragma function(_strset,memchr,memcmp,memcpy,memset,strcat,strcmp,strcpy,strlen)
 #ifdef __REACTOS__
 #if defined(_M_ARM) || _MSC_VER >= 1932 // VS2022 version 17.2 and later
-#pragma function(strncpy,strncmp)
+#pragma function(strncmp,strncpy)
 #endif
 #endif
 #endif

--- a/dll/win32/msvcrt/string.c
+++ b/dll/win32/msvcrt/string.c
@@ -38,7 +38,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 
 #ifdef _MSC_VER
 #pragma function(_strset,memchr,memcmp,memcpy,memset,strcat,strcmp,strcpy,strlen)
-#if _MSC_VER >= 1932 // VS2022 version 17.2 and later
+#if defined(_M_ARM) || _MSC_VER >= 1932 // VS2022 version 17.2 and later
 #pragma function(strncpy,strncmp)
 #endif
 #endif

--- a/dll/win32/msvcrt/string.c
+++ b/dll/win32/msvcrt/string.c
@@ -38,7 +38,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 
 #ifdef _MSC_VER
 #pragma function(_strset,memchr,memcmp,memcpy,memset,strcat,strcmp,strcpy,strlen)
-#if _MSC_VER >= 1932 // VS2022 Version 17.2 and later
+#if _MSC_VER >= 1932 // VS2022 version 17.2 and later
 #pragma function(strncpy,strncmp)
 #endif
 #endif

--- a/dll/win32/msvcrt/string.c
+++ b/dll/win32/msvcrt/string.c
@@ -37,7 +37,7 @@
 WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 
 #ifdef _MSC_VER
-#pragma function(_strset,memchr,memcmp,memcpy,memset,strcat,strcmp,strcpy,strlen)
+#pragma function(_strset,memchr,memcmp,memcpy,memset,strcat,strcmp,strcpy,strlen,strncpy,strncmp)
 #endif
 
 /*********************************************************************

--- a/dll/win32/msvcrt/wcs.c
+++ b/dll/win32/msvcrt/wcs.c
@@ -35,7 +35,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 
 #ifdef _MSC_VER
 #pragma function(_wcsset,wcscat,wcscmp,wcscpy,wcslen)
-#if _MSC_VER >= 1932 // VS2022 version 17.2 and later
+#if defined(_M_ARM) || _MSC_VER >= 1932 // VS2022 version 17.2 and later
 #pragma function(wcsncmp,wcsncpy)
 #endif
 #endif

--- a/dll/win32/msvcrt/wcs.c
+++ b/dll/win32/msvcrt/wcs.c
@@ -35,8 +35,10 @@ WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 
 #ifdef _MSC_VER
 #pragma function(_wcsset,wcscat,wcscmp,wcscpy,wcslen)
+#ifdef __REACTOS__
 #if defined(_M_ARM) || _MSC_VER >= 1932 // VS2022 version 17.2 and later
 #pragma function(wcsncmp,wcsncpy)
+#endif
 #endif
 #endif
 

--- a/dll/win32/msvcrt/wcs.c
+++ b/dll/win32/msvcrt/wcs.c
@@ -34,7 +34,10 @@
 WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 
 #ifdef _MSC_VER
-#pragma function(_wcsset,wcscat,wcscmp,wcscpy,wcslen,wcsncmp,wcsncpy)
+#pragma function(_wcsset,wcscat,wcscmp,wcscpy,wcslen)
+#if _MSC_VER >= 1932 // VS2022 Version 17.2 and later
+#pragma function(wcsncmp,wcsncpy)
+#endif
 #endif
 
 typedef struct

--- a/dll/win32/msvcrt/wcs.c
+++ b/dll/win32/msvcrt/wcs.c
@@ -35,7 +35,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 
 #ifdef _MSC_VER
 #pragma function(_wcsset,wcscat,wcscmp,wcscpy,wcslen)
-#if _MSC_VER >= 1932 // VS2022 Version 17.2 and later
+#if _MSC_VER >= 1932 // VS2022 version 17.2 and later
 #pragma function(wcsncmp,wcsncpy)
 #endif
 #endif

--- a/dll/win32/msvcrt/wcs.c
+++ b/dll/win32/msvcrt/wcs.c
@@ -34,7 +34,7 @@
 WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 
 #ifdef _MSC_VER
-#pragma function(_wcsset,wcscat,wcscmp,wcscpy,wcslen)
+#pragma function(_wcsset,wcscat,wcscmp,wcscpy,wcslen,wcsncmp,wcsncpy)
 #endif
 
 typedef struct

--- a/sdk/lib/crt/libcntpr.cmake
+++ b/sdk/lib/crt/libcntpr.cmake
@@ -24,6 +24,9 @@ set_source_files_properties(${LIBCNTPR_ASM_SOURCE} PROPERTIES COMPILE_DEFINITION
 add_asm_files(libcntpr_asm ${LIBCNTPR_ASM_SOURCE})
 
 add_library(libcntpr STATIC ${LIBCNTPR_SOURCE} ${libcntpr_asm})
+if(MSVC)
+    target_compile_options(libcntpr PRIVATE /Oi-)
+endif()
 target_compile_definitions(libcntpr
  PRIVATE    NO_RTL_INLINES
     _NTSYSTEM_

--- a/sdk/lib/crt/libcntpr.cmake
+++ b/sdk/lib/crt/libcntpr.cmake
@@ -25,7 +25,7 @@ add_asm_files(libcntpr_asm ${LIBCNTPR_ASM_SOURCE})
 
 add_library(libcntpr STATIC ${LIBCNTPR_SOURCE} ${libcntpr_asm})
 if(MSVC)
-    target_compile_options(libcntpr PRIVATE /Oi-)
+    target_compile_options(libcntpr PRIVATE /Oi-) # Disable intrinsic functions
 endif()
 target_compile_definitions(libcntpr
  PRIVATE    NO_RTL_INLINES

--- a/sdk/lib/crt/libcntpr.cmake
+++ b/sdk/lib/crt/libcntpr.cmake
@@ -21,9 +21,6 @@ list(APPEND LIBCNTPR_ASM_SOURCE
 )
 
 set_source_files_properties(${LIBCNTPR_ASM_SOURCE} PROPERTIES COMPILE_DEFINITIONS "NO_RTL_INLINES;_NTSYSTEM_;_NTDLLBUILD_;_LIBCNT_;__CRT__NO_INLINE;CRTDLL")
-if(MSVC)
-    set_source_files_properties(${LIBCNTPR_STRING_SOURCE} PROPERTIES COMPILE_OPTIONS "/Oi-") # Disable intrinsic functions for string
-endif()
 add_asm_files(libcntpr_asm ${LIBCNTPR_ASM_SOURCE})
 
 add_library(libcntpr STATIC ${LIBCNTPR_SOURCE} ${libcntpr_asm})

--- a/sdk/lib/crt/libcntpr.cmake
+++ b/sdk/lib/crt/libcntpr.cmake
@@ -21,12 +21,12 @@ list(APPEND LIBCNTPR_ASM_SOURCE
 )
 
 set_source_files_properties(${LIBCNTPR_ASM_SOURCE} PROPERTIES COMPILE_DEFINITIONS "NO_RTL_INLINES;_NTSYSTEM_;_NTDLLBUILD_;_LIBCNT_;__CRT__NO_INLINE;CRTDLL")
+if(MSVC)
+    set_source_files_properties(${LIBCNTPR_STRING_SOURCE} PROPERTIES COMPILE_OPTIONS "/Oi-") # Disable intrinsic functions for string
+endif()
 add_asm_files(libcntpr_asm ${LIBCNTPR_ASM_SOURCE})
 
 add_library(libcntpr STATIC ${LIBCNTPR_SOURCE} ${libcntpr_asm})
-if(MSVC)
-    target_compile_options(libcntpr PRIVATE /Oi-) # Disable intrinsic functions
-endif()
 target_compile_definitions(libcntpr
  PRIVATE    NO_RTL_INLINES
     _NTSYSTEM_

--- a/sdk/lib/crt/string/tcsncmp.h
+++ b/sdk/lib/crt/string/tcsncmp.h
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <tchar.h>
 
-#if defined(_MSC_VER) && defined(_M_ARM)
+#if defined(_MSC_VER)
 #pragma function(_tcsncmp)
 #endif /* _MSC_VER */
 

--- a/sdk/lib/crt/string/tcsncmp.h
+++ b/sdk/lib/crt/string/tcsncmp.h
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <tchar.h>
 
-#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 Version 17.2 and later
+#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 version 17.2 and later
 #pragma function(_tcsncmp)
 #endif /* _MSC_VER */
 

--- a/sdk/lib/crt/string/tcsncmp.h
+++ b/sdk/lib/crt/string/tcsncmp.h
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <tchar.h>
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 Version 17.2 and later
 #pragma function(_tcsncmp)
 #endif /* _MSC_VER */
 

--- a/sdk/lib/crt/string/tcsncmp.h
+++ b/sdk/lib/crt/string/tcsncmp.h
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <tchar.h>
 
-#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 version 17.2 and later
+#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1932) // VS2022 version 17.2 and later
 #pragma function(_tcsncmp)
 #endif /* _MSC_VER */
 

--- a/sdk/lib/crt/string/tcsncpy.h
+++ b/sdk/lib/crt/string/tcsncpy.h
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <tchar.h>
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 Version 17.2 and later
 #pragma function(_tcsncpy)
 #endif /* _MSC_VER */
 

--- a/sdk/lib/crt/string/tcsncpy.h
+++ b/sdk/lib/crt/string/tcsncpy.h
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <tchar.h>
 
-#if defined(_MSC_VER) && defined(_M_ARM)
+#if defined(_MSC_VER)
 #pragma function(_tcsncpy)
 #endif /* _MSC_VER */
 

--- a/sdk/lib/crt/string/tcsncpy.h
+++ b/sdk/lib/crt/string/tcsncpy.h
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <tchar.h>
 
-#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 Version 17.2 and later
+#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 version 17.2 and later
 #pragma function(_tcsncpy)
 #endif /* _MSC_VER */
 

--- a/sdk/lib/crt/string/tcsncpy.h
+++ b/sdk/lib/crt/string/tcsncpy.h
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <tchar.h>
 
-#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 version 17.2 and later
+#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1932) // VS2022 version 17.2 and later
 #pragma function(_tcsncpy)
 #endif /* _MSC_VER */
 

--- a/sdk/lib/ucrt/string/strncmp.c
+++ b/sdk/lib/ucrt/string/strncmp.c
@@ -11,7 +11,7 @@
 
 #include <string.h>
 
-#if defined(_M_ARM) || (defined(_MSC_VER) && _MSC_VER >= 1932) // VS2022 version 17.2 and later
+#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1932) // VS2022 version 17.2 and later
     #pragma function(strncmp)
 #endif
 

--- a/sdk/lib/ucrt/string/strncmp.c
+++ b/sdk/lib/ucrt/string/strncmp.c
@@ -11,7 +11,7 @@
 
 #include <string.h>
 
-#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 version 17.2 and later
+#if defined(_M_ARM) || (defined(_MSC_VER) && _MSC_VER >= 1932) // VS2022 version 17.2 and later
     #pragma function(strncmp)
 #endif
 

--- a/sdk/lib/ucrt/string/strncmp.c
+++ b/sdk/lib/ucrt/string/strncmp.c
@@ -11,7 +11,7 @@
 
 #include <string.h>
 
-#ifdef _M_ARM
+#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 version 17.2 and later
     #pragma function(strncmp)
 #endif
 

--- a/sdk/lib/ucrt/string/strncpy.c
+++ b/sdk/lib/ucrt/string/strncpy.c
@@ -10,7 +10,7 @@
 
 #include <string.h>
 
-#if defined(_M_ARM) || (defined(_MSC_VER) && _MSC_VER >= 1932) // VS2022 version 17.2 and later
+#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1932) // VS2022 version 17.2 and later
     #pragma function(strncpy)
 #endif
 

--- a/sdk/lib/ucrt/string/strncpy.c
+++ b/sdk/lib/ucrt/string/strncpy.c
@@ -10,7 +10,7 @@
 
 #include <string.h>
 
-#if defined _M_ARM
+#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 version 17.2 and later
     #pragma function(strncpy)
 #endif
 

--- a/sdk/lib/ucrt/string/strncpy.c
+++ b/sdk/lib/ucrt/string/strncpy.c
@@ -10,7 +10,7 @@
 
 #include <string.h>
 
-#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 version 17.2 and later
+#if defined(_M_ARM) || (defined(_MSC_VER) && _MSC_VER >= 1932) // VS2022 version 17.2 and later
     #pragma function(strncpy)
 #endif
 

--- a/sdk/lib/ucrt/string/wcsncmp.cpp
+++ b/sdk/lib/ucrt/string/wcsncmp.cpp
@@ -19,7 +19,7 @@
 
 
 
-#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 version 17.2 and later
+#if defined(_M_ARM) || (defined(_MSC_VER) && _MSC_VER >= 1932) // VS2022 version 17.2 and later
     #pragma function(wcsncmp)
 #endif
 

--- a/sdk/lib/ucrt/string/wcsncmp.cpp
+++ b/sdk/lib/ucrt/string/wcsncmp.cpp
@@ -19,7 +19,7 @@
 
 
 
-#if defined(_M_ARM) || (defined(_MSC_VER) && _MSC_VER >= 1932) // VS2022 version 17.2 and later
+#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1932) // VS2022 version 17.2 and later
     #pragma function(wcsncmp)
 #endif
 

--- a/sdk/lib/ucrt/string/wcsncmp.cpp
+++ b/sdk/lib/ucrt/string/wcsncmp.cpp
@@ -19,7 +19,7 @@
 
 
 
-#ifdef _M_ARM
+#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 version 17.2 and later
     #pragma function(wcsncmp)
 #endif
 

--- a/sdk/lib/ucrt/string/wcsncpy.cpp
+++ b/sdk/lib/ucrt/string/wcsncpy.cpp
@@ -12,7 +12,7 @@
 #pragma warning(disable:__WARNING_POSTCONDITION_NULLTERMINATION_VIOLATION) // 26036
 
 
-#ifdef _M_ARM
+#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 version 17.2 and later
     #pragma function(wcsncpy)
 #endif
 

--- a/sdk/lib/ucrt/string/wcsncpy.cpp
+++ b/sdk/lib/ucrt/string/wcsncpy.cpp
@@ -12,7 +12,7 @@
 #pragma warning(disable:__WARNING_POSTCONDITION_NULLTERMINATION_VIOLATION) // 26036
 
 
-#if defined(_MSC_VER) && _MSC_VER >= 1932 // VS2022 version 17.2 and later
+#if defined(_M_ARM) || (defined(_MSC_VER) && _MSC_VER >= 1932) // VS2022 version 17.2 and later
     #pragma function(wcsncpy)
 #endif
 

--- a/sdk/lib/ucrt/string/wcsncpy.cpp
+++ b/sdk/lib/ucrt/string/wcsncpy.cpp
@@ -12,7 +12,7 @@
 #pragma warning(disable:__WARNING_POSTCONDITION_NULLTERMINATION_VIOLATION) // 26036
 
 
-#if defined(_M_ARM) || (defined(_MSC_VER) && _MSC_VER >= 1932) // VS2022 version 17.2 and later
+#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1932) // VS2022 version 17.2 and later
     #pragma function(wcsncpy)
 #endif
 


### PR DESCRIPTION
## Purpose

Retrial of #9149. Another approach of #9151.

VS2022 version 17.2 and later (`_MSC_VER >= 1932`) added new intrinsic functions (`strncmp`, `strncpy`, `wcsncmp`, and `wcsncpy`). As we implement these ourselves, we have to avoid compiler error C2169.

JIRA issue: N/A

## Proposed changes

- Use `#pragma function(...)` to disable new intrinsic functions.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108283,108321
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108284,108322