### PR TITLE
[KEYBOARD] Fix AltGr

### DIFF
--- a/dll/keyboard/kbdda/kbdda.c
+++ b/dll/keyboard/kbdda/kbdda.c
@@ -152,7 +152,7 @@ ROSDATA VK_TO_BIT modifier_keys[] = {
 ROSDATA MODIFIERS modifier_bits = {
   modifier_keys,
   6,
-  { 0, 1, 2, 4, SHFT_INVALID, SHFT_INVALID, 3 } /* Modifier bit order, NONE, SHIFT, CTRL, ALT, MENU, SHIFT + MENU, CTRL + MENU */
+  { 0, 1, 2, 6, SHFT_INVALID, SHFT_INVALID, 3 } /* Modifier bit order, NONE, SHIFT, CTRL, ALT, MENU, SHIFT + MENU, CTRL + MENU */
 };
 
 ROSDATA VK_TO_WCHARS2 key_to_chars_2mod[] = {

--- a/dll/keyboard/kbdfi/kbdfi.c
+++ b/dll/keyboard/kbdfi/kbdfi.c
@@ -155,7 +155,7 @@ ROSDATA VK_TO_BIT modifier_keys[] = {
 ROSDATA MODIFIERS modifier_bits = {
   modifier_keys,
   6,
-  { 0, 1, 2, 4, SHFT_INVALID, SHFT_INVALID, 3 }
+  { 0, 1, 2, 6, SHFT_INVALID, SHFT_INVALID, 3 }
 };
 
 ROSDATA VK_TO_WCHARS2 key_to_chars_2mod[] = {

--- a/dll/keyboard/kbdfr/kbdfr.c
+++ b/dll/keyboard/kbdfr/kbdfr.c
@@ -162,7 +162,7 @@ ROSDATA VK_TO_BIT modifier_keys[] = {
 ROSDATA MODIFIERS modifier_bits = {
   modifier_keys,
   6,
-  { 0, 1, 2, 4, SHFT_INVALID, SHFT_INVALID, 3 }
+  { 0, 1, 2, 6, SHFT_INVALID, SHFT_INVALID, 3 }
   /* Modifier bit order: NONE, SHIFT, CTRL, ALT, ?, ?, SHIFT-CTRL */
 };
 

--- a/dll/keyboard/kbdno/kbdno.c
+++ b/dll/keyboard/kbdno/kbdno.c
@@ -152,7 +152,7 @@ ROSDATA VK_TO_BIT modifier_keys[] = {
 ROSDATA MODIFIERS modifier_bits = {
   modifier_keys,
   6,
-  { 0, 1, 2, 4, SHFT_INVALID, SHFT_INVALID, 3 } /* Modifier bit order, NONE, SHIFT, CTRL, ALT, MENU, SHIFT + MENU, CTRL + MENU */
+  { 0, 1, 2, 6, SHFT_INVALID, SHFT_INVALID, 3 } /* Modifier bit order, NONE, SHIFT, CTRL, ALT, MENU, SHIFT + MENU, CTRL + MENU */
 };
 
 ROSDATA VK_TO_WCHARS2 key_to_chars_2mod[] = {

--- a/dll/keyboard/kbdsw/kbdsw.c
+++ b/dll/keyboard/kbdsw/kbdsw.c
@@ -157,7 +157,7 @@ ROSDATA VK_TO_BIT modifier_keys[] = {
 ROSDATA MODIFIERS modifier_bits = {
   modifier_keys,
   6,
-  { 0, 1, 2, 4, SHFT_INVALID, SHFT_INVALID, 3 } /* Modifier bit order, NONE, SHIFT, CTRL, ALT, MENU, SHIFT + MENU, CTRL + MENU */
+  { 0, 1, 2, 6, SHFT_INVALID, SHFT_INVALID, 3 } /* Modifier bit order, NONE, SHIFT, CTRL, ALT, MENU, SHIFT + MENU, CTRL + MENU */
 };
 
 ROSDATA VK_TO_WCHARS2 key_to_chars_2mod[] = {


### PR DESCRIPTION
`VkKeyScanW(0x7D)` (`}`) is supposed to return 6 in the HIBYTE like it does on Windows (Ctrl+Alt (AltGr) instead of just Alt).

There are probably more keyboards with similar issues but those familiar with the keyboards in question need to investigate.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: