### PR TITLE
[NTOS:KE][AMD64] Move KD initialization after HalInitializeProcessor call

### DIFF
--- a/ntoskrnl/ke/amd64/kiinit.c
+++ b/ntoskrnl/ke/amd64/kiinit.c
@@ -556,7 +556,7 @@ KiSystemStartup(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 
     if (Cpu == 0)
     {
-         /* Initialize debugging system */
+        /* Initialize debugging system */
         KdInitSystem(0, KeLoaderBlock);
 
         /* Check for break-in */

--- a/ntoskrnl/ke/amd64/kiinit.c
+++ b/ntoskrnl/ke/amd64/kiinit.c
@@ -536,16 +536,7 @@ KiSystemStartup(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 
         /* Setup the IDT */
         KeInitExceptions();
-
-         /* Initialize debugging system */
-        KdInitSystem(0, KeLoaderBlock);
-
-        /* Check for break-in */
-        if (KdPollBreakIn()) DbgBreakPointWithStatus(DBG_STATUS_CONTROL_C);
     }
-
-    DPRINT1("Pcr = %p, Gdt = %p, Idt = %p, Tss = %p\n",
-           Pcr, Pcr->GdtBase, Pcr->IdtBase, Pcr->TssBase);
 
     /* Acquire lock */
     while (InterlockedBitTestAndSet64((PLONG64)&KiFreezeExecutionLock, 0))
@@ -562,6 +553,18 @@ KiSystemStartup(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 
     /* Release lock */
     InterlockedAnd64((PLONG64)&KiFreezeExecutionLock, 0);
+
+    if (Cpu == 0)
+    {
+         /* Initialize debugging system */
+        KdInitSystem(0, KeLoaderBlock);
+
+        /* Check for break-in */
+        if (KdPollBreakIn()) DbgBreakPointWithStatus(DBG_STATUS_CONTROL_C);
+    }
+
+    DPRINT1("Pcr = %p, Gdt = %p, Idt = %p, Tss = %p\n",
+           Pcr, Pcr->GdtBase, Pcr->IdtBase, Pcr->TssBase);
 
     /* Raise to HIGH_LEVEL */
     KfRaiseIrql(HIGH_LEVEL);


### PR DESCRIPTION
This is needed for PCI debugging devices whose KD modules depend on the functions registered in `HalpRegisterKdSupportFunctions()`.

Necessary for PR #9156 on AMD64.

JIRA issue: [CORE-20385](https://jira.reactos.org/browse/CORE-20385)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: