### PR TITLE
[NTDLL] Implement LdrGetProcedureAddressEx for NT6

### DIFF
--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -158,7 +158,7 @@
 @ stdcall -stub -version=0x600+ LdrGetFileNameFromLoadAsDataTable(ptr ptr)
 @ stdcall -stub -version=0x600+ -arch=x86_64 LdrGetKnownDllSectionHandle(wstr long ptr)
 @ stdcall LdrGetProcedureAddress(ptr ptr long ptr)
-@ stdcall -stub -version=0x600+ LdrGetProcedureAddressEx(ptr ptr long ptr long)
+@ stdcall -version=0x600+ LdrGetProcedureAddressEx(ptr ptr long ptr long)
 @ stdcall -stub LdrHotPatchRoutine(ptr)
 @ stdcall LdrInitShimEngineDynamic(ptr)
 @ stdcall LdrInitializeThunk(long long long long)

--- a/dll/ntdll/ldr/ldrapi.c
+++ b/dll/ntdll/ldr/ldrapi.c
@@ -796,6 +796,20 @@ LdrGetProcedureAddress(
     return LdrpGetProcedureAddress(BaseAddress, Name, Ordinal, ProcedureAddress, TRUE);
 }
 
+NTSTATUS
+NTAPI
+LdrGetProcedureAddressEx(
+    _In_ PVOID BaseAddress,
+    _In_opt_ _When_(Ordinal == 0, _Notnull_) PANSI_STRING Name,
+    _In_opt_ _When_(Name == NULL, _In_range_(>, 0)) ULONG Ordinal,
+    _Out_ PVOID *ProcedureAddress,
+    _In_ ULONG Flags)
+{
+    /* Call the internal routine and execute DllInit depending of flags */
+    BOOLEAN ExecuteInit = !(Flags & LDR_GET_PROCEDURE_ADDRESS_DONT_RECORD_FORWARDER);
+    return LdrpGetProcedureAddress(BaseAddress, Name, Ordinal, ProcedureAddress, ExecuteInit);
+}
+
 /*
  * @implemented
  */

--- a/sdk/include/ndk/ldrfuncs.h
+++ b/sdk/include/ndk/ldrfuncs.h
@@ -97,6 +97,19 @@ LdrGetProcedureAddress(
     _Out_ PVOID *ProcedureAddress
 );
 
+// See https://ntdoc.m417z.com/ldr_get_procedure_address_dont_record_forwarder
+#define LDR_GET_PROCEDURE_ADDRESS_DONT_RECORD_FORWARDER 0x00000001
+
+// See https://ntdoc.m417z.com/ldrgetprocedureaddressex
+NTSTATUS
+NTAPI
+LdrGetProcedureAddressEx(
+    _In_ PVOID BaseAddress,
+    _In_opt_ _When_(Ordinal == 0, _Notnull_) PANSI_STRING Name,
+    _In_opt_ _When_(Name == NULL, _In_range_(>, 0)) ULONG Ordinal,
+    _Out_ PVOID *ProcedureAddress,
+    _In_ ULONG Flags);
+
 ULONG
 NTAPI
 LdrRelocateImage(


### PR DESCRIPTION
## Purpose

Implement LdrGetProcedureAddressEx for NT6.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108572,108573,108575 
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108571,108574,108576