### PR TITLE
[SETUP:REACTOS] Fix page transition in setup wizard

### DIFF
--- a/base/setup/reactos/reactos.c
+++ b/base/setup/reactos/reactos.c
@@ -528,6 +528,7 @@ TypeDlgProc(
                                 (PNTOS_INSTALLATION)GetListEntryData(GetCurrentListEntry(pSetupData->NtOsInstallsList));
                             InstallPartition = pSetupData->CurrentInstallation->Volume->PartEntry;
 
+                            /* Jump to the Summary page during repair/upgrade */
                             SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_SUMMARYPAGE);
                         }
                     }
@@ -958,7 +959,7 @@ UpgradeRepairDlgProc(
                     /* We perform an upgrade */
                     pSetupData->RepairUpdateFlag = TRUE;
                     InstallPartition = pSetupData->CurrentInstallation->Volume->PartEntry;
-                    /* Skip to the Summary page during repair/upgrade */
+                    /* Jump to the Summary page during repair/upgrade */
                     SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_SUMMARYPAGE);
                     return TRUE;
                 }

--- a/base/setup/reactos/reactos.c
+++ b/base/setup/reactos/reactos.c
@@ -959,7 +959,7 @@ UpgradeRepairDlgProc(
                     pSetupData->RepairUpdateFlag = TRUE;
                     InstallPartition = pSetupData->CurrentInstallation->Volume->PartEntry;
                     /* Skip to summary page during repair/upgrade */
-                    PropSheet_SetCurSelByID(GetParent(hwndDlg), IDD_SUMMARYPAGE);
+                    SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_SUMMARYPAGE);
                     return TRUE;
                 }
 

--- a/base/setup/reactos/reactos.c
+++ b/base/setup/reactos/reactos.c
@@ -958,7 +958,7 @@ UpgradeRepairDlgProc(
                     /* We perform an upgrade */
                     pSetupData->RepairUpdateFlag = TRUE;
                     InstallPartition = pSetupData->CurrentInstallation->Volume->PartEntry;
-                    /* Skip to summary page during repair/upgrade */
+                    /* Skip to the Summary page during repair/upgrade */
                     SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_SUMMARYPAGE);
                     return TRUE;
                 }
@@ -1068,7 +1068,7 @@ DeviceDlgProc(
 
                 case PSN_WIZBACK:
                 {
-                    /* Return to installation type page instead of Repair/Upgrade page */
+                    /* Return to the Install type selection page instead of the Repair/Upgrade page */
                     SetWindowLongW(hwndDlg, DWLP_MSGRESULT, IDD_TYPEPAGE);
                     return TRUE;
                 }
@@ -1254,27 +1254,23 @@ SummaryDlgProc(
 
                 case PSN_WIZBACK:
                 {
-                    if (pSetupData->RepairUpdateFlag)
+                    /* When the user performs a regular installation, go back to the previous page */
+                    if (!pSetupData->RepairUpdateFlag)
+                        break;
+
+                    if (GetNumberOfListEntries(pSetupData->NtOsInstallsList) > 1)
                     {
-                        if (pSetupData->NtOsInstallsList->NumOfEntries > 1)
-                        {
-                            /* Return to installations list page
-                             * when user was upgrading and there was more than one installation available
-                             */
-                            SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_UPDATEREPAIRPAGE);
-                        }
-                        else
-                        {
-                            /* Return to installation type page
-                             * when user was upgrading and there was less than one installation available
-                             */
-
-                            SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_TYPEPAGE);
-                        }
-                        
-                        return TRUE;
+                        /* Return to the Upgrade/Repair selection page, when the user is
+                         * upgrading and there are more than one installation available */
+                        SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_UPDATEREPAIRPAGE);
                     }
-
+                    else
+                    {
+                        /* Return to the Install type selection page, when the user is
+                         * upgrading and there is at most one installation available */
+                        SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_TYPEPAGE);
+                    }
+                    return TRUE;
                 }
 
                 default:

--- a/base/setup/reactos/reactos.c
+++ b/base/setup/reactos/reactos.c
@@ -1245,6 +1245,31 @@ SummaryDlgProc(
                     return TRUE;
                 }
 
+                case PSN_WIZBACK:
+                {
+                    if (pSetupData->RepairUpdateFlag)
+                    {
+                        if (pSetupData->NtOsInstallsList->NumOfEntries > 1)
+                        {
+                            /* Return to installations list page
+                             * when user was upgrading and there was more than one installation available
+                             */
+                            SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_UPDATEREPAIRPAGE);
+                        }
+                        else
+                        {
+                            /* Return to installation type page
+                             * when user was upgrading and there was less than one installation available
+                             */
+
+                            SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_TYPEPAGE);
+                        }
+                        
+                        return TRUE;
+                    }
+
+                }
+
                 default:
                     break;
             }

--- a/base/setup/reactos/reactos.c
+++ b/base/setup/reactos/reactos.c
@@ -1066,6 +1066,13 @@ DeviceDlgProc(
                     return TRUE;
                 }
 
+                case PSN_WIZBACK:
+                {
+                    /* Return to installation type page instead of Repair/Upgrade page */
+                    SetWindowLongW(hwndDlg, DWLP_MSGRESULT, IDD_TYPEPAGE);
+                    return TRUE;
+                }
+
                 default:
                     break;
             }

--- a/base/setup/reactos/reactos.c
+++ b/base/setup/reactos/reactos.c
@@ -526,8 +526,9 @@ TypeDlgProc(
                             /* Retrieve the current installation */
                             pSetupData->CurrentInstallation =
                                 (PNTOS_INSTALLATION)GetListEntryData(GetCurrentListEntry(pSetupData->NtOsInstallsList));
+                            InstallPartition = pSetupData->CurrentInstallation->Volume->PartEntry;
 
-                            SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_DEVICEPAGE);
+                            SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_SUMMARYPAGE);
                         }
                     }
                     else
@@ -956,6 +957,9 @@ UpgradeRepairDlgProc(
 
                     /* We perform an upgrade */
                     pSetupData->RepairUpdateFlag = TRUE;
+                    InstallPartition = pSetupData->CurrentInstallation->Volume->PartEntry;
+                    /* Skip to summary page during repair/upgrade */
+                    PropSheet_SetCurSelByID(GetParent(hwndDlg), IDD_SUMMARYPAGE);
                     return TRUE;
                 }
 

--- a/base/setup/reactos/reactos.c
+++ b/base/setup/reactos/reactos.c
@@ -527,6 +527,9 @@ TypeDlgProc(
                             pSetupData->CurrentInstallation =
                                 (PNTOS_INSTALLATION)GetListEntryData(GetCurrentListEntry(pSetupData->NtOsInstallsList));
                             InstallPartition = pSetupData->CurrentInstallation->Volume->PartEntry;
+                            StringCchCopyW(pSetupData->USetupData.InstallationDirectory,
+                                           _countof(pSetupData->USetupData.InstallationDirectory),
+                                           pSetupData->CurrentInstallation->PathComponent);
 
                             /* Jump to the Summary page during repair/upgrade */
                             SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_SUMMARYPAGE);
@@ -955,10 +958,13 @@ UpgradeRepairDlgProc(
                     /* Retrieve the current installation */
                     pSetupData->CurrentInstallation =
                         (PNTOS_INSTALLATION)GetListEntryData(GetCurrentListEntry(pSetupData->NtOsInstallsList));
+                    InstallPartition = pSetupData->CurrentInstallation->Volume->PartEntry;
+                    StringCchCopyW(pSetupData->USetupData.InstallationDirectory,
+                                   _countof(pSetupData->USetupData.InstallationDirectory),
+                                   pSetupData->CurrentInstallation->PathComponent);
 
                     /* We perform an upgrade */
                     pSetupData->RepairUpdateFlag = TRUE;
-                    InstallPartition = pSetupData->CurrentInstallation->Volume->PartEntry;
                     /* Jump to the Summary page during repair/upgrade */
                     SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, IDD_SUMMARYPAGE);
                     return TRUE;


### PR DESCRIPTION
## Purpose

The GUI-mode setup asks user for device configuration and installation destination partition, even when upgrading or repairing an existing installation. It doesn't make sense to ask, e.g. you shouldn't be able to upgrade an installation in C: to D: partition, and the setup ignores what user chooses, e.g. if your installation is using 1024x768 resolution choosing another resolution during the SETUP won't change resolution. So I thought actually setup should skip these pages without asking anything from user. That's also consistent with USETUP's behavior.

JIRA issues: [CORE-20661](https://jira.reactos.org/browse/CORE-20661), [CORE-13525](https://jira.reactos.org/browse/CORE-13525)

## Proposed changes

The installation expects `InstallPartition` and `InstallationDirectory` to be set. Skipping "Partitioning" page would leave these uninitialized, so instead I pull them from `pSetupData->CurrentInstallation->Volume->PartEntry` (which points to the repair/upgrade target) and `pSetupData->CurrentInstallation->PathComponent`.
Also "Installation Type" page and "Upgrade/Repair" page are set to jump to "Summary Page" instead of "Device configuration" page, and backward navigation is also handled properly.

TLDR;
* Set `InstallPartition` and `InstallationDirectory` to selected repair/upgrade target volume and directory.
* Jump to Summary page from install type/upgrade pages.
* Return to install type/upgrade page when navigating backward in summary page.
* Return to type page when navigating backward in device page.
