### PR TITLE
[KMTESTS:CM] ZwNotifyChangeKey tests

### DIFF
--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -57,6 +57,7 @@ list(APPEND KMTEST_DRV_SOURCE
     npfs/NpfsVolumeInfo.c
     novp_fsrtl/FsRtlRemoveDotsFromPath.c
     ntos_cm/CmSecurity.c
+    ntos_cm/CmNotify.c
     ntos_ex/ExCallback.c
     ntos_ex/ExDoubleList.c
     ntos_ex/ExFastMutex.c

--- a/modules/rostests/kmtests/kmtest_drv/testlist.c
+++ b/modules/rostests/kmtests/kmtest_drv/testlist.c
@@ -88,6 +88,7 @@ KMT_TESTFUNC Test_RtlStrSafe;
 KMT_TESTFUNC Test_RtlUnicodeString;
 KMT_TESTFUNC Test_ZwAllocateVirtualMemory;
 KMT_TESTFUNC Test_ZwCreateSection;
+KMT_TESTFUNC Test_ZwNotifyChangeKey;
 KMT_TESTFUNC Test_ZwMapViewOfSection;
 KMT_TESTFUNC Test_ZwWaitForMultipleObjects;
 
@@ -175,6 +176,7 @@ const KMT_TEST TestList[] =
     { "ZwAllocateVirtualMemory",            Test_ZwAllocateVirtualMemory },
     { "ZwCreateSection",                    Test_ZwCreateSection },
     { "ZwMapViewOfSection",                 Test_ZwMapViewOfSection },
+    { "ZwNotifyChangeKey",                  Test_ZwNotifyChangeKey },
     { "ZwWaitForMultipleObjects",           Test_ZwWaitForMultipleObjects},
 #ifdef _M_AMD64
     { "RtlCaptureContextKM",                Test_RtlCaptureContext },

--- a/modules/rostests/kmtests/kmtest_drv/testlist.c
+++ b/modules/rostests/kmtests/kmtest_drv/testlist.c
@@ -89,6 +89,7 @@ KMT_TESTFUNC Test_RtlStrSafe;
 KMT_TESTFUNC Test_RtlUnicodeString;
 KMT_TESTFUNC Test_ZwAllocateVirtualMemory;
 KMT_TESTFUNC Test_ZwCreateSection;
+KMT_TESTFUNC Test_ZwNotifyChangeKey;
 KMT_TESTFUNC Test_ZwMapViewOfSection;
 KMT_TESTFUNC Test_ZwWaitForMultipleObjects;
 
@@ -177,6 +178,7 @@ const KMT_TEST TestList[] =
     { "ZwAllocateVirtualMemory",            Test_ZwAllocateVirtualMemory },
     { "ZwCreateSection",                    Test_ZwCreateSection },
     { "ZwMapViewOfSection",                 Test_ZwMapViewOfSection },
+    { "ZwNotifyChangeKey",                  Test_ZwNotifyChangeKey },
     { "ZwWaitForMultipleObjects",           Test_ZwWaitForMultipleObjects},
 #ifdef _M_AMD64
     { "RtlCaptureContextKM",                Test_RtlCaptureContext },

--- a/modules/rostests/kmtests/ntos_cm/CmNotify.c
+++ b/modules/rostests/kmtests/ntos_cm/CmNotify.c
@@ -1,0 +1,193 @@
+/*
+ * PROJECT:     ReactOS Kernel-Mode tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for registry change notification
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include <kmt_test.h>
+
+/* Timeout definition for use with KeDelayExecutionThread function */
+#define TIMEOUT_MICROSECONDS 10 /* The unit used by KeDelayExecutionThread is 100 nanoseconds, multiplying by 10 makes it 1 microsecond */
+#define RELATIVE_TIMEOUT(x) (-1 * (x)) /* KeDelayExecutionThread uses negative values to indicate relative time */
+
+#define SYNC_THREAD_WAIT_TIMEOUT RELATIVE_TIMEOUT(100 * TIMEOUT_MICROSECONDS)
+
+/* Thread to watch for registry changes for synchronous mode test */
+typedef struct _WATCH_THREAD_STATE
+{
+    NTSTATUS Status;
+    HANDLE KeyHandle;
+    IO_STATUS_BLOCK IoStatusBlock;
+} WATCH_THREAD_STATE, *PWATCH_THREAD_STATE;
+
+_Function_class_(KSTART_ROUTINE)
+VOID NTAPI ZwNotifyChangeKey_WatchThread(_In_ PVOID lpParameter)
+{
+    PWATCH_THREAD_STATE State = (PWATCH_THREAD_STATE)lpParameter;
+    State->Status = ZwNotifyChangeKey(State->KeyHandle, NULL, NULL, NULL, &State->IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, FALSE);
+}
+
+/* WorkerQueueItem for asynchronous mode test */
+_Function_class_(WORKER_THREAD_ROUTINE)
+VOID NTAPI ZwNotifyChangeKey_ItemWorker(_In_ PVOID pParameter)
+{
+    PKEVENT event = (PKEVENT)pParameter;
+    KeSetEvent(event, 1, FALSE);
+}
+
+/* Main */
+START_TEST(ZwNotifyChangeKey)
+{
+    NTSTATUS Status;
+    IO_STATUS_BLOCK IoStatusBlock;
+    /* Registry key handles and values */
+    HANDLE KeyHandle = NULL;
+    UNICODE_STRING KeyName;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    UNICODE_STRING ValueName;
+    DWORD32 Value1 = 0x12345678;
+    DWORD32 Value2 = 0x87654321;
+    /* Thread/Event/WorkQueueItem-related objects and data */
+    LARGE_INTEGER WaitTimeout;
+    WATCH_THREAD_STATE WatchThreadState;
+    HANDLE WatchThreadHandle = NULL;
+    PKTHREAD WatchThreadObject = NULL;
+    HANDLE EventHandle = NULL;
+    PKEVENT EventObject = NULL;
+    WORK_QUEUE_ITEM WorkQueueItem;
+
+    /* Create registry keys */
+    RtlInitUnicodeString(&KeyName, L"\\Registry\\Machine\\SOFTWARE\\TestKey");
+    InitializeObjectAttributes(&ObjectAttributes, &KeyName, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
+    RtlInitUnicodeString(&ValueName, L"TestValue");
+    Status = ZwCreateKey(&KeyHandle, KEY_ALL_ACCESS, &ObjectAttributes, 0, NULL, REG_OPTION_NON_VOLATILE, NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        skip(FALSE, "Failed to create registry key");
+        return;
+    }
+    Status = ZwSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+    if (!NT_SUCCESS(Status))
+    {
+        skip(FALSE, "Failed to set default value for registry key");
+        ZwDeleteKey(KeyHandle);
+        ObCloseHandle(KeyHandle, KernelMode);
+        return;
+    }
+
+    /* Synchronous wait test */
+
+    /* Create a thread */
+    WatchThreadState.KeyHandle = KeyHandle;
+    WatchThreadState.IoStatusBlock.Status = 0xdeadbeef;
+    Status = PsCreateSystemThread(&WatchThreadHandle, THREAD_ALL_ACCESS, NULL, NULL, NULL, ZwNotifyChangeKey_WatchThread, &WatchThreadState);
+    if (NT_SUCCESS(Status))
+    {
+        Status = ObReferenceObjectByHandle(WatchThreadHandle, THREAD_ALL_ACCESS, NULL, KernelMode, (PVOID*)&WatchThreadObject, NULL);
+    }
+    if (NT_SUCCESS(Status))
+    {
+        /* Verify the thread is still running */
+        WaitTimeout.QuadPart = SYNC_THREAD_WAIT_TIMEOUT;
+        Status = KeWaitForSingleObject(WatchThreadObject, Executive, KernelMode, FALSE, &WaitTimeout);
+        ok_eq_hex(Status, STATUS_TIMEOUT);
+        /* Make change to the registry key */
+        Status = ZwSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value2, sizeof(Value2));
+        ok_eq_hex(Status, STATUS_SUCCESS);
+        /* Give system some time to process the change and notify our watch thread */
+        KeDelayExecutionThread(KernelMode, FALSE, &WaitTimeout);
+        /* Verify that the thread is notified */
+        Status = KeWaitForSingleObject(WatchThreadObject, Executive, KernelMode, FALSE, &WaitTimeout);
+        ok_eq_hex(Status, STATUS_WAIT_0);
+        /* Verify thread's return value */
+        ok_eq_hex(WatchThreadState.Status, STATUS_NOTIFY_ENUM_DIR);
+        ok_eq_hex(WatchThreadState.IoStatusBlock.Status, STATUS_NOTIFY_ENUM_DIR);
+        /* cleanup */
+        ObDereferenceObject(WatchThreadObject);
+        WatchThreadObject = NULL;
+        ObCloseHandle(WatchThreadHandle, KernelMode);
+        WatchThreadHandle = NULL;
+        IoStatusBlock.Status = 0xdeadbeef;
+    }
+    else
+    {
+        skip(FALSE, "Failed to create thread");
+
+        if (WatchThreadHandle)
+        {
+            ObCloseHandle(WatchThreadHandle, KernelMode);
+        }
+    }
+
+    /* Event-based asynchronous wait mode */
+
+    /* Initialize event */
+    Status = ZwCreateEvent(&EventHandle, EVENT_ALL_ACCESS, NULL, NotificationEvent, FALSE);
+    if (NT_SUCCESS(Status))
+    {
+        Status = ObReferenceObjectByHandle(EventHandle, EVENT_ALL_ACCESS, NULL, KernelMode, (PVOID*)&EventObject, NULL);
+    }
+    if (!NT_SUCCESS(Status))
+    {
+        skip(FALSE, "Failed to create event");
+        /* All remaining tests depend on a KEVENT object */
+        goto Cleanup;
+    }
+    /* Listen for notification */
+    Status = ZwNotifyChangeKey(KeyHandle, EventHandle, NULL, NULL, &IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    ok_eq_hex(Status, STATUS_PENDING);
+    /* Check event state */
+    Status = KeWaitForSingleObject(EventObject, Executive, KernelMode, FALSE, &WaitTimeout);
+    ok_eq_hex(Status, STATUS_TIMEOUT);
+    /* Make change to the registry key */
+    Status = ZwSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+    ok_eq_hex(Status, STATUS_SUCCESS);
+    /* Verify that the event is signaled */
+    Status = KeWaitForSingleObject(EventObject, Executive, KernelMode, FALSE, &WaitTimeout);
+    ok_eq_hex(Status, STATUS_WAIT_0);
+    /* cleanup */
+    KeClearEvent(EventObject);
+    IoStatusBlock.Status = 0xdeadbeef;
+
+    /* Test pending notification mode */
+    Status = ZwSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value2, sizeof(Value2));
+    ok_eq_hex(Status, STATUS_SUCCESS);
+    Status = ZwNotifyChangeKey(KeyHandle, EventHandle, NULL, NULL, &IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+    Status = KeWaitForSingleObject(EventObject, Executive, KernelMode, FALSE, &WaitTimeout);
+    ok_eq_hex(Status, STATUS_WAIT_0);
+    /* cleanup */
+    KeClearEvent(EventObject);
+    IoStatusBlock.Status = 0xdeadbeef;
+
+    /* WorkQueueItem-based asynchronous wait mode */
+
+    /* Initialize Work Queue Item */
+    ExInitializeWorkItem(&WorkQueueItem, ZwNotifyChangeKey_ItemWorker, EventObject);
+    /* Listen for notification */
+    Status = ZwNotifyChangeKey(KeyHandle, NULL, (PVOID)&WorkQueueItem, (PVOID)DelayedWorkQueue, &IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    ok_eq_hex(Status, STATUS_PENDING);
+    /* Check event state */
+    Status = KeWaitForSingleObject(EventObject, Executive, KernelMode, FALSE, &WaitTimeout);
+    ok_eq_hex(Status, STATUS_TIMEOUT);
+    /* Make change to the registry key */
+    Status = ZwSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+    ok_eq_hex(Status, STATUS_SUCCESS);
+    /* Verify that the event is signaled */
+    Status = KeWaitForSingleObject(EventObject, Executive, KernelMode, FALSE, &WaitTimeout);
+    ok_eq_hex(Status, STATUS_WAIT_0);
+
+Cleanup:
+    if (EventObject)
+    {
+        ObDereferenceObject(EventObject);
+    }
+    if (EventHandle)
+    {
+        ObCloseHandle(EventHandle, KernelMode);
+    }
+    /* Cleanup keys created for the test */
+    ZwDeleteKey(KeyHandle);
+    ObCloseHandle(KeyHandle, KernelMode);
+}


### PR DESCRIPTION
## Purpose

This PR implements tests for `ZwNotifyChangeKey` function, that are guaranteed to pass on Windows and cover every feature supported by this function. I tested it on Windows XP, Windows Server 2003, Windows 7 and Windows 11.

This is part of #8848 and #7914 PRs, first one in the series of re-implementing the feature using smaller and easy-to-review PRs.

<img width="697" height="356" alt="image" src="https://github.com/user-attachments/assets/2b9fda37-341e-4298-8d8b-0e020bdeb947" />

JIRA issue: [CORE-11865](https://jira.reactos.org/browse/CORE-11865)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: