### PR TITLE
[NTGDI] IntGdiCreateDisplayDC: Call internal GreCreateCompatibleDC instead of the NtGdi syscall stub

### DIFF
--- a/win32ss/gdi/ntgdi/dclife.c
+++ b/win32ss/gdi/ntgdi/dclife.c
@@ -1066,7 +1066,7 @@ IntGdiCreateDisplayDC(HDEV hDev, ULONG DcType, BOOL EmptyDC)
     UNIMPLEMENTED;
 
     if (DcType == DCTYPE_MEMORY)
-        hDC = NtGdiCreateCompatibleDC(NULL); // OH~ Yuck! I think I taste vomit in my mouth!
+        hDC = GreCreateCompatibleDC(NULL, FALSE);
     else
         hDC = IntGdiCreateDC(NULL, NULL, NULL, NULL, (DcType == DCTYPE_INFO));
 


### PR DESCRIPTION
beside the comment itself no need for a syscall, a direct call to GreCreateCompatibleDC keeps the convention clean
## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: