### PR TITLE
[NTOS:OB] Enhancements to NtSetInformationObject(), ObSetHandleAttributes() and ObpSetHandleAttributes()

### DIFF
--- a/ntoskrnl/include/internal/ob.h
+++ b/ntoskrnl/include/internal/ob.h
@@ -302,14 +302,6 @@ ObpSetHandleAttributes(
     IN ULONG_PTR Context
 );
 
-NTSTATUS
-NTAPI
-ObQueryDeviceMapInformation(
-    _In_opt_ PEPROCESS Process,
-    _Out_ PPROCESS_DEVICEMAP_INFORMATION DeviceMapInfo,
-    _In_ ULONG Flags
-);
-
 //
 // Object Lifetime Functions
 //
@@ -408,6 +400,14 @@ ObReferenceFileObjectForWrite(
 //
 // DOS Devices Functions
 //
+NTSTATUS
+NTAPI
+ObQueryDeviceMapInformation(
+    _In_opt_ PEPROCESS Process,
+    _Out_ PPROCESS_DEVICEMAP_INFORMATION DeviceMapInfo,
+    _In_ ULONG Flags
+);
+
 NTSTATUS
 NTAPI
 ObSetDeviceMap(

--- a/ntoskrnl/include/internal/ob.h
+++ b/ntoskrnl/include/internal/ob.h
@@ -293,16 +293,6 @@ ObpLookupObjectName(
 );
 
 //
-// Object Attribute Functions
-//
-BOOLEAN
-NTAPI
-ObpSetHandleAttributes(
-    IN OUT PHANDLE_TABLE_ENTRY HandleTableEntry,
-    IN ULONG_PTR Context
-);
-
-//
 // Object Lifetime Functions
 //
 VOID

--- a/ntoskrnl/ob/obhandle.c
+++ b/ntoskrnl/ob/obhandle.c
@@ -1838,62 +1838,65 @@ ObpCloseHandle(IN HANDLE Handle,
     return Status;
 }
 
-/*++
-* @name ObpSetHandleAttributes
-*
-*     The ObpSetHandleAttributes routine <FILLMEIN>
-*
-* @param HandleTableEntry
-*        <FILLMEIN>.
-*
-* @param Context
-*        <FILLMEIN>.
-*
-* @return <FILLMEIN>.
-*
-* @remarks None.
-*
-*--*/
-BOOLEAN
+/**
+ * @brief
+ * Internal callback used by ObSetHandleAttributes().
+ * Updates the attributes of a handle given by its handle table entry.
+ *
+ * This routine sets or clears the @p OBJ_INHERIT attribute and the
+ * internal close-protection bit corresponding to the protect-from-close
+ * handle attribute.
+ *
+ * @param[in,out]   HandleTableEntry
+ * Pointer to an entry in a process' handle table, representing the
+ * handle whose attributes are to be modified.
+ *
+ * @param[in]   Context
+ * Pointer-sized value to an @p OBP_SET_HANDLE_ATTRIBUTES_CONTEXT structure,
+ * that supplies the requested handle attribute values and the caller mode
+ * captured by ObSetHandleAttributes().
+ *
+ * @return
+ * TRUE if the handle attributes are updated successfully, or FALSE
+ * if the requested change is not permitted.
+ *
+ * @remarks
+ * This routine is an internal callback for ExChangeHandle()
+ * (type: @p PEX_CHANGE_HANDLE_CALLBACK).
+ * It updates per-handle state rather than the underlying object.
+ * Requests to make a handle inheritable fail if the target object
+ * type does not permit the @p OBJ_INHERIT attribute.
+ **/
+static BOOLEAN
 NTAPI
-ObpSetHandleAttributes(IN OUT PHANDLE_TABLE_ENTRY HandleTableEntry,
-                       IN ULONG_PTR Context)
+ObpSetHandleAttributes(
+    _Inout_ PHANDLE_TABLE_ENTRY HandleTableEntry,
+    _In_ ULONG_PTR Context)
 {
     POBP_SET_HANDLE_ATTRIBUTES_CONTEXT SetHandleInfo = (PVOID)Context;
-    POBJECT_HEADER ObjectHeader = ObpGetHandleObject(HandleTableEntry);
 
-    /* Check if making the handle inheritable */
+    /* Define the handle inheritance, using the OBJ_INHERIT attribute */
     if (SetHandleInfo->Information.Inherit)
     {
-        /* Check if inheriting is not supported for this object */
+        /* If inheritance is not supported for this object,
+         * fail without changing anything */
+        POBJECT_HEADER ObjectHeader = ObpGetHandleObject(HandleTableEntry);
         if (ObjectHeader->Type->TypeInfo.InvalidAttributes & OBJ_INHERIT)
-        {
-            /* Fail without changing anything */
             return FALSE;
-        }
 
-        /* Set the flag */
         HandleTableEntry->ObAttributes |= OBJ_INHERIT;
     }
     else
     {
-        /* Otherwise this implies we're removing the flag */
         HandleTableEntry->ObAttributes &= ~OBJ_INHERIT;
     }
 
-    /* Check if making the handle protected */
+    /* Define the handle protection, using the protect-from-close bit */
     if (SetHandleInfo->Information.ProtectFromClose)
-    {
-        /* Set the flag */
         HandleTableEntry->GrantedAccess |= ObpAccessProtectCloseBit;
-    }
     else
-    {
-        /* Otherwise, remove it */
         HandleTableEntry->GrantedAccess &= ~ObpAccessProtectCloseBit;
-    }
 
-    /* Return success */
     return TRUE;
 }
 
@@ -3283,36 +3286,45 @@ ObInsertObject(IN PVOID Object,
     return RealStatus;
 }
 
-/*++
-* @name ObSetHandleAttributes
-* @implemented NT5.1
-*
-*     The ObSetHandleAttributes routine <FILLMEIN>
-*
-* @param Handle
-*        <FILLMEIN>.
-*
-* @param HandleFlags
-*        <FILLMEIN>.
-*
-* @param PreviousMode
-*        <FILLMEIN>.
-*
-* @return <FILLMEIN>.
-*
-* @remarks None.
-*
-*--*/
+/**
+ * @brief
+ * Sets the attributes (inheritable and protect-from-close) of an
+ * existing object handle.
+ *
+ * @param[in]   Handle
+ * Handle whose attributes are to be modified.
+ *
+ * @param[in]   HandleFlags
+ * Pointer to an @p OBJECT_HANDLE_ATTRIBUTE_INFORMATION structure
+ * specifying the new values for the handle's inherit and
+ * protect-from-close attributes.
+ *
+ * @param[in]   PreviousMode
+ * Processor mode of the original caller. This is used to determine
+ * whether @p Handle may refer to a kernel handle.
+ *
+ * @return
+ * STATUS_SUCCESS on success, or STATUS_ACCESS_DENIED if the handle
+ * could not be located or its attributes could not be changed.
+ *
+ * @remarks
+ * This routine operates on per-handle state rather than on the
+ * underlying object itself.
+ * Requests to make a handle inheritable fail if the target object
+ * type does not permit the @p OBJ_INHERIT attribute.
+ **/
 NTSTATUS
 NTAPI
-ObSetHandleAttributes(IN HANDLE Handle,
-                      IN POBJECT_HANDLE_ATTRIBUTE_INFORMATION HandleFlags,
-                      IN KPROCESSOR_MODE PreviousMode)
+ObSetHandleAttributes(
+    _In_ HANDLE Handle,
+    _In_ POBJECT_HANDLE_ATTRIBUTE_INFORMATION HandleFlags,
+    _In_ KPROCESSOR_MODE PreviousMode)
 {
     OBP_SET_HANDLE_ATTRIBUTES_CONTEXT SetHandleAttributesContext;
-    BOOLEAN Result, AttachedToSystemProcess = FALSE;
+    BOOLEAN Result, AttachedToProcess = FALSE;
     PHANDLE_TABLE HandleTable;
     KAPC_STATE ApcState;
+
     PAGED_CODE();
 
     /* Check if this is a kernel handle */
@@ -3327,7 +3339,7 @@ ObSetHandleAttributes(IN HANDLE Handle,
         {
             /* Attach to the system process */
             KeStackAttachProcess(&PsInitialSystemProcess->Pcb, &ApcState);
-            AttachedToSystemProcess = TRUE;
+            AttachedToProcess = TRUE;
         }
     }
     else
@@ -3346,15 +3358,12 @@ ObSetHandleAttributes(IN HANDLE Handle,
                             ObpSetHandleAttributes,
                             (ULONG_PTR)&SetHandleAttributesContext);
 
-    /* Did we attach to the system process? */
-    if (AttachedToSystemProcess)
-    {
-        /* Detach from it */
+    /* Detach from the system process if needed */
+    if (AttachedToProcess)
         KeUnstackDetachProcess(&ApcState);
-    }
 
     /* Return the result as an NTSTATUS value */
-    return Result ? STATUS_SUCCESS : STATUS_ACCESS_DENIED;
+    return (Result ? STATUS_SUCCESS : STATUS_ACCESS_DENIED);
 }
 
 /*++

--- a/ntoskrnl/ob/oblife.c
+++ b/ntoskrnl/ob/oblife.c
@@ -1796,72 +1796,84 @@ NtQueryObject(IN HANDLE ObjectHandle,
     return Status;
 }
 
-/*++
-* @name NtSetInformationObject
-* @implemented NT4
-*
-*     The NtSetInformationObject routine <FILLMEIN>
-*
-* @param ObjectHandle
-*        <FILLMEIN>
-*
-* @param ObjectInformationClass
-*        <FILLMEIN>
-*
-* @param ObjectInformation
-*        <FILLMEIN>
-*
-* @param Length
-*        <FILLMEIN>
-*
-* @return STATUS_SUCCESS or appropriate error value.
-*
-* @remarks None.
-*
-*--*/
+/**
+ * @brief
+ * Sets information for an object or for a handle to an object.
+ *
+ * @param[in]   ObjectHandle
+ * Handle to the target object.
+ * For the @p ObjectHandleFlagInformation class, this is the handle
+ * whose attributes are to be modified.
+ * For the @p ObjectSessionInformation class, this must be a handle
+ * to a directory object.
+ *
+ * @param[in]   ObjectInformationClass
+ * Specifies the type of information to set. The only supported classes
+ * are: ObjectHandleFlagInformation and ObjectSessionInformation.
+ * (Windows 10 RS2 added support for ObjectSessionObjectInformation.
+ *  Windows 11 25H2 added support for ObjectSetRefTraceInformation.)
+ *
+ * @param[in]   ObjectInformation
+ * Pointer to a caller-supplied buffer containing the information to set.
+ * For the @p ObjectHandleFlagInformation class, this buffer must point
+ * to an @p OBJECT_HANDLE_ATTRIBUTE_INFORMATION structure describing the
+ * desired handle attributes (inherit and protect-from-close).
+ * For the @p ObjectSessionInformation class, this parameter is ignored.
+ *
+ * @param[in]   Length
+ * The size in bytes, of the buffer pointed to by @p ObjectInformation.
+ * For the @p ObjectHandleFlagInformation class, this must be
+ * sizeof(OBJECT_HANDLE_ATTRIBUTE_INFORMATION).
+ * For the @p ObjectSessionInformation class, this parameter is ignored.
+ *
+ * @return
+ * STATUS_SUCCESS or an appropriate error value.
+ *
+ * @remarks
+ * This routine only supports the following classes:
+ * - @p ObjectHandleFlagInformation, to set the @p OBJ_INHERIT and
+ *   @p OBJ_PROTECT_CLOSE attributes of a handle.
+ * - @p ObjectSessionInformation, to associate a directory object with the
+ *   caller's current session identifier; this requires the SeTcbPrivilege.
+ *
+ * @p ObjectHandleFlagInformation operates on per-handle state rather than
+ * on the underlying object itself.
+ **/
 NTSTATUS
 NTAPI
-NtSetInformationObject(IN HANDLE ObjectHandle,
-                       IN OBJECT_INFORMATION_CLASS ObjectInformationClass,
-                       IN PVOID ObjectInformation,
-                       IN ULONG Length)
+NtSetInformationObject(
+    _In_ HANDLE ObjectHandle,
+    _In_ OBJECT_INFORMATION_CLASS ObjectInformationClass,
+    _In_reads_bytes_(Length) PVOID ObjectInformation,
+    _In_ ULONG Length)
 {
     NTSTATUS Status;
-    OBP_SET_HANDLE_ATTRIBUTES_CONTEXT Context;
-    PVOID ObjectTable;
-    KAPC_STATE ApcState;
-    POBJECT_DIRECTORY Directory;
     KPROCESSOR_MODE PreviousMode;
-    BOOLEAN AttachedToProcess = FALSE;
+
     PAGED_CODE();
 
     /* Validate the information class */
     switch (ObjectInformationClass)
     {
         case ObjectHandleFlagInformation:
+        {
+            OBJECT_HANDLE_ATTRIBUTE_INFORMATION HandleFlags;
 
             /* Validate the length */
-            if (Length != sizeof(OBJECT_HANDLE_ATTRIBUTE_INFORMATION))
-            {
-                /* Invalid length */
+            if (Length != sizeof(HandleFlags))
                 return STATUS_INFO_LENGTH_MISMATCH;
-            }
 
             /* Save the previous mode */
-            Context.PreviousMode = ExGetPreviousMode();
+            PreviousMode = ExGetPreviousMode();
 
-            /* Check if we were called from user mode */
-            if (Context.PreviousMode != KernelMode)
+            /* If we were called from user mode, probe and capture the
+             * attribute buffer, otherwise just copy it directly. */
+            if (PreviousMode != KernelMode)
             {
-                /* Enter SEH */
                 _SEH2_TRY
                 {
-                    /* Probe and capture the attribute buffer */
-                    ProbeForRead(ObjectInformation,
-                                 sizeof(OBJECT_HANDLE_ATTRIBUTE_INFORMATION),
-                                 sizeof(BOOLEAN));
-                    Context.Information = *(POBJECT_HANDLE_ATTRIBUTE_INFORMATION)
-                                            ObjectInformation;
+                    ProbeForRead(ObjectInformation, sizeof(HandleFlags), sizeof(BOOLEAN));
+                    HandleFlags = *(POBJECT_HANDLE_ATTRIBUTE_INFORMATION)ObjectInformation;
                 }
                 _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
                 {
@@ -1872,87 +1884,52 @@ NtSetInformationObject(IN HANDLE ObjectHandle,
             }
             else
             {
-                /* Just copy the buffer directly */
-                Context.Information = *(POBJECT_HANDLE_ATTRIBUTE_INFORMATION)
-                                        ObjectInformation;
+                HandleFlags = *(POBJECT_HANDLE_ATTRIBUTE_INFORMATION)ObjectInformation;
             }
 
-            /* Check if this is a kernel handle */
-            if (ObpIsKernelHandle(ObjectHandle, Context.PreviousMode))
-            {
-                /* Get the actual handle */
-                ObjectHandle = ObKernelHandleToHandle(ObjectHandle);
-                ObjectTable = ObpKernelHandleTable;
-
-                /* Check if we're not in the system process */
-                if (PsGetCurrentProcess() != PsInitialSystemProcess)
-                {
-                    /* Attach to it */
-                    KeStackAttachProcess(&PsInitialSystemProcess->Pcb, &ApcState);
-                    AttachedToProcess = TRUE;
-                }
-            }
-            else
-            {
-                /* Use the current table */
-                ObjectTable = PsGetCurrentProcess()->ObjectTable;
-            }
-
-            /* Change the handle attributes */
-            if (!ExChangeHandle(ObjectTable,
-                                ObjectHandle,
-                                ObpSetHandleAttributes,
-                                (ULONG_PTR)&Context))
-            {
-                /* Some failure */
-                Status = STATUS_ACCESS_DENIED;
-            }
-            else
-            {
-                /* We are done */
-                Status = STATUS_SUCCESS;
-            }
-
-            /* De-attach if we were attached, and return status */
-            if (AttachedToProcess) KeUnstackDetachProcess(&ApcState);
+            Status = ObSetHandleAttributes(ObjectHandle, &HandleFlags, PreviousMode);
             break;
+        }
 
         case ObjectSessionInformation:
+        {
+            POBJECT_DIRECTORY Directory;
+
+            UNREFERENCED_PARAMETER(ObjectInformation);
+            UNREFERENCED_PARAMETER(Length);
 
             /* Only a system process can do this */
             PreviousMode = ExGetPreviousMode();
             if (!SeSinglePrivilegeCheck(SeTcbPrivilege, PreviousMode))
             {
-                /* Fail */
                 DPRINT1("Privilege not held\n");
-                Status = STATUS_PRIVILEGE_NOT_HELD;
+                return STATUS_PRIVILEGE_NOT_HELD;
             }
-            else
+
+            /* Get the object directory */
+            Status = ObReferenceObjectByHandle(ObjectHandle,
+                                               0,
+                                               ObpDirectoryObjectType,
+                                               PreviousMode,
+                                               (PVOID*)&Directory,
+                                               NULL);
+            if (NT_SUCCESS(Status))
             {
-                /* Get the object directory */
-                Status = ObReferenceObjectByHandle(ObjectHandle,
-                                                   0,
-                                                   ObpDirectoryObjectType,
-                                                   PreviousMode,
-                                                   (PVOID*)&Directory,
-                                                   NULL);
-                if (NT_SUCCESS(Status))
-                {
-                    /* Setup a lookup context */
-                    OBP_LOOKUP_CONTEXT LookupContext;
-                    ObpInitializeLookupContext(&LookupContext);
+                /* Setup a lookup context */
+                OBP_LOOKUP_CONTEXT LookupContext;
+                ObpInitializeLookupContext(&LookupContext);
 
-                    /* Set the directory session ID */
-                    ObpAcquireDirectoryLockExclusive(Directory, &LookupContext);
-                    Directory->SessionId = PsGetCurrentProcessSessionId();
-                    ObpReleaseDirectoryLock(Directory, &LookupContext);
+                /* Set the directory session ID */
+                ObpAcquireDirectoryLockExclusive(Directory, &LookupContext);
+                Directory->SessionId = PsGetCurrentProcessSessionId();
+                ObpReleaseDirectoryLock(Directory, &LookupContext);
 
-                    /* We're done, release the context and dereference the directory */
-                    ObpReleaseLookupContext(&LookupContext);
-                    ObDereferenceObject(Directory);
-                }
+                /* We're done, release the context and dereference the directory */
+                ObpReleaseLookupContext(&LookupContext);
+                ObDereferenceObject(Directory);
             }
             break;
+        }
 
         default:
             /* Unsupported class */

--- a/sdk/include/ndk/obfuncs.h
+++ b/sdk/include/ndk/obfuncs.h
@@ -81,9 +81,27 @@ ObCreateObjectType(
 NTKERNELAPI
 VOID
 NTAPI
+ObDereferenceObjectDeferDelete(
+    _In_ PVOID Object
+);
+
+NTKERNELAPI
+VOID
+NTAPI
 ObDereferenceSecurityDescriptor(
     _Inout_ PSECURITY_DESCRIPTOR SecurityDescriptor,
     _In_ ULONG Count
+);
+
+NTKERNELAPI
+BOOLEAN
+NTAPI
+ObFindHandleForObject(
+    _In_ PEPROCESS Process,
+    _In_ PVOID Object,
+    _In_ POBJECT_TYPE ObjectType,
+    _In_opt_ POBJECT_HANDLE_INFORMATION HandleInformation,
+    _Out_opt_ PHANDLE Handle
 );
 
 NTKERNELAPI
@@ -144,24 +162,6 @@ ObSetSecurityObjectByPointer(
     _In_ PVOID Object,
     _In_ SECURITY_INFORMATION SecurityInformation,
     _In_ PSECURITY_DESCRIPTOR SecurityDescriptor
-);
-
-NTKERNELAPI
-BOOLEAN
-NTAPI
-ObFindHandleForObject(
-    _In_ PEPROCESS Process,
-    _In_ PVOID Object,
-    _In_ POBJECT_TYPE ObjectType,
-    _In_opt_ POBJECT_HANDLE_INFORMATION HandleInformation,
-    _Out_opt_ PHANDLE Handle
-);
-
-NTKERNELAPI
-VOID
-NTAPI
-ObDereferenceObjectDeferDelete(
-    _In_ PVOID Object
 );
 
 #endif

--- a/sdk/include/ndk/obfuncs.h
+++ b/sdk/include/ndk/obfuncs.h
@@ -158,6 +158,15 @@ ObReferenceSecurityDescriptor(
 NTKERNELAPI
 NTSTATUS
 NTAPI
+ObSetHandleAttributes(
+    _In_ HANDLE Handle,
+    _In_ POBJECT_HANDLE_ATTRIBUTE_INFORMATION HandleFlags,
+    _In_ KPROCESSOR_MODE PreviousMode
+);
+
+NTKERNELAPI
+NTSTATUS
+NTAPI
 ObSetSecurityObjectByPointer(
     _In_ PVOID Object,
     _In_ SECURITY_INFORMATION SecurityInformation,

--- a/sdk/include/ndk/obfuncs.h
+++ b/sdk/include/ndk/obfuncs.h
@@ -323,7 +323,7 @@ NTAPI
 NtSetInformationObject(
     _In_ HANDLE ObjectHandle,
     _In_ OBJECT_INFORMATION_CLASS ObjectInformationClass,
-    _In_ PVOID ObjectInformation,
+    _In_reads_bytes_(Length) PVOID ObjectInformation,
     _In_ ULONG Length
 );
 


### PR DESCRIPTION
## Proposed changes

- ### `[NDK][NTOS:INCLUDE] Minor reshuffling of some functions`

- ### `[NTOS:OB] Enhancements to NtSetInformationObject()`

  - Simplify the `ObjectHandleFlagInformation` class implementation, by directly invoking the `ObSetHandleAttributes()` routine.
    Addendum to commit 02d0bb9dbd (r22228) that implemented the class, and to commit 91105c7915 (r61037) that implemented `ObSetHandleAttributes()`.

  - Use SAL2 annotations; write Doxygen documentation (based on GPT-5.4 feedback and https://ntdoc.m417z.com/ntsetinformationobject).

- ### `[NTOS:OB][NDK] Enhancements to ObSetHandleAttributes() and ObpSetHandleAttributes()`

  - Use SAL2 annotations; write Doxygen documentation (based on GPT-5.4 feedback).
  - Simplify some of the code.
  - Add the `ObSetHandleAttributes()` prototype to `ndk/obfuncs.h`, since it is exported by ntoskrnl.exe
