### PR TITLE
[SETUPAPI] Fix SetupGetBinaryField not reading HEX values from INF files

### DIFF
--- a/dll/win32/setupapi/parser.c
+++ b/dll/win32/setupapi/parser.c
@@ -2,7 +2,7 @@
  * INF file parsing
  *
  * Copyright 2002 Alexandre Julliard for CodeWeavers
- *           2005-2006 Hervé Poussineau (hpoussin@reactos.org)
+ *           2005-2006 HervÃ© Poussineau (hpoussin@reactos.org)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -2002,7 +2002,7 @@ BOOL WINAPI SetupGetBinaryField( PINFCONTEXT context, DWORD index, BYTE *buffer,
     field = &file->fields[line->first_field + index];
     for (i = index; i < line->nb_fields; i++, field++)
     {
-#if __REACTOS__ /* The HEX parser from Wine is broken */
+#ifdef __REACTOS__ /* The HEX parser from Wine is broken */
         errno = 0;
         ULONG value = wcstoul(field->text, NULL, 16);
         if (value > 255 || errno != 0)
@@ -2010,7 +2010,6 @@ BOOL WINAPI SetupGetBinaryField( PINFCONTEXT context, DWORD index, BYTE *buffer,
             SetLastError( ERROR_INVALID_DATA );
             return FALSE;
         }
-
         buffer[i - index] = (BYTE)value;
 #else
         const WCHAR *p;

--- a/dll/win32/setupapi/parser.c
+++ b/dll/win32/setupapi/parser.c
@@ -2002,6 +2002,17 @@ BOOL WINAPI SetupGetBinaryField( PINFCONTEXT context, DWORD index, BYTE *buffer,
     field = &file->fields[line->first_field + index];
     for (i = index; i < line->nb_fields; i++, field++)
     {
+#if __REACTOS__ /* The HEX parser from Wine is broken */
+        errno = 0;
+        ULONG value = wcstoul(field->text, NULL, 16);
+        if (value > 255 || errno != 0)
+        {
+            SetLastError( ERROR_INVALID_DATA );
+            return FALSE;
+        }
+
+        buffer[i - index] = (BYTE)value;
+#else
         const WCHAR *p;
         DWORD value = 0;
         for (p = field->text; *p && isxdigitW(*p); p++)
@@ -2015,6 +2026,7 @@ BOOL WINAPI SetupGetBinaryField( PINFCONTEXT context, DWORD index, BYTE *buffer,
             else value |= (tolowerW(*p) - 'a' + 10);
         }
         buffer[i - index] = value;
+#endif
     }
     if (TRACE_ON(setupapi))
     {


### PR DESCRIPTION
## Purpose

This PR fixes an issue in `SetupGetBinaryField` that makes the GUI installer unable to read INF files properly. For this reason, all the binary values in the registry on a fresh ReactOS installation are all `0x00`.

JIRA issues: [CORE-20657](https://jira.reactos.org/browse/CORE-20657), [CORE-13525](https://jira.reactos.org/browse/CORE-13525)

## Proposed changes

The custom HEX parser in Wine's `SetupGetBinaryField` is broken. As a solution, we can replace it with a call to C's standard `wcstoul` function.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108464,108519
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108465,108520

Tests OK since none actually test setupapi!SetupGetBinaryField (wine introduced a test for it only on Wine-11). No other binary-only registry data that ReactOS may install during setup and might be used by other APIs during testing appear to affect the end-results...