### PR TITLE
[NTDLL_APITESTS] Add tests for NtNotifyChangeMultipleKeys

### DIFF
--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -67,6 +67,7 @@ list(APPEND SOURCE
     NtLoadUnloadKey.c
     NtMapViewOfSection.c
     NtMutant.c
+    NtNotifyChangeMultipleKeys.c
     NtOpenKey.c
     NtOpenProcessToken.c
     NtOpenThreadToken.c

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -1,0 +1,314 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Test for NtNotifyChangeMultipleKeys
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "precomp.h"
+#include "winreg.h"
+
+/* Registry watcher thread for testing synchronous mode */
+typedef struct _WATCH_THREAD_STATE
+{
+    NTSTATUS Status;
+    HANDLE KeyHandle;
+    PIO_STATUS_BLOCK IoStatusBlock;
+} WATCH_THREAD_STATE, *PWATCH_THREAD_STATE;
+
+DWORD WINAPI NtNotifyChangeMultipleKeys_WatchThread(LPVOID lpParameter)
+{
+    PWATCH_THREAD_STATE State = (PWATCH_THREAD_STATE)lpParameter;
+    
+    State->Status = NtNotifyChangeMultipleKeys(State->KeyHandle, 0, NULL, NULL, NULL, NULL, State->IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, FALSE);
+
+    return 0;
+}
+
+/* APC Routine for testing asynchronous mode */
+VOID WINAPI NtNotifyChangeMultipleKeys_ApcRoutine(PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, ULONG Reserved)
+{
+    UNREFERENCED_PARAMETER(IoStatusBlock);
+    UNREFERENCED_PARAMETER(Reserved);
+
+    BOOLEAN* ApcRan = (BOOLEAN*)ApcContext;
+    *ApcRan = TRUE;
+}
+
+START_TEST(NtNotifyChangeMultipleKeys)
+{
+    NTSTATUS Status;
+    IO_STATUS_BLOCK IoStatusBlock;
+    OBJECT_ATTRIBUTES SubordinateObjects[1];
+    WATCH_THREAD_STATE WatchThreadState;
+    BOOLEAN ApcRan = FALSE;
+    /* Registry key object attributes */
+    UNICODE_STRING KeyName, SubKeyName, SecondaryKeyName, ThirdKeyName;
+    UNICODE_STRING ValueName;
+    OBJECT_ATTRIBUTES ObjectAttributes, SubKeyObjectAttributes, SecondaryObjectAttributes, ThirdObjectAttributes;
+    DWORD Value1 = 0x12345678, Value2 = 0x87654321;
+    /* handles */
+    HANDLE KeyHandle = NULL, SubKeyHandle = NULL, SecondaryKeyHandle = NULL;
+    HANDLE WatchThreadHandle = NULL, EventHandle = NULL;
+    
+    RtlInitUnicodeString(&KeyName, L"\\Registry\\Machine\\SOFTWARE\\TestKey");
+    RtlInitUnicodeString(&SubKeyName, L"\\Registry\\Machine\\SOFTWARE\\TestKey\\TestSubKey");
+    RtlInitUnicodeString(&SecondaryKeyName, L"\\Registry\\User\\.DEFAULT\\SOFTWARE\\TestKey");
+    RtlInitUnicodeString(&ThirdKeyName, L"\\Registry\\Machine\\Software\\Microsoft\\Windows");
+    RtlInitUnicodeString(&ValueName, L"TestValue");
+    InitializeObjectAttributes(&ObjectAttributes, &KeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    InitializeObjectAttributes(&SubKeyObjectAttributes, &SubKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    InitializeObjectAttributes(&SecondaryObjectAttributes, &SecondaryKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    InitializeObjectAttributes(&ThirdObjectAttributes, &ThirdKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+
+    /* Create event */
+    EventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (EventHandle == NULL)
+    {
+        skip(FALSE, "Failed to create event");
+        return;
+    }
+    /* Create registry keys */
+    Status = NtCreateKey(&KeyHandle, KEY_ALL_ACCESS, &ObjectAttributes, 0, NULL, REG_OPTION_NON_VOLATILE, NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        skip(FALSE, "Failed to create registry key");
+        goto Cleanup;
+    }
+    NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+    
+    /* Synchronous mode */
+
+    /* Create a thread */
+    WatchThreadState.KeyHandle = KeyHandle;
+    WatchThreadState.IoStatusBlock = &IoStatusBlock;
+    WatchThreadHandle = CreateThread(NULL, 0, NtNotifyChangeMultipleKeys_WatchThread, &WatchThreadState, 0, NULL);
+    if (WatchThreadHandle)
+    {
+        /* Verify the thread is still running */
+        Status = WaitForSingleObject(WatchThreadHandle, 100);
+        ok_ntstatus(Status, WAIT_TIMEOUT);
+        /* Make change to the registry key */
+        Status = NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value2, sizeof(Value2));
+        ok_ntstatus(Status, STATUS_SUCCESS);
+        /* Verify that the thread is notified */
+        Status = WaitForSingleObject(WatchThreadHandle, 100);
+        ok_ntstatus(Status, WAIT_OBJECT_0);
+        /* Verify the status code */
+        ok_ntstatus(WatchThreadState.Status, STATUS_NOTIFY_ENUM_DIR);
+        ok_ntstatus(WatchThreadState.IoStatusBlock->Status, STATUS_NOTIFY_ENUM_DIR);
+        /* cleanup */
+        CloseHandle(WatchThreadHandle);
+        WatchThreadHandle = NULL;
+        WatchThreadState.Status = 0xdeadbeef;
+        WatchThreadState.IoStatusBlock->Status = 0xdeadbeef;
+    }
+    else
+    {
+        skip(FALSE, "Failed to create watch thread");
+    }
+    /* Watch again, but this time close the handle without making any change */
+    WatchThreadHandle = CreateThread(NULL, 0, NtNotifyChangeMultipleKeys_WatchThread, &WatchThreadState, 0, NULL);
+    if (WatchThreadHandle)
+    {
+        Status = WaitForSingleObject(WatchThreadHandle, 100);
+        ok_ntstatus(Status, WAIT_TIMEOUT);
+        NtClose(KeyHandle);
+        KeyHandle = NULL;
+        Status = WaitForSingleObject(WatchThreadHandle, 100);
+        ok_ntstatus(Status, WAIT_OBJECT_0);
+        ok_ntstatus(WatchThreadState.Status, STATUS_NOTIFY_CLEANUP);
+        ok_ntstatus(WatchThreadState.IoStatusBlock->Status, STATUS_NOTIFY_CLEANUP);
+        /* cleanup */
+        CloseHandle(WatchThreadHandle);
+        WatchThreadHandle = NULL;
+    }
+    else
+    {
+        skip(FALSE, "Failed to create watch thread");
+    }
+
+    /* Event-based asynchronous mode */
+
+    if (!KeyHandle)
+    {
+        Status = NtOpenKey(&KeyHandle, KEY_ALL_ACCESS, &ObjectAttributes);
+        if (!NT_SUCCESS(Status))
+        {
+            skip(FALSE, "Failed to open registry key");
+            goto Cleanup;
+        }
+    }
+    /* Start watching for changes */
+    Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL, EventHandle, NULL, NULL, &IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    ok_ntstatus(Status, STATUS_PENDING);
+    /* Check event state */
+    Status = WaitForSingleObject(EventHandle, 0);
+    ok_ntstatus(Status, WAIT_TIMEOUT);
+    /* Make change to the registry key */
+    Status = NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    /* Verify that the event is signaled */
+    NtTestAlert();
+    Status = WaitForSingleObject(EventHandle, 100);
+    ok_ntstatus(Status, WAIT_OBJECT_0);
+    /* Verify the status code */
+    ok_ntstatus(IoStatusBlock.Status, STATUS_NOTIFY_ENUM_DIR);
+
+    /* Watch again, but this time close the handle without making any change */
+    Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL, EventHandle, NULL, NULL, &IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    ok_ntstatus(Status, STATUS_PENDING);
+    Status = WaitForSingleObject(EventHandle, 0);
+    ok_ntstatus(Status, WAIT_TIMEOUT);
+    NtClose(KeyHandle);
+    KeyHandle = NULL;
+    NtTestAlert();
+    Status = WaitForSingleObject(EventHandle, 100);
+    ok_ntstatus(Status, WAIT_OBJECT_0);
+    ok_ntstatus(IoStatusBlock.Status, STATUS_NOTIFY_CLEANUP);
+
+    /* Watching subtree */
+
+    if (!KeyHandle)
+    {
+        Status = NtOpenKey(&KeyHandle, KEY_ALL_ACCESS, &ObjectAttributes);
+        if (!NT_SUCCESS(Status))
+        {
+            skip(FALSE, "Failed to open registry key");
+            goto Cleanup;
+        }
+    }
+    Status = NtCreateKey(&SubKeyHandle, KEY_ALL_ACCESS, &SubKeyObjectAttributes, 0, NULL, REG_OPTION_NON_VOLATILE, NULL);
+    if (NT_SUCCESS(Status))
+    {
+        /* Start watching for changes */
+        Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL, EventHandle, NULL, NULL, &IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, TRUE, NULL, 0, TRUE);
+        ok_ntstatus(Status, STATUS_PENDING);
+        /* Check event state */
+        Status = WaitForSingleObject(EventHandle, 0);
+        ok_ntstatus(Status, WAIT_TIMEOUT);
+        /* Make change to the subkey */
+        Status = NtSetValueKey(SubKeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+        ok_ntstatus(Status, STATUS_SUCCESS);
+        /* Verify that the event is signaled */
+        NtTestAlert();
+        Status = WaitForSingleObject(EventHandle, 100);
+        ok_ntstatus(Status, WAIT_OBJECT_0);
+    }
+    else
+    {
+        skip(FALSE, "Failed to create subkey");
+    }
+
+    /* Watching multiple keys */
+
+    Status = NtCreateKey(&SecondaryKeyHandle, KEY_ALL_ACCESS, &SecondaryObjectAttributes, 0, NULL, REG_OPTION_NON_VOLATILE, NULL);
+    if (NT_SUCCESS(Status))
+    {
+        CloseHandle(SecondaryKeyHandle);
+        InitializeObjectAttributes(&SubordinateObjects[0], &SecondaryKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+        Status = NtNotifyChangeMultipleKeys(KeyHandle,
+                                            _countof(SubordinateObjects),
+                                            SubordinateObjects,
+                                            EventHandle,
+                                            NULL,
+                                            NULL,
+                                            &IoStatusBlock,
+                                            REG_NOTIFY_CHANGE_LAST_SET,
+                                            TRUE,
+                                            NULL,
+                                            0,
+                                            TRUE);
+        ok_ntstatus(Status, STATUS_PENDING);
+        /* Check event state */
+        Status = WaitForSingleObject(EventHandle, 0);
+        ok_ntstatus(Status, WAIT_TIMEOUT);
+        /* Make change to the secondary key */
+        Status = NtOpenKey(&SecondaryKeyHandle, KEY_SET_VALUE | KEY_NOTIFY | DELETE, &SecondaryObjectAttributes);
+        if (NT_SUCCESS(Status))
+        {
+            Status = NtSetValueKey(SecondaryKeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+            ok_ntstatus(Status, STATUS_SUCCESS);
+            CloseHandle(SecondaryKeyHandle);
+        }
+        /* Verify that the event is signaled */
+        NtTestAlert();
+        Status = WaitForSingleObject(EventHandle, 100);
+        ok_ntstatus(Status, WAIT_OBJECT_0);
+    }
+    else
+    {
+        skip(FALSE, "Failed to create secondary key");
+    }
+    /* Test if the function fails if the given subordinate key is same with master key */
+    InitializeObjectAttributes(&SubordinateObjects[0], &KeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    Status = NtNotifyChangeMultipleKeys(KeyHandle,
+                                        _countof(SubordinateObjects),
+                                        SubordinateObjects,
+                                        EventHandle,
+                                        NULL,
+                                        NULL,
+                                        &IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        TRUE,
+                                        NULL,
+                                        0,
+                                        TRUE);
+    /* The status is STATUS_INVALID_PARAMETER on Windows Server 2003 and STATUS_INVALID_OBJECT_NAME on Windows 10 */
+    ok(!NT_SUCCESS(Status), "NtNotifyChangeMultipleKeys succeeded unexpectedly.\n");
+    /* Test if the function fails if the the given subordinate key is in the same hive as the master key */
+    InitializeObjectAttributes(&SubordinateObjects[0], &ThirdKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    Status = NtNotifyChangeMultipleKeys(KeyHandle,
+                                        _countof(SubordinateObjects),
+                                        SubordinateObjects,
+                                        EventHandle,
+                                        NULL,
+                                        NULL,
+                                        &IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        TRUE,
+                                        NULL,
+                                        0,
+                                        TRUE);
+    ok(!NT_SUCCESS(Status), "NtNotifyChangeMultipleKeys succeeded unexpectedly.\n");
+    
+    /* APC-based asynchronous mode */
+    Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL, NULL, NtNotifyChangeMultipleKeys_ApcRoutine, &ApcRan, &IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    ok_ntstatus(Status, STATUS_PENDING);
+    /* Make change to the registry key */
+    Status = NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value2, sizeof(Value2));
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    /* Force system to run queued APC routines */
+    NtTestAlert();
+    ok(ApcRan == TRUE, "The APC routine did not ran.\n");
+
+Cleanup:
+    if (WatchThreadHandle)
+    {
+        CloseHandle(WatchThreadHandle);
+    }
+    if (SubKeyHandle)
+    {
+        NtDeleteKey(SubKeyHandle);
+        CloseHandle(SubKeyHandle);
+    }
+    if (!KeyHandle)
+    {
+        Status = NtOpenKey(&KeyHandle, DELETE, &ObjectAttributes);
+        if (!NT_SUCCESS(Status))
+        {
+            KeyHandle = NULL;
+        }
+    }
+    if (KeyHandle)
+    {
+        NtDeleteKey(KeyHandle);
+        CloseHandle(KeyHandle);
+    }
+    Status = NtOpenKey(&SecondaryKeyHandle, DELETE, &SecondaryObjectAttributes);
+    if (NT_SUCCESS(Status))
+    {
+        NtDeleteKey(SecondaryKeyHandle);   
+        CloseHandle(SecondaryKeyHandle);
+    }
+}

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -16,17 +16,23 @@ typedef struct _WATCH_THREAD_STATE
     PIO_STATUS_BLOCK IoStatusBlock;
 } WATCH_THREAD_STATE, *PWATCH_THREAD_STATE;
 
-DWORD WINAPI NtNotifyChangeMultipleKeys_WatchThread(LPVOID lpParameter)
+DWORD WINAPI
+NtNotifyChangeMultipleKeys_WatchThread(LPVOID lpParameter)
 {
     PWATCH_THREAD_STATE State = (PWATCH_THREAD_STATE)lpParameter;
 
-    State->Status = NtNotifyChangeMultipleKeys(State->KeyHandle, 0, NULL, NULL, NULL, NULL, State->IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, FALSE);
+    State->Status = NtNotifyChangeMultipleKeys(State->KeyHandle, 0,
+                                               NULL, NULL, NULL, NULL,
+                                               State->IoStatusBlock,
+                                               REG_NOTIFY_CHANGE_LAST_SET,
+                                               FALSE, NULL, 0, FALSE);
 
     return 0;
 }
 
 /* APC Routine for testing asynchronous mode */
-VOID WINAPI NtNotifyChangeMultipleKeys_ApcRoutine(PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, ULONG Reserved)
+VOID WINAPI
+NtNotifyChangeMultipleKeys_ApcRoutine(PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, ULONG Reserved)
 {
     UNREFERENCED_PARAMETER(IoStatusBlock);
     UNREFERENCED_PARAMETER(Reserved);
@@ -43,9 +49,11 @@ START_TEST(NtNotifyChangeMultipleKeys)
     WATCH_THREAD_STATE WatchThreadState;
     BOOLEAN ApcRan = FALSE;
     /* Registry key object attributes */
-    UNICODE_STRING KeyName, SubKeyName, SecondaryKeyName, ThirdKeyName;
+    UNICODE_STRING KeyName, SubKeyName,
+                   SecondaryKeyName, ThirdKeyName;
+    OBJECT_ATTRIBUTES ObjectAttributes, SubKeyObjectAttributes,
+                      SecondaryObjectAttributes, ThirdObjectAttributes;
     UNICODE_STRING ValueName;
-    OBJECT_ATTRIBUTES ObjectAttributes, SubKeyObjectAttributes, SecondaryObjectAttributes, ThirdObjectAttributes;
     DWORD Value1 = 0x12345678, Value2 = 0x87654321;
     /* handles */
     HANDLE KeyHandle = NULL, SubKeyHandle = NULL, SecondaryKeyHandle = NULL;
@@ -148,7 +156,11 @@ START_TEST(NtNotifyChangeMultipleKeys)
         }
     }
     /* Start watching for changes */
-    Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL, EventHandle, NULL, NULL, &IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL,
+                                        EventHandle, NULL, NULL,
+                                        &IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        FALSE, NULL, 0, TRUE);
     ok_ntstatus(Status, STATUS_PENDING);
     /* Check event state */
     Status = WaitForSingleObject(EventHandle, 0);
@@ -164,7 +176,11 @@ START_TEST(NtNotifyChangeMultipleKeys)
     ok_ntstatus(IoStatusBlock.Status, STATUS_NOTIFY_ENUM_DIR);
 
     /* Watch again, but this time close the handle without making any change */
-    Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL, EventHandle, NULL, NULL, &IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL,
+                                        EventHandle, NULL, NULL,
+                                        &IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        FALSE, NULL, 0, TRUE);
     ok_ntstatus(Status, STATUS_PENDING);
     Status = WaitForSingleObject(EventHandle, 0);
     ok_ntstatus(Status, WAIT_TIMEOUT);
@@ -190,7 +206,11 @@ START_TEST(NtNotifyChangeMultipleKeys)
     if (NT_SUCCESS(Status))
     {
         /* Start watching for changes */
-        Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL, EventHandle, NULL, NULL, &IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, TRUE, NULL, 0, TRUE);
+        Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL,
+                                            EventHandle, NULL, NULL,
+                                            &IoStatusBlock,
+                                            REG_NOTIFY_CHANGE_LAST_SET,
+                                            TRUE, NULL, 0, TRUE);
         ok_ntstatus(Status, STATUS_PENDING);
         /* Check event state */
         Status = WaitForSingleObject(EventHandle, 0);
@@ -281,7 +301,11 @@ START_TEST(NtNotifyChangeMultipleKeys)
     ok(!NT_SUCCESS(Status), "NtNotifyChangeMultipleKeys succeeded unexpectedly.\n");
 
     /* APC-based asynchronous mode */
-    Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL, NULL, NtNotifyChangeMultipleKeys_ApcRoutine, &ApcRan, &IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL,
+                                        NULL, NtNotifyChangeMultipleKeys_ApcRoutine, &ApcRan,
+                                        &IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        FALSE, NULL, 0, TRUE);
     ok_ntstatus(Status, STATUS_PENDING);
     /* Make change to the registry key */
     Status = NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value2, sizeof(Value2));

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -44,30 +44,23 @@ NtNotifyChangeMultipleKeys_ApcRoutine(PVOID ApcContext, PIO_STATUS_BLOCK IoStatu
 START_TEST(NtNotifyChangeMultipleKeys)
 {
     NTSTATUS Status;
-    IO_STATUS_BLOCK IoStatusBlock;
+    IO_STATUS_BLOCK IoStatusBlock = { 0 };
     OBJECT_ATTRIBUTES SubordinateObjects[1];
-    WATCH_THREAD_STATE WatchThreadState;
+    WATCH_THREAD_STATE WatchThreadState = { 0 };
     BOOLEAN ApcRan = FALSE;
     /* Registry key object attributes */
-    UNICODE_STRING KeyName, SubKeyName,
-                   SecondaryKeyName, ThirdKeyName;
-    OBJECT_ATTRIBUTES ObjectAttributes, SubKeyObjectAttributes,
-                      SecondaryObjectAttributes, ThirdObjectAttributes;
-    UNICODE_STRING ValueName;
+    UNICODE_STRING KeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\SOFTWARE\\TestKey"),
+                   SubKeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\SOFTWARE\\TestKey\\TestSubKey"),
+                   SecondaryKeyName = RTL_CONSTANT_STRING(L"\\Registry\\User\\.DEFAULT\\SOFTWARE\\TestKey"),
+                   ThirdKeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\Software\\Microsoft\\Windows");
+    OBJECT_ATTRIBUTES ObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&KeyName, OBJ_CASE_INSENSITIVE),
+                      SubKeyObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&SubKeyName, OBJ_CASE_INSENSITIVE),
+                      SecondaryObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&SecondaryKeyName, OBJ_CASE_INSENSITIVE);
+    UNICODE_STRING ValueName = RTL_CONSTANT_STRING(L"TestValue");
     DWORD Value1 = 0x12345678, Value2 = 0x87654321;
     /* handles */
     HANDLE KeyHandle = NULL, SubKeyHandle = NULL, SecondaryKeyHandle = NULL;
     HANDLE WatchThreadHandle = NULL, EventHandle = NULL;
-
-    RtlInitUnicodeString(&KeyName, L"\\Registry\\Machine\\SOFTWARE\\TestKey");
-    RtlInitUnicodeString(&SubKeyName, L"\\Registry\\Machine\\SOFTWARE\\TestKey\\TestSubKey");
-    RtlInitUnicodeString(&SecondaryKeyName, L"\\Registry\\User\\.DEFAULT\\SOFTWARE\\TestKey");
-    RtlInitUnicodeString(&ThirdKeyName, L"\\Registry\\Machine\\Software\\Microsoft\\Windows");
-    RtlInitUnicodeString(&ValueName, L"TestValue");
-    InitializeObjectAttributes(&ObjectAttributes, &KeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
-    InitializeObjectAttributes(&SubKeyObjectAttributes, &SubKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
-    InitializeObjectAttributes(&SecondaryObjectAttributes, &SecondaryKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
-    InitializeObjectAttributes(&ThirdObjectAttributes, &ThirdKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
 
     /* Create event */
     EventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -19,7 +19,7 @@ typedef struct _WATCH_THREAD_STATE
 DWORD WINAPI NtNotifyChangeMultipleKeys_WatchThread(LPVOID lpParameter)
 {
     PWATCH_THREAD_STATE State = (PWATCH_THREAD_STATE)lpParameter;
-    
+
     State->Status = NtNotifyChangeMultipleKeys(State->KeyHandle, 0, NULL, NULL, NULL, NULL, State->IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, FALSE);
 
     return 0;
@@ -50,7 +50,7 @@ START_TEST(NtNotifyChangeMultipleKeys)
     /* handles */
     HANDLE KeyHandle = NULL, SubKeyHandle = NULL, SecondaryKeyHandle = NULL;
     HANDLE WatchThreadHandle = NULL, EventHandle = NULL;
-    
+
     RtlInitUnicodeString(&KeyName, L"\\Registry\\Machine\\SOFTWARE\\TestKey");
     RtlInitUnicodeString(&SubKeyName, L"\\Registry\\Machine\\SOFTWARE\\TestKey\\TestSubKey");
     RtlInitUnicodeString(&SecondaryKeyName, L"\\Registry\\User\\.DEFAULT\\SOFTWARE\\TestKey");
@@ -76,7 +76,7 @@ START_TEST(NtNotifyChangeMultipleKeys)
         goto Cleanup;
     }
     NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
-    
+
     /* Synchronous mode */
 
     /* Create a thread */
@@ -98,6 +98,10 @@ START_TEST(NtNotifyChangeMultipleKeys)
         ok_ntstatus(WatchThreadState.Status, STATUS_NOTIFY_ENUM_DIR);
         ok_ntstatus(WatchThreadState.IoStatusBlock->Status, STATUS_NOTIFY_ENUM_DIR);
         /* cleanup */
+        if (WaitForSingleObject(WatchThreadHandle, 0) == WAIT_TIMEOUT)
+        {
+            TerminateThread(WatchThreadHandle, 0);
+        }
         CloseHandle(WatchThreadHandle);
         WatchThreadHandle = NULL;
         WatchThreadState.Status = 0xdeadbeef;
@@ -120,6 +124,10 @@ START_TEST(NtNotifyChangeMultipleKeys)
         ok_ntstatus(WatchThreadState.Status, STATUS_NOTIFY_CLEANUP);
         ok_ntstatus(WatchThreadState.IoStatusBlock->Status, STATUS_NOTIFY_CLEANUP);
         /* cleanup */
+        if (WaitForSingleObject(WatchThreadHandle, 0) == WAIT_TIMEOUT)
+        {
+            TerminateThread(WatchThreadHandle, 0);
+        }
         CloseHandle(WatchThreadHandle);
         WatchThreadHandle = NULL;
     }
@@ -271,7 +279,7 @@ START_TEST(NtNotifyChangeMultipleKeys)
                                         0,
                                         TRUE);
     ok(!NT_SUCCESS(Status), "NtNotifyChangeMultipleKeys succeeded unexpectedly.\n");
-    
+
     /* APC-based asynchronous mode */
     Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL, NULL, NtNotifyChangeMultipleKeys_ApcRoutine, &ApcRan, &IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
     ok_ntstatus(Status, STATUS_PENDING);
@@ -308,7 +316,7 @@ Cleanup:
     Status = NtOpenKey(&SecondaryKeyHandle, DELETE, &SecondaryObjectAttributes);
     if (NT_SUCCESS(Status))
     {
-        NtDeleteKey(SecondaryKeyHandle);   
+        NtDeleteKey(SecondaryKeyHandle);
         CloseHandle(SecondaryKeyHandle);
     }
 }

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -1,0 +1,375 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Test for NtNotifyChangeMultipleKeys
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "precomp.h"
+#include "winreg.h"
+
+/* Registry watcher thread for testing synchronous mode */
+typedef struct _WATCH_THREAD_CONTEXT
+{
+    NTSTATUS Status;
+    HANDLE KeyHandle;
+    PIO_STATUS_BLOCK IoStatusBlock;
+} WATCH_THREAD_CONTEXT, *PWATCH_THREAD_CONTEXT;
+
+DWORD WINAPI
+NtNotifyChangeMultipleKeys_WatchThread(LPVOID lpParameter)
+{
+    PWATCH_THREAD_CONTEXT State = (PWATCH_THREAD_CONTEXT)lpParameter;
+
+    State->Status = NtNotifyChangeMultipleKeys(State->KeyHandle, 0,
+                                               NULL, NULL, NULL, NULL,
+                                               State->IoStatusBlock,
+                                               REG_NOTIFY_CHANGE_LAST_SET,
+                                               FALSE, NULL, 0, FALSE);
+
+    return 0;
+}
+
+typedef struct _APC_CONTEXT
+{
+    BOOLEAN ApcRan;
+} APC_CONTEXT, *PAPC_CONTEXT;
+
+/* APC Routine for testing asynchronous mode */
+VOID WINAPI
+NtNotifyChangeMultipleKeys_ApcRoutine(PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, ULONG Reserved)
+{
+    UNREFERENCED_PARAMETER(IoStatusBlock);
+    UNREFERENCED_PARAMETER(Reserved);
+
+    PAPC_CONTEXT ApcState = ApcContext;
+    ApcState->ApcRan = TRUE;
+}
+
+START_TEST(NtNotifyChangeMultipleKeys)
+{
+    NTSTATUS Status;
+    IO_STATUS_BLOCK IoStatusBlock = { 0 };
+    OBJECT_ATTRIBUTES SubordinateObjects[1];
+    PWATCH_THREAD_CONTEXT WatchThread1State = NULL,
+                          WatchThread2State = NULL;
+    PAPC_CONTEXT ApcContext = NULL;
+    /* Registry key object attributes */
+    UNICODE_STRING KeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\SOFTWARE\\TestKey"),
+                   SubKeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\SOFTWARE\\TestKey\\TestSubKey"),
+                   SecondaryKeyName = RTL_CONSTANT_STRING(L"\\Registry\\User\\.DEFAULT\\SOFTWARE\\TestKey"),
+                   ThirdKeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\Software\\Microsoft\\Windows");
+    OBJECT_ATTRIBUTES ObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&KeyName, OBJ_CASE_INSENSITIVE),
+                      SubKeyObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&SubKeyName, OBJ_CASE_INSENSITIVE),
+                      SecondaryObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&SecondaryKeyName, OBJ_CASE_INSENSITIVE);
+    UNICODE_STRING ValueName = RTL_CONSTANT_STRING(L"TestValue");
+    DWORD Value1 = 0x12345678, Value2 = 0x87654321;
+    /* handles */
+    HANDLE KeyHandle = NULL, SubKeyHandle = NULL, SecondaryKeyHandle = NULL;
+    HANDLE WatchThread1Handle = NULL,
+           WatchThread2Handle = NULL,
+           EventHandle = NULL;
+
+    /* Create event */
+    EventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (EventHandle == NULL)
+    {
+        skip("Failed to create event");
+        return;
+    }
+    /* Create registry keys */
+    Status = NtCreateKey(&KeyHandle, KEY_ALL_ACCESS, &ObjectAttributes, 0, NULL, REG_OPTION_NON_VOLATILE, NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        skip("Failed to create registry key");
+        goto Cleanup;
+    }
+    NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+
+    /* Synchronous mode */
+
+    /* Create a thread */
+    WatchThread1State = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WATCH_THREAD_CONTEXT));
+    if (WatchThread1State == NULL)
+    {
+        skip("Failed to allocate memory for watch thread state");
+        goto Cleanup;
+    }
+    WatchThread1State->KeyHandle = KeyHandle;
+    WatchThread1State->IoStatusBlock = &IoStatusBlock;
+    WatchThread1Handle = CreateThread(NULL, 0, NtNotifyChangeMultipleKeys_WatchThread, WatchThread1State, 0, NULL);
+    if (WatchThread1Handle)
+    {
+        /* Verify the thread is still running */
+        Status = WaitForSingleObject(WatchThread1Handle, 100);
+        ok_ntstatus(Status, WAIT_TIMEOUT);
+        /* Make change to the registry key */
+        Status = NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value2, sizeof(Value2));
+        ok_ntstatus(Status, STATUS_SUCCESS);
+        /* Verify that the thread is notified */
+        Status = WaitForSingleObject(WatchThread1Handle, 100);
+        ok_ntstatus(Status, WAIT_OBJECT_0);
+        /* Verify the status code */
+        ok_ntstatus(WatchThread1State->Status, STATUS_NOTIFY_ENUM_DIR);
+        ok_ntstatus(WatchThread1State->IoStatusBlock->Status, STATUS_NOTIFY_ENUM_DIR);
+        /* cleanup */
+        CloseHandle(WatchThread1Handle);
+        WatchThread1Handle = NULL;
+        WatchThread1State->Status = 0xdeadbeef;
+        WatchThread1State->IoStatusBlock->Status = 0xdeadbeef;
+    }
+    else
+    {
+        skip("Failed to create watch thread");
+    }
+    /* Watch again, but this time close the handle without making any change */
+    WatchThread2State = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WATCH_THREAD_CONTEXT));
+    if (WatchThread2State == NULL)
+    {
+        skip("Failed to allocate memory for watch thread state");
+        goto Cleanup;
+    }
+    WatchThread2State->KeyHandle = KeyHandle;
+    WatchThread2State->IoStatusBlock = &IoStatusBlock;
+    WatchThread2Handle = CreateThread(NULL, 0, NtNotifyChangeMultipleKeys_WatchThread, WatchThread2State, 0, NULL);
+    if (WatchThread2Handle)
+    {
+        Status = WaitForSingleObject(WatchThread2Handle, 100);
+        ok_ntstatus(Status, WAIT_TIMEOUT);
+        NtClose(KeyHandle);
+        KeyHandle = NULL;
+        Status = WaitForSingleObject(WatchThread2Handle, 100);
+        ok_ntstatus(Status, WAIT_OBJECT_0);
+        ok_ntstatus(WatchThread2State->Status, STATUS_NOTIFY_CLEANUP);
+        ok_ntstatus(WatchThread2State->IoStatusBlock->Status, STATUS_NOTIFY_CLEANUP);
+        /* cleanup */
+        CloseHandle(WatchThread2Handle);
+        WatchThread2Handle = NULL;
+    }
+    else
+    {
+        skip("Failed to create watch thread");
+    }
+
+    /* Event-based asynchronous mode */
+
+    if (!KeyHandle)
+    {
+        Status = NtOpenKey(&KeyHandle, KEY_ALL_ACCESS, &ObjectAttributes);
+        if (!NT_SUCCESS(Status))
+        {
+            skip("Failed to open registry key");
+            goto Cleanup;
+        }
+    }
+    /* Start watching for changes */
+    Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL,
+                                        EventHandle, NULL, NULL,
+                                        &IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        FALSE, NULL, 0, TRUE);
+    ok_ntstatus(Status, STATUS_PENDING);
+    /* Check event state */
+    Status = WaitForSingleObject(EventHandle, 0);
+    ok_ntstatus(Status, WAIT_TIMEOUT);
+    /* Make change to the registry key */
+    Status = NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    /* Verify that the event is signaled */
+    NtTestAlert();
+    Status = WaitForSingleObject(EventHandle, 100);
+    ok_ntstatus(Status, WAIT_OBJECT_0);
+    /* Verify the status code */
+    ok_ntstatus(IoStatusBlock.Status, STATUS_NOTIFY_ENUM_DIR);
+
+    /* Watch again, but this time close the handle without making any change */
+    Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL,
+                                        EventHandle, NULL, NULL,
+                                        &IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        FALSE, NULL, 0, TRUE);
+    ok_ntstatus(Status, STATUS_PENDING);
+    Status = WaitForSingleObject(EventHandle, 0);
+    ok_ntstatus(Status, WAIT_TIMEOUT);
+    NtClose(KeyHandle);
+    KeyHandle = NULL;
+    NtTestAlert();
+    Status = WaitForSingleObject(EventHandle, 100);
+    ok_ntstatus(Status, WAIT_OBJECT_0);
+    ok_ntstatus(IoStatusBlock.Status, STATUS_NOTIFY_CLEANUP);
+
+    /* Watching subtree */
+
+    if (!KeyHandle)
+    {
+        Status = NtOpenKey(&KeyHandle, KEY_ALL_ACCESS, &ObjectAttributes);
+        if (!NT_SUCCESS(Status))
+        {
+            skip("Failed to open registry key");
+            goto Cleanup;
+        }
+    }
+    Status = NtCreateKey(&SubKeyHandle, KEY_ALL_ACCESS, &SubKeyObjectAttributes, 0, NULL, REG_OPTION_NON_VOLATILE, NULL);
+    if (NT_SUCCESS(Status))
+    {
+        /* Start watching for changes */
+        Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL,
+                                            EventHandle, NULL, NULL,
+                                            &IoStatusBlock,
+                                            REG_NOTIFY_CHANGE_LAST_SET,
+                                            TRUE, NULL, 0, TRUE);
+        ok_ntstatus(Status, STATUS_PENDING);
+        /* Check event state */
+        Status = WaitForSingleObject(EventHandle, 0);
+        ok_ntstatus(Status, WAIT_TIMEOUT);
+        /* Make change to the subkey */
+        Status = NtSetValueKey(SubKeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+        ok_ntstatus(Status, STATUS_SUCCESS);
+        /* Verify that the event is signaled */
+        NtTestAlert();
+        Status = WaitForSingleObject(EventHandle, 100);
+        ok_ntstatus(Status, WAIT_OBJECT_0);
+    }
+    else
+    {
+        skip("Failed to create subkey");
+    }
+
+    /* Watching multiple keys */
+
+    Status = NtCreateKey(&SecondaryKeyHandle, KEY_ALL_ACCESS, &SecondaryObjectAttributes, 0, NULL, REG_OPTION_NON_VOLATILE, NULL);
+    if (NT_SUCCESS(Status))
+    {
+        CloseHandle(SecondaryKeyHandle);
+        InitializeObjectAttributes(&SubordinateObjects[0], &SecondaryKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+        Status = NtNotifyChangeMultipleKeys(KeyHandle,
+                                            _countof(SubordinateObjects),
+                                            SubordinateObjects,
+                                            EventHandle,
+                                            NULL,
+                                            NULL,
+                                            &IoStatusBlock,
+                                            REG_NOTIFY_CHANGE_LAST_SET,
+                                            TRUE,
+                                            NULL,
+                                            0,
+                                            TRUE);
+        ok_ntstatus(Status, STATUS_PENDING);
+        /* Check event state */
+        Status = WaitForSingleObject(EventHandle, 0);
+        ok_ntstatus(Status, WAIT_TIMEOUT);
+        /* Make change to the secondary key */
+        Status = NtOpenKey(&SecondaryKeyHandle, KEY_SET_VALUE | KEY_NOTIFY | DELETE, &SecondaryObjectAttributes);
+        if (NT_SUCCESS(Status))
+        {
+            Status = NtSetValueKey(SecondaryKeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+            ok_ntstatus(Status, STATUS_SUCCESS);
+            CloseHandle(SecondaryKeyHandle);
+        }
+        /* Verify that the event is signaled */
+        NtTestAlert();
+        Status = WaitForSingleObject(EventHandle, 100);
+        ok_ntstatus(Status, WAIT_OBJECT_0);
+    }
+    else
+    {
+        skip("Failed to create secondary key");
+    }
+    /* Test if the function fails if the given subordinate key is same with master key */
+    InitializeObjectAttributes(&SubordinateObjects[0], &KeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    Status = NtNotifyChangeMultipleKeys(KeyHandle,
+                                        _countof(SubordinateObjects),
+                                        SubordinateObjects,
+                                        EventHandle,
+                                        NULL,
+                                        NULL,
+                                        &IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        TRUE,
+                                        NULL,
+                                        0,
+                                        TRUE);
+    /* The status is STATUS_INVALID_PARAMETER on Windows Server 2003 and STATUS_INVALID_OBJECT_NAME on Windows 10 */
+    ok(!NT_SUCCESS(Status), "NtNotifyChangeMultipleKeys succeeded unexpectedly.\n");
+    /* Test if the function fails if the the given subordinate key is in the same hive as the master key */
+    InitializeObjectAttributes(&SubordinateObjects[0], &ThirdKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    Status = NtNotifyChangeMultipleKeys(KeyHandle,
+                                        _countof(SubordinateObjects),
+                                        SubordinateObjects,
+                                        EventHandle,
+                                        NULL,
+                                        NULL,
+                                        &IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        TRUE,
+                                        NULL,
+                                        0,
+                                        TRUE);
+    ok(!NT_SUCCESS(Status), "NtNotifyChangeMultipleKeys succeeded unexpectedly.\n");
+
+    /* APC-based asynchronous mode */
+    ApcContext = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(APC_CONTEXT));
+    if (ApcContext == NULL)
+    {
+        skip("Failed to allocate memory for APC context");
+        goto Cleanup;
+    }
+    Status = NtNotifyChangeMultipleKeys(KeyHandle, 0, NULL,
+                                        NULL, NtNotifyChangeMultipleKeys_ApcRoutine, ApcContext,
+                                        &IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        FALSE, NULL, 0, TRUE);
+    ok_ntstatus(Status, STATUS_PENDING);
+    /* Make change to the registry key */
+    Status = NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value2, sizeof(Value2));
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    /* Force system to run queued APC routines */
+    NtTestAlert();
+    ok(ApcContext->ApcRan == TRUE, "The APC routine did not ran.\n");
+
+Cleanup:
+    if (WatchThread1Handle)
+    {
+        CloseHandle(WatchThread1Handle);
+    }
+    if (WatchThread2Handle)
+    {
+        CloseHandle(WatchThread2Handle);
+    }
+    if (WatchThread1State)
+    {
+        HeapFree(GetProcessHeap(), 0, WatchThread1State);
+    }
+    if (WatchThread2State)
+    {
+        HeapFree(GetProcessHeap(), 0, WatchThread2State);
+    }
+    if (ApcContext)
+    {
+        HeapFree(GetProcessHeap(), 0, ApcContext);
+    }
+    if (SubKeyHandle)
+    {
+        NtDeleteKey(SubKeyHandle);
+        CloseHandle(SubKeyHandle);
+    }
+    if (!KeyHandle)
+    {
+        Status = NtOpenKey(&KeyHandle, DELETE, &ObjectAttributes);
+        if (!NT_SUCCESS(Status))
+        {
+            KeyHandle = NULL;
+        }
+    }
+    if (KeyHandle)
+    {
+        NtDeleteKey(KeyHandle);
+        CloseHandle(KeyHandle);
+    }
+    Status = NtOpenKey(&SecondaryKeyHandle, DELETE, &SecondaryObjectAttributes);
+    if (NT_SUCCESS(Status))
+    {
+        NtDeleteKey(SecondaryKeyHandle);
+        CloseHandle(SecondaryKeyHandle);
+    }
+}

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -342,6 +342,10 @@ Cleanup:
     {
         CloseHandle(WatchThread2Handle);
     }
+    if (EventHandle)
+    {
+        CloseHandle(EventHandle);
+    }
     if (WatchThread1State)
     {
         HeapFree(GetProcessHeap(), 0, WatchThread1State);

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -95,7 +95,7 @@ START_TEST(NtNotifyChangeMultipleKeys)
     /* Synchronous mode */
 
     /* Create a thread */
-    WatchThread1State = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WATCH_THREAD_CONTEXT));
+    WatchThread1State = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*WatchThread1State));
     if (WatchThread1State == NULL)
     {
         skip("Failed to allocate memory for watch thread state");
@@ -129,7 +129,7 @@ START_TEST(NtNotifyChangeMultipleKeys)
         skip("Failed to create watch thread");
     }
     /* Watch again, but this time close the handle without making any change */
-    WatchThread2State = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WATCH_THREAD_CONTEXT));
+    WatchThread2State = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*WatchThread2State));
     if (WatchThread2State == NULL)
     {
         skip("Failed to allocate memory for watch thread state");
@@ -314,7 +314,7 @@ START_TEST(NtNotifyChangeMultipleKeys)
     ok(!NT_SUCCESS(Status), "NtNotifyChangeMultipleKeys succeeded unexpectedly.\n");
 
     /* APC-based asynchronous mode */
-    ApcContext = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(APC_CONTEXT));
+    ApcContext = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*ApcContext));
     if (ApcContext == NULL)
     {
         skip("Failed to allocate memory for APC context");

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -49,6 +49,7 @@ NtNotifyChangeMultipleKeys_ApcRoutine(PVOID ApcContext, PIO_STATUS_BLOCK IoStatu
 START_TEST(NtNotifyChangeMultipleKeys)
 {
     NTSTATUS Status;
+    DWORD WaitStatus;
     IO_STATUS_BLOCK IoStatusBlock = { 0 };
     OBJECT_ATTRIBUTES SubordinateObjects[1];
     PWATCH_THREAD_CONTEXT WatchThread1State = NULL,
@@ -101,14 +102,14 @@ START_TEST(NtNotifyChangeMultipleKeys)
     if (WatchThread1Handle)
     {
         /* Verify the thread is still running */
-        Status = WaitForSingleObject(WatchThread1Handle, 100);
-        ok_ntstatus(Status, WAIT_TIMEOUT);
+        WaitStatus = WaitForSingleObject(WatchThread1Handle, 100);
+        ok_eq_ulong(WaitStatus, WAIT_TIMEOUT);
         /* Make change to the registry key */
         Status = NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value2, sizeof(Value2));
         ok_ntstatus(Status, STATUS_SUCCESS);
         /* Verify that the thread is notified */
-        Status = WaitForSingleObject(WatchThread1Handle, 100);
-        ok_ntstatus(Status, WAIT_OBJECT_0);
+        WaitStatus = WaitForSingleObject(WatchThread1Handle, 100);
+        ok_eq_ulong(WaitStatus, WAIT_OBJECT_0);
         /* Verify the status code */
         ok_ntstatus(WatchThread1State->Status, STATUS_NOTIFY_ENUM_DIR);
         ok_ntstatus(WatchThread1State->IoStatusBlock->Status, STATUS_NOTIFY_ENUM_DIR);
@@ -134,12 +135,12 @@ START_TEST(NtNotifyChangeMultipleKeys)
     WatchThread2Handle = CreateThread(NULL, 0, NtNotifyChangeMultipleKeys_WatchThread, WatchThread2State, 0, NULL);
     if (WatchThread2Handle)
     {
-        Status = WaitForSingleObject(WatchThread2Handle, 100);
-        ok_ntstatus(Status, WAIT_TIMEOUT);
+        WaitStatus = WaitForSingleObject(WatchThread2Handle, 100);
+        ok_eq_ulong(WaitStatus, WAIT_TIMEOUT);
         NtClose(KeyHandle);
         KeyHandle = NULL;
-        Status = WaitForSingleObject(WatchThread2Handle, 100);
-        ok_ntstatus(Status, WAIT_OBJECT_0);
+        WaitStatus = WaitForSingleObject(WatchThread2Handle, 100);
+        ok_eq_ulong(WaitStatus, WAIT_OBJECT_0);
         ok_ntstatus(WatchThread2State->Status, STATUS_NOTIFY_CLEANUP);
         ok_ntstatus(WatchThread2State->IoStatusBlock->Status, STATUS_NOTIFY_CLEANUP);
         /* cleanup */
@@ -170,15 +171,15 @@ START_TEST(NtNotifyChangeMultipleKeys)
                                         FALSE, NULL, 0, TRUE);
     ok_ntstatus(Status, STATUS_PENDING);
     /* Check event state */
-    Status = WaitForSingleObject(EventHandle, 0);
-    ok_ntstatus(Status, WAIT_TIMEOUT);
+    WaitStatus = WaitForSingleObject(EventHandle, 0);
+    ok_eq_ulong(WaitStatus, WAIT_TIMEOUT);
     /* Make change to the registry key */
     Status = NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
     ok_ntstatus(Status, STATUS_SUCCESS);
     /* Verify that the event is signaled */
     NtTestAlert();
-    Status = WaitForSingleObject(EventHandle, 100);
-    ok_ntstatus(Status, WAIT_OBJECT_0);
+    WaitStatus = WaitForSingleObject(EventHandle, 100);
+    ok_eq_ulong(WaitStatus, WAIT_OBJECT_0);
     /* Verify the status code */
     ok_ntstatus(IoStatusBlock.Status, STATUS_NOTIFY_ENUM_DIR);
 
@@ -189,13 +190,13 @@ START_TEST(NtNotifyChangeMultipleKeys)
                                         REG_NOTIFY_CHANGE_LAST_SET,
                                         FALSE, NULL, 0, TRUE);
     ok_ntstatus(Status, STATUS_PENDING);
-    Status = WaitForSingleObject(EventHandle, 0);
-    ok_ntstatus(Status, WAIT_TIMEOUT);
+    WaitStatus = WaitForSingleObject(EventHandle, 0);
+    ok_eq_ulong(WaitStatus, WAIT_TIMEOUT);
     NtClose(KeyHandle);
     KeyHandle = NULL;
     NtTestAlert();
-    Status = WaitForSingleObject(EventHandle, 100);
-    ok_ntstatus(Status, WAIT_OBJECT_0);
+    WaitStatus = WaitForSingleObject(EventHandle, 100);
+    ok_eq_ulong(WaitStatus, WAIT_OBJECT_0);
     ok_ntstatus(IoStatusBlock.Status, STATUS_NOTIFY_CLEANUP);
 
     /* Watching subtree */
@@ -220,15 +221,15 @@ START_TEST(NtNotifyChangeMultipleKeys)
                                             TRUE, NULL, 0, TRUE);
         ok_ntstatus(Status, STATUS_PENDING);
         /* Check event state */
-        Status = WaitForSingleObject(EventHandle, 0);
-        ok_ntstatus(Status, WAIT_TIMEOUT);
+        WaitStatus = WaitForSingleObject(EventHandle, 0);
+        ok_eq_ulong(WaitStatus, WAIT_TIMEOUT);
         /* Make change to the subkey */
         Status = NtSetValueKey(SubKeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
         ok_ntstatus(Status, STATUS_SUCCESS);
         /* Verify that the event is signaled */
         NtTestAlert();
-        Status = WaitForSingleObject(EventHandle, 100);
-        ok_ntstatus(Status, WAIT_OBJECT_0);
+        WaitStatus = WaitForSingleObject(EventHandle, 100);
+        ok_eq_ulong(WaitStatus, WAIT_OBJECT_0);
     }
     else
     {
@@ -256,8 +257,8 @@ START_TEST(NtNotifyChangeMultipleKeys)
                                             TRUE);
         ok_ntstatus(Status, STATUS_PENDING);
         /* Check event state */
-        Status = WaitForSingleObject(EventHandle, 0);
-        ok_ntstatus(Status, WAIT_TIMEOUT);
+        WaitStatus = WaitForSingleObject(EventHandle, 0);
+        ok_eq_ulong(WaitStatus, WAIT_TIMEOUT);
         /* Make change to the secondary key */
         Status = NtOpenKey(&SecondaryKeyHandle, KEY_SET_VALUE | KEY_NOTIFY | DELETE, &SecondaryObjectAttributes);
         if (NT_SUCCESS(Status))
@@ -268,8 +269,8 @@ START_TEST(NtNotifyChangeMultipleKeys)
         }
         /* Verify that the event is signaled */
         NtTestAlert();
-        Status = WaitForSingleObject(EventHandle, 100);
-        ok_ntstatus(Status, WAIT_OBJECT_0);
+        WaitStatus = WaitForSingleObject(EventHandle, 100);
+        ok_eq_ulong(WaitStatus, WAIT_OBJECT_0);
     }
     else
     {

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -121,13 +121,13 @@ START_TEST(NtNotifyChangeMultipleKeys)
         /* cleanup */
         CloseHandle(WatchThread1Handle);
         WatchThread1Handle = NULL;
-        WatchThread1State->Status = 0xdeadbeef;
-        WatchThread1State->IoStatusBlock->Status = 0xdeadbeef;
     }
     else
     {
         skip("Failed to create watch thread");
     }
+    HeapFree(GetProcessHeap(), 0, WatchThread1State);
+    WatchThread1State = NULL;
     /* Watch again, but this time close the handle without making any change */
     WatchThread2State = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*WatchThread2State));
     if (WatchThread2State == NULL)
@@ -156,6 +156,8 @@ START_TEST(NtNotifyChangeMultipleKeys)
     {
         skip("Failed to create watch thread");
     }
+    HeapFree(GetProcessHeap(), 0, WatchThread2State);
+    WatchThread2State = NULL;
 
     /* Event-based asynchronous mode */
 
@@ -345,14 +347,6 @@ Cleanup:
     if (EventHandle)
     {
         CloseHandle(EventHandle);
-    }
-    if (WatchThread1State)
-    {
-        HeapFree(GetProcessHeap(), 0, WatchThread1State);
-    }
-    if (WatchThread2State)
-    {
-        HeapFree(GetProcessHeap(), 0, WatchThread2State);
     }
     if (ApcContext)
     {

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -246,7 +246,7 @@ START_TEST(NtNotifyChangeMultipleKeys)
     Status = NtCreateKey(&SecondaryKeyHandle, KEY_ALL_ACCESS, &SecondaryObjectAttributes, 0, NULL, REG_OPTION_NON_VOLATILE, NULL);
     if (NT_SUCCESS(Status))
     {
-        CloseHandle(SecondaryKeyHandle);
+        NtClose(SecondaryKeyHandle);
         InitializeObjectAttributes(&SubordinateObjects[0], &SecondaryKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
         Status = NtNotifyChangeMultipleKeys(KeyHandle,
                                             _countof(SubordinateObjects),
@@ -270,7 +270,7 @@ START_TEST(NtNotifyChangeMultipleKeys)
         {
             Status = NtSetValueKey(SecondaryKeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
             ok_ntstatus(Status, STATUS_SUCCESS);
-            CloseHandle(SecondaryKeyHandle);
+            NtClose(SecondaryKeyHandle);
         }
         /* Verify that the event is signaled */
         NtTestAlert();
@@ -357,7 +357,7 @@ Cleanup:
     if (SubKeyHandle)
     {
         NtDeleteKey(SubKeyHandle);
-        CloseHandle(SubKeyHandle);
+        NtClose(SubKeyHandle);
     }
     if (!KeyHandle)
     {
@@ -370,12 +370,12 @@ Cleanup:
     if (KeyHandle)
     {
         NtDeleteKey(KeyHandle);
-        CloseHandle(KeyHandle);
+        NtClose(KeyHandle);
     }
     Status = NtOpenKey(&SecondaryKeyHandle, DELETE, &SecondaryObjectAttributes);
     if (NT_SUCCESS(Status))
     {
         NtDeleteKey(SecondaryKeyHandle);
-        CloseHandle(SecondaryKeyHandle);
+        NtClose(SecondaryKeyHandle);
     }
 }

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -85,7 +85,12 @@ START_TEST(NtNotifyChangeMultipleKeys)
         skip("Failed to create registry key");
         goto Cleanup;
     }
-    NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+    Status = NtSetValueKey(KeyHandle, &ValueName, 0, REG_DWORD, &Value1, sizeof(Value1));
+    if (!NT_SUCCESS(Status))
+    {
+        skip("Failed to set initial test value");
+        goto Cleanup;
+    }
 
     /* Synchronous mode */
 

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -6,7 +6,7 @@
  */
 
 #include "precomp.h"
-#include "winreg.h"
+#include <winreg.h>
 
 /* Registry watcher thread for testing synchronous mode */
 typedef struct _WATCH_THREAD_CONTEXT
@@ -52,24 +52,25 @@ START_TEST(NtNotifyChangeMultipleKeys)
     DWORD WaitStatus;
     IO_STATUS_BLOCK IoStatusBlock = { 0 };
     OBJECT_ATTRIBUTES SubordinateObjects[1];
-    PWATCH_THREAD_CONTEXT WatchThread1State = NULL,
-                          WatchThread2State = NULL;
+
+    PWATCH_THREAD_CONTEXT WatchThread1State = NULL, WatchThread2State = NULL;
     PAPC_CONTEXT ApcContext = NULL;
+
     /* Registry key object attributes */
-    UNICODE_STRING KeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\SOFTWARE\\TestKey"),
-                   SubKeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\SOFTWARE\\TestKey\\TestSubKey"),
-                   SecondaryKeyName = RTL_CONSTANT_STRING(L"\\Registry\\User\\.DEFAULT\\SOFTWARE\\TestKey"),
-                   ThirdKeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\Software\\Microsoft\\Windows");
-    OBJECT_ATTRIBUTES ObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&KeyName, OBJ_CASE_INSENSITIVE),
-                      SubKeyObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&SubKeyName, OBJ_CASE_INSENSITIVE),
-                      SecondaryObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&SecondaryKeyName, OBJ_CASE_INSENSITIVE);
+    UNICODE_STRING KeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\SOFTWARE\\TestKey");
+    UNICODE_STRING SubKeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\SOFTWARE\\TestKey\\TestSubKey");
+    UNICODE_STRING SecondaryKeyName = RTL_CONSTANT_STRING(L"\\Registry\\User\\.DEFAULT\\SOFTWARE\\TestKey");
+    UNICODE_STRING ThirdKeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\Software\\Microsoft\\Windows");
+    OBJECT_ATTRIBUTES ObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&KeyName, OBJ_CASE_INSENSITIVE);
+    OBJECT_ATTRIBUTES SubKeyObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&SubKeyName, OBJ_CASE_INSENSITIVE);
+    OBJECT_ATTRIBUTES SecondaryObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&SecondaryKeyName, OBJ_CASE_INSENSITIVE);
     UNICODE_STRING ValueName = RTL_CONSTANT_STRING(L"TestValue");
     DWORD Value1 = 0x12345678, Value2 = 0x87654321;
-    /* handles */
+
+    /* Handles */
     HANDLE KeyHandle = NULL, SubKeyHandle = NULL, SecondaryKeyHandle = NULL;
-    HANDLE WatchThread1Handle = NULL,
-           WatchThread2Handle = NULL,
-           EventHandle = NULL;
+    HANDLE WatchThread1Handle = NULL, WatchThread2Handle = NULL;
+    HANDLE EventHandle = NULL;
 
     /* Create event */
     EventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -52,6 +52,7 @@ extern void func_NtImpersonateAnonymousToken(void);
 extern void func_NtLoadUnloadKey(void);
 extern void func_NtMapViewOfSection(void);
 extern void func_NtMutant(void);
+extern void func_NtNotifyChangeMultipleKeys(void);
 extern void func_NtOpenKey(void);
 extern void func_NtOpenProcessToken(void);
 extern void func_NtOpenThreadToken(void);
@@ -191,6 +192,7 @@ const struct test winetest_testlist[] =
     { "NtLoadUnloadKey",                func_NtLoadUnloadKey },
     { "NtMapViewOfSection",             func_NtMapViewOfSection },
     { "NtMutant",                       func_NtMutant },
+    { "NtNotifyChangeMultipleKeys",     func_NtNotifyChangeMultipleKeys },
     { "NtOpenKey",                      func_NtOpenKey },
     { "NtOpenProcessToken",             func_NtOpenProcessToken },
     { "NtOpenThreadToken",              func_NtOpenThreadToken },

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -52,6 +52,7 @@ extern void func_NtImpersonateAnonymousToken(void);
 extern void func_NtLoadUnloadKey(void);
 extern void func_NtMapViewOfSection(void);
 extern void func_NtMutant(void);
+extern void func_NtNotifyChangeMultipleKeys(void);
 extern void func_NtOpenKey(void);
 extern void func_NtOpenProcessToken(void);
 extern void func_NtOpenThreadToken(void);
@@ -192,6 +193,7 @@ const struct test winetest_testlist[] =
     { "NtLoadUnloadKey",                func_NtLoadUnloadKey },
     { "NtMapViewOfSection",             func_NtMapViewOfSection },
     { "NtMutant",                       func_NtMutant },
+    { "NtNotifyChangeMultipleKeys",     func_NtNotifyChangeMultipleKeys },
     { "NtOpenKey",                      func_NtOpenKey },
     { "NtOpenProcessToken",             func_NtOpenProcessToken },
     { "NtOpenThreadToken",              func_NtOpenThreadToken },


### PR DESCRIPTION
## Purpose

This PR implements APITESTS for `NtNotifyChangeMultipleKeys` function, that are guaranteed to pass on Windows and cover every feature supported by this function. I tested it on Windows XP, Windows Server 2003, Windows 7 and Windows 11.

This is part of #8848 and #7914 PRs, second one in the series of re-implementing the feature using smaller and easy-to-review PRs.

<img width="693" height="370" alt="image" src="https://github.com/user-attachments/assets/9a8389ca-c35e-496c-b0a7-99be32f9ffaf" />


JIRA issue: [CORE-11865](https://jira.reactos.org/browse/CORE-11865)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109715,109720
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109716,109721
- [x] Test WHS: https://reactos.org/testman/compare.php?ids=109678,109732
- [x] W2K3 x64: https://reactos.org/testman/compare.php?ids=109711,109731