### PR TITLE
[MSPAINT] Adjust scroll amount properly

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -429,7 +429,7 @@ VOID CCanvasWindow::OnHVScroll(WPARAM wParam, INT fnBar)
         case SB_LINELEFT: // SB_LINEUP
             si.nPos -= 15;
             break;
-        case SB_LINERIGHT: // SB_LINEUP
+        case SB_LINERIGHT: // SB_LINEDOWN
             si.nPos += 15;
             break;
         case SB_PAGELEFT: // SB_PAGEUP

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -426,10 +426,10 @@ VOID CCanvasWindow::OnHVScroll(WPARAM wParam, INT fnBar)
             si.nPos = (SHORT)HIWORD(wParam);
             break;
         case SB_LINELEFT:
-            si.nPos -= 5;
+            si.nPos -= 15;
             break;
         case SB_LINERIGHT:
-            si.nPos += 5;
+            si.nPos += 15;
             break;
         case SB_PAGELEFT:
             si.nPos -= si.nPage;

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -421,7 +421,7 @@ VOID CCanvasWindow::OnHVScroll(WPARAM wParam, INT fnBar)
     GetScrollInfo(fnBar, &si);
 
     INT nCount;
-#define CHAR_WIDTH 8
+    const INT CHAR_WIDTH = 8;
     switch (LOWORD(wParam))
     {
         case SB_THUMBTRACK:

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -420,7 +420,7 @@ VOID CCanvasWindow::OnHVScroll(WPARAM wParam, INT fnBar)
     si.fMask = SIF_ALL;
     GetScrollInfo(fnBar, &si);
 
-    INT nCount;
+    INT nCount = 3;
     const INT CHAR_WIDTH = 8, LINE_HEIGHT = 8;
     switch (LOWORD(wParam))
     {

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -421,7 +421,7 @@ VOID CCanvasWindow::OnHVScroll(WPARAM wParam, INT fnBar)
     GetScrollInfo(fnBar, &si);
 
     INT nCount;
-    const INT CHAR_WIDTH = 8;
+    const INT CHAR_WIDTH = 8, LINE_HEIGHT = 8;
     switch (LOWORD(wParam))
     {
         case SB_THUMBTRACK:
@@ -429,12 +429,28 @@ VOID CCanvasWindow::OnHVScroll(WPARAM wParam, INT fnBar)
             si.nPos = (SHORT)HIWORD(wParam);
             break;
         case SB_LINELEFT:
-            SystemParametersInfoW(SPI_GETWHEELSCROLLCHARS, 0, &nCount, 0);
-            si.nPos -= nCount * CHAR_WIDTH;
+            if (fnBar == SB_HORZ)
+            {
+                SystemParametersInfoW(SPI_GETWHEELSCROLLCHARS, 0, &nCount, 0);
+                si.nPos -= nCount * CHAR_WIDTH;
+            }
+            else
+            {
+                SystemParametersInfoW(SPI_GETWHEELSCROLLLINES, 0, &nCount, 0);
+                si.nPos -= nCount * LINE_HEIGHT;
+            }
             break;
         case SB_LINERIGHT:
-            SystemParametersInfoW(SPI_GETWHEELSCROLLCHARS, 0, &nCount, 0);
-            si.nPos += nCount * CHAR_WIDTH;
+            if (fnBar == SB_HORZ)
+            {
+                SystemParametersInfoW(SPI_GETWHEELSCROLLCHARS, 0, &nCount, 0);
+                si.nPos += nCount * CHAR_WIDTH;
+            }
+            else
+            {
+                SystemParametersInfoW(SPI_GETWHEELSCROLLLINES, 0, &nCount, 0);
+                si.nPos += nCount * LINE_HEIGHT;
+            }
             break;
         case SB_PAGELEFT:
             si.nPos -= si.nPage;

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -419,6 +419,9 @@ VOID CCanvasWindow::OnHVScroll(WPARAM wParam, INT fnBar)
     si.cbSize = sizeof(SCROLLINFO);
     si.fMask = SIF_ALL;
     GetScrollInfo(fnBar, &si);
+
+    INT nCount;
+#define CHAR_WIDTH 8
     switch (LOWORD(wParam))
     {
         case SB_THUMBTRACK:
@@ -426,10 +429,12 @@ VOID CCanvasWindow::OnHVScroll(WPARAM wParam, INT fnBar)
             si.nPos = (SHORT)HIWORD(wParam);
             break;
         case SB_LINELEFT:
-            si.nPos -= 15;
+            SystemParametersInfoW(SPI_GETWHEELSCROLLCHARS, 0, &nCount, 0);
+            si.nPos -= nCount * CHAR_WIDTH;
             break;
         case SB_LINERIGHT:
-            si.nPos += 15;
+            SystemParametersInfoW(SPI_GETWHEELSCROLLCHARS, 0, &nCount, 0);
+            si.nPos += nCount * CHAR_WIDTH;
             break;
         case SB_PAGELEFT:
             si.nPos -= si.nPage;

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -420,42 +420,22 @@ VOID CCanvasWindow::OnHVScroll(WPARAM wParam, INT fnBar)
     si.fMask = SIF_ALL;
     GetScrollInfo(fnBar, &si);
 
-    INT nCount = 3;
-    const INT CHAR_WIDTH = 8, LINE_HEIGHT = 8;
     switch (LOWORD(wParam))
     {
         case SB_THUMBTRACK:
         case SB_THUMBPOSITION:
             si.nPos = (SHORT)HIWORD(wParam);
             break;
-        case SB_LINELEFT:
-            if (fnBar == SB_HORZ)
-            {
-                SystemParametersInfoW(SPI_GETWHEELSCROLLCHARS, 0, &nCount, 0);
-                si.nPos -= nCount * CHAR_WIDTH;
-            }
-            else
-            {
-                SystemParametersInfoW(SPI_GETWHEELSCROLLLINES, 0, &nCount, 0);
-                si.nPos -= nCount * LINE_HEIGHT;
-            }
+        case SB_LINELEFT: // SB_LINEUP
+            si.nPos -= 15;
             break;
-        case SB_LINERIGHT:
-            if (fnBar == SB_HORZ)
-            {
-                SystemParametersInfoW(SPI_GETWHEELSCROLLCHARS, 0, &nCount, 0);
-                si.nPos += nCount * CHAR_WIDTH;
-            }
-            else
-            {
-                SystemParametersInfoW(SPI_GETWHEELSCROLLLINES, 0, &nCount, 0);
-                si.nPos += nCount * LINE_HEIGHT;
-            }
+        case SB_LINERIGHT: // SB_LINEUP
+            si.nPos += 15;
             break;
-        case SB_PAGELEFT:
+        case SB_PAGELEFT: // SB_PAGEUP
             si.nPos -= si.nPage;
             break;
-        case SB_PAGERIGHT:
+        case SB_PAGERIGHT: // SB_PAGEDOWN
             si.nPos += si.nPage;
             break;
     }

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -416,7 +416,7 @@ LRESULT CCanvasWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
 VOID CCanvasWindow::OnHVScroll(WPARAM wParam, INT fnBar)
 {
     SCROLLINFO si;
-    si.cbSize = sizeof(SCROLLINFO);
+    si.cbSize = sizeof(si);
     si.fMask = SIF_ALL;
     GetScrollInfo(fnBar, &si);
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -500,6 +500,9 @@ LRESULT CMainWindow::OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL&
         UINT nCount = 3;
         if (::GetAsyncKeyState(VK_SHIFT) < 0)
         {
+#ifndef SPI_GETWHEELSCROLLCHARS
+    #define SPI_GETWHEELSCROLLCHARS 0x006C  // Needed for pre-NT6 PSDK
+#endif
             SystemParametersInfoW(SPI_GETWHEELSCROLLCHARS, 0, &nCount, 0);
             for (UINT i = 0; i < nCount; ++i)
             {

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -500,9 +500,6 @@ LRESULT CMainWindow::OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL&
         UINT nCount = 3;
         if (::GetAsyncKeyState(VK_SHIFT) < 0)
         {
-#ifndef SPI_GETWHEELSCROLLCHARS
-    #define SPI_GETWHEELSCROLLCHARS 0x006C  // Needed for pre-NT6 PSDK
-#endif
             SystemParametersInfoW(SPI_GETWHEELSCROLLCHARS, 0, &nCount, 0);
             for (UINT i = 0; i < nCount; ++i)
             {

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -504,9 +504,9 @@ LRESULT CMainWindow::OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL&
             for (UINT i = 0; i < nCount; ++i)
             {
                 if (zDelta < 0)
-                    ::PostMessageW(canvasWindow, WM_HSCROLL, MAKEWPARAM(SB_LINEDOWN, 0), 0);
+                    ::PostMessageW(canvasWindow, WM_HSCROLL, MAKEWPARAM(SB_LINERIGHT, 0), 0);
                 else if (zDelta > 0)
-                    ::PostMessageW(canvasWindow, WM_HSCROLL, MAKEWPARAM(SB_LINEUP, 0), 0);
+                    ::PostMessageW(canvasWindow, WM_HSCROLL, MAKEWPARAM(SB_LINELEFT, 0), 0);
             }
         }
         else

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -52,6 +52,10 @@
 #define WM_TOOLSMODELZOOMCHANGED         (WM_APP + 2)
 #define WM_PALETTEMODELCOLORCHANGED      (WM_APP + 3)
 
+#ifndef SPI_GETWHEELSCROLLCHARS
+    #define SPI_GETWHEELSCROLLCHARS 0x006C  // Needed for pre-NT6 PSDK
+#endif
+
 enum HITTEST // hit
 {
     HIT_NONE = 0, // Nothing hit or outside

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -52,10 +52,6 @@
 #define WM_TOOLSMODELZOOMCHANGED         (WM_APP + 2)
 #define WM_PALETTEMODELCOLORCHANGED      (WM_APP + 3)
 
-#ifndef SPI_GETWHEELSCROLLCHARS
-    #define SPI_GETWHEELSCROLLCHARS 0x006C  // Needed for pre-NT6 PSDK
-#endif
-
 enum HITTEST // hit
 {
     HIT_NONE = 0, // Nothing hit or outside


### PR DESCRIPTION
## Purpose

Scrolling the canvas with mouse wheel was a hard work, due to small scroll amount.
JIRA issue: [CORE-19466](https://jira.reactos.org/browse/CORE-19466)

## Proposed changes

- Adjust the scroll amount from `5` to `15` in `CCanvasWindow::OnHVScroll`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108438,108552
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108439,108551