### PR TITLE
[SPEC2DEF] Fix some issues

### DIFF
--- a/sdk/tools/spec2def/spec2def.c
+++ b/sdk/tools/spec2def/spec2def.c
@@ -1206,6 +1206,10 @@ ParseFile(char* pcStart, FILE *fileDest, unsigned *cExports)
             {
                 exp.uFlags |= FL_REGISTER;
             }
+            else if (CompareToken(pc, "-import"))
+            {
+                /* The export is imported from an import library. Ignored. */
+            }
             else
             {
                 fprintf(stdout,

--- a/sdk/tools/spec2def/spec2def.c
+++ b/sdk/tools/spec2def/spec2def.c
@@ -1467,6 +1467,7 @@ ApplyOrdinals(EXPORT* pexports, unsigned cExports)
             if (used[pexports[i].nOrdinal] != 0)
             {
                 fprintf(stderr, "Found duplicate ordinal: %u\n", pexports[i].nOrdinal);
+                free(used);
                 return -1;
             }
             used[pexports[i].nOrdinal] = 1;

--- a/sdk/tools/spec2def/spec2def.c
+++ b/sdk/tools/spec2def/spec2def.c
@@ -1458,7 +1458,7 @@ ApplyOrdinals(EXPORT* pexports, unsigned cExports)
     /* Pass 1: mark the ordinals that are already used */
     for (i = 0; i < cExports; i++)
     {
-        if (pexports[i].uFlags & FL_ORDINAL)
+        if ((pexports[i].uFlags & FL_ORDINAL) && pexports[i].bVersionIncluded)
         {
             if (used[pexports[i].nOrdinal] != 0)
             {


### PR DESCRIPTION
## Purpose

Some fixes to spec2def.

## Proposed changes

* [SPEC2DEF] Fix version handling for ordinals
* [SPEC2DEF] Ignore -import flag in spec files

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108512,108514,108518
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108511,108513,108517
