### PR TITLE
[WINVER][MYCOMPUT][MYDOCS][RUNDLL32] Add Korean (ko-KR) translation

### DIFF
--- a/base/applications/winver/lang/ko-KR.rc
+++ b/base/applications/winver/lang/ko-KR.rc
@@ -1,0 +1,14 @@
+/*
+ * PROJECT:      ReactOS Version Program
+ * LICENSE:      MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:      Korean (South Korea) resource file
+ * TRANSLATOR:   Copyright 2026 Jiho Kim
+*/
+
+LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
+
+STRINGTABLE
+BEGIN
+    IDS_OSINFO_COMPAT_FORMAT "NT %s (빌드 %s%s)"
+    IDS_OSINFO_SPK_FORMAT ": %s"
+END

--- a/base/applications/winver/winver.rc
+++ b/base/applications/winver/winver.rc
@@ -17,3 +17,7 @@
 #ifdef LANGUAGE_EN_US
     #include "lang/en-US.rc"
 #endif
+
+#ifdef LANGUAGE_KO_KR
+    #include "lang/ko-KR.rc"
+#endif

--- a/base/system/rundll32/lang/ko-KR.rc
+++ b/base/system/rundll32/lang/ko-KR.rc
@@ -1,6 +1,6 @@
 /*
  * PROJECT:      ReactOS rundll32
- * LICENSE:      MIT (https://spdx.org/licenses/MIT)
+ * LICENSE:      GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:      Korean (South Korea) resource file
  * TRANSLATOR:   Copyright 2026 Jiho Kim
  */

--- a/base/system/rundll32/lang/ko-KR.rc
+++ b/base/system/rundll32/lang/ko-KR.rc
@@ -1,0 +1,14 @@
+/*
+ * PROJECT:      ReactOS rundll32
+ * LICENSE:      MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:      Korean (South Korea) resource file
+ * TRANSLATOR:   Copyright 2026 Jiho Kim
+ */
+
+LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
+
+STRINGTABLE
+BEGIN
+    IDS_DllNotLoaded "LoadLibrary가 '%s'을(를) 로드하지 못했습니다"
+    IDS_MissingEntry "%s 진입점을 찾을 수 없습니다.\n(%s)"
+END

--- a/base/system/rundll32/rundll32.rc
+++ b/base/system/rundll32/rundll32.rc
@@ -45,6 +45,9 @@ IDI_MAIN ICON "res/main.ico"
 #ifdef LANGUAGE_IT_IT
     #include "lang/it-IT.rc"
 #endif
+#ifdef LANGUAGE_KO_KR
+    #include "lang/ko-KR.rc"
+#endif
 #ifdef LANGUAGE_LT_LT
     #include "lang/lt-LT.rc"
 #endif

--- a/dll/shellext/mydocs/lang/ko-KR.rc
+++ b/dll/shellext/mydocs/lang/ko-KR.rc
@@ -1,0 +1,13 @@
+/*
+ * PROJECT:      ReactOS My Documents Shell Extension
+ * LICENSE:      MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:      Korean (South Korea) resource file
+ * TRANSLATOR:   Copyright 2026 Jiho Kim
+ */
+
+LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
+
+STRINGTABLE
+{
+    IDS_NOSRCFILEFOUND "원본 파일 또는 폴더 '%ls'을(를) 찾을 수 없습니다."
+}

--- a/dll/shellext/mydocs/lang/ko-KR.rc
+++ b/dll/shellext/mydocs/lang/ko-KR.rc
@@ -1,6 +1,6 @@
 /*
  * PROJECT:      ReactOS My Documents Shell Extension
- * LICENSE:      MIT (https://spdx.org/licenses/MIT)
+ * LICENSE:      LGPL-2.1+ (https://spdx.org/licenses/LGPL-2.1+)
  * PURPOSE:      Korean (South Korea) resource file
  * TRANSLATOR:   Copyright 2026 Jiho Kim
  */

--- a/dll/shellext/mydocs/mydocs.rc
+++ b/dll/shellext/mydocs/mydocs.rc
@@ -30,6 +30,9 @@ IDR_MYDOCS REGISTRY "res/mydocs.rgs"
 #ifdef LANGUAGE_JA_JP
     #include "lang/ja-JP.rc"
 #endif
+#ifdef LANGUAGE_KO_KR
+    #include "lang/ko-KR.rc"
+#endif
 #ifdef LANGUAGE_PL_PL
     #include "lang/pl-PL.rc"
 #endif

--- a/dll/win32/mycomput/lang/ko-KR.rc
+++ b/dll/win32/mycomput/lang/ko-KR.rc
@@ -1,0 +1,13 @@
+/*
+ * PROJECT:      ReactOS My Computer Shell Extension
+ * LICENSE:      MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:      Korean (South Korea) resource file
+ * TRANSLATOR:   Copyright 2026 Jiho Kim
+ */
+
+LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
+
+STRINGTABLE
+BEGIN
+    IDS_MANAGE "관리"
+END

--- a/dll/win32/mycomput/lang/ko-KR.rc
+++ b/dll/win32/mycomput/lang/ko-KR.rc
@@ -1,6 +1,6 @@
 /*
  * PROJECT:      ReactOS My Computer Shell Extension
- * LICENSE:      MIT (https://spdx.org/licenses/MIT)
+ * LICENSE:      GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:      Korean (South Korea) resource file
  * TRANSLATOR:   Copyright 2026 Jiho Kim
  */

--- a/dll/win32/mycomput/mycomput.rc
+++ b/dll/win32/mycomput/mycomput.rc
@@ -39,6 +39,9 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 #ifdef LANGUAGE_JA_JP
     #include "lang/ja-JP.rc"
 #endif
+#ifdef LANGUAGE_KO_KR
+    #include "lang/ko-KR.rc"
+#endif
 #ifdef LANGUAGE_PL_PL
     #include "lang/pl-PL.rc"
 #endif


### PR DESCRIPTION
## Purpose
Add the missing Korean (ko-KR) translation for winver, mycomput, mydocs, and rundll32.

## Proposed changes
- Added base/applications/winver/lang/ko-KR.rc
- Updated base/applications/winver/winver.rc
- Added dll/win32/mycomput/lang/ko-KR.rc
- Updated dll/win32/mycomput/mycomput.rc
- Added dll/shellext/mydocs/lang/ko-KR.rc
- Updated dll/shellext/mydocs/mydocs.rc
- Added base/system/rundll32/lang/ko-KR.rc
- Updated base/system/rundll32/rundll32.rc
## Testbot runs (Filled in by Devs)
- [x] KVM x86:
- [x] KVM x64: