### PR TITLE
[MSPAINT] Support dithering drawing

### DIFF
--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -3,11 +3,21 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    The drawing functions used by the tools
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
+ *             Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include "precomp.h"
 
 /* FUNCTIONS ********************************************************/
+
+HPEN CreateGeometricPen(COLORREF rgbColor, INT thickness)
+{
+    LOGBRUSH logbrush;
+    logbrush.lbStyle = BS_SOLID;
+    logbrush.lbColor = rgbColor;
+    logbrush.lbHatch = 0;
+    return ExtCreatePen(PS_GEOMETRIC | PS_SOLID | PS_ENDCAP_ROUND | PS_JOIN_ROUND, thickness, &logbrush, 0, NULL);
+}
 
 void
 Line(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, int thickness)
@@ -17,6 +27,25 @@ Line(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, int thickness)
     LineTo(hdc, x2, y2);
     SetPixelV(hdc, x2, y2, color);
     DeleteObject(SelectObject(hdc, oldPen));
+}
+
+void
+Line(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, INT thickness)
+{
+    HGDIOBJ oldPen = SelectObject(hdc, CreateGeometricPen(0, thickness));
+    BeginPath(hdc);
+    MoveToEx(hdc, x1, y1, NULL);
+    LineTo(hdc, x2, y2);
+    EndPath(hdc);
+    WidenPath(hdc);
+    DeleteObject(SelectObject(hdc, oldPen));
+
+    HRGN hRgn = PathToRegion(hdc);
+    FillRgn(hdc, hRgn, hBrush);
+    DeleteObject(hRgn);
+
+    RECT rc = { x2, y2, x2 + 1, y2 + 1 };
+    FillRect(hdc, &rc, hBrush);
 }
 
 void
@@ -35,6 +64,33 @@ Rect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg,  COLORREF bg, int
 }
 
 void
+Rect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hFgBrush, HBRUSH hBgBrush, INT thickness, INT style)
+{
+    HGDIOBJ hPenOld;
+    if (style != 0)
+    {
+        HGDIOBJ hBrushOld = SelectObject(hdc, (style == 2) ? hFgBrush : hBgBrush);
+        hPenOld = SelectObject(hdc, GetStockObject(NULL_PEN));
+        Rectangle(hdc, x1, y1, x2, y2);
+        SelectObject(hdc, hBrushOld);
+        SelectObject(hdc, hPenOld);
+    }
+
+    HPEN hPen = CreateGeometricPen(0, thickness);
+    hPenOld = SelectObject(hdc, hPen);
+    BeginPath(hdc);
+    Rectangle(hdc, x1, y1, x2, y2);
+    EndPath(hdc);
+    WidenPath(hdc);
+    SelectObject(hdc, hPenOld);
+    DeleteObject(hPen);
+
+    HRGN hRgn = PathToRegion(hdc);
+    FillRgn(hdc, hRgn, hFgBrush);
+    DeleteObject(hRgn);
+}
+
+void
 Ellp(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg,  COLORREF bg, int thickness, int style)
 {
     HBRUSH oldBrush;
@@ -50,6 +106,33 @@ Ellp(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg,  COLORREF bg, int
 }
 
 void
+Ellp(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hFgBrush, HBRUSH hBgBrush, INT thickness, INT style)
+{
+    HGDIOBJ hPenOld;
+    if (style != 0)
+    {
+        HGDIOBJ hBrushOld = SelectObject(hdc, (style == 2) ? hFgBrush : hBgBrush);
+        hPenOld = SelectObject(hdc, GetStockObject(NULL_PEN));
+        Ellipse(hdc, x1, y1, x2, y2);
+        SelectObject(hdc, hBrushOld);
+        SelectObject(hdc, hPenOld);
+    }
+
+    HPEN hPen = CreateGeometricPen(0, thickness);
+    hPenOld = SelectObject(hdc, hPen);
+    BeginPath(hdc);
+    Ellipse(hdc, x1, y1, x2, y2);
+    EndPath(hdc);
+    WidenPath(hdc);
+    SelectObject(hdc, hPenOld);
+    DeleteObject(hPen);
+
+    HRGN hRgn = PathToRegion(hdc);
+    FillRgn(hdc, hRgn, hFgBrush);
+    DeleteObject(hRgn);
+}
+
+void
 RRect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg,  COLORREF bg, int thickness, int style)
 {
     LOGBRUSH logbrush;
@@ -62,6 +145,33 @@ RRect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg,  COLORREF bg, in
     RoundRect(hdc, x1, y1, x2, y2, 16, 16);
     DeleteObject(SelectObject(hdc, oldBrush));
     DeleteObject(SelectObject(hdc, oldPen));
+}
+
+void
+RRect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hFgBrush, HBRUSH hBgBrush, INT thickness, INT style)
+{
+    HGDIOBJ hPenOld;
+    if (style != 0)
+    {
+        HGDIOBJ hBrushOld = SelectObject(hdc, (style == 2) ? hFgBrush : hBgBrush);
+        hPenOld = SelectObject(hdc, GetStockObject(NULL_PEN));
+        RoundRect(hdc, x1, y1, x2, y2, 16, 16);
+        SelectObject(hdc, hBrushOld);
+        SelectObject(hdc, hPenOld);
+    }
+
+    HPEN hPen = CreateGeometricPen(0, thickness);
+    hPenOld = SelectObject(hdc, hPen);
+    BeginPath(hdc);
+    RoundRect(hdc, x1, y1, x2, y2, 16, 16);
+    EndPath(hdc);
+    WidenPath(hdc);
+    SelectObject(hdc, hPenOld);
+    DeleteObject(hPen);
+
+    HRGN hRgn = PathToRegion(hdc);
+    FillRgn(hdc, hRgn, hFgBrush);
+    DeleteObject(hRgn);
 }
 
 void
@@ -90,6 +200,45 @@ Poly(HDC hdc, POINT * lpPoints, int nCount,  COLORREF fg,  COLORREF bg, int thic
 }
 
 void
+Poly(HDC hdc, HBRUSH hFgBrush, HBRUSH hBgBrush, POINT *lpPoints, INT nCount, INT thickness, INT style, BOOL closed, BOOL inverted)
+{
+    UINT oldRop = GetROP2(hdc);
+    if (inverted)
+        SetROP2(hdc, R2_NOTXORPEN);
+
+    HGDIOBJ hPenOld;
+    if (style != 0)
+    {
+        HGDIOBJ hBrushOld = SelectObject(hdc, (style == 2) ? hFgBrush : hBgBrush);
+        hPenOld = SelectObject(hdc, GetStockObject(NULL_PEN));
+        if (closed)
+            Polygon(hdc, lpPoints, nCount);
+        else
+            Polyline(hdc, lpPoints, nCount);
+        SelectObject(hdc, hBrushOld);
+        SelectObject(hdc, hPenOld);
+    }
+
+    HPEN hPen = CreateGeometricPen(0, thickness);
+    hPenOld = SelectObject(hdc, hPen);
+    BeginPath(hdc);
+    if (closed)
+        Polygon(hdc, lpPoints, nCount);
+    else
+        Polyline(hdc, lpPoints, nCount);
+    EndPath(hdc);
+    WidenPath(hdc);
+    SelectObject(hdc, hPenOld);
+    DeleteObject(hPen);
+
+    HRGN hRgn = PathToRegion(hdc);
+    FillRgn(hdc, hRgn, hFgBrush);
+    DeleteObject(hRgn);
+
+    SetROP2(hdc, oldRop);
+}
+
+void
 Bezier(HDC hdc, POINT p1, POINT p2, POINT p3, POINT p4, COLORREF color, int thickness)
 {
     HPEN oldPen;
@@ -104,9 +253,39 @@ Bezier(HDC hdc, POINT p1, POINT p2, POINT p3, POINT p4, COLORREF color, int thic
 }
 
 void
+Bezier(HDC hdc, HBRUSH hBrush, POINT p1, POINT p2, POINT p3, POINT p4, INT thickness)
+{
+    HPEN oldPen;
+    POINT fourPoints[4];
+    fourPoints[0] = p1;
+    fourPoints[1] = p2;
+    fourPoints[2] = p3;
+    fourPoints[3] = p4;
+    oldPen = (HPEN) SelectObject(hdc, CreateGeometricPen(0, thickness));
+    BeginPath(hdc);
+    PolyBezier(hdc, fourPoints, 4);
+    EndPath(hdc);
+    WidenPath(hdc);
+
+    HRGN hRgn = PathToRegion(hdc);
+    FillRgn(hdc, hRgn, hBrush);
+    DeleteObject(hRgn);
+
+    DeleteObject(SelectObject(hdc, oldPen));
+}
+
+void
 Fill(HDC hdc, LONG x, LONG y, COLORREF color)
 {
     HBRUSH oldBrush = (HBRUSH) SelectObject(hdc, CreateSolidBrush(color));
+    ExtFloodFill(hdc, x, y, GetPixel(hdc, x, y), FLOODFILLSURFACE);
+    DeleteObject(SelectObject(hdc, oldBrush));
+}
+
+void
+Fill(HDC hdc, LONG x, LONG y, HBRUSH hBrush)
+{
+    HBRUSH oldBrush = (HBRUSH) SelectObject(hdc, hBrush);
     ExtFloodFill(hdc, x, y, GetPixel(hdc, x, y), FLOODFILLSURFACE);
     DeleteObject(SelectObject(hdc, oldBrush));
 }
@@ -126,6 +305,20 @@ Erase(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG radius)
     }
 
     ::DeleteObject(hbr);
+}
+
+void
+Erase(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, LONG radius)
+{
+    LONG b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
+
+    for (LONG a = 0; a <= b; a++)
+    {
+        LONG cx = (x1 * (b - a) + x2 * a) / b;
+        LONG cy = (y1 * (b - a) + y2 * a) / b;
+        RECT rc = { cx - radius, cy - radius, cx + radius, cy + radius };
+        ::FillRect(hdc, &rc, hBrush);
+    }
 }
 
 void
@@ -150,6 +343,30 @@ Replace(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, L
 }
 
 void
+Replace(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, HBRUSH hBgBrush, LONG radius)
+{
+    LONG b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
+
+    for (LONG a = 0; a <= b; a++)
+    {
+        LONG cx = (x1 * (b - a) + x2 * a) / b;
+        LONG cy = (y1 * (b - a) + y2 * a) / b;
+        RECT rc = { cx - radius, cy - radius, cx + radius, cy + radius };
+        for (LONG y = rc.top; y < rc.bottom; ++y)
+        {
+            for (LONG x = rc.left; x < rc.right; ++x)
+            {
+                if (::GetPixel(hdc, x, y) == fg)
+                {
+                    RECT rc = { x, y, x + 1, y + 1 };
+                    FillRect(hdc, &rc, hBgBrush);
+                }
+            }
+        }
+    }
+}
+
+void
 Airbrush(HDC hdc, LONG x, LONG y, COLORREF color, LONG r)
 {
     for (LONG dy = -r; dy <= r; dy++)
@@ -158,6 +375,22 @@ Airbrush(HDC hdc, LONG x, LONG y, COLORREF color, LONG r)
         {
             if ((dx * dx + dy * dy <= r * r) && (rand() % r == 0))
                 ::SetPixelV(hdc, x + dx, y + dy, color);
+        }
+    }
+}
+
+void
+Airbrush(HDC hdc, LONG x, LONG y, HBRUSH hBrush, LONG r)
+{
+    for (LONG dy = -r; dy <= r; dy++)
+    {
+        for (LONG dx = -r; dx <= r; dx++)
+        {
+            if ((dx * dx + dy * dy <= r * r) && (rand() % r == 0))
+            {
+                RECT rc = { x + dx, y + dy, x + dx + 1, y + dy + 1 };
+                FillRect(hdc, &rc, hBrush);
+            }
         }
     }
 }
@@ -230,6 +463,73 @@ Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG style, I
 }
 
 void
+Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, LONG style, INT thickness)
+{
+    HPEN oldPen = (HPEN) SelectObject(hdc, GetStockObject(NULL_PEN));
+    HBRUSH oldBrush = (HBRUSH) SelectObject(hdc, hBrush);
+
+    if (thickness <= 1)
+    {
+        Line(hdc, x1, y1, x2, y2, hBrush, thickness);
+    }
+    else
+    {
+        LONG a, b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
+        switch ((BrushStyle)style)
+        {
+            case BrushStyleRound:
+                for (a = 0; a <= b; a++)
+                {
+                    Ellipse(hdc,
+                            (x1 * (b - a) + x2 * a) / b - (thickness / 2),
+                            (y1 * (b - a) + y2 * a) / b - (thickness / 2),
+                            (x1 * (b - a) + x2 * a) / b + (thickness / 2),
+                            (y1 * (b - a) + y2 * a) / b + (thickness / 2));
+                }
+                break;
+
+            case BrushStyleSquare:
+                for (a = 0; a <= b; a++)
+                {
+                    Rectangle(hdc,
+                              (x1 * (b - a) + x2 * a) / b - (thickness / 2),
+                              (y1 * (b - a) + y2 * a) / b - (thickness / 2),
+                              (x1 * (b - a) + x2 * a) / b + (thickness / 2),
+                              (y1 * (b - a) + y2 * a) / b + (thickness / 2));
+                }
+                break;
+
+            case BrushStyleForeSlash:
+            case BrushStyleBackSlash:
+            {
+                POINT offsetTop, offsetBottom;
+                if ((BrushStyle)style == BrushStyleForeSlash)
+                {
+                    offsetTop    = { (thickness - 1) / 2, -(thickness - 1) / 2 };
+                    offsetBottom = { -thickness      / 2,   thickness      / 2 };
+                }
+                else
+                {
+                    offsetTop =    { -thickness      / 2, -thickness      / 2 };
+                    offsetBottom = { (thickness - 1) / 2, (thickness - 1) / 2 };
+                }
+                POINT points[4] =
+                {
+                    { x1 + offsetTop.x,    y1 + offsetTop.y    },
+                    { x1 + offsetBottom.x, y1 + offsetBottom.y },
+                    { x2 + offsetBottom.x, y2 + offsetBottom.y },
+                    { x2 + offsetTop.x,    y2 + offsetTop.y    },
+                };
+                Polygon(hdc, points, _countof(points));
+                break;
+            }
+        }
+    }
+    SelectObject(hdc, oldBrush);
+    SelectObject(hdc, oldPen);
+}
+
+void
 RectSel(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2)
 {
     HBRUSH oldBrush;
@@ -278,6 +578,35 @@ Text(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, LPCW
     const UINT uFormat = DT_LEFT | DT_TOP | DT_EDITCONTROL | DT_NOPREFIX | DT_NOCLIP |
                          DT_EXPANDTABS | DT_WORDBREAK;
     ::DrawTextW(hdc, lpchText, -1, &rc, uFormat);
+    ::SelectObject(hdc, hFontOld);
+
+    ::RestoreDC(hdc, iSaveDC); // Restore
+}
+
+void
+Text(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hFgBrush, HBRUSH hBgBrush, LPCWSTR lpchText, HFONT font, LONG style)
+{
+    INT iSaveDC = ::SaveDC(hdc); // We will modify the clipping region. Save now.
+
+    CRect rc = { x1, y1, x2, y2 };
+
+    ::SetBkMode(hdc, TRANSPARENT);
+    if (style != 0) // Not Transparent
+        ::FillRect(hdc, &rc, hBgBrush); // Fill the background
+
+    IntersectClipRect(hdc, rc.left, rc.top, rc.right, rc.bottom);
+
+    HGDIOBJ hFontOld = ::SelectObject(hdc, font);
+    const UINT uFormat = DT_LEFT | DT_TOP | DT_EDITCONTROL | DT_NOPREFIX | DT_NOCLIP |
+                         DT_EXPANDTABS | DT_WORDBREAK;
+    ::BeginPath(hdc);
+    ::DrawTextW(hdc, lpchText, -1, &rc, uFormat);
+    ::EndPath(hdc);
+
+    HRGN hRgn = PathToRegion(hdc);
+    FillRgn(hdc, hRgn, hFgBrush);
+    DeleteObject(hRgn);
+
     ::SelectObject(hdc, hFontOld);
 
     ::RestoreDC(hdc, iSaveDC); // Restore
@@ -368,4 +697,70 @@ void DrawXorRect(HDC hdc, const RECT *prc)
     ::SetROP2(hdc, oldRop2);
     ::SelectObject(hdc, oldBrush);
     ::DeleteObject(::SelectObject(hdc, oldPen));
+}
+
+HBRUSH CreateDitherBrush(COLORREF color, COLORREF monoColor0, COLORREF monoColor1)
+{
+    // 8x8 Bayer ordered dithering matrix (0 to 63)
+    static const BYTE s_bayerMatrix[8][8] =
+    {
+        {  0, 32,  8, 40,  2, 34, 10, 42 },
+        { 48, 16, 56, 24, 50, 18, 58, 26 },
+        { 12, 44,  4, 36, 14, 46,  6, 38 },
+        { 60, 28, 52, 20, 62, 30, 54, 22 },
+        {  3, 35, 11, 43,  1, 33,  9, 41 },
+        { 51, 19, 59, 27, 49, 17, 57, 25 },
+        { 15, 47,  7, 39, 13, 45,  5, 37 },
+        { 63, 31, 55, 23, 61, 29, 53, 21 },
+    };
+    INT sum = GetRValue(color) + GetGValue(color) + GetBValue(color);
+    INT brightness = sum / 3;
+    if (brightness < 0)
+        brightness = 0;
+    if (brightness >= 255)
+        brightness = 256; // White out
+
+    BITMAPINFO bmi = {};
+    bmi.bmiHeader.biSize     = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth    = 8;
+    bmi.bmiHeader.biHeight   = -8; // Top-down
+    bmi.bmiHeader.biPlanes   = 1;
+    bmi.bmiHeader.biBitCount = 24;
+
+    const BYTE b0 = GetBValue(monoColor0), g0 = GetGValue(monoColor0), r0 = GetRValue(monoColor0);
+    const BYTE b1 = GetBValue(monoColor1), g1 = GetGValue(monoColor1), r1 = GetRValue(monoColor1);
+
+    BYTE pixels[8 * 8 * 3];
+    for (INT y = 0; y < 8; ++y)
+    {
+        INT index = y * (3 * CHAR_BIT);
+        for (INT x = 0; x < 8; ++x)
+        {
+            const INT threshold = s_bayerMatrix[y][x] * 255 / 63;
+            if (brightness > threshold)
+            {
+                pixels[index++] = b1; // Blue
+                pixels[index++] = g1; // Green
+                pixels[index++] = r1; // Red
+            }
+            else
+            {
+                pixels[index++] = b0; // Blue
+                pixels[index++] = g0; // Green
+                pixels[index++] = r0; // Red
+            }
+        }
+    }
+
+    HDC hdc = GetDC(NULL);
+    HBITMAP hBitmap = CreateDIBitmap(hdc, &bmi.bmiHeader, CBM_INIT, pixels, &bmi, DIB_RGB_COLORS);
+    ReleaseDC(NULL, hdc);
+
+    if (!hBitmap)
+        return NULL;
+
+    HBRUSH hBrush = CreatePatternBrush(hBitmap);
+    DeleteObject(hBitmap);
+
+    return hBrush;
 }

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -728,7 +728,7 @@ HBRUSH CreateDitherBrush(COLORREF color, COLORREF monoColor0, COLORREF monoColor
         brightness = 256; // White out
 
     BITMAPINFO bmi = {};
-    bmi.bmiHeader.biSize     = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biSize     = sizeof(bmi.bmiHeader);
     bmi.bmiHeader.biWidth    = 8;
     bmi.bmiHeader.biHeight   = -8; // Top-down
     bmi.bmiHeader.biPlanes   = 1;

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -38,6 +38,7 @@ Line(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, INT thickness)
     MoveToEx(hdc, x1, y1, NULL);
     LineTo(hdc, x2, y2);
     EndPath(hdc);
+    SetPolyFillMode(hdc, WINDING);
     WidenPath(hdc);
     DeleteObject(SelectObject(hdc, oldPen));
 
@@ -82,6 +83,7 @@ Rect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hFgBrush, HBRUSH hBgBru
     BeginPath(hdc);
     Rectangle(hdc, x1, y1, x2, y2);
     EndPath(hdc);
+    SetPolyFillMode(hdc, WINDING);
     WidenPath(hdc);
     SelectObject(hdc, hPenOld);
     DeleteObject(hPen);
@@ -124,6 +126,7 @@ Ellp(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hFgBrush, HBRUSH hBgBru
     BeginPath(hdc);
     Ellipse(hdc, x1, y1, x2, y2);
     EndPath(hdc);
+    SetPolyFillMode(hdc, WINDING);
     WidenPath(hdc);
     SelectObject(hdc, hPenOld);
     DeleteObject(hPen);
@@ -166,6 +169,7 @@ RRect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hFgBrush, HBRUSH hBgBr
     BeginPath(hdc);
     RoundRect(hdc, x1, y1, x2, y2, 16, 16);
     EndPath(hdc);
+    SetPolyFillMode(hdc, WINDING);
     WidenPath(hdc);
     SelectObject(hdc, hPenOld);
     DeleteObject(hPen);
@@ -228,6 +232,7 @@ Poly(HDC hdc, HBRUSH hFgBrush, HBRUSH hBgBrush, POINT *lpPoints, INT nCount, INT
     else
         Polyline(hdc, lpPoints, nCount);
     EndPath(hdc);
+    SetPolyFillMode(hdc, WINDING);
     WidenPath(hdc);
     SelectObject(hdc, hPenOld);
     DeleteObject(hPen);
@@ -266,6 +271,7 @@ Bezier(HDC hdc, HBRUSH hBrush, POINT p1, POINT p2, POINT p3, POINT p4, INT thick
     BeginPath(hdc);
     PolyBezier(hdc, fourPoints, 4);
     EndPath(hdc);
+    SetPolyFillMode(hdc, WINDING);
     WidenPath(hdc);
 
     HRGN hRgn = PathToRegion(hdc);

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -300,18 +300,9 @@ Fill(HDC hdc, LONG x, LONG y, HBRUSH hBrush)
 void
 Erase(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG radius)
 {
-    LONG b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
-    HBRUSH hbr = ::CreateSolidBrush(color);
-
-    for (LONG a = 0; a <= b; a++)
-    {
-        LONG cx = (x1 * (b - a) + x2 * a) / b;
-        LONG cy = (y1 * (b - a) + y2 * a) / b;
-        RECT rc = { cx - radius, cy - radius, cx + radius, cy + radius };
-        ::FillRect(hdc, &rc, hbr);
-    }
-
-    ::DeleteObject(hbr);
+    HBRUSH hBrush = ::CreateSolidBrush(color);
+    Erase(hdc, x1, y1, x2, y2, hBrush, radius);
+    ::DeleteObject(hBrush);
 }
 
 void

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -10,6 +10,7 @@
 
 /* FUNCTIONS ********************************************************/
 
+// WidenPath requires a geometric pen
 HPEN CreateGeometricPen(COLORREF rgbColor, INT thickness)
 {
     LOGBRUSH logbrush;
@@ -285,9 +286,9 @@ Fill(HDC hdc, LONG x, LONG y, COLORREF color)
 void
 Fill(HDC hdc, LONG x, LONG y, HBRUSH hBrush)
 {
-    HBRUSH oldBrush = (HBRUSH) SelectObject(hdc, hBrush);
+    HBRUSH oldBrush = (HBRUSH)SelectObject(hdc, hBrush);
     ExtFloodFill(hdc, x, y, GetPixel(hdc, x, y), FLOODFILLSURFACE);
-    DeleteObject(SelectObject(hdc, oldBrush));
+    SelectObject(hdc, oldBrush);
 }
 
 void

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -284,9 +284,9 @@ Bezier(HDC hdc, POINT p1, POINT p2, POINT p3, POINT p4, HBRUSH hBrush, INT thick
 void
 Fill(HDC hdc, LONG x, LONG y, COLORREF color)
 {
-    HBRUSH oldBrush = (HBRUSH) SelectObject(hdc, CreateSolidBrush(color));
-    ExtFloodFill(hdc, x, y, GetPixel(hdc, x, y), FLOODFILLSURFACE);
-    DeleteObject(SelectObject(hdc, oldBrush));
+    HBRUSH hBrush = CreateSolidBrush(color);
+    Fill(hdc, x, y, hBrush);
+    DeleteObject(hBrush);
 }
 
 void

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -205,7 +205,7 @@ Poly(HDC hdc, POINT * lpPoints, int nCount,  COLORREF fg,  COLORREF bg, int thic
 }
 
 void
-Poly(HDC hdc, HBRUSH hFgBrush, HBRUSH hBgBrush, POINT *lpPoints, INT nCount, INT thickness, INT style, BOOL closed, BOOL inverted)
+Poly(HDC hdc, POINT *lpPoints, INT nCount, HBRUSH hFgBrush, HBRUSH hBgBrush, INT thickness, INT style, BOOL closed, BOOL inverted)
 {
     UINT oldRop = GetROP2(hdc);
     if (inverted)
@@ -259,7 +259,7 @@ Bezier(HDC hdc, POINT p1, POINT p2, POINT p3, POINT p4, COLORREF color, int thic
 }
 
 void
-Bezier(HDC hdc, HBRUSH hBrush, POINT p1, POINT p2, POINT p3, POINT p4, INT thickness)
+Bezier(HDC hdc, POINT p1, POINT p2, POINT p3, POINT p4, HBRUSH hBrush, INT thickness)
 {
     HPEN oldPen;
     POINT fourPoints[4];

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -474,7 +474,7 @@ Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, LONG style, IN
     HGDIOBJ oldBrush = SelectObject(hdc, hBrush);
     BrushInternal(hdc, x1, y1, x2, y2, style, thickness);
     SelectObject(hdc, oldBrush);
-    DeleteObject(SelectObject(hdc, oldPen));
+    SelectObject(hdc, oldPen);
 }
 
 void

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -11,7 +11,8 @@
 /* FUNCTIONS ********************************************************/
 
 // WidenPath requires a geometric pen
-HPEN CreateGeometricPen(COLORREF rgbColor, INT thickness)
+static HPEN
+CreateGeometricPen(COLORREF rgbColor, INT thickness)
 {
     LOGBRUSH logbrush;
     logbrush.lbStyle = BS_SOLID;

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -483,23 +483,10 @@ Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, LONG style, IN
     }
     // Otherwise a dither brush
 
-    // Fill inner
     HGDIOBJ oldPen = SelectObject(hdc, CreatePen(PS_NULL, 0, 0)); // 1px off
     HGDIOBJ oldBrush = SelectObject(hdc, hBrush);
     BrushInternal(hdc, x1, y1, x2, y2, style, thickness, TRUE);
     SelectObject(hdc, oldBrush);
-    DeleteObject(SelectObject(hdc, oldPen));
-
-    // Fill border
-    oldPen = SelectObject(hdc, CreateGeometricPen(RGB(255, 255, 255), 1));
-    oldBrush = SelectObject(hdc, GetStockObject(NULL_BRUSH));
-    BeginPath(hdc);
-    BrushInternal(hdc, x1, y1, x2, y2, style, thickness, TRUE);
-    EndPath(hdc);
-    HRGN hRgn = PathToRegion(hdc);
-    SelectObject(hdc, oldBrush);
-    FillRgn(hdc, hRgn, hBrush);
-    DeleteObject(hRgn);
     DeleteObject(SelectObject(hdc, oldPen));
 }
 

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -470,7 +470,7 @@ Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, LONG style, IN
         return;
     }
 
-    HGDIOBJ oldPen = SelectObject(hdc, CreatePen(PS_NULL, 0, 0)); // 1px off
+    HGDIOBJ oldPen = SelectObject(hdc, GetStockObject(NULL_PEN)); // 1px off
     HGDIOBJ oldBrush = SelectObject(hdc, hBrush);
     BrushInternal(hdc, x1, y1, x2, y2, style, thickness);
     SelectObject(hdc, oldBrush);

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -394,138 +394,118 @@ Airbrush(HDC hdc, LONG x, LONG y, HBRUSH hBrush, LONG r)
     }
 }
 
+static void
+BrushInternal(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, LONG style, INT thickness)
+{
+    LONG a, b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
+    switch ((BrushStyle)style)
+    {
+        case BrushStyleRound:
+            for (a = 0; a <= b; a++)
+            {
+                Ellipse(hdc,
+                        (x1 * (b - a) + x2 * a) / b - (thickness / 2),
+                        (y1 * (b - a) + y2 * a) / b - (thickness / 2),
+                        (x1 * (b - a) + x2 * a) / b + (thickness / 2),
+                        (y1 * (b - a) + y2 * a) / b + (thickness / 2));
+            }
+            break;
+
+        case BrushStyleSquare:
+            for (a = 0; a <= b; a++)
+            {
+                Rectangle(hdc,
+                          (x1 * (b - a) + x2 * a) / b - (thickness / 2),
+                          (y1 * (b - a) + y2 * a) / b - (thickness / 2),
+                          (x1 * (b - a) + x2 * a) / b + (thickness / 2),
+                          (y1 * (b - a) + y2 * a) / b + (thickness / 2));
+            }
+            break;
+
+        case BrushStyleForeSlash:
+        case BrushStyleBackSlash:
+        {
+            POINT offsetTop, offsetBottom;
+            if ((BrushStyle)style == BrushStyleForeSlash)
+            {
+                offsetTop    = { (thickness - 1) / 2, -(thickness - 1) / 2 };
+                offsetBottom = { -thickness      / 2,   thickness      / 2 };
+            }
+            else
+            {
+                offsetTop =    { -thickness      / 2, -thickness      / 2 };
+                offsetBottom = { (thickness - 1) / 2, (thickness - 1) / 2 };
+            }
+            POINT points[4] =
+            {
+                { x1 + offsetTop.x,    y1 + offsetTop.y    },
+                { x1 + offsetBottom.x, y1 + offsetBottom.y },
+                { x2 + offsetBottom.x, y2 + offsetBottom.y },
+                { x2 + offsetTop.x,    y2 + offsetTop.y    },
+            };
+            Polygon(hdc, points, _countof(points));
+            break;
+        }
+    }
+}
+
 void
 Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG style, INT thickness)
 {
-    HPEN oldPen = (HPEN) SelectObject(hdc, CreatePen(PS_SOLID, 1, color));
-    HBRUSH oldBrush = (HBRUSH) SelectObject(hdc, CreateSolidBrush(color));
-
-    if (thickness <= 1)
-    {
-        Line(hdc, x1, y1, x2, y2, color, thickness);
-    }
-    else
-    {
-        LONG a, b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
-        switch ((BrushStyle)style)
-        {
-            case BrushStyleRound:
-                for (a = 0; a <= b; a++)
-                {
-                    Ellipse(hdc,
-                            (x1 * (b - a) + x2 * a) / b - (thickness / 2),
-                            (y1 * (b - a) + y2 * a) / b - (thickness / 2),
-                            (x1 * (b - a) + x2 * a) / b + (thickness / 2),
-                            (y1 * (b - a) + y2 * a) / b + (thickness / 2));
-                }
-                break;
-
-            case BrushStyleSquare:
-                for (a = 0; a <= b; a++)
-                {
-                    Rectangle(hdc,
-                              (x1 * (b - a) + x2 * a) / b - (thickness / 2),
-                              (y1 * (b - a) + y2 * a) / b - (thickness / 2),
-                              (x1 * (b - a) + x2 * a) / b + (thickness / 2),
-                              (y1 * (b - a) + y2 * a) / b + (thickness / 2));
-                }
-                break;
-
-            case BrushStyleForeSlash:
-            case BrushStyleBackSlash:
-            {
-                POINT offsetTop, offsetBottom;
-                if ((BrushStyle)style == BrushStyleForeSlash)
-                {
-                    offsetTop    = { (thickness - 1) / 2, -(thickness - 1) / 2 };
-                    offsetBottom = { -thickness      / 2,   thickness      / 2 };
-                }
-                else
-                {
-                    offsetTop =    { -thickness      / 2, -thickness      / 2 };
-                    offsetBottom = { (thickness - 1) / 2, (thickness - 1) / 2 };
-                }
-                POINT points[4] =
-                {
-                    { x1 + offsetTop.x,    y1 + offsetTop.y    },
-                    { x1 + offsetBottom.x, y1 + offsetBottom.y },
-                    { x2 + offsetBottom.x, y2 + offsetBottom.y },
-                    { x2 + offsetTop.x,    y2 + offsetTop.y    },
-                };
-                Polygon(hdc, points, _countof(points));
-                break;
-            }
-        }
-    }
-    DeleteObject(SelectObject(hdc, oldBrush));
-    DeleteObject(SelectObject(hdc, oldPen));
+    HBRUSH hBrush = CreateSolidBrush(color);
+    Brush(hdc, x1, y1, x2, y2, hBrush, style, thickness);
+    DeleteObject(hBrush);
 }
 
 void
 Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, LONG style, INT thickness)
 {
-    HPEN oldPen = (HPEN) SelectObject(hdc, GetStockObject(NULL_PEN));
-    HBRUSH oldBrush = (HBRUSH) SelectObject(hdc, hBrush);
-
     if (thickness <= 1)
     {
         Line(hdc, x1, y1, x2, y2, hBrush, thickness);
+        return;
     }
-    else
+
+    LOGBRUSH lb;
+    GetObjectW(hBrush, sizeof(lb), &lb);
+    if (lb.lbStyle == BS_SOLID) // It's a solid brush. Do quick draw
     {
-        LONG a, b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
-        switch ((BrushStyle)style)
-        {
-            case BrushStyleRound:
-                for (a = 0; a <= b; a++)
-                {
-                    Ellipse(hdc,
-                            (x1 * (b - a) + x2 * a) / b - (thickness / 2),
-                            (y1 * (b - a) + y2 * a) / b - (thickness / 2),
-                            (x1 * (b - a) + x2 * a) / b + (thickness / 2),
-                            (y1 * (b - a) + y2 * a) / b + (thickness / 2));
-                }
-                break;
-
-            case BrushStyleSquare:
-                for (a = 0; a <= b; a++)
-                {
-                    Rectangle(hdc,
-                              (x1 * (b - a) + x2 * a) / b - (thickness / 2),
-                              (y1 * (b - a) + y2 * a) / b - (thickness / 2),
-                              (x1 * (b - a) + x2 * a) / b + (thickness / 2),
-                              (y1 * (b - a) + y2 * a) / b + (thickness / 2));
-                }
-                break;
-
-            case BrushStyleForeSlash:
-            case BrushStyleBackSlash:
-            {
-                POINT offsetTop, offsetBottom;
-                if ((BrushStyle)style == BrushStyleForeSlash)
-                {
-                    offsetTop    = { (thickness - 1) / 2, -(thickness - 1) / 2 };
-                    offsetBottom = { -thickness      / 2,   thickness      / 2 };
-                }
-                else
-                {
-                    offsetTop =    { -thickness      / 2, -thickness      / 2 };
-                    offsetBottom = { (thickness - 1) / 2, (thickness - 1) / 2 };
-                }
-                POINT points[4] =
-                {
-                    { x1 + offsetTop.x,    y1 + offsetTop.y    },
-                    { x1 + offsetBottom.x, y1 + offsetBottom.y },
-                    { x2 + offsetBottom.x, y2 + offsetBottom.y },
-                    { x2 + offsetTop.x,    y2 + offsetTop.y    },
-                };
-                Polygon(hdc, points, _countof(points));
-                break;
-            }
-        }
+        HGDIOBJ oldPen = SelectObject(hdc, CreatePen(PS_SOLID, 1, lb.lbColor));
+        HGDIOBJ oldBrush = SelectObject(hdc, hBrush);
+        BrushInternal(hdc, x1, y1, x2, y2, style, thickness);
+        SelectObject(hdc, oldBrush);
+        DeleteObject(SelectObject(hdc, oldPen));
+        return;
     }
-    SelectObject(hdc, oldBrush);
-    SelectObject(hdc, oldPen);
+
+    // NOTE: There appears to be a misalignment between the line stroke region and the fill
+    //       region in Windows path rendering. Detailed region calculation required.
+
+    // Create inner region
+    BeginPath(hdc);
+    BrushInternal(hdc, x1, y1, x2, y2, style, thickness);
+    EndPath(hdc);
+    SetPolyFillMode(hdc, WINDING);
+    HRGN hRgnInner = PathToRegion(hdc);
+
+    // Create border region
+    HGDIOBJ oldPen = SelectObject(hdc, CreateGeometricPen(0, 1));
+    BeginPath(hdc);
+    BrushInternal(hdc, x1, y1, x2, y2, style, thickness);
+    EndPath(hdc);
+    WidenPath(hdc);
+    HRGN hRgnOuter = PathToRegion(hdc);
+    DeleteObject(SelectObject(hdc, oldPen));
+
+    // Create combined region
+    HRGN hRgnCombined = CreateRectRgn(0, 0, 0, 0);
+    CombineRgn(hRgnCombined, hRgnOuter, hRgnInner, RGN_OR);
+
+    FillRgn(hdc, hRgnCombined, hBrush);
+
+    DeleteObject(hRgnOuter);
+    DeleteObject(hRgnInner);
+    DeleteObject(hRgnCombined);
 }
 
 void

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -395,7 +395,7 @@ Airbrush(HDC hdc, LONG x, LONG y, HBRUSH hBrush, LONG r)
 }
 
 static void
-BrushInternal(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, LONG style, INT thickness, BOOL bOnePixelOff)
+BrushInternal(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, LONG style, INT thickness)
 {
     LONG a, b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
     switch ((BrushStyle)style)
@@ -406,8 +406,8 @@ BrushInternal(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, LONG style, INT thick
                 Ellipse(hdc,
                         (x1 * (b - a) + x2 * a) / b - (thickness / 2),
                         (y1 * (b - a) + y2 * a) / b - (thickness / 2),
-                        (x1 * (b - a) + x2 * a) / b + (thickness / 2) + bOnePixelOff,
-                        (y1 * (b - a) + y2 * a) / b + (thickness / 2) + bOnePixelOff);
+                        (x1 * (b - a) + x2 * a) / b + (thickness / 2) + 1,
+                        (y1 * (b - a) + y2 * a) / b + (thickness / 2) + 1);
             }
             break;
 
@@ -417,8 +417,8 @@ BrushInternal(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, LONG style, INT thick
                 Rectangle(hdc,
                           (x1 * (b - a) + x2 * a) / b - (thickness / 2),
                           (y1 * (b - a) + y2 * a) / b - (thickness / 2),
-                          (x1 * (b - a) + x2 * a) / b + (thickness / 2) + bOnePixelOff,
-                          (y1 * (b - a) + y2 * a) / b + (thickness / 2) + bOnePixelOff);
+                          (x1 * (b - a) + x2 * a) / b + (thickness / 2) + 1,
+                          (y1 * (b - a) + y2 * a) / b + (thickness / 2) + 1);
             }
             break;
 
@@ -428,15 +428,15 @@ BrushInternal(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, LONG style, INT thick
             POINT offsetTop, offsetBottom;
             if ((BrushStyle)style == BrushStyleForeSlash)
             {
-                offsetTop    = { (thickness - 1) / 2 + bOnePixelOff, -(thickness - 1) / 2                };
-                offsetBottom = { -thickness      / 2               ,   thickness      / 2 + bOnePixelOff };
+                offsetTop    = { (thickness - 1) / 2 + 1, -(thickness - 1) / 2     };
+                offsetBottom = { -thickness      / 2    ,   thickness      / 2 + 1 };
             }
             else
             {
-                offsetTop =    { -thickness      / 2               , -thickness      / 2                };
-                offsetBottom = { (thickness - 1) / 2 + bOnePixelOff, (thickness - 1) / 2 + bOnePixelOff };
+                offsetTop =    { -thickness      / 2    , -thickness      / 2     };
+                offsetBottom = { (thickness - 1) / 2 + 1, (thickness - 1) / 2 + 1 };
             }
-            if (bOnePixelOff && x1 == x2 && y1 == y2)
+            if (x1 == x2 && y1 == y2)
             {
                 ++x2;
             }
@@ -470,22 +470,9 @@ Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, LONG style, IN
         return;
     }
 
-    LOGBRUSH lb;
-    GetObjectW(hBrush, sizeof(lb), &lb);
-    if (lb.lbStyle == BS_SOLID) // It's a solid brush. Do quick draw
-    {
-        HGDIOBJ oldPen = SelectObject(hdc, CreatePen(PS_SOLID, 1, lb.lbColor));
-        HGDIOBJ oldBrush = SelectObject(hdc, hBrush);
-        BrushInternal(hdc, x1, y1, x2, y2, style, thickness, FALSE);
-        SelectObject(hdc, oldBrush);
-        DeleteObject(SelectObject(hdc, oldPen));
-        return;
-    }
-    // Otherwise a dither brush
-
     HGDIOBJ oldPen = SelectObject(hdc, CreatePen(PS_NULL, 0, 0)); // 1px off
     HGDIOBJ oldBrush = SelectObject(hdc, hBrush);
-    BrushInternal(hdc, x1, y1, x2, y2, style, thickness, TRUE);
+    BrushInternal(hdc, x1, y1, x2, y2, style, thickness);
     SelectObject(hdc, oldBrush);
     DeleteObject(SelectObject(hdc, oldPen));
 }

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -395,7 +395,7 @@ Airbrush(HDC hdc, LONG x, LONG y, HBRUSH hBrush, LONG r)
 }
 
 static void
-BrushInternal(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, LONG style, INT thickness)
+BrushInternal(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, LONG style, INT thickness, BOOL bOnePixelOff)
 {
     LONG a, b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
     switch ((BrushStyle)style)
@@ -406,8 +406,8 @@ BrushInternal(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, LONG style, INT thick
                 Ellipse(hdc,
                         (x1 * (b - a) + x2 * a) / b - (thickness / 2),
                         (y1 * (b - a) + y2 * a) / b - (thickness / 2),
-                        (x1 * (b - a) + x2 * a) / b + (thickness / 2),
-                        (y1 * (b - a) + y2 * a) / b + (thickness / 2));
+                        (x1 * (b - a) + x2 * a) / b + (thickness / 2) + bOnePixelOff,
+                        (y1 * (b - a) + y2 * a) / b + (thickness / 2) + bOnePixelOff);
             }
             break;
 
@@ -417,8 +417,8 @@ BrushInternal(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, LONG style, INT thick
                 Rectangle(hdc,
                           (x1 * (b - a) + x2 * a) / b - (thickness / 2),
                           (y1 * (b - a) + y2 * a) / b - (thickness / 2),
-                          (x1 * (b - a) + x2 * a) / b + (thickness / 2),
-                          (y1 * (b - a) + y2 * a) / b + (thickness / 2));
+                          (x1 * (b - a) + x2 * a) / b + (thickness / 2) + bOnePixelOff,
+                          (y1 * (b - a) + y2 * a) / b + (thickness / 2) + bOnePixelOff);
             }
             break;
 
@@ -428,13 +428,17 @@ BrushInternal(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, LONG style, INT thick
             POINT offsetTop, offsetBottom;
             if ((BrushStyle)style == BrushStyleForeSlash)
             {
-                offsetTop    = { (thickness - 1) / 2, -(thickness - 1) / 2 };
-                offsetBottom = { -thickness      / 2,   thickness      / 2 };
+                offsetTop    = { (thickness - 1) / 2 + bOnePixelOff, -(thickness - 1) / 2                };
+                offsetBottom = { -thickness      / 2               ,   thickness      / 2 + bOnePixelOff };
             }
             else
             {
-                offsetTop =    { -thickness      / 2, -thickness      / 2 };
-                offsetBottom = { (thickness - 1) / 2, (thickness - 1) / 2 };
+                offsetTop =    { -thickness      / 2               , -thickness      / 2                };
+                offsetBottom = { (thickness - 1) / 2 + bOnePixelOff, (thickness - 1) / 2 + bOnePixelOff };
+            }
+            if (bOnePixelOff && x1 == x2 && y1 == y2)
+            {
+                ++x2;
             }
             POINT points[4] =
             {
@@ -472,40 +476,31 @@ Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, LONG style, IN
     {
         HGDIOBJ oldPen = SelectObject(hdc, CreatePen(PS_SOLID, 1, lb.lbColor));
         HGDIOBJ oldBrush = SelectObject(hdc, hBrush);
-        BrushInternal(hdc, x1, y1, x2, y2, style, thickness);
+        BrushInternal(hdc, x1, y1, x2, y2, style, thickness, FALSE);
         SelectObject(hdc, oldBrush);
         DeleteObject(SelectObject(hdc, oldPen));
         return;
     }
+    // Otherwise a dither brush
 
-    // NOTE: There appears to be a misalignment between the line stroke region and the fill
-    //       region in Windows path rendering. Detailed region calculation required.
-
-    // Create inner region
-    BeginPath(hdc);
-    BrushInternal(hdc, x1, y1, x2, y2, style, thickness);
-    EndPath(hdc);
-    SetPolyFillMode(hdc, WINDING);
-    HRGN hRgnInner = PathToRegion(hdc);
-
-    // Create border region
-    HGDIOBJ oldPen = SelectObject(hdc, CreateGeometricPen(0, 1));
-    BeginPath(hdc);
-    BrushInternal(hdc, x1, y1, x2, y2, style, thickness);
-    EndPath(hdc);
-    WidenPath(hdc);
-    HRGN hRgnOuter = PathToRegion(hdc);
+    // Fill inner
+    HGDIOBJ oldPen = SelectObject(hdc, CreatePen(PS_NULL, 0, 0)); // 1px off
+    HGDIOBJ oldBrush = SelectObject(hdc, hBrush);
+    BrushInternal(hdc, x1, y1, x2, y2, style, thickness, TRUE);
+    SelectObject(hdc, oldBrush);
     DeleteObject(SelectObject(hdc, oldPen));
 
-    // Create combined region
-    HRGN hRgnCombined = CreateRectRgn(0, 0, 0, 0);
-    CombineRgn(hRgnCombined, hRgnOuter, hRgnInner, RGN_OR);
-
-    FillRgn(hdc, hRgnCombined, hBrush);
-
-    DeleteObject(hRgnOuter);
-    DeleteObject(hRgnInner);
-    DeleteObject(hRgnCombined);
+    // Fill border
+    oldPen = SelectObject(hdc, CreateGeometricPen(RGB(255, 255, 255), 1));
+    oldBrush = SelectObject(hdc, GetStockObject(NULL_BRUSH));
+    BeginPath(hdc);
+    BrushInternal(hdc, x1, y1, x2, y2, style, thickness, TRUE);
+    EndPath(hdc);
+    HRGN hRgn = PathToRegion(hdc);
+    SelectObject(hdc, oldBrush);
+    FillRgn(hdc, hRgn, hBrush);
+    DeleteObject(hRgn);
+    DeleteObject(SelectObject(hdc, oldPen));
 }
 
 void

--- a/base/applications/mspaint/drawing.h
+++ b/base/applications/mspaint/drawing.h
@@ -3,35 +3,48 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    The drawing functions used by the tools
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
+ *             Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once
 
 void Line(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, int thickness);
+void Line(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, INT thickness);
 
 void Rect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, int thickness, int style);
+void Rect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hFgBrush, HBRUSH hBgBrush, INT thickness, INT style);
 
 void Ellp(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, int thickness, int style);
+void Ellp(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hFgBrush, HBRUSH hBgBrush, INT thickness, INT style);
 
 void RRect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, int thickness, int style);
+void RRect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hFgBrush, HBRUSH hBgBrush, INT thickness, INT style);
 
 void Poly(HDC hdc, POINT *lpPoints, int nCount, COLORREF fg, COLORREF bg, int thickness, int style, BOOL closed, BOOL inverted);
+void Poly(HDC hdc, HBRUSH hFgBrush, HBRUSH hBgBrush, POINT *lpPoints, INT nCount, INT thickness, INT style, BOOL closed, BOOL inverted);
 
 void Bezier(HDC hdc, POINT p1, POINT p2, POINT p3, POINT p4, COLORREF color, int thickness);
+void Bezier(HDC hdc, HBRUSH hBrush, POINT p1, POINT p2, POINT p3, POINT p4, INT thickness);
 
 void Fill(HDC hdc, LONG x, LONG y, COLORREF color);
+void Fill(HDC hdc, LONG x, LONG y, HBRUSH hBrush);
 
 void Erase(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG radius);
+void Erase(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, LONG radius);
 
 void Replace(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, LONG radius);
+void Replace(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, HBRUSH hBgBrush, LONG radius);
 
 void Airbrush(HDC hdc, LONG x, LONG y, COLORREF color, LONG r);
+void Airbrush(HDC hdc, LONG x, LONG y, HBRUSH hBrush, LONG r);
 
 void Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG style, INT thickness);
+void Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, LONG style, INT thickness);
 
 void RectSel(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2);
 
 void Text(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, LPCWSTR lpchText, HFONT font, LONG style);
+void Text(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hFgBrush, HBRUSH hBgBrush, LPCWSTR lpchText, HFONT font, LONG style);
 
 BOOL
 ColorKeyedMaskBlt(HDC hdcDest, int nXDest, int nYDest, int nWidth, int nHeight,
@@ -39,3 +52,5 @@ ColorKeyedMaskBlt(HDC hdcDest, int nXDest, int nYDest, int nWidth, int nHeight,
                   HBITMAP hbmMask, COLORREF keyColor);
 
 void DrawXorRect(HDC hdc, const RECT *prc);
+
+HBRUSH CreateDitherBrush(COLORREF color, COLORREF monoColor0, COLORREF monoColor1);

--- a/base/applications/mspaint/drawing.h
+++ b/base/applications/mspaint/drawing.h
@@ -21,10 +21,10 @@ void RRect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg
 void RRect(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hFgBrush, HBRUSH hBgBrush, INT thickness, INT style);
 
 void Poly(HDC hdc, POINT *lpPoints, int nCount, COLORREF fg, COLORREF bg, int thickness, int style, BOOL closed, BOOL inverted);
-void Poly(HDC hdc, HBRUSH hFgBrush, HBRUSH hBgBrush, POINT *lpPoints, INT nCount, INT thickness, INT style, BOOL closed, BOOL inverted);
+void Poly(HDC hdc, POINT *lpPoints, INT nCount, HBRUSH hFgBrush, HBRUSH hBgBrush, INT thickness, INT style, BOOL closed, BOOL inverted);
 
 void Bezier(HDC hdc, POINT p1, POINT p2, POINT p3, POINT p4, COLORREF color, int thickness);
-void Bezier(HDC hdc, HBRUSH hBrush, POINT p1, POINT p2, POINT p3, POINT p4, INT thickness);
+void Bezier(HDC hdc, POINT p1, POINT p2, POINT p3, POINT p4, HBRUSH hBrush, INT thickness);
 
 void Fill(HDC hdc, LONG x, LONG y, COLORREF color);
 void Fill(HDC hdc, LONG x, LONG y, HBRUSH hBrush);

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -560,7 +560,7 @@ struct FreeSelTool : SelectionBaseTool
         if (!selectionModel.m_bShow && m_bDrawing)
         {
             /* Draw the freehand selection inverted/xored */
-            Poly(hdc, s_pPoints, (INT)s_cPoints, 0, 0, 2, 0, FALSE, TRUE);
+            Poly(hdc, s_pPoints, (INT)s_cPoints, (int)0, 0, 2, 0, FALSE, TRUE);
         }
     }
 };
@@ -918,10 +918,10 @@ struct BezierTool : ToolBase
                 Line(hdc, s_pPoints[0].x, s_pPoints[0].y, s_pPoints[1].x, s_pPoints[1].y, hBrush, toolsModel.GetLineWidth());
                 break;
             case 3:
-                Bezier(hdc, hBrush, s_pPoints[0], s_pPoints[2], s_pPoints[2], s_pPoints[1], toolsModel.GetLineWidth());
+                Bezier(hdc, s_pPoints[0], s_pPoints[2], s_pPoints[2], s_pPoints[1], hBrush, toolsModel.GetLineWidth());
                 break;
             case 4:
-                Bezier(hdc, hBrush, s_pPoints[0], s_pPoints[2], s_pPoints[3], s_pPoints[1], toolsModel.GetLineWidth());
+                Bezier(hdc, s_pPoints[0], s_pPoints[2], s_pPoints[3], s_pPoints[1], hBrush, toolsModel.GetLineWidth());
                 break;
         }
     }
@@ -1008,9 +1008,9 @@ struct ShapeTool : ToolBase
             return;
 
         if (m_bLeftButton)
-            Poly(hdc, toolsModel.GetFgBrush(), toolsModel.GetBgBrush(), s_pPoints, (INT)s_cPoints, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
+            Poly(hdc, s_pPoints, (INT)s_cPoints, toolsModel.GetFgBrush(), toolsModel.GetBgBrush(), toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
         else
-            Poly(hdc, toolsModel.GetBgBrush(), toolsModel.GetFgBrush(), s_pPoints, (INT)s_cPoints, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
+            Poly(hdc, s_pPoints, (INT)s_cPoints, toolsModel.GetBgBrush(), toolsModel.GetFgBrush(), toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
     }
 
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick) override

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -586,10 +586,6 @@ struct RubberTool : SmoothDrawTool
 {
     void OnDraw(HDC hdc, BOOL bLeftButton, POINT pt0, POINT pt1) override
     {
-        //if (bLeftButton)
-        //    Erase(hdc, pt0.x, pt0.y, pt1.x, pt1.y, m_bg, toolsModel.GetRubberRadius());
-        //else
-        //    Replace(hdc, pt0.x, pt0.y, pt1.x, pt1.y, m_fg, m_bg, toolsModel.GetRubberRadius());
         if (bLeftButton)
             Erase(hdc, pt0.x, pt0.y, pt1.x, pt1.y, toolsModel.GetBgBrush(), toolsModel.GetRubberRadius());
         else
@@ -608,7 +604,6 @@ struct FillTool : ToolBase
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick) override
     {
         imageModel.PushImageForUndo();
-        //Fill(m_hdc, x, y, bLeftButton ? m_fg : m_bg);
         if (bLeftButton)
             Fill(m_hdc, x, y, toolsModel.GetFgBrush());
         else
@@ -713,8 +708,6 @@ struct PenTool : SmoothDrawTool
 {
     void OnDraw(HDC hdc, BOOL bLeftButton, POINT pt0, POINT pt1) override
     {
-        //COLORREF rgb = bLeftButton ? m_fg : m_bg;
-        //Line(hdc, pt0.x, pt0.y, pt1.x, pt1.y, rgb, toolsModel.GetPenWidth());
         if (bLeftButton)
             Line(hdc, pt0.x, pt0.y, pt1.x, pt1.y, toolsModel.GetFgBrush(), toolsModel.GetPenWidth());
         else
@@ -732,9 +725,6 @@ struct BrushTool : SmoothDrawTool
 {
     void OnDraw(HDC hdc, BOOL bLeftButton, POINT pt0, POINT pt1) override
     {
-        //COLORREF rgb = bLeftButton ? m_fg : m_bg;
-        //Brush(hdc, pt0.x, pt0.y, pt1.x, pt1.y, rgb, toolsModel.GetBrushStyle(),
-        //      toolsModel.GetBrushWidth());
         if (bLeftButton)
             Brush(hdc, pt0.x, pt0.y, pt1.x, pt1.y, toolsModel.GetFgBrush(), toolsModel.GetBrushStyle(),
                   toolsModel.GetBrushWidth());
@@ -768,8 +758,6 @@ struct AirBrushTool : SmoothDrawTool
 
     void OnDraw(HDC hdc, BOOL bLeftButton, POINT pt0, POINT pt1) override
     {
-        //COLORREF rgb = bLeftButton ? m_fg : m_bg;
-        //Airbrush(hdc, pt1.x, pt1.y, rgb, toolsModel.GetAirBrushRadius());
         if (bLeftButton)
             Airbrush(hdc, pt1.x, pt1.y, toolsModel.GetFgBrush(), toolsModel.GetAirBrushRadius());
         else
@@ -829,8 +817,6 @@ struct TextTool : ToolBase
 
         // Draw the text
         INT style = (toolsModel.IsBackgroundTransparent() ? 0 : 1);
-        //Text(hdc, rc.left, rc.top, rc.right, rc.bottom, m_fg, m_bg, szText,
-        //     textEditWindow.GetFont(), style);
         Text(hdc, rc.left, rc.top, rc.right, rc.bottom, toolsModel.GetFgBrush(), toolsModel.GetBgBrush(), szText,
              textEditWindow.GetFont(), style);
     }
@@ -922,8 +908,6 @@ struct LineTool : TwoPointDrawTool
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
             roundTo8Directions(g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y);
-        //COLORREF rgb = m_bLeftButton ? m_fg : m_bg;
-        //Line(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, rgb, toolsModel.GetLineWidth());
         if (m_bLeftButton)
             Line(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetFgBrush(), toolsModel.GetLineWidth());
         else
@@ -938,12 +922,9 @@ struct BezierTool : ToolBase
 
     void OnDrawOverlayOnImage(HDC hdc)
     {
-        //COLORREF rgb = (m_bLeftButton ? m_fg : m_bg);
         switch (s_cPoints)
         {
             case 2:
-                //Line(hdc, s_pPoints[0].x, s_pPoints[0].y, s_pPoints[1].x, s_pPoints[1].y, rgb,
-                //     toolsModel.GetLineWidth());
                 if (m_bLeftButton)
                     Line(hdc, s_pPoints[0].x, s_pPoints[0].y, s_pPoints[1].x, s_pPoints[1].y, toolsModel.GetFgBrush(),
                          toolsModel.GetLineWidth());
@@ -952,14 +933,12 @@ struct BezierTool : ToolBase
                          toolsModel.GetLineWidth());
                 break;
             case 3:
-                //Bezier(hdc, s_pPoints[0], s_pPoints[2], s_pPoints[2], s_pPoints[1], rgb, toolsModel.GetLineWidth());
                 if (m_bLeftButton)
                     Bezier(hdc, toolsModel.GetFgBrush(), s_pPoints[0], s_pPoints[2], s_pPoints[2], s_pPoints[1], toolsModel.GetLineWidth());
                 else
                     Bezier(hdc, toolsModel.GetBgBrush(), s_pPoints[0], s_pPoints[2], s_pPoints[2], s_pPoints[1], toolsModel.GetLineWidth());
                 break;
             case 4:
-                //Bezier(hdc, s_pPoints[0], s_pPoints[2], s_pPoints[3], s_pPoints[1], rgb, toolsModel.GetLineWidth());
                 if (m_bLeftButton)
                     Bezier(hdc, toolsModel.GetFgBrush(), s_pPoints[0], s_pPoints[2], s_pPoints[3], s_pPoints[1], toolsModel.GetLineWidth());
                 else
@@ -1031,10 +1010,6 @@ struct RectTool : TwoPointDrawTool
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
             regularize(g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y);
-        //if (m_bLeftButton)
-        //    Rect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_fg, m_bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
-        //else
-        //    Rect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
         if (m_bLeftButton)
             Rect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetFgBrush(), toolsModel.GetBgBrush(), toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
         else
@@ -1053,10 +1028,6 @@ struct ShapeTool : ToolBase
         if (s_cPoints <= 0)
             return;
 
-        //if (m_bLeftButton)
-        //    Poly(hdc, s_pPoints, (INT)s_cPoints, m_fg, m_bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
-        //else
-        //    Poly(hdc, s_pPoints, (INT)s_cPoints, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
         if (m_bLeftButton)
             Poly(hdc, toolsModel.GetFgBrush(), toolsModel.GetBgBrush(), s_pPoints, (INT)s_cPoints, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
         else
@@ -1150,10 +1121,6 @@ struct EllipseTool : TwoPointDrawTool
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
             regularize(g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y);
-        //if (m_bLeftButton)
-        //    Ellp(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_fg, m_bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
-        //else
-        //    Ellp(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
         if (m_bLeftButton)
             Ellp(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetFgBrush(), toolsModel.GetBgBrush(), toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
         else
@@ -1170,10 +1137,6 @@ struct RRectTool : TwoPointDrawTool
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
             regularize(g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y);
-        //if (m_bLeftButton)
-        //    RRect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_fg, m_bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
-        //else
-        //    RRect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
         if (m_bLeftButton)
             RRect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetFgBrush(), toolsModel.GetBgBrush(), toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
         else

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -586,10 +586,14 @@ struct RubberTool : SmoothDrawTool
 {
     void OnDraw(HDC hdc, BOOL bLeftButton, POINT pt0, POINT pt1) override
     {
+        //if (bLeftButton)
+        //    Erase(hdc, pt0.x, pt0.y, pt1.x, pt1.y, m_bg, toolsModel.GetRubberRadius());
+        //else
+        //    Replace(hdc, pt0.x, pt0.y, pt1.x, pt1.y, m_fg, m_bg, toolsModel.GetRubberRadius());
         if (bLeftButton)
-            Erase(hdc, pt0.x, pt0.y, pt1.x, pt1.y, m_bg, toolsModel.GetRubberRadius());
+            Erase(hdc, pt0.x, pt0.y, pt1.x, pt1.y, toolsModel.GetBgBrush(), toolsModel.GetRubberRadius());
         else
-            Replace(hdc, pt0.x, pt0.y, pt1.x, pt1.y, m_fg, m_bg, toolsModel.GetRubberRadius());
+            Replace(hdc, pt0.x, pt0.y, pt1.x, pt1.y, m_fg, toolsModel.GetBgBrush(), toolsModel.GetRubberRadius());
     }
 
     void OnSpecialTweak(BOOL bMinus) override
@@ -604,7 +608,11 @@ struct FillTool : ToolBase
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick) override
     {
         imageModel.PushImageForUndo();
-        Fill(m_hdc, x, y, bLeftButton ? m_fg : m_bg);
+        //Fill(m_hdc, x, y, bLeftButton ? m_fg : m_bg);
+        if (bLeftButton)
+            Fill(m_hdc, x, y, toolsModel.GetFgBrush());
+        else
+            Fill(m_hdc, x, y, toolsModel.GetBgBrush());
     }
 };
 
@@ -705,8 +713,12 @@ struct PenTool : SmoothDrawTool
 {
     void OnDraw(HDC hdc, BOOL bLeftButton, POINT pt0, POINT pt1) override
     {
-        COLORREF rgb = bLeftButton ? m_fg : m_bg;
-        Line(hdc, pt0.x, pt0.y, pt1.x, pt1.y, rgb, toolsModel.GetPenWidth());
+        //COLORREF rgb = bLeftButton ? m_fg : m_bg;
+        //Line(hdc, pt0.x, pt0.y, pt1.x, pt1.y, rgb, toolsModel.GetPenWidth());
+        if (bLeftButton)
+            Line(hdc, pt0.x, pt0.y, pt1.x, pt1.y, toolsModel.GetFgBrush(), toolsModel.GetPenWidth());
+        else
+            Line(hdc, pt0.x, pt0.y, pt1.x, pt1.y, toolsModel.GetBgBrush(), toolsModel.GetPenWidth());
     }
 
     void OnSpecialTweak(BOOL bMinus) override
@@ -720,9 +732,15 @@ struct BrushTool : SmoothDrawTool
 {
     void OnDraw(HDC hdc, BOOL bLeftButton, POINT pt0, POINT pt1) override
     {
-        COLORREF rgb = bLeftButton ? m_fg : m_bg;
-        Brush(hdc, pt0.x, pt0.y, pt1.x, pt1.y, rgb, toolsModel.GetBrushStyle(),
-              toolsModel.GetBrushWidth());
+        //COLORREF rgb = bLeftButton ? m_fg : m_bg;
+        //Brush(hdc, pt0.x, pt0.y, pt1.x, pt1.y, rgb, toolsModel.GetBrushStyle(),
+        //      toolsModel.GetBrushWidth());
+        if (bLeftButton)
+            Brush(hdc, pt0.x, pt0.y, pt1.x, pt1.y, toolsModel.GetFgBrush(), toolsModel.GetBrushStyle(),
+                  toolsModel.GetBrushWidth());
+        else
+            Brush(hdc, pt0.x, pt0.y, pt1.x, pt1.y, toolsModel.GetBgBrush(), toolsModel.GetBrushStyle(),
+                  toolsModel.GetBrushWidth());
     }
 
     void OnSpecialTweak(BOOL bMinus) override
@@ -750,8 +768,12 @@ struct AirBrushTool : SmoothDrawTool
 
     void OnDraw(HDC hdc, BOOL bLeftButton, POINT pt0, POINT pt1) override
     {
-        COLORREF rgb = bLeftButton ? m_fg : m_bg;
-        Airbrush(hdc, pt1.x, pt1.y, rgb, toolsModel.GetAirBrushRadius());
+        //COLORREF rgb = bLeftButton ? m_fg : m_bg;
+        //Airbrush(hdc, pt1.x, pt1.y, rgb, toolsModel.GetAirBrushRadius());
+        if (bLeftButton)
+            Airbrush(hdc, pt1.x, pt1.y, toolsModel.GetFgBrush(), toolsModel.GetAirBrushRadius());
+        else
+            Airbrush(hdc, pt1.x, pt1.y, toolsModel.GetBgBrush(), toolsModel.GetAirBrushRadius());
     }
 
     void OnSpecialTweak(BOOL bMinus) override
@@ -807,7 +829,9 @@ struct TextTool : ToolBase
 
         // Draw the text
         INT style = (toolsModel.IsBackgroundTransparent() ? 0 : 1);
-        Text(hdc, rc.left, rc.top, rc.right, rc.bottom, m_fg, m_bg, szText,
+        //Text(hdc, rc.left, rc.top, rc.right, rc.bottom, m_fg, m_bg, szText,
+        //     textEditWindow.GetFont(), style);
+        Text(hdc, rc.left, rc.top, rc.right, rc.bottom, toolsModel.GetFgBrush(), toolsModel.GetBgBrush(), szText,
              textEditWindow.GetFont(), style);
     }
 
@@ -898,8 +922,12 @@ struct LineTool : TwoPointDrawTool
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
             roundTo8Directions(g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y);
-        COLORREF rgb = m_bLeftButton ? m_fg : m_bg;
-        Line(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, rgb, toolsModel.GetLineWidth());
+        //COLORREF rgb = m_bLeftButton ? m_fg : m_bg;
+        //Line(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, rgb, toolsModel.GetLineWidth());
+        if (m_bLeftButton)
+            Line(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetFgBrush(), toolsModel.GetLineWidth());
+        else
+            Line(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetBgBrush(), toolsModel.GetLineWidth());
     }
 };
 
@@ -910,18 +938,32 @@ struct BezierTool : ToolBase
 
     void OnDrawOverlayOnImage(HDC hdc)
     {
-        COLORREF rgb = (m_bLeftButton ? m_fg : m_bg);
+        //COLORREF rgb = (m_bLeftButton ? m_fg : m_bg);
         switch (s_cPoints)
         {
             case 2:
-                Line(hdc, s_pPoints[0].x, s_pPoints[0].y, s_pPoints[1].x, s_pPoints[1].y, rgb,
-                     toolsModel.GetLineWidth());
+                //Line(hdc, s_pPoints[0].x, s_pPoints[0].y, s_pPoints[1].x, s_pPoints[1].y, rgb,
+                //     toolsModel.GetLineWidth());
+                if (m_bLeftButton)
+                    Line(hdc, s_pPoints[0].x, s_pPoints[0].y, s_pPoints[1].x, s_pPoints[1].y, toolsModel.GetFgBrush(),
+                         toolsModel.GetLineWidth());
+                else
+                    Line(hdc, s_pPoints[0].x, s_pPoints[0].y, s_pPoints[1].x, s_pPoints[1].y, toolsModel.GetBgBrush(),
+                         toolsModel.GetLineWidth());
                 break;
             case 3:
-                Bezier(hdc, s_pPoints[0], s_pPoints[2], s_pPoints[2], s_pPoints[1], rgb, toolsModel.GetLineWidth());
+                //Bezier(hdc, s_pPoints[0], s_pPoints[2], s_pPoints[2], s_pPoints[1], rgb, toolsModel.GetLineWidth());
+                if (m_bLeftButton)
+                    Bezier(hdc, toolsModel.GetFgBrush(), s_pPoints[0], s_pPoints[2], s_pPoints[2], s_pPoints[1], toolsModel.GetLineWidth());
+                else
+                    Bezier(hdc, toolsModel.GetBgBrush(), s_pPoints[0], s_pPoints[2], s_pPoints[2], s_pPoints[1], toolsModel.GetLineWidth());
                 break;
             case 4:
-                Bezier(hdc, s_pPoints[0], s_pPoints[2], s_pPoints[3], s_pPoints[1], rgb, toolsModel.GetLineWidth());
+                //Bezier(hdc, s_pPoints[0], s_pPoints[2], s_pPoints[3], s_pPoints[1], rgb, toolsModel.GetLineWidth());
+                if (m_bLeftButton)
+                    Bezier(hdc, toolsModel.GetFgBrush(), s_pPoints[0], s_pPoints[2], s_pPoints[3], s_pPoints[1], toolsModel.GetLineWidth());
+                else
+                    Bezier(hdc, toolsModel.GetBgBrush(), s_pPoints[0], s_pPoints[2], s_pPoints[3], s_pPoints[1], toolsModel.GetLineWidth());
                 break;
         }
     }
@@ -989,10 +1031,14 @@ struct RectTool : TwoPointDrawTool
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
             regularize(g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y);
+        //if (m_bLeftButton)
+        //    Rect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_fg, m_bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
+        //else
+        //    Rect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
         if (m_bLeftButton)
-            Rect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_fg, m_bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
+            Rect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetFgBrush(), toolsModel.GetBgBrush(), toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
         else
-            Rect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
+            Rect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetBgBrush(), toolsModel.GetFgBrush(), toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
     }
 };
 
@@ -1007,10 +1053,14 @@ struct ShapeTool : ToolBase
         if (s_cPoints <= 0)
             return;
 
+        //if (m_bLeftButton)
+        //    Poly(hdc, s_pPoints, (INT)s_cPoints, m_fg, m_bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
+        //else
+        //    Poly(hdc, s_pPoints, (INT)s_cPoints, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
         if (m_bLeftButton)
-            Poly(hdc, s_pPoints, (INT)s_cPoints, m_fg, m_bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
+            Poly(hdc, toolsModel.GetFgBrush(), toolsModel.GetBgBrush(), s_pPoints, (INT)s_cPoints, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
         else
-            Poly(hdc, s_pPoints, (INT)s_cPoints, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
+            Poly(hdc, toolsModel.GetBgBrush(), toolsModel.GetFgBrush(), s_pPoints, (INT)s_cPoints, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), m_bClosed, FALSE);
     }
 
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick) override
@@ -1100,10 +1150,14 @@ struct EllipseTool : TwoPointDrawTool
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
             regularize(g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y);
+        //if (m_bLeftButton)
+        //    Ellp(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_fg, m_bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
+        //else
+        //    Ellp(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
         if (m_bLeftButton)
-            Ellp(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_fg, m_bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
+            Ellp(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetFgBrush(), toolsModel.GetBgBrush(), toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
         else
-            Ellp(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
+            Ellp(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetBgBrush(), toolsModel.GetFgBrush(), toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
     }
 };
 
@@ -1116,10 +1170,14 @@ struct RRectTool : TwoPointDrawTool
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
             regularize(g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y);
+        //if (m_bLeftButton)
+        //    RRect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_fg, m_bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
+        //else
+        //    RRect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
         if (m_bLeftButton)
-            RRect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_fg, m_bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
+            RRect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetFgBrush(), toolsModel.GetBgBrush(), toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
         else
-            RRect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
+            RRect(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetBgBrush(), toolsModel.GetFgBrush(), toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
     }
 };
 

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -560,7 +560,7 @@ struct FreeSelTool : SelectionBaseTool
         if (!selectionModel.m_bShow && m_bDrawing)
         {
             /* Draw the freehand selection inverted/xored */
-            Poly(hdc, s_pPoints, (INT)s_cPoints, (int)0, 0, 2, 0, FALSE, TRUE);
+            Poly(hdc, s_pPoints, (INT)s_cPoints, (COLORREF)0, (COLORREF)0, 2, 0, FALSE, TRUE);
         }
     }
 };

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -706,10 +706,8 @@ struct PenTool : SmoothDrawTool
 {
     void OnDraw(HDC hdc, BOOL bLeftButton, POINT pt0, POINT pt1) override
     {
-        if (bLeftButton)
-            Line(hdc, pt0.x, pt0.y, pt1.x, pt1.y, toolsModel.GetFgBrush(), toolsModel.GetPenWidth());
-        else
-            Line(hdc, pt0.x, pt0.y, pt1.x, pt1.y, toolsModel.GetBgBrush(), toolsModel.GetPenWidth());
+        HBRUSH hBrush = (bLeftButton ? toolsModel.GetFgBrush() : toolsModel.GetBgBrush());
+        Line(hdc, pt0.x, pt0.y, pt1.x, pt1.y, hBrush, toolsModel.GetPenWidth());
     }
 
     void OnSpecialTweak(BOOL bMinus) override
@@ -723,12 +721,9 @@ struct BrushTool : SmoothDrawTool
 {
     void OnDraw(HDC hdc, BOOL bLeftButton, POINT pt0, POINT pt1) override
     {
-        if (bLeftButton)
-            Brush(hdc, pt0.x, pt0.y, pt1.x, pt1.y, toolsModel.GetFgBrush(), toolsModel.GetBrushStyle(),
-                  toolsModel.GetBrushWidth());
-        else
-            Brush(hdc, pt0.x, pt0.y, pt1.x, pt1.y, toolsModel.GetBgBrush(), toolsModel.GetBrushStyle(),
-                  toolsModel.GetBrushWidth());
+        HBRUSH hBrush = (bLeftButton ? toolsModel.GetFgBrush() : toolsModel.GetBgBrush());
+        Brush(hdc, pt0.x, pt0.y, pt1.x, pt1.y, hBrush, toolsModel.GetBrushStyle(),
+              toolsModel.GetBrushWidth());
     }
 
     void OnSpecialTweak(BOOL bMinus) override
@@ -756,10 +751,8 @@ struct AirBrushTool : SmoothDrawTool
 
     void OnDraw(HDC hdc, BOOL bLeftButton, POINT pt0, POINT pt1) override
     {
-        if (bLeftButton)
-            Airbrush(hdc, pt1.x, pt1.y, toolsModel.GetFgBrush(), toolsModel.GetAirBrushRadius());
-        else
-            Airbrush(hdc, pt1.x, pt1.y, toolsModel.GetBgBrush(), toolsModel.GetAirBrushRadius());
+        HBRUSH hBrush = (bLeftButton ? toolsModel.GetFgBrush() : toolsModel.GetBgBrush());
+        Airbrush(hdc, pt1.x, pt1.y, hBrush, toolsModel.GetAirBrushRadius());
     }
 
     void OnSpecialTweak(BOOL bMinus) override
@@ -906,10 +899,8 @@ struct LineTool : TwoPointDrawTool
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
             roundTo8Directions(g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y);
-        if (m_bLeftButton)
-            Line(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetFgBrush(), toolsModel.GetLineWidth());
-        else
-            Line(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, toolsModel.GetBgBrush(), toolsModel.GetLineWidth());
+        HBRUSH hBrush = (m_bLeftButton ? toolsModel.GetFgBrush() : toolsModel.GetBgBrush());
+        Line(hdc, g_ptStart.x, g_ptStart.y, g_ptEnd.x, g_ptEnd.y, hBrush, toolsModel.GetLineWidth());
     }
 };
 
@@ -920,27 +911,17 @@ struct BezierTool : ToolBase
 
     void OnDrawOverlayOnImage(HDC hdc)
     {
+        HBRUSH hBrush = (m_bLeftButton ? toolsModel.GetFgBrush() : toolsModel.GetBgBrush());
         switch (s_cPoints)
         {
             case 2:
-                if (m_bLeftButton)
-                    Line(hdc, s_pPoints[0].x, s_pPoints[0].y, s_pPoints[1].x, s_pPoints[1].y, toolsModel.GetFgBrush(),
-                         toolsModel.GetLineWidth());
-                else
-                    Line(hdc, s_pPoints[0].x, s_pPoints[0].y, s_pPoints[1].x, s_pPoints[1].y, toolsModel.GetBgBrush(),
-                         toolsModel.GetLineWidth());
+                Line(hdc, s_pPoints[0].x, s_pPoints[0].y, s_pPoints[1].x, s_pPoints[1].y, hBrush, toolsModel.GetLineWidth());
                 break;
             case 3:
-                if (m_bLeftButton)
-                    Bezier(hdc, toolsModel.GetFgBrush(), s_pPoints[0], s_pPoints[2], s_pPoints[2], s_pPoints[1], toolsModel.GetLineWidth());
-                else
-                    Bezier(hdc, toolsModel.GetBgBrush(), s_pPoints[0], s_pPoints[2], s_pPoints[2], s_pPoints[1], toolsModel.GetLineWidth());
+                Bezier(hdc, hBrush, s_pPoints[0], s_pPoints[2], s_pPoints[2], s_pPoints[1], toolsModel.GetLineWidth());
                 break;
             case 4:
-                if (m_bLeftButton)
-                    Bezier(hdc, toolsModel.GetFgBrush(), s_pPoints[0], s_pPoints[2], s_pPoints[3], s_pPoints[1], toolsModel.GetLineWidth());
-                else
-                    Bezier(hdc, toolsModel.GetBgBrush(), s_pPoints[0], s_pPoints[2], s_pPoints[3], s_pPoints[1], toolsModel.GetLineWidth());
+                Bezier(hdc, hBrush, s_pPoints[0], s_pPoints[2], s_pPoints[3], s_pPoints[1], toolsModel.GetLineWidth());
                 break;
         }
     }

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -604,10 +604,8 @@ struct FillTool : ToolBase
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick) override
     {
         imageModel.PushImageForUndo();
-        if (bLeftButton)
-            Fill(m_hdc, x, y, toolsModel.GetFgBrush());
-        else
-            Fill(m_hdc, x, y, toolsModel.GetBgBrush());
+        HBRUSH hBrush = (bLeftButton ? toolsModel.GetFgBrush() : toolsModel.GetBgBrush());
+        Fill(m_hdc, x, y, hBrush);
     }
 };
 

--- a/base/applications/mspaint/palette.cpp
+++ b/base/applications/mspaint/palette.cpp
@@ -109,24 +109,22 @@ LRESULT CPaletteWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& b
     rc.top = Y_MARGIN + (CXY_BIGBOX * 5 / 8) - (CXY_SELECTEDBOX / 2);
     rc.right = rc.left + CXY_SELECTEDBOX;
     rc.bottom = rc.top + CXY_SELECTEDBOX;
-    HBRUSH hbrBg = paletteModel.CreateBgBrush();
+    HBRUSH hbrBg = toolsModel.GetBgBrush();
     drawColorBox(hMemDC, &rc, hbrBg, BDR_RAISEDINNER);
-    DeleteObject(hbrBg);
 
     /* Draw the black box (overlapping the white box), at 3/8 position */
     rc.left = X_MARGIN + (CXY_BIGBOX * 3 / 8) - (CXY_SELECTEDBOX / 2);
     rc.top = Y_MARGIN + (CXY_BIGBOX * 3 / 8) - (CXY_SELECTEDBOX / 2);
     rc.right = rc.left + CXY_SELECTEDBOX;
     rc.bottom = rc.top + CXY_SELECTEDBOX;
-    HBRUSH hbrFg = paletteModel.CreateFgBrush();
+    HBRUSH hbrFg = toolsModel.GetFgBrush();
     drawColorBox(hMemDC, &rc, hbrFg, BDR_RAISEDINNER);
-    DeleteObject(hbrFg);
 
     /* Draw the normal color boxes */
     for (INT i = 0; i < COLOR_COUNT; i++)
     {
         getColorBoxRect(&rc, rcClient, i);
-        HBRUSH hbr = paletteModel.CreateColorBrush(paletteModel.GetColor(i));
+        HBRUSH hbr = toolsModel.CreateColorBrush(paletteModel.GetColor(i));
         drawColorBox(hMemDC, &rc, hbr, BDR_SUNKENOUTER);
         DeleteObject(hbr);
     }

--- a/base/applications/mspaint/palette.cpp
+++ b/base/applications/mspaint/palette.cpp
@@ -124,7 +124,7 @@ LRESULT CPaletteWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& b
     for (INT i = 0; i < COLOR_COUNT; i++)
     {
         getColorBoxRect(&rc, rcClient, i);
-        HBRUSH hbr = toolsModel.CreateColorBrush(paletteModel.GetColor(i));
+        HBRUSH hbr = toolsModel.CreateVirtualBrush(paletteModel.GetColor(i));
         drawColorBox(hMemDC, &rc, hbr, BDR_SUNKENOUTER);
         DeleteObject(hbr);
     }

--- a/base/applications/mspaint/palette.cpp
+++ b/base/applications/mspaint/palette.cpp
@@ -109,16 +109,14 @@ LRESULT CPaletteWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& b
     rc.top = Y_MARGIN + (CXY_BIGBOX * 5 / 8) - (CXY_SELECTEDBOX / 2);
     rc.right = rc.left + CXY_SELECTEDBOX;
     rc.bottom = rc.top + CXY_SELECTEDBOX;
-    HBRUSH hbrBg = toolsModel.GetBgBrush();
-    drawColorBox(hMemDC, &rc, hbrBg, BDR_RAISEDINNER);
+    drawColorBox(hMemDC, &rc, toolsModel.GetBgBrush(), BDR_RAISEDINNER);
 
     /* Draw the black box (overlapping the white box), at 3/8 position */
     rc.left = X_MARGIN + (CXY_BIGBOX * 3 / 8) - (CXY_SELECTEDBOX / 2);
     rc.top = Y_MARGIN + (CXY_BIGBOX * 3 / 8) - (CXY_SELECTEDBOX / 2);
     rc.right = rc.left + CXY_SELECTEDBOX;
     rc.bottom = rc.top + CXY_SELECTEDBOX;
-    HBRUSH hbrFg = toolsModel.GetFgBrush();
-    drawColorBox(hMemDC, &rc, hbrFg, BDR_RAISEDINNER);
+    drawColorBox(hMemDC, &rc, toolsModel.GetFgBrush(), BDR_RAISEDINNER);
 
     /* Draw the normal color boxes */
     for (INT i = 0; i < COLOR_COUNT; i++)

--- a/base/applications/mspaint/palette.cpp
+++ b/base/applications/mspaint/palette.cpp
@@ -122,7 +122,7 @@ LRESULT CPaletteWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& b
     for (INT i = 0; i < COLOR_COUNT; i++)
     {
         getColorBoxRect(&rc, rcClient, i);
-        HBRUSH hbr = toolsModel.CreateVirtualBrush(paletteModel.GetColor(i));
+        HBRUSH hbr = toolsModel.CreateBrush(paletteModel.GetColor(i));
         drawColorBox(hMemDC, &rc, hbr, BDR_SUNKENOUTER);
         DeleteObject(hbr);
     }

--- a/base/applications/mspaint/palette.cpp
+++ b/base/applications/mspaint/palette.cpp
@@ -119,10 +119,11 @@ LRESULT CPaletteWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& b
     drawColorBox(hMemDC, &rc, toolsModel.GetFgBrush(), BDR_RAISEDINNER);
 
     /* Draw the normal color boxes */
+    const PAL_TYPE palette = paletteModel.SelectedPalette();
     for (INT i = 0; i < COLOR_COUNT; i++)
     {
         getColorBoxRect(&rc, rcClient, i);
-        HBRUSH hbr = toolsModel.CreateBrush(paletteModel.GetColor(i));
+        HBRUSH hbr = toolsModel.CreateBrush(palette, paletteModel.GetColor(i));
         drawColorBox(hMemDC, &rc, hbr, BDR_SUNKENOUTER);
         DeleteObject(hbr);
     }

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -12,13 +12,13 @@ PaletteModel paletteModel;
 
 /* FUNCTIONS ********************************************************/
 
-ColorBrush::~ColorBrush()
+VirtualBrush::~VirtualBrush()
 {
     if (m_hBrush)
         DeleteObject(m_hBrush);
 }
 
-HBRUSH ColorBrush::GetColorBrush(PAL_TYPE palette, COLORREF rgbColor)
+HBRUSH VirtualBrush::GetVirtualBrush(PAL_TYPE palette, COLORREF rgbColor)
 {
     if (m_hBrush &&
         m_palette == palette &&

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -12,6 +12,34 @@ PaletteModel paletteModel;
 
 /* FUNCTIONS ********************************************************/
 
+ColorBrush::~ColorBrush()
+{
+    if (m_hBrush)
+        DeleteObject(m_hBrush);
+}
+
+HBRUSH ColorBrush::GetColorBrush(PAL_TYPE palette, COLORREF rgbColor)
+{
+    if (m_hBrush &&
+        m_palette == palette &&
+        m_rgbColor == rgbColor)
+    {
+        return m_hBrush;
+    }
+
+    if (m_hBrush)
+        ::DeleteObject(m_hBrush);
+
+    if (palette == PAL_MONOCHROME)
+        m_hBrush = CreateDitherBrush(rgbColor, RGB(0, 0, 0), RGB(255, 255, 255));
+    else
+        m_hBrush = CreateSolidBrush(rgbColor);
+
+    m_palette = palette;
+    m_rgbColor = rgbColor;
+    return m_hBrush;
+}
+
 PaletteModel::PaletteModel()
 {
     m_fgColor = RGB(0, 0, 0);
@@ -119,79 +147,4 @@ void PaletteModel::NotifyPaletteChanged()
 {
     if (paletteWindow.IsWindow())
         paletteWindow.Invalidate(FALSE);
-}
-
-HBRUSH
-PaletteModel::CreateDitherBrush(COLORREF color, COLORREF monoColor0, COLORREF monoColor1)
-{
-    // 8x8 Bayer ordered dithering matrix (0 to 63)
-    static const BYTE s_bayerMatrix[8][8] =
-    {
-        {  0, 32,  8, 40,  2, 34, 10, 42 },
-        { 48, 16, 56, 24, 50, 18, 58, 26 },
-        { 12, 44,  4, 36, 14, 46,  6, 38 },
-        { 60, 28, 52, 20, 62, 30, 54, 22 },
-        {  3, 35, 11, 43,  1, 33,  9, 41 },
-        { 51, 19, 59, 27, 49, 17, 57, 25 },
-        { 15, 47,  7, 39, 13, 45,  5, 37 },
-        { 63, 31, 55, 23, 61, 29, 53, 21 },
-    };
-    INT sum = GetRValue(color) + GetGValue(color) + GetBValue(color);
-    INT brightness = sum / 3;
-    if (brightness < 0)
-        brightness = 0;
-    if (brightness >= 255)
-        brightness = 256; // White out
-
-    BITMAPINFO bmi = {};
-    bmi.bmiHeader.biSize     = sizeof(BITMAPINFOHEADER);
-    bmi.bmiHeader.biWidth    = 8;
-    bmi.bmiHeader.biHeight   = -8; // Top-down
-    bmi.bmiHeader.biPlanes   = 1;
-    bmi.bmiHeader.biBitCount = 24;
-
-    const BYTE b0 = GetBValue(monoColor0), g0 = GetGValue(monoColor0), r0 = GetRValue(monoColor0);
-    const BYTE b1 = GetBValue(monoColor1), g1 = GetGValue(monoColor1), r1 = GetRValue(monoColor1);
-
-    BYTE pixels[8 * 8 * 3];
-    for (INT y = 0; y < 8; ++y)
-    {
-        INT index = y * (3 * CHAR_BIT);
-        for (INT x = 0; x < 8; ++x)
-        {
-            const INT threshold = s_bayerMatrix[y][x] * 255 / 63;
-            if (brightness > threshold)
-            {
-                pixels[index++] = b1; // Blue
-                pixels[index++] = g1; // Green
-                pixels[index++] = r1; // Red
-            }
-            else
-            {
-                pixels[index++] = b0; // Blue
-                pixels[index++] = g0; // Green
-                pixels[index++] = r0; // Red
-            }
-        }
-    }
-
-    HDC hdc = GetDC(NULL);
-    HBITMAP hBitmap = CreateDIBitmap(hdc, &bmi.bmiHeader, CBM_INIT, pixels, &bmi, DIB_RGB_COLORS);
-    ReleaseDC(NULL, hdc);
-
-    if (!hBitmap)
-        return NULL;
-
-    HBRUSH hBrush = CreatePatternBrush(hBitmap);
-    DeleteObject(hBitmap);
-
-    return hBrush;
-}
-
-HBRUSH PaletteModel::CreateColorBrush(COLORREF color)
-{
-    if (m_nSelectedPalette == PAL_MONOCHROME)
-        return CreateDitherBrush(color, RGB(0, 0, 0), RGB(255, 255, 255));
-    else
-        return CreateSolidBrush(color);
 }

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -12,34 +12,6 @@ PaletteModel paletteModel;
 
 /* FUNCTIONS ********************************************************/
 
-VirtualBrush::~VirtualBrush()
-{
-    if (m_hBrush)
-        DeleteObject(m_hBrush);
-}
-
-HBRUSH VirtualBrush::GetBrush(PAL_TYPE palette, COLORREF rgbColor)
-{
-    if (m_hBrush &&
-        m_palette == palette &&
-        m_rgbColor == rgbColor)
-    {
-        return m_hBrush;
-    }
-
-    if (m_hBrush)
-        ::DeleteObject(m_hBrush);
-
-    if (palette == PAL_MONOCHROME)
-        m_hBrush = CreateDitherBrush(rgbColor, RGB(0, 0, 0), RGB(255, 255, 255));
-    else
-        m_hBrush = CreateSolidBrush(rgbColor);
-
-    m_palette = palette;
-    m_rgbColor = rgbColor;
-    return m_hBrush;
-}
-
 PaletteModel::PaletteModel()
 {
     m_fgColor = RGB(0, 0, 0);

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -18,7 +18,7 @@ VirtualBrush::~VirtualBrush()
         DeleteObject(m_hBrush);
 }
 
-HBRUSH VirtualBrush::GetVirtualBrush(PAL_TYPE palette, COLORREF rgbColor)
+HBRUSH VirtualBrush::GetBrush(PAL_TYPE palette, COLORREF rgbColor)
 {
     if (m_hBrush &&
         m_palette == palette &&

--- a/base/applications/mspaint/palettemodel.h
+++ b/base/applications/mspaint/palettemodel.h
@@ -9,7 +9,7 @@
 
 #define NUM_COLORS 28
 
-enum PAL_TYPE
+enum PAL_TYPE : int
 {
     PAL_MODERN = 1,
     PAL_OLDTYPE = 2,
@@ -18,6 +18,19 @@ enum PAL_TYPE
 };
 
 /* CLASSES **********************************************************/
+
+class ColorBrush
+{
+protected:
+    COLORREF m_rgbColor = RGB(0, 0, 0);
+    PAL_TYPE m_palette = PAL_MODERN;
+    HBRUSH m_hBrush = NULL;
+
+public:
+    ~ColorBrush();
+
+    HBRUSH GetColorBrush(PAL_TYPE palette, COLORREF rgbColor);
+};
 
 class PaletteModel
 {
@@ -29,7 +42,6 @@ private:
 
     void NotifyColorChanged();
     void NotifyPaletteChanged();
-    static HBRUSH CreateDitherBrush(COLORREF color, COLORREF monoColor0, COLORREF monoColor1);
 
 public:
     PaletteModel();
@@ -41,7 +53,4 @@ public:
     void SetFgColor(COLORREF newColor);
     COLORREF GetBgColor() const;
     void SetBgColor(COLORREF newColor);
-    HBRUSH CreateColorBrush(COLORREF color);
-    HBRUSH CreateFgBrush() { return CreateColorBrush(m_fgColor); }
-    HBRUSH CreateBgBrush() { return CreateColorBrush(m_bgColor); }
 };

--- a/base/applications/mspaint/palettemodel.h
+++ b/base/applications/mspaint/palettemodel.h
@@ -19,7 +19,7 @@ enum PAL_TYPE
 
 /* CLASSES **********************************************************/
 
-class ColorBrush
+class VirtualBrush
 {
 protected:
     COLORREF m_rgbColor = RGB(0, 0, 0);
@@ -27,9 +27,9 @@ protected:
     HBRUSH m_hBrush = NULL;
 
 public:
-    ~ColorBrush();
+    ~VirtualBrush();
 
-    HBRUSH GetColorBrush(PAL_TYPE palette, COLORREF rgbColor);
+    HBRUSH GetVirtualBrush(PAL_TYPE palette, COLORREF rgbColor);
 };
 
 class PaletteModel

--- a/base/applications/mspaint/palettemodel.h
+++ b/base/applications/mspaint/palettemodel.h
@@ -9,7 +9,7 @@
 
 #define NUM_COLORS 28
 
-enum PAL_TYPE : int
+enum PAL_TYPE
 {
     PAL_MODERN = 1,
     PAL_OLDTYPE = 2,

--- a/base/applications/mspaint/palettemodel.h
+++ b/base/applications/mspaint/palettemodel.h
@@ -19,19 +19,6 @@ enum PAL_TYPE
 
 /* CLASSES **********************************************************/
 
-class VirtualBrush
-{
-protected:
-    COLORREF m_rgbColor = RGB(0, 0, 0);
-    PAL_TYPE m_palette = PAL_MODERN;
-    HBRUSH m_hBrush = NULL;
-
-public:
-    ~VirtualBrush();
-
-    HBRUSH GetBrush(PAL_TYPE palette, COLORREF rgbColor);
-};
-
 class PaletteModel
 {
 private:

--- a/base/applications/mspaint/palettemodel.h
+++ b/base/applications/mspaint/palettemodel.h
@@ -29,7 +29,7 @@ protected:
 public:
     ~VirtualBrush();
 
-    HBRUSH GetVirtualBrush(PAL_TYPE palette, COLORREF rgbColor);
+    HBRUSH GetBrush(PAL_TYPE palette, COLORREF rgbColor);
 };
 
 class PaletteModel

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -321,3 +321,21 @@ void ToolsModel::selectAll()
     OnMouseMove(TRUE, imageModel.GetWidth(), imageModel.GetHeight());
     OnButtonUp(TRUE, imageModel.GetWidth(), imageModel.GetHeight());
 }
+
+HBRUSH ToolsModel::CreateColorBrush(COLORREF color)
+{
+    if (paletteModel.SelectedPalette() == PAL_MONOCHROME)
+        return CreateDitherBrush(color, RGB(0, 0, 0), RGB(255, 255, 255));
+    else
+        return ::CreateSolidBrush(color);
+}
+
+HBRUSH ToolsModel::GetFgBrush()
+{
+    return m_fgBrush.GetColorBrush(paletteModel.SelectedPalette(), paletteModel.GetFgColor());
+}
+
+HBRUSH ToolsModel::GetBgBrush()
+{
+    return m_bgBrush.GetColorBrush(paletteModel.SelectedPalette(), paletteModel.GetBgColor());
+}

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -322,7 +322,7 @@ void ToolsModel::selectAll()
     OnButtonUp(TRUE, imageModel.GetWidth(), imageModel.GetHeight());
 }
 
-HBRUSH ToolsModel::CreateColorBrush(COLORREF color)
+HBRUSH ToolsModel::CreateVirtualBrush(COLORREF color)
 {
     if (paletteModel.SelectedPalette() == PAL_MONOCHROME)
         return CreateDitherBrush(color, RGB(0, 0, 0), RGB(255, 255, 255));
@@ -332,10 +332,10 @@ HBRUSH ToolsModel::CreateColorBrush(COLORREF color)
 
 HBRUSH ToolsModel::GetFgBrush()
 {
-    return m_fgBrush.GetColorBrush(paletteModel.SelectedPalette(), paletteModel.GetFgColor());
+    return m_fgBrush.GetVirtualBrush(paletteModel.SelectedPalette(), paletteModel.GetFgColor());
 }
 
 HBRUSH ToolsModel::GetBgBrush()
 {
-    return m_bgBrush.GetColorBrush(paletteModel.SelectedPalette(), paletteModel.GetBgColor());
+    return m_bgBrush.GetVirtualBrush(paletteModel.SelectedPalette(), paletteModel.GetBgColor());
 }

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -322,7 +322,7 @@ void ToolsModel::selectAll()
     OnButtonUp(TRUE, imageModel.GetWidth(), imageModel.GetHeight());
 }
 
-HBRUSH ToolsModel::CreateVirtualBrush(COLORREF color)
+HBRUSH ToolsModel::CreateBrush(COLORREF color)
 {
     if (paletteModel.SelectedPalette() == PAL_MONOCHROME)
         return CreateDitherBrush(color, RGB(0, 0, 0), RGB(255, 255, 255));

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -332,10 +332,10 @@ HBRUSH ToolsModel::CreateBrush(COLORREF color)
 
 HBRUSH ToolsModel::GetFgBrush()
 {
-    return m_fgBrush.GetVirtualBrush(paletteModel.SelectedPalette(), paletteModel.GetFgColor());
+    return m_fgBrush.GetBrush(paletteModel.SelectedPalette(), paletteModel.GetFgColor());
 }
 
 HBRUSH ToolsModel::GetBgBrush()
 {
-    return m_bgBrush.GetVirtualBrush(paletteModel.SelectedPalette(), paletteModel.GetBgColor());
+    return m_bgBrush.GetBrush(paletteModel.SelectedPalette(), paletteModel.GetBgColor());
 }

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -11,6 +11,34 @@ ToolsModel toolsModel;
 
 /* FUNCTIONS ********************************************************/
 
+ToolsModel::VirtualBrush::~VirtualBrush()
+{
+    if (m_hBrush)
+        DeleteObject(m_hBrush);
+}
+
+HBRUSH ToolsModel::VirtualBrush::GetBrush(PAL_TYPE palette, COLORREF rgbColor)
+{
+    if (m_hBrush &&
+        m_palette == palette &&
+        m_rgbColor == rgbColor)
+    {
+        return m_hBrush;
+    }
+
+    if (m_hBrush)
+        ::DeleteObject(m_hBrush);
+
+    if (palette == PAL_MONOCHROME)
+        m_hBrush = CreateDitherBrush(rgbColor, RGB(0, 0, 0), RGB(255, 255, 255));
+    else
+        m_hBrush = CreateSolidBrush(rgbColor);
+
+    m_palette = palette;
+    m_rgbColor = rgbColor;
+    return m_hBrush;
+}
+
 ToolsModel::ToolsModel()
 {
     m_lineWidth = m_penWidth = 1;

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -350,9 +350,9 @@ void ToolsModel::selectAll()
     OnButtonUp(TRUE, imageModel.GetWidth(), imageModel.GetHeight());
 }
 
-HBRUSH ToolsModel::CreateBrush(COLORREF color)
+HBRUSH ToolsModel::CreateBrush(PAL_TYPE palette, COLORREF color)
 {
-    if (paletteModel.SelectedPalette() == PAL_MONOCHROME)
+    if (palette == PAL_MONOCHROME)
         return CreateDitherBrush(color, RGB(0, 0, 0), RGB(255, 255, 255));
     else
         return ::CreateSolidBrush(color);

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -14,7 +14,7 @@ ToolsModel toolsModel;
 ToolsModel::VirtualBrush::~VirtualBrush()
 {
     if (m_hBrush)
-        DeleteObject(m_hBrush);
+        ::DeleteObject(m_hBrush);
 }
 
 HBRUSH ToolsModel::VirtualBrush::GetBrush(PAL_TYPE palette, COLORREF rgbColor)

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -29,11 +29,7 @@ HBRUSH ToolsModel::VirtualBrush::GetBrush(PAL_TYPE palette, COLORREF rgbColor)
     if (m_hBrush)
         ::DeleteObject(m_hBrush);
 
-    if (palette == PAL_MONOCHROME)
-        m_hBrush = CreateDitherBrush(rgbColor, RGB(0, 0, 0), RGB(255, 255, 255));
-    else
-        m_hBrush = CreateSolidBrush(rgbColor);
-
+    m_hBrush = ToolsModel::CreateBrush(palette, rgbColor);
     m_palette = palette;
     m_rgbColor = rgbColor;
     return m_hBrush;

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -79,6 +79,8 @@ private:
     BOOL m_transpBg;
     int m_zoom;
     ToolBase *m_pToolObject;
+    ColorBrush m_fgBrush;
+    ColorBrush m_bgBrush;
 
     ToolBase *GetOrCreateTool(TOOLTYPE nTool);
     void SendSetCursor();
@@ -144,6 +146,10 @@ public:
     void SpecialTweak(BOOL bMinus);
 
     void DrawWithMouseTool(POINT pt, WPARAM wParam);
+
+    HBRUSH GetFgBrush();
+    HBRUSH GetBgBrush();
+    HBRUSH CreateColorBrush(COLORREF color);
 };
 
 extern ToolsModel toolsModel;

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -79,8 +79,8 @@ private:
     BOOL m_transpBg;
     int m_zoom;
     ToolBase *m_pToolObject;
-    ColorBrush m_fgBrush;
-    ColorBrush m_bgBrush;
+    VirtualBrush m_fgBrush;
+    VirtualBrush m_bgBrush;
 
     ToolBase *GetOrCreateTool(TOOLTYPE nTool);
     void SendSetCursor();
@@ -149,7 +149,7 @@ public:
 
     HBRUSH GetFgBrush();
     HBRUSH GetBgBrush();
-    HBRUSH CreateColorBrush(COLORREF color);
+    HBRUSH CreateVirtualBrush(COLORREF color);
 };
 
 extern ToolsModel toolsModel;

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -67,6 +67,19 @@ struct ToolBase
 class ToolsModel
 {
 private:
+    class VirtualBrush
+    {
+    protected:
+        COLORREF m_rgbColor = RGB(0, 0, 0);
+        PAL_TYPE m_palette = PAL_MODERN;
+        HBRUSH m_hBrush = NULL;
+
+    public:
+        ~VirtualBrush();
+
+        HBRUSH GetBrush(PAL_TYPE palette, COLORREF rgbColor);
+    };
+
     int m_lineWidth;
     INT m_penWidth;
     INT m_brushWidth;

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -162,7 +162,7 @@ public:
 
     HBRUSH GetFgBrush();
     HBRUSH GetBgBrush();
-    HBRUSH CreateBrush(COLORREF color);
+    static HBRUSH CreateBrush(PAL_TYPE palette, COLORREF color);
 };
 
 extern ToolsModel toolsModel;

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -149,7 +149,7 @@ public:
 
     HBRUSH GetFgBrush();
     HBRUSH GetBgBrush();
-    HBRUSH CreateVirtualBrush(COLORREF color);
+    HBRUSH CreateBrush(COLORREF color);
 };
 
 extern ToolsModel toolsModel;


### PR DESCRIPTION
## Purpose

Support drawing with dithering on monochrome palette mode.
JIRA issue: [CORE-15990](https://jira.reactos.org/browse/CORE-15990)

## Proposed changes

- Enhance drawing routines for dithering in `drawing.cpp`.
- Add `VirtualBrush` class to the tools model in order to virtualize the drawing colors.
- Move `PaletteModel::CreateDitherBrush` to `drawing.cpp` `::CreateDitherBrush`.

## Screenshot

(After choosing `[Colors]` --> `[Monochrome palette]`)

<img width="640" height="480" alt="after" src="https://github.com/user-attachments/assets/d77b3a3b-e8e7-4c17-ab33-190fc772ab9c" />

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108438,108547
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108439,108548