### PR TITLE
[SDK][SHELL32_APITEST][USER32_APITEST] Update <msgdump.h> to version 21

### DIFF
--- a/modules/rostests/apitests/shell32/SHAppBarMessage.cpp
+++ b/modules/rostests/apitests/shell32/SHAppBarMessage.cpp
@@ -12,7 +12,7 @@
 
 /* Based on https://github.com/katahiromz/AppBarSample */
 
-/* #define VERBOSE */
+//#define VERBOSE
 
 #define IDT_AUTOHIDE 1
 #define IDT_AUTOUNHIDE 2

--- a/modules/rostests/apitests/shell32/SHAppBarMessage.cpp
+++ b/modules/rostests/apitests/shell32/SHAppBarMessage.cpp
@@ -12,7 +12,7 @@
 
 /* Based on https://github.com/katahiromz/AppBarSample */
 
-//#define VERBOSE
+/* #define VERBOSE */
 
 #define IDT_AUTOHIDE 1
 #define IDT_AUTOUNHIDE 2
@@ -74,21 +74,7 @@ SHAppBarMessageWrap(DWORD dwMessage, PAPPBARDATA pData)
 #undef ARRAYSIZE
 #define ARRAYSIZE _countof
 
-void appbar_tprintf(const TCHAR *fmt, ...)
-{
-    TCHAR szText[512];
-    va_list va;
-    va_start(va, fmt);
-    wvsprintf(szText, fmt, va);
-#ifdef UNICODE
-    printf("%ls", szText);
-#else
-    printf("%s", szText);
-#endif
-    va_end(va);
-}
-
-#define MSGDUMP_TPRINTF appbar_tprintf
+#define MSGDUMP_PRINTF printf
 #include "msgdump.h"
 
 #endif  // def VERBOSE

--- a/modules/rostests/apitests/user32/MessageStateAnalyzer.c
+++ b/modules/rostests/apitests/user32/MessageStateAnalyzer.c
@@ -11,7 +11,7 @@
 #include <imm.h>
 #include <strsafe.h>
 
-/* #define VERBOSE */
+//#define VERBOSE
 
 #define MAX_MSGS 512
 

--- a/modules/rostests/apitests/user32/MessageStateAnalyzer.c
+++ b/modules/rostests/apitests/user32/MessageStateAnalyzer.c
@@ -25,7 +25,7 @@ static WNDPROC s_fnOldEditWndProc = NULL;
 static WNDPROC s_fnOldImeWndProc = NULL;
 
 #ifdef VERBOSE
-    #define MSGDUMP_PRINTF trace
+    #define MSGDUMP_PRINTF printf
     #define MSGDUMP_PREFIX s_prefix
     #include "msgdump.h" /* msgdump.h needs MSGDUMP_PRINTF and MSGDUMP_PREFIX */
 #else

--- a/modules/rostests/apitests/user32/MessageStateAnalyzer.c
+++ b/modules/rostests/apitests/user32/MessageStateAnalyzer.c
@@ -24,7 +24,7 @@ static WNDPROC s_fnOldImeWndProc = NULL;
 
 #define MSGDUMP_PRINTF trace
 #define MSGDUMP_PREFIX s_prefix
-#include "msgdump.h"    /* msgdump.h needs MSGDUMP_TPRINTF and MSGDUMP_PREFIX */
+#include "msgdump.h" /* msgdump.h needs MSGDUMP_PRINTF and MSGDUMP_PREFIX */
 
 static void MD_build_prefix(void)
 {

--- a/modules/rostests/apitests/user32/MessageStateAnalyzer.c
+++ b/modules/rostests/apitests/user32/MessageStateAnalyzer.c
@@ -11,6 +11,8 @@
 #include <imm.h>
 #include <strsafe.h>
 
+/* #define VERBOSE */
+
 #define MAX_MSGS 512
 
 static MSG s_Msgs[MAX_MSGS];
@@ -22,9 +24,14 @@ static HWND s_hImeWnd = NULL;
 static WNDPROC s_fnOldEditWndProc = NULL;
 static WNDPROC s_fnOldImeWndProc = NULL;
 
-#define MSGDUMP_PRINTF trace
-#define MSGDUMP_PREFIX s_prefix
-#include "msgdump.h" /* msgdump.h needs MSGDUMP_PRINTF and MSGDUMP_PREFIX */
+#ifdef VERBOSE
+    #define MSGDUMP_PRINTF trace
+    #define MSGDUMP_PREFIX s_prefix
+    #include "msgdump.h" /* msgdump.h needs MSGDUMP_PRINTF and MSGDUMP_PREFIX */
+#else
+    #define MD_msgdump(hwnd, uMsg, wParam, lParam)
+    #define MD_msgresult(hwnd, uMsg, wParam, lParam, lResult)
+#endif
 
 static void MD_build_prefix(void)
 {

--- a/sdk/include/reactos/msgdump.h
+++ b/sdk/include/reactos/msgdump.h
@@ -6103,7 +6103,8 @@ MD_msgresult_def_proc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESUL
         MSGDUMP_PRINTF("%sWM_APP+%u(hwnd:%p, lResult:%p)\n",
                        MSGDUMP_PREFIX, uMsg - WM_APP, (void *)hwnd, (void *)lResult);
     }
-    if (0xC000 <= uMsg && uMsg <= 0xFFFF && GlobalGetAtomNameA(uMsg, szName, _countof(szName)))
+    else if (0xC000 <= uMsg && uMsg <= 0xFFFF &&
+             GlobalGetAtomNameA(uMsg, szName, _countof(szName)))
     {
         /* RegisterWindowMessage'd message */
         MSGDUMP_PRINTF("%s'%s'(%u)(hwnd:%p, wParam:%p, lParam:%p)\n",

--- a/sdk/include/reactos/msgdump.h
+++ b/sdk/include/reactos/msgdump.h
@@ -18,7 +18,7 @@
 #include <strsafe.h>
 
 #ifndef MSGDUMP_PRINTF
-    #error Please define MSGDUMP_PRINTF macro before #include "msgdump.h".
+    #define MSGDUMP_PRINTF printf
 #endif
 
 #ifndef MSGDUMP_API

--- a/sdk/include/reactos/msgdump.h
+++ b/sdk/include/reactos/msgdump.h
@@ -29,7 +29,8 @@
     #define MSGDUMP_PREFIX ""
 #endif
 
-typedef LRESULT (CALLBACK *MD_MSGRESULT_PROC)(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult);
+typedef LRESULT (CALLBACK *MD_MSGRESULT_PROC)(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
+                                              LRESULT lResult);
 
 /* MD_msgdump function */
 static __inline LRESULT MSGDUMP_API
@@ -41,7 +42,8 @@ MD_msgdump_ex(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, WNDPROC fnDefP
 static __inline LRESULT MSGDUMP_API
 MD_msgresult(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult);
 static __inline LRESULT MSGDUMP_API
-MD_msgresult_ex(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult, MD_MSGRESULT_PROC fnDefProc);
+MD_msgresult_ex(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult,
+                MD_MSGRESULT_PROC fnDefProc);
 
 static __inline LRESULT CALLBACK
 MD_msgdump_def_proc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
@@ -651,7 +653,8 @@ MD_GetNotifyCode(HWND hwndFrom, UINT code)
 static __inline LRESULT MSGDUMP_API
 MD_OnNotify(HWND hwnd, int idFrom, LPNMHDR pnmhdr)
 {
-    MSGDUMP_PRINTF("%sWM_NOTIFY(hwnd:%p, idFrom:%d, pnmhdr:%p, hwndFrom:%p, pnmhdr->idFrom:%d, code:%s)\n",
+    MSGDUMP_PRINTF("%sWM_NOTIFY(hwnd:%p, idFrom:%d, pnmhdr:%p, "
+                   "hwndFrom:%p, pnmhdr->idFrom:%d, code:%s)\n",
                    MSGDUMP_PREFIX, (void *)hwnd, idFrom, (void *)pnmhdr,
                    pnmhdr->hwndFrom, pnmhdr->idFrom,
                    MD_GetNotifyCode(pnmhdr->hwndFrom, pnmhdr->code));
@@ -1058,7 +1061,8 @@ static __inline void MSGDUMP_API
 MD_MDIActivate(HWND hwnd, BOOL fActive, HWND hwndActivate, HWND hwndDeactivate)
 {
     MSGDUMP_PRINTF("%sWM_MDIACTIVATE(hwnd:%p, fActive:%d, hwndActivate:%p, hwndDeactivate:%p)\n",
-                   MSGDUMP_PREFIX, (void *)hwnd, fActive, (void *)hwndActivate, (void *)hwndDeactivate);
+                   MSGDUMP_PREFIX, (void *)hwnd, fActive, (void *)hwndActivate,
+                   (void *)hwndDeactivate);
 }
 
 static __inline void MSGDUMP_API
@@ -1168,7 +1172,8 @@ static __inline HMENU MSGDUMP_API
 MD_MDISetMenu(HWND hwnd, BOOL fRefresh, HMENU hmenuFrame, HMENU hmenuWindow)
 {
     MSGDUMP_PRINTF("%sWM_MDISETMENU(hwnd:%p, fRefresh:%d, hmenuFrame:%p, hmenuWindow:%p)\n",
-                   MSGDUMP_PREFIX, (void *)hwnd, fRefresh, (void *)hmenuFrame, (void *)hmenuWindow);
+                   MSGDUMP_PREFIX, (void *)hwnd, fRefresh, (void *)hmenuFrame,
+                   (void *)hmenuWindow);
     return NULL;
 }
 
@@ -1440,8 +1445,9 @@ MD_OnNCXButtonDown(HWND hwnd, BOOL fDoubleClick, UINT nHitTest, WORD fwButton,
 {
     if (fDoubleClick)
     {
-        MSGDUMP_PRINTF("%sWM_NCXBUTTONDBLCLK(hwnd:%p, nHitTest:%u, fwButton:%u, xPos:%d, yPos:%d)\n",
-                      MSGDUMP_PREFIX, (void *)hwnd, nHitTest, fwButton, xPos, yPos);
+        MSGDUMP_PRINTF("%sWM_NCXBUTTONDBLCLK(hwnd:%p, nHitTest:%u, fwButton:%u, "
+                       "xPos:%d, yPos:%d)\n",
+                       MSGDUMP_PREFIX, (void *)hwnd, nHitTest, fwButton, xPos, yPos);
     }
     else
     {
@@ -5371,10 +5377,12 @@ MD_msgdump(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 }
 
 static __inline LRESULT MSGDUMP_API
-MD_msgresult_ex(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult, MD_MSGRESULT_PROC fnDefProc)
+MD_msgresult_ex(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult,
+                MD_MSGRESULT_PROC fnDefProc)
 {
-#define DEFINE_RESULT(WM_) case WM_: MSGDUMP_PRINTF("%s" #WM_ ": hwnd:%p, lResult:%p\n", \
-                                                    MSGDUMP_PREFIX, (void *)hwnd, (void *)lResult); break
+#define DEFINE_RESULT(WM_) \
+    case WM_: MSGDUMP_PRINTF("%s" #WM_ ": hwnd:%p, lResult:%p\n", \
+                             MSGDUMP_PREFIX, (void *)hwnd, (void *)lResult); break
     char szClass[64], sz[2];
     szClass[0] = 0;
     GetClassNameA(hwnd, szClass, _countof(szClass));

--- a/sdk/include/reactos/msgdump.h
+++ b/sdk/include/reactos/msgdump.h
@@ -2,16 +2,11 @@
  * PROJECT:     ReactOS header files
  * LICENSE:     CC-BY-4.0 (https://spdx.org/licenses/CC-BY-4.0)
  * PURPOSE:     Win32API message dumping
- * COPYRIGHT:   Copyright 2018-2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ * COPYRIGHT:   Copyright 2018-2026 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 #ifndef _INC_MSGDUMP
-#define _INC_MSGDUMP    19   /* Version 19 */
+#define _INC_MSGDUMP    21   /* Version 21 */
 
-/*
- * NOTE: MD_msgdump function in this file provides Win32API message dump feature.
- * NOTE: This header file takes time to compile.
- *       You might indirectly use MD_msgdump function.
- */
 #pragma once
 
 #ifndef _INC_WINXX
@@ -34,13 +29,24 @@
     #define MSGDUMP_PREFIX ""
 #endif
 
+typedef LRESULT (CALLBACK *MD_MSGRESULT_PROC)(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult);
+
 /* MD_msgdump function */
 static __inline LRESULT MSGDUMP_API
 MD_msgdump(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+static __inline LRESULT MSGDUMP_API
+MD_msgdump_ex(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, WNDPROC fnDefProc);
 
 /* MD_msgresult function */
 static __inline LRESULT MSGDUMP_API
 MD_msgresult(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult);
+static __inline LRESULT MSGDUMP_API
+MD_msgresult_ex(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult, MD_MSGRESULT_PROC fnDefProc);
+
+static __inline LRESULT CALLBACK
+MD_msgdump_def_proc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+static __inline LRESULT CALLBACK
+MD_msgresult_def_proc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult);
 
 /*---- The below codes are boring details of MD_msgdump and MD_msgresult implementation. ----*/
 
@@ -65,8 +71,7 @@ static __inline LRESULT MSGDUMP_API
 MD_OnUnknown(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     char szName[64];
-    if (0xC000 <= uMsg && uMsg <= 0xFFFF &&
-        GlobalGetAtomNameA(uMsg, szName, _countof(szName)))
+    if (0xC000 <= uMsg && uMsg <= 0xFFFF && GlobalGetAtomNameA(uMsg, szName, _countof(szName)))
     {
         /* RegisterWindowMessage'd message */
         MSGDUMP_PRINTF("%s'%s'(%u)(hwnd:%p, wParam:%p, lParam:%p)\n",
@@ -169,18 +174,18 @@ MD_OnSetRedraw(HWND hwnd, BOOL fRedraw)
 }
 
 static __inline void MSGDUMP_API
-MD_OnSetText(HWND hwnd, PCSTR lpszText)
+MD_OnSetText(HWND hwnd, LPCVOID lpszText)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sWM_SETTEXT(hwnd:%p, lpszText:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, (PCWSTR)lpszText);
     else
-        MSGDUMP_PRINTF("%sWM_SETTEXT(hwnd:%p, lpszText:%s)\n",
+        MSGDUMP_PRINTF("%sWM_SETTEXT(hwnd:%p, lpszText:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, (PCSTR)lpszText);
 }
 
 static __inline INT MSGDUMP_API
-MD_OnGetText(HWND hwnd, int cchTextMax, LPTSTR lpszText)
+MD_OnGetText(HWND hwnd, int cchTextMax, PVOID lpszText)
 {
     MSGDUMP_PRINTF("%sWM_GETTEXT(hwnd:%p, cchTextMax:%d, lpszText:%p)\n",
                    MSGDUMP_PREFIX, (void *)hwnd, cchTextMax, (void *)lpszText);
@@ -262,21 +267,25 @@ MD_OnShowWindow(HWND hwnd, BOOL fShow, UINT status)
 }
 
 static __inline LRESULT MSGDUMP_API
-MD_OnSettingChange(HWND hwnd, UINT_PTR wFlag, PCSTR pszSection)
+MD_OnSettingChange(HWND hwnd, UINT_PTR wFlag, LPCVOID pszSection)
 {
-    MSGDUMP_PRINTF("%sWM_SETTINGCHANGE(hwnd:%p, wFlag:%p, pszSection:%s)\n",
-                   MSGDUMP_PREFIX, (void *)hwnd, (void *)wFlag, pszSection);
+    if (IsWindowUnicode(hwnd))
+        MSGDUMP_PRINTF("%sWM_SETTINGCHANGE(hwnd:%p, wFlag:%p, pszSection:%ls)\n",
+                       MSGDUMP_PREFIX, (void *)hwnd, (void *)wFlag, (PCWSTR)pszSection);
+    else
+        MSGDUMP_PRINTF("%sWM_SETTINGCHANGE(hwnd:%p, wFlag:%p, pszSection:%hs)\n",
+                       MSGDUMP_PREFIX, (void *)hwnd, (void *)wFlag, (PCSTR)pszSection);
     return 0;
 }
 
 static __inline void MSGDUMP_API
-MD_OnDevModeChange(HWND hwnd, PCSTR lpszDeviceName)
+MD_OnDevModeChange(HWND hwnd, LPCVOID lpszDeviceName)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sWM_DEVMODECHANGE(hwnd:%p, lpszDeviceName:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, (PCWSTR)lpszDeviceName);
     else
-        MSGDUMP_PRINTF("%sWM_DEVMODECHANGE(hwnd:%p, lpszDeviceName:%s)\n",
+        MSGDUMP_PRINTF("%sWM_DEVMODECHANGE(hwnd:%p, lpszDeviceName:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, (PCSTR)lpszDeviceName);
 }
 
@@ -483,7 +492,7 @@ MD_OnCopyData(HWND hwnd, HWND hwndFrom, PCOPYDATASTRUCT pcds)
 static __inline LPCSTR MSGDUMP_API
 MD_GetNotifyCode(HWND hwndFrom, UINT code)
 {
-    char szClass[24], sz[2];
+    char szClass[64], sz[2];
     static char s_szText[64];
 
     switch (code)
@@ -1258,7 +1267,7 @@ MD_OnSizeClipboard(HWND hwnd, HWND hwndCBViewer, const LPRECT lprc)
 }
 
 static __inline void MSGDUMP_API
-MD_OnAskCBFormatName(HWND hwnd, int cchMax, LPTSTR rgchName)
+MD_OnAskCBFormatName(HWND hwnd, int cchMax, PVOID rgchName)
 {
     MSGDUMP_PRINTF("%sWM_ASKCBFORMATNAME(hwnd:%p, cchMax:%d, rgchName:%p)\n",
                    MSGDUMP_PREFIX, (void *)hwnd, cchMax, (void *)rgchName);
@@ -1867,7 +1876,7 @@ MD_Edit_OnLineLength(HWND hwnd, INT ich)
 }
 
 static __inline void MSGDUMP_API
-MD_Edit_OnReplaceSel(HWND hwnd, BOOL fCanUndo, PCSTR lpszReplace)
+MD_Edit_OnReplaceSel(HWND hwnd, BOOL fCanUndo, LPCVOID lpszReplace)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sEM_REPLACESEL(hwnd:%p, fCanUndo:%d, %ls)\n",
@@ -1878,13 +1887,13 @@ MD_Edit_OnReplaceSel(HWND hwnd, BOOL fCanUndo, PCSTR lpszReplace)
 }
 
 static __inline INT MSGDUMP_API
-MD_Edit_OnGetLine(HWND hwnd, INT line, PCSTR lpch)
+MD_Edit_OnGetLine(HWND hwnd, INT line, LPCVOID lpch)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sEM_GETLINE(hwnd:%p, line:%d, lpch:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, line, (PCWSTR)lpch);
     else
-        MSGDUMP_PRINTF("%sEM_GETLINE(hwnd:%p, line:%d, lpch:%s)\n",
+        MSGDUMP_PRINTF("%sEM_GETLINE(hwnd:%p, line:%d, lpch:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, line, (PCSTR)lpch);
     return 0;
 }
@@ -2077,25 +2086,25 @@ MD_Static_OnGetImage(HWND hwnd, UINT fImageType)
 }
 
 static __inline INT MSGDUMP_API
-MD_ListBox_OnAddString(HWND hwnd, PCSTR lpsz)
+MD_ListBox_OnAddString(HWND hwnd, LPCVOID lpsz)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sLB_ADDSTRING(hwnd:%p, lpsz:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, (PCWSTR)lpsz);
     else
-        MSGDUMP_PRINTF("%sLB_ADDSTRING(hwnd:%p, lpsz:%s)\n",
+        MSGDUMP_PRINTF("%sLB_ADDSTRING(hwnd:%p, lpsz:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, (PCSTR)lpsz);
     return 0;
 }
 
 static __inline INT MSGDUMP_API
-MD_ListBox_OnInsertString(HWND hwnd, INT index, PCSTR lpsz)
+MD_ListBox_OnInsertString(HWND hwnd, INT index, LPCVOID lpsz)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sLB_INSERTSTRING(hwnd:%p, index:%d, lpsz:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, index, (PCWSTR)lpsz);
     else
-        MSGDUMP_PRINTF("%sLB_INSERTSTRING(hwnd:%p, index:%d, lpsz:%s)\n",
+        MSGDUMP_PRINTF("%sLB_INSERTSTRING(hwnd:%p, index:%d, lpsz:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, index, (PCSTR)lpsz);
     return 0;
 }
@@ -2156,7 +2165,7 @@ MD_ListBox_OnGetCurSel(HWND hwnd)
 }
 
 static __inline INT MSGDUMP_API
-MD_ListBox_OnGetText(HWND hwnd, INT index, LPTSTR lpszBuffer)
+MD_ListBox_OnGetText(HWND hwnd, INT index, PVOID lpszBuffer)
 {
     MSGDUMP_PRINTF("%sLB_GETTEXT(hwnd:%p, lpszBuffer:%p)\n",
                    MSGDUMP_PREFIX, (void *)hwnd, (void *)lpszBuffer);
@@ -2180,25 +2189,25 @@ MD_ListBox_OnGetCount(HWND hwnd)
 }
 
 static __inline INT MSGDUMP_API
-MD_ListBox_OnSelectString(HWND hwnd, INT indexStart, PCSTR lpszFind)
+MD_ListBox_OnSelectString(HWND hwnd, INT indexStart, LPCVOID lpszFind)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sLB_SELECTSTRING(hwnd:%p, indexStart:%d, lpszFind:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, indexStart, (PCWSTR)lpszFind);
     else
-        MSGDUMP_PRINTF("%sLB_SELECTSTRING(hwnd:%p, indexStart:%d, lpszFind:%s)\n",
+        MSGDUMP_PRINTF("%sLB_SELECTSTRING(hwnd:%p, indexStart:%d, lpszFind:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, indexStart, (PCSTR)lpszFind);
     return 0;
 }
 
 static __inline INT MSGDUMP_API
-MD_ListBox_OnDir(HWND hwnd, UINT uAttrs, PCSTR lpszFileSpec)
+MD_ListBox_OnDir(HWND hwnd, UINT uAttrs, LPCVOID lpszFileSpec)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sLB_DIR(hwnd:%p, uAttrs:%u, lpszFileSpec:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, uAttrs, (PCWSTR)lpszFileSpec);
     else
-        MSGDUMP_PRINTF("%sLB_DIR(hwnd:%p, uAttrs:%u, lpszFileSpec:%s)\n",
+        MSGDUMP_PRINTF("%sLB_DIR(hwnd:%p, uAttrs:%u, lpszFileSpec:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, uAttrs, (PCSTR)lpszFileSpec);
     return 0;
 }
@@ -2212,13 +2221,13 @@ MD_ListBox_OnGetTopIndex(HWND hwnd)
 }
 
 static __inline INT MSGDUMP_API
-MD_ListBox_OnFindString(HWND hwnd, INT indexStart, PCSTR lpszFind)
+MD_ListBox_OnFindString(HWND hwnd, INT indexStart, LPCVOID lpszFind)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sLB_FINDSTRING(hwnd:%p, indexStart:%d, lpszFind:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, indexStart, (PCWSTR)lpszFind);
     else
-        MSGDUMP_PRINTF("%sLB_FINDSTRING(hwnd:%p, indexStart:%d, lpszFind:%s)\n",
+        MSGDUMP_PRINTF("%sLB_FINDSTRING(hwnd:%p, indexStart:%d, lpszFind:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, indexStart, (PCSTR)lpszFind);
     return 0;
 }
@@ -2270,13 +2279,13 @@ MD_ListBox_OnSetColumnWidth(HWND hwnd, INT cxColumn)
 }
 
 static __inline INT MSGDUMP_API
-MD_ListBox_OnAddFile(HWND hwnd, PCSTR lpszFilename)
+MD_ListBox_OnAddFile(HWND hwnd, LPCVOID lpszFilename)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sLB_ADDFILE(hwnd:%p, lpszFilename:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, (PCWSTR)lpszFilename);
     else
-        MSGDUMP_PRINTF("%sLB_ADDFILE(hwnd:%p, lpszFilename:%s)\n",
+        MSGDUMP_PRINTF("%sLB_ADDFILE(hwnd:%p, lpszFilename:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, (PCSTR)lpszFilename);
     return 0;
 }
@@ -2370,13 +2379,13 @@ MD_ListBox_OnGetItemHeight(HWND hwnd, INT index)
 }
 
 static __inline INT MSGDUMP_API
-MD_ListBox_OnFindStringExact(HWND hwnd, INT indexStart, PCSTR lpszFind)
+MD_ListBox_OnFindStringExact(HWND hwnd, INT indexStart, LPCVOID lpszFind)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sLB_FINDSTRINGEXACT(hwnd:%p, indexStart:%d, lpszFind:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, indexStart, (PCWSTR)lpszFind);
     else
-        MSGDUMP_PRINTF("%sLB_FINDSTRINGEXACT(hwnd:%p, indexStart:%d, lpszFind:%s)\n",
+        MSGDUMP_PRINTF("%sLB_FINDSTRINGEXACT(hwnd:%p, indexStart:%d, lpszFind:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, indexStart, (PCSTR)lpszFind);
     return 0;
 }
@@ -2445,13 +2454,13 @@ MD_ComboBox_OnSetEditSel(HWND hwnd, INT ichStart, INT ichEnd)
 }
 
 static __inline INT MSGDUMP_API
-MD_ComboBox_OnAddString(HWND hwnd, PCSTR lpsz)
+MD_ComboBox_OnAddString(HWND hwnd, LPCVOID lpsz)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sCB_ADDSTRING(hwnd:%p, lpsz:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, (PCWSTR)lpsz);
     else
-        MSGDUMP_PRINTF("%sCB_ADDSTRING(hwnd:%p, lpsz:%s)\n",
+        MSGDUMP_PRINTF("%sCB_ADDSTRING(hwnd:%p, lpsz:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, (PCSTR)lpsz);
     return 0;
 }
@@ -2465,13 +2474,13 @@ MD_ComboBox_OnDeleteString(HWND hwnd, INT index)
 }
 
 static __inline INT MSGDUMP_API
-MD_ComboBox_OnDir(HWND hwnd, UINT uAttrs, PCSTR lpszFileSpec)
+MD_ComboBox_OnDir(HWND hwnd, UINT uAttrs, LPCVOID lpszFileSpec)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sCB_DIR(hwnd:%p, uAttrs:%u, lpszFileSpec:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, uAttrs, (PCWSTR)lpszFileSpec);
     else
-        MSGDUMP_PRINTF("%sCB_DIR(hwnd:%p, uAttrs:%u, lpszFileSpec:%s)\n",
+        MSGDUMP_PRINTF("%sCB_DIR(hwnd:%p, uAttrs:%u, lpszFileSpec:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, uAttrs, (PCSTR)lpszFileSpec);
     return 0;
 }
@@ -2509,13 +2518,13 @@ MD_ComboBox_OnGetLBTextLen(HWND hwnd, INT index)
 }
 
 static __inline INT MSGDUMP_API
-MD_ComboBox_OnInsertString(HWND hwnd, INT index, PCSTR lpsz)
+MD_ComboBox_OnInsertString(HWND hwnd, INT index, LPCVOID lpsz)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sCB_INSERTSTRING(hwnd:%p, index:%d, lpsz:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, index, (PCWSTR)lpsz);
     else
-        MSGDUMP_PRINTF("%sCB_INSERTSTRING(hwnd:%p, index:%d, lpsz:%s)\n",
+        MSGDUMP_PRINTF("%sCB_INSERTSTRING(hwnd:%p, index:%d, lpsz:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, index, (PCSTR)lpsz);
     return 0;
 }
@@ -2528,25 +2537,25 @@ MD_ComboBox_OnResetContent(HWND hwnd)
 }
 
 static __inline INT MSGDUMP_API
-MD_ComboBox_OnFindString(HWND hwnd, INT indexStart, PCSTR lpszFind)
+MD_ComboBox_OnFindString(HWND hwnd, INT indexStart, LPCVOID lpszFind)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sCB_FINDSTRING(hwnd:%p, indexStart:%d, lpszFind:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, indexStart, (PCWSTR)lpszFind);
     else
-        MSGDUMP_PRINTF("%sCB_FINDSTRING(hwnd:%p, indexStart:%d, lpszFind:%s)\n",
+        MSGDUMP_PRINTF("%sCB_FINDSTRING(hwnd:%p, indexStart:%d, lpszFind:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, indexStart, (PCSTR)lpszFind);
     return 0;
 }
 
 static __inline INT MSGDUMP_API
-MD_ComboBox_OnSelectString(HWND hwnd, INT indexStart, PCSTR lpszSelect)
+MD_ComboBox_OnSelectString(HWND hwnd, INT indexStart, LPCVOID lpszSelect)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sCB_SELECTSTRING(hwnd:%p, indexStart:%d, lpszSelect:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, indexStart, (PCWSTR)lpszSelect);
     else
-        MSGDUMP_PRINTF("%sCB_SELECTSTRING(hwnd:%p, indexStart:%d, lpszSelect:%s)\n",
+        MSGDUMP_PRINTF("%sCB_SELECTSTRING(hwnd:%p, indexStart:%d, lpszSelect:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, indexStart, (PCSTR)lpszSelect);
     return 0;
 }
@@ -2631,13 +2640,13 @@ MD_ComboBox_OnGetDroppedState(HWND hwnd)
 }
 
 static __inline INT MSGDUMP_API
-MD_ComboBox_OnFindStringExact(HWND hwnd, INT indexStart, PCSTR lpszFind)
+MD_ComboBox_OnFindStringExact(HWND hwnd, INT indexStart, LPCVOID lpszFind)
 {
     if (IsWindowUnicode(hwnd))
         MSGDUMP_PRINTF("%sCB_FINDSTRINGEXACT(hwnd:%p, indexStart:%d, lpszFind:%ls)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, indexStart, (PCWSTR)lpszFind);
     else
-        MSGDUMP_PRINTF("%sCB_FINDSTRINGEXACT(hwnd:%p, indexStart:%d, lpszFind:%s)\n",
+        MSGDUMP_PRINTF("%sCB_FINDSTRINGEXACT(hwnd:%p, indexStart:%d, lpszFind:%hs)\n",
                        MSGDUMP_PREFIX, (void *)hwnd, indexStart, (PCSTR)lpszFind);
     return 0;
 }
@@ -4652,9 +4661,9 @@ MD_RichEdit_OnGetTextMode(HWND hwnd)
 }
 
 static __inline LRESULT MSGDUMP_API
-MD_msgdump(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+MD_msgdump_ex(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, WNDPROC fnDefProc)
 {
-    char szClass[24], sz[2], szMsg[64];
+    char szClass[64], sz[2];
     szClass[0] = 0;
     GetClassNameA(hwnd, szClass, _countof(szClass));
     sz[0] = szClass[0];
@@ -5340,36 +5349,33 @@ MD_msgdump(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         HANDLE_MSG(hwnd, WM_APPCOMMAND, MD_OnAppCommand);
 #endif
         default:
-        {
-            if (WM_USER <= uMsg && uMsg < WM_APP)
-            {
-                return MD_OnUser(hwnd, uMsg, wParam, lParam);
-            }
-            if (WM_APP <= uMsg && uMsg < MAXINTATOM)
-            {
-                return MD_OnApp(hwnd, uMsg, wParam, lParam);
-            }
-            else if (MAXINTATOM <= uMsg && uMsg <= MAXWORD &&
-                     GetClipboardFormatNameA(uMsg, szMsg, _countof(szMsg)))
-            {
-                MSGDUMP_PRINTF("%sWM_%u[\"%s\"](hwnd:%p, wParam:%p, lParam:%p)\n",
-                               MSGDUMP_PREFIX, uMsg, szMsg, (void *)hwnd, (void *)wParam, (void *)lParam);
-            }
-            else
-            {
-                return MD_OnUnknown(hwnd, uMsg, wParam, lParam);
-            }
-        }
+            return fnDefProc(hwnd, uMsg, wParam, lParam);
     }
     return 0;
 }
 
+static __inline LRESULT CALLBACK
+MD_msgdump_def_proc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    if (WM_USER <= uMsg && uMsg < WM_APP)
+        return MD_OnUser(hwnd, uMsg, wParam, lParam);
+    if (WM_APP <= uMsg && uMsg < MAXINTATOM)
+        return MD_OnApp(hwnd, uMsg, wParam, lParam);
+    return MD_OnUnknown(hwnd, uMsg, wParam, lParam);
+}
+
 static __inline LRESULT MSGDUMP_API
-MD_msgresult(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult)
+MD_msgdump(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    return MD_msgdump_ex(hwnd, uMsg, wParam, lParam, MD_msgdump_def_proc);
+}
+
+static __inline LRESULT MSGDUMP_API
+MD_msgresult_ex(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult, MD_MSGRESULT_PROC fnDefProc)
 {
 #define DEFINE_RESULT(WM_) case WM_: MSGDUMP_PRINTF("%s" #WM_ ": hwnd:%p, lResult:%p\n", \
                                                     MSGDUMP_PREFIX, (void *)hwnd, (void *)lResult); break
-    char szClass[24], sz[2], szMsg[64];
+    char szClass[64], sz[2];
     szClass[0] = 0;
     GetClassNameA(hwnd, szClass, _countof(szClass));
     sz[0] = szClass[0];
@@ -6069,30 +6075,45 @@ MD_msgresult(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult
     DEFINE_RESULT(WM_GETTITLEBARINFOEX);
 #endif
     default:
-        if (WM_USER <= uMsg && uMsg < WM_APP)
-        {
-            MSGDUMP_PRINTF("%sWM_USER+%u(hwnd:%p, lResult:%p)\n",
-                           MSGDUMP_PREFIX, uMsg - WM_USER, (void *)hwnd, (void *)lResult);
-        }
-        else if (WM_APP <= uMsg && uMsg < MAXINTATOM)
-        {
-            MSGDUMP_PRINTF("%sWM_APP+%u(hwnd:%p, lResult:%p)\n",
-                           MSGDUMP_PREFIX, uMsg - WM_APP, (void *)hwnd, (void *)lResult);
-        }
-        else if (MAXINTATOM <= uMsg && uMsg <= MAXWORD &&
-                 GetClipboardFormatNameA(uMsg, szMsg, _countof(szMsg)))
-        {
-            MSGDUMP_PRINTF("%sWM_%u[\"%s\"](hwnd:%p, lResult:%p)\n",
-                           MSGDUMP_PREFIX, uMsg, szMsg, (void *)hwnd, (void *)lResult);
-        }
-        else
-        {
-            MSGDUMP_PRINTF("%sWM_%u(hwnd:%p, lResult:%p)\n",
-                           MSGDUMP_PREFIX, uMsg, (void *)hwnd, (void *)lResult);
-        }
+        return fnDefProc(hwnd, uMsg, wParam, lParam, lResult);
 #undef DEFINE_RESULT
     }
     return 0;
+}
+
+static __inline LRESULT CALLBACK
+MD_msgresult_def_proc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult)
+{
+    CHAR szName[64];
+    if (WM_USER <= uMsg && uMsg < WM_APP)
+    {
+        MSGDUMP_PRINTF("%sWM_USER+%u(hwnd:%p, lResult:%p)\n",
+                       MSGDUMP_PREFIX, uMsg - WM_USER, (void *)hwnd, (void *)lResult);
+    }
+    else if (WM_APP <= uMsg && uMsg < MAXINTATOM)
+    {
+        MSGDUMP_PRINTF("%sWM_APP+%u(hwnd:%p, lResult:%p)\n",
+                       MSGDUMP_PREFIX, uMsg - WM_APP, (void *)hwnd, (void *)lResult);
+    }
+    if (0xC000 <= uMsg && uMsg <= 0xFFFF && GlobalGetAtomNameA(uMsg, szName, _countof(szName)))
+    {
+        /* RegisterWindowMessage'd message */
+        MSGDUMP_PRINTF("%s'%s'(%u)(hwnd:%p, wParam:%p, lParam:%p)\n",
+                       MSGDUMP_PREFIX, szName, uMsg, (void *)hwnd, (void *)wParam,
+                       (void *)lParam);
+    }
+    else
+    {
+        MSGDUMP_PRINTF("%sWM_%u(hwnd:%p, lResult:%p)\n",
+                       MSGDUMP_PREFIX, uMsg, (void *)hwnd, (void *)lResult);
+    }
+    return 0;
+}
+
+static __inline LRESULT MSGDUMP_API
+MD_msgresult(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT lResult)
+{
+    return MD_msgresult_ex(hwnd, uMsg, wParam, lParam, lResult, MD_msgresult_def_proc);
 }
 
 #endif


### PR DESCRIPTION
## Purpose

Modernize development tools.
JIRA issue: N/A

## Proposed changes

- Update `<msgdump.h>` to version 21.
- Adapt `shell32_apitest` and `user32_apitest`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108416,108420
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108417,108421