### PR TITLE
[NTOS:EX] Implement/fix a number of cases for NtQuerySystemInformation

### DIFF
--- a/hal/halx86/generic/sysinfo.c
+++ b/hal/halx86/generic/sysinfo.c
@@ -10,6 +10,9 @@
 /* INCLUDES *******************************************************************/
 
 #include <hal.h>
+typedef unsigned int UINT;
+#include <x86x64/Cpuid.h>
+
 #define NDEBUG
 #include <debug.h>
 
@@ -48,6 +51,47 @@ HaliHandlePCIConfigSpaceAccess(_In_ BOOLEAN IsRead,
     DPRINT1("HaliHandlePCIConfigSpaceAccess: IsRead %X, Port 0x%X, Length %u, Buffer %p\n", IsRead, Port, Length, Buffer);
     //ASSERT(FALSE);
     return STATUS_NOT_IMPLEMENTED;
+}
+
+static
+NTSTATUS
+HaliQueryProcessorBrandString(
+    _Out_writes_(BrandStringLength) PCHAR BrandString,
+    _In_ ULONG BrandStringLength,
+    _Out_ PULONG ReturnedLength)
+{
+    CPUID_EXTENDED_FUNCTION_REGS ExtendedFunction;
+    union
+    {
+        INT AsInt[3 * 4];
+        CHAR Chars[49];
+    } BrandStringUnion;
+
+    *ReturnedLength = sizeof(BrandStringUnion.Chars);
+    if (BrandStringLength < *ReturnedLength)
+    {
+        DPRINT1("HaliQueryProcessorBrandString: Buffer too small (%u < %u)\n", BrandStringLength, *ReturnedLength);
+        return STATUS_INFO_LENGTH_MISMATCH;
+    }
+
+    /* Check if we can query the brand string */
+    __cpuid(ExtendedFunction.AsInt32, CPUID_EXTENDED_FUNCTION);
+    if (ExtendedFunction.MaxLeaf < CPUID_BRAND_STRING3)
+    {
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    __cpuid(&BrandStringUnion.AsInt[0], CPUID_BRAND_STRING1);
+    __cpuid(&BrandStringUnion.AsInt[4], CPUID_BRAND_STRING2);
+    __cpuid(&BrandStringUnion.AsInt[8], CPUID_BRAND_STRING3);
+    BrandStringUnion.Chars[48] = '\0'; // Ensure null-termination
+
+    /* Copy the brand string to the output buffer */
+    RtlCopyMemory(BrandString,
+                  BrandStringUnion.Chars,
+                  sizeof(BrandStringUnion.Chars));
+
+    return STATUS_SUCCESS;
 }
 
 NTSTATUS
@@ -102,7 +146,10 @@ HaliQuerySystemInformation(IN HAL_QUERY_INFORMATION_CLASS InformationClass,
         REPORT_THIS_CASE(HalQueryProfileSourceList);
         REPORT_THIS_CASE(HalInitLogInformation);
         REPORT_THIS_CASE(HalFrequencyInformation);
-        REPORT_THIS_CASE(HalProcessorBrandString);
+        case HalProcessorBrandString:
+        {
+            return HaliQueryProcessorBrandString((PCHAR)Buffer, BufferSize, ReturnedLength);
+        }
         REPORT_THIS_CASE(HalHypervisorInformation);
         REPORT_THIS_CASE(HalPlatformTimerInformation);
         REPORT_THIS_CASE(HalAcpiAuditInformation);

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -2491,6 +2491,12 @@ QSI_DEF(SystemNumaAvailableMemory)
     return STATUS_SUCCESS;
 }
 
+/* Class 62 - Emulation Basic Information */
+QSI_DEF(SystemEmulationBasicInformation)
+{
+    return QSISystemBasicInformation(Buffer, Size, ReqSize);
+}
+
 /* Class 64 - Extended handle information */
 QSI_DEF(SystemExtendedHandleInformation)
 {
@@ -2908,7 +2914,7 @@ CallQS[] =
     SI_XX(SystemComPlusPackage),
     SI_QX(SystemNumaAvailableMemory),
     SI_XX(SystemProcessorPowerInformation), /* FIXME: not implemented */
-    SI_XX(SystemEmulationBasicInformation), /* FIXME: not implemented */
+    SI_QX(SystemEmulationBasicInformation),
     SI_XX(SystemEmulationProcessorInformation), /* FIXME: not implemented */
     SI_QX(SystemExtendedHandleInformation),
     SI_XX(SystemLostDelayedWriteInformation), /* FIXME: not implemented */

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -1561,7 +1561,8 @@ QSI_DEF(SystemInterruptInformation)
     ULONG ti;
     PSYSTEM_INTERRUPT_INFORMATION sii = (PSYSTEM_INTERRUPT_INFORMATION)Buffer;
 
-    if(Size < KeNumberProcessors * sizeof(SYSTEM_INTERRUPT_INFORMATION))
+    *ReqSize = KeNumberProcessors * sizeof(SYSTEM_INTERRUPT_INFORMATION);
+    if (Size < *ReqSize)
     {
         return STATUS_INFO_LENGTH_MISMATCH;
     }
@@ -1572,7 +1573,7 @@ QSI_DEF(SystemInterruptInformation)
     {
         Prcb = KiProcessorBlock[i];
         sii->ContextSwitches = KeGetContextSwitches(Prcb);
-        sii->DpcCount = Prcb->DpcData[0].DpcCount;
+        sii->DpcCount = Prcb->DpcData[DPC_NORMAL].DpcCount;
         sii->DpcRate = Prcb->DpcRequestRate;
         sii->TimeIncrement = ti;
         sii->DpcBypassCount = 0;

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -881,11 +881,19 @@ QSI_DEF(SystemPathInformation)
     return STATUS_NOT_IMPLEMENTED;
 }
 
-/* Class 5 - Process Information */
-QSI_DEF(SystemProcessInformation)
+/* Class 5 - Process Information / 57 - SystemExtendedProcessInformation  */
+static
+NTSTATUS
+ExpQuerySystemProcessInformation(
+    _Out_writes_bytes_(Size) PVOID Buffer,
+    _In_ ULONG Size,
+    _Out_ PULONG ReqSize,
+    _In_ BOOLEAN Extended)
 {
+    const ULONG ThreadInfoSize = Extended ? sizeof(SYSTEM_EXTENDED_THREAD_INFORMATION) : sizeof(SYSTEM_THREAD_INFORMATION);
     PSYSTEM_PROCESS_INFORMATION SpiCurrent;
     PSYSTEM_THREAD_INFORMATION ThreadInfo;
+    PSYSTEM_EXTENDED_THREAD_INFORMATION ThreadInfoEx;
     PEPROCESS Process = NULL, SystemProcess;
     PETHREAD CurrentThread;
     ANSI_STRING ImageName;
@@ -952,12 +960,13 @@ QSI_DEF(SystemProcessInformation)
             CurrentEntry = Process->Pcb.ThreadListHead.Flink;
             while (CurrentEntry != &Process->Pcb.ThreadListHead)
             {
+                CurrentThread = CONTAINING_RECORD(CurrentEntry, ETHREAD, Tcb.ThreadListEntry);
                 ThreadsCount++;
                 CurrentEntry = CurrentEntry->Flink;
             }
 
             // size of the structure for every process
-            CurrentSize = sizeof(SYSTEM_PROCESS_INFORMATION) + sizeof(SYSTEM_THREAD_INFORMATION) * ThreadsCount;
+            CurrentSize = sizeof(SYSTEM_PROCESS_INFORMATION) + ThreadInfoSize * ThreadsCount;
             ImageNameLength = 0;
             Status = SeLocateProcessImageName(Process, &TempProcessImageName);
             ProcessImageName = TempProcessImageName;
@@ -1051,10 +1060,12 @@ QSI_DEF(SystemProcessInformation)
                 SpiCurrent->PagefileUsage = Process->QuotaUsage[PsPageFile];
                 SpiCurrent->PeakPagefileUsage = Process->QuotaPeak[PsPageFile];
                 SpiCurrent->PrivatePageCount = Process->CommitCharge;
-                ThreadInfo = (PSYSTEM_THREAD_INFORMATION)(SpiCurrent + 1);
 
-                CurrentEntry = Process->Pcb.ThreadListHead.Flink;
-                while (CurrentEntry != &Process->Pcb.ThreadListHead)
+                /* Now do the threads */
+                ThreadInfo = (PSYSTEM_THREAD_INFORMATION)(SpiCurrent + 1);
+                for (CurrentEntry = Process->Pcb.ThreadListHead.Flink;
+                     CurrentEntry != &Process->Pcb.ThreadListHead;
+                     CurrentEntry = CurrentEntry->Flink)
                 {
                     CurrentThread = CONTAINING_RECORD(CurrentEntry, ETHREAD, Tcb.ThreadListEntry);
 
@@ -1069,9 +1080,17 @@ QSI_DEF(SystemProcessInformation)
                     ThreadInfo->ContextSwitches = CurrentThread->Tcb.ContextSwitches;
                     ThreadInfo->ThreadState = CurrentThread->Tcb.State;
                     ThreadInfo->WaitReason = CurrentThread->Tcb.WaitReason;
+                    if (Extended)
+                    {
+                        ThreadInfoEx = (PSYSTEM_EXTENDED_THREAD_INFORMATION)ThreadInfo;
+                        ThreadInfoEx->StackBase = CurrentThread->Tcb.StackBase;
+                        ThreadInfoEx->StackLimit = (PVOID)CurrentThread->Tcb.StackLimit;
+                        ThreadInfoEx->Win32StartAddress = (CurrentThread->Win32StartAddress ?
+                            CurrentThread->Win32StartAddress : CurrentThread->StartAddress);
+                        ThreadInfoEx->TebBase = CurrentThread->Tcb.Teb;
+                    }
 
-                    ThreadInfo++;
-                    CurrentEntry = CurrentEntry->Flink;
+                    ThreadInfo = (PSYSTEM_THREAD_INFORMATION)((PUCHAR)ThreadInfo + ThreadInfoSize);
                 }
 
                 /* Query total user/kernel times of a process */
@@ -1130,6 +1149,12 @@ Skip:
 
     *ReqSize = TotalSize;
     return Status;
+}
+
+/* Class 5 - Process Information */
+QSI_DEF(SystemProcessInformation)
+{
+    return ExpQuerySystemProcessInformation(Buffer, Size, ReqSize, FALSE);
 }
 
 /* Class 6 - Call Count Information */
@@ -2424,9 +2449,7 @@ QSI_DEF(SystemPrefetcherInformation)
 /* Class 57 - Extended process information */
 QSI_DEF(SystemExtendedProcessInformation)
 {
-    /* FIXME */
-    DPRINT1("NtQuerySystemInformation - SystemExtendedProcessInformation not implemented\n");
-    return STATUS_NOT_IMPLEMENTED;
+    return ExpQuerySystemProcessInformation(Buffer, Size, ReqSize, TRUE);
 }
 
 /* Class 58 - Recommended shared data alignment */

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -2852,6 +2852,35 @@ QSI_DEF(SystemFirmwareTableInformation)
     return Status;
 }
 
+/* Class 105 - Processor Brand String */
+QSI_DEF(SystemProcessorBrandString)
+{
+    CHAR BrandString[128];
+    NTSTATUS Status;
+
+    /* Call hal to query the brand string */
+    Status = HalQuerySystemInformation(HalProcessorBrandString,
+                                       sizeof(BrandString),
+                                       BrandString,
+                                       ReqSize);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("HalQuerySystemInformation failed: 0x%lx\n", Status);
+        return Status;
+    }
+
+    if (Size < *ReqSize)
+    {
+        DPRINT1("Buffer too small for processor brand string\n");
+        return STATUS_INFO_LENGTH_MISMATCH;
+    }
+
+    /* Copy the brand string to the user buffer */
+    RtlCopyMemory(Buffer, BrandString, *ReqSize);
+
+    return STATUS_SUCCESS;
+}
+
 /* Query/Set Calls Table */
 typedef
 struct _QSSI_CALLS
@@ -2951,6 +2980,9 @@ CallQS[] =
     SI_XX(SystemWow64SharedInformationObsolete), /* FIXME: not implemented */
     SI_XX(SystemRegisterFirmwareTableInformationHandler), /* FIXME: not implemented */
     SI_QX(SystemFirmwareTableInformation),
+
+    // Vista and later
+    SI_QX(SystemProcessorBrandString),
 };
 
 C_ASSERT(SystemBasicInformation == 0);

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -2455,9 +2455,17 @@ QSI_DEF(SystemExtendedProcessInformation)
 /* Class 58 - Recommended shared data alignment */
 QSI_DEF(SystemRecommendedSharedDataAlignment)
 {
-    /* FIXME */
-    DPRINT1("NtQuerySystemInformation - SystemRecommendedSharedDataAlignment not implemented\n");
-    return STATUS_NOT_IMPLEMENTED;
+    PULONG Alignment = (PULONG)Buffer;
+
+    /* Check user buffer's size */
+    *ReqSize = sizeof(ULONG);
+    if (Size < *ReqSize)
+    {
+        return STATUS_INFO_LENGTH_MISMATCH;
+    }
+
+    *Alignment = KeGetRecommendedSharedDataAlignment();
+    return STATUS_SUCCESS;
 }
 
 /* Class 60 - NUMA memory information */

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -1719,9 +1719,9 @@ QSI_DEF(SystemTimeAdjustmentInformation)
         (PSYSTEM_QUERY_TIME_ADJUST_INFORMATION)Buffer;
 
     /* Check if enough storage was provided */
-    if (sizeof(SYSTEM_QUERY_TIME_ADJUST_INFORMATION) > Size)
+    *ReqSize = sizeof(SYSTEM_QUERY_TIME_ADJUST_INFORMATION);
+    if (Size != *ReqSize)
     {
-        * ReqSize = sizeof(SYSTEM_QUERY_TIME_ADJUST_INFORMATION);
         return STATUS_INFO_LENGTH_MISMATCH;
     }
 

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -2884,6 +2884,13 @@ QSI_DEF(SystemFirmwareTableInformation)
     return Status;
 }
 
+/* Class 77 - Extended module information */
+QSI_DEF(SystemModuleInformationEx)
+{
+    /* For now return STATUS_INVALID_INFO_CLASS to avoid crashing in wine tests */
+    return STATUS_INVALID_INFO_CLASS;
+}
+
 /* Class 105 - Processor Brand String */
 QSI_DEF(SystemProcessorBrandString)
 {
@@ -3014,6 +3021,7 @@ CallQS[] =
     SI_QX(SystemFirmwareTableInformation),
 
     // Vista and later
+    SI_QX(SystemModuleInformationEx),
     SI_QX(SystemProcessorBrandString),
 };
 

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -2497,6 +2497,28 @@ QSI_DEF(SystemEmulationBasicInformation)
     return QSISystemBasicInformation(Buffer, Size, ReqSize);
 }
 
+/* Class 63 - Emulation Processor Information */
+QSI_DEF(SystemEmulationProcessorInformation)
+{
+    NTSTATUS Status;
+
+    /* Query native information */
+    Status = QSISystemProcessorInformation(Buffer, Size, ReqSize);
+#if defined(_M_AMD64) || defined(_M_ARM64)
+    if (NT_SUCCESS(Status))
+    {
+        PSYSTEM_PROCESSOR_INFORMATION Spi = (PSYSTEM_PROCESSOR_INFORMATION)Buffer;
+#if defined(_M_AMD64)
+        Spi->ProcessorArchitecture = PROCESSOR_ARCHITECTURE_INTEL;
+#elif defined(_M_ARM64)
+        Spi->ProcessorArchitecture = PROCESSOR_ARCHITECTURE_ARM;
+#endif /* _M_AMD64 | _M_ARM64 */
+    }
+#endif /* defined(_M_AMD64) || defined(_M_ARM64) */
+
+    return Status;
+}
+
 /* Class 64 - Extended handle information */
 QSI_DEF(SystemExtendedHandleInformation)
 {
@@ -2915,7 +2937,7 @@ CallQS[] =
     SI_QX(SystemNumaAvailableMemory),
     SI_XX(SystemProcessorPowerInformation), /* FIXME: not implemented */
     SI_QX(SystemEmulationBasicInformation),
-    SI_XX(SystemEmulationProcessorInformation), /* FIXME: not implemented */
+    SI_QX(SystemEmulationProcessorInformation),
     SI_QX(SystemExtendedHandleInformation),
     SI_XX(SystemLostDelayedWriteInformation), /* FIXME: not implemented */
     SI_XX(SystemBigPoolInformation), /* FIXME: not implemented */

--- a/sdk/include/ndk/extypes.h
+++ b/sdk/include/ndk/extypes.h
@@ -1063,6 +1063,25 @@ typedef struct _SYSTEM_THREAD_INFORMATION
 C_ASSERT(sizeof(SYSTEM_THREAD_INFORMATION) == 0x40); // Must be 8-byte aligned
 #endif
 
+// Class 5
+typedef struct _SYSTEM_EXTENDED_THREAD_INFORMATION
+{
+    SYSTEM_THREAD_INFORMATION ThreadInfo;
+    PVOID StackBase;
+    PVOID StackLimit;
+    PVOID Win32StartAddress;
+    PVOID TebBase;
+    ULONG_PTR Reserved2;
+    ULONG_PTR Reserved3;
+    ULONG_PTR Reserved4;
+    // x86: ULONG Padding;
+} SYSTEM_EXTENDED_THREAD_INFORMATION, *PSYSTEM_EXTENDED_THREAD_INFORMATION;
+#ifdef _WIN64
+C_ASSERT(sizeof(SYSTEM_EXTENDED_THREAD_INFORMATION) == 0x88);
+#else
+C_ASSERT(sizeof(SYSTEM_EXTENDED_THREAD_INFORMATION) == 0x60);
+#endif
+
 typedef struct _SYSTEM_PROCESS_INFORMATION
 {
     ULONG NextEntryOffset;


### PR DESCRIPTION
## Purpose

Implement/fix a number of cases for NtQuerySystemInformation

## Proposed changes

* [NTOS:EX] Implement query of SystemEmulationBasicInformation
* [NTOS:EX] Implement query of SystemEmulationProcessorInformation
* [HAL] Implement HaliQueryProcessorBrandString
* [NTOS:EX] Implement query of SystemProcessorBrandString
* [NDK] Add SYSTEM_EXTENDED_THREAD_INFORMATION
* [NTOS:EX] Implement query of SystemExtendedProcessInformation
* [NTOS:EX] Implement query of SystemRecommendedSharedDataAlignment
* [NTOS:EX] Fix query of SystemInterruptInformation
* [NTOS:EX] Fix query of SystemTimeAdjustmentInformation

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108774,108776,108777
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108773,108775,108778