### PR TITLE
[NTOS:CM] Implement CmpReportNotify and CmpFlushNotify

### DIFF
--- a/ntoskrnl/config/cminit.c
+++ b/ntoskrnl/config/cminit.c
@@ -105,8 +105,6 @@ CmpInitializeHive(
     Hive->UseCountLog.Next = 0;
     Hive->LockHiveLog.Next = 0;
     Hive->FileObject = NULL;
-    Hive->NotifyList.Flink = NULL;
-    Hive->NotifyList.Blink = NULL;
 
     /* Set the loading flag */
     Hive->HiveIsLoading = TRUE;
@@ -118,6 +116,7 @@ CmpInitializeHive(
     InitializeListHead(&Hive->KcbConvertListHead);
     InitializeListHead(&Hive->KnodeConvertListHead);
     InitializeListHead(&Hive->TrustClassEntry);
+    InitializeListHead(&Hive->NotifyList);
 
     /* Allocate the view log */
     Hive->ViewLock = ExAllocatePoolWithTag(NonPagedPool,

--- a/ntoskrnl/config/cmnotify.c
+++ b/ntoskrnl/config/cmnotify.c
@@ -213,12 +213,85 @@ CmpReportNotify(IN PCM_KEY_CONTROL_BLOCK Kcb,
     }
 }
 
+/**
+ * @brief Terminates a notification session and releases all the resources used by the attached CM_NOTIFY_BLOCK
+ * 
+ * This function is called when the system is releasing a registry key object,
+ * to signal the listeners that the notification session has ended, then releases
+ * all the resources used for the notification session.
+ * 
+ * @param[in] KeyBody The registry key object being released
+ * 
+ * @param[in] LockHeld TRUE if the KCB lock is already held by the caller, FALSE otherwise
+ * 
+ */
 VOID
 NTAPI
 CmpFlushNotify(IN PCM_KEY_BODY KeyBody,
                IN BOOLEAN LockHeld)
 {
-    /* FIXME: TODO */
-    return;
+    PLIST_ENTRY ListHead, NextEntry;
+    PCMP_POST_BLOCK PostBlock, SecondaryPostBlock;
+
+    /* Lock the KCB so no one would try to make changes
+     * to NotifyBlock while we are releasing its resources */
+    if (!LockHeld)
+        CmpAcquireKcbLockExclusive(KeyBody->KeyControlBlock);
+
+    ListHead = &(KeyBody->NotifyBlock->PostList);
+    NextEntry = ListHead->Flink;
+    while (NextEntry != ListHead)
+    {
+        PostBlock = CONTAINING_RECORD(NextEntry, CMP_POST_BLOCK, NotifyList);
+        NextEntry = NextEntry->Flink;
+
+        /* This shouldn't happen, We don't assign subordinate NotifyBlocks to a KeyBody */
+        ASSERT(PostBlock->IsPrimary);
+
+        if (PostBlock->IoStatusBlock)
+        {
+            _SEH2_TRY
+            {
+                /* We are ending the notification session without signalling the caller for any change */
+                PostBlock->IoStatusBlock->Status = STATUS_NOTIFY_CLEANUP;
+                PostBlock->IoStatusBlock->Information = 0;
+            }
+            _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+            {
+                NTSTATUS Status = _SEH2_GetExceptionCode();
+                DPRINT1("CmpFlushNotify: Writing to IO_STATUS_BLOCK failed with %lx. Process=0x%lx, IoStatusBlock=0x%lx\n", Status, PostBlock->OwnerProcess, PostBlock->IoStatusBlock);
+            }
+            _SEH2_END;
+        }
+
+        if (PostBlock->Event)
+        {
+            KeSetEvent(PostBlock->Event, 1, FALSE);
+            ObDereferenceObject(PostBlock->Event);
+        }
+
+        if (PostBlock->UserApc)
+            ExFreePoolWithTag(PostBlock->UserApc, TAG_CM_NOTIFY);
+
+        if (PostBlock->SecondaryBlock)
+        {
+            SecondaryPostBlock = CONTAINING_RECORD(PostBlock->SecondaryBlock->PostList.Flink, CMP_POST_BLOCK, NotifyList);
+            RemoveEntryList(&SecondaryPostBlock->NotifyList);
+            ExFreePoolWithTag(SecondaryPostBlock, TAG_CM_NOTIFY);
+            ExFreePoolWithTag(PostBlock->SecondaryBlock, TAG_CM_NOTIFY);
+        }
+
+        RemoveEntryList(&(PostBlock->NotifyList));
+        ExFreePoolWithTag(PostBlock, TAG_CM_NOTIFY);
+    }
+
+    /* Free the NotifyBlock */
+    RemoveEntryList(&(KeyBody->NotifyBlock->HiveList));
+    ExFreePoolWithTag(KeyBody->NotifyBlock, TAG_CM_NOTIFY);
+    KeyBody->NotifyBlock = NULL;
+
+    /* Unlock the Kcb if we locked it previously */
+    if (!LockHeld)
+        CmpReleaseKcbLock(KeyBody->KeyControlBlock);
 }
 

--- a/ntoskrnl/config/cmnotify.c
+++ b/ntoskrnl/config/cmnotify.c
@@ -12,8 +12,144 @@
 #define NDEBUG
 #include "debug.h"
 
+/* PRIVATE FUNCTIONS *********************************************************/
+
+/**
+ * @brief Report a change in registry to a listener represented by the post block
+ * 
+ * This function signals the listener that a change has occurred in the registry,
+ * then releases the resources used by the @p PostBlock as the notification session
+ * has finished.
+ * This is an utility function used by CmpReportNotify to report changes to each
+ * CMP_POST_BLOCK attached to a CM_NOTIFY_BLOCK.
+ * 
+ * @param[in] PostBlock The change notification receiver
+ */
+VOID
+NTAPI
+CmpReportNotifyToPostBlock(_In_ PCMP_POST_BLOCK PostBlock)
+{
+    PCMP_POST_BLOCK SecondaryPostBlock;
+
+    /* Report the operation result using caller-allocated IO_STATUS_BLOCK buffer  */
+    if (PostBlock->IoStatusBlock)
+    {
+        /* Write to an IO_STATUS_BLOCK allocated by an user-mode caller */
+        if (PostBlock->OwnerProcess != NULL)
+        {
+            /* Attach to caller's context if necessary */
+            KAPC_STATE ApcState;
+            BOOLEAN IsSameProcess = PostBlock->OwnerProcess == &PsGetCurrentProcess()->Pcb;
+            if (!IsSameProcess)
+                KeStackAttachProcess(PostBlock->OwnerProcess, &ApcState);
+
+            /* Try to write status to buffer */
+            _SEH2_TRY
+            {
+                PostBlock->IoStatusBlock->Status = STATUS_NOTIFY_ENUM_DIR;
+                PostBlock->IoStatusBlock->Information = 0;
+            }
+            _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+            {
+                NTSTATUS Status = _SEH2_GetExceptionCode();
+                DPRINT1("CmpReportNotifyToPostBlock: Writing to IO_STATUS_BLOCK failed with %lx. Process=0x%lx, IoStatusBlock=0x%lx\n", Status, PostBlock->OwnerProcess, PostBlock->IoStatusBlock);
+            }
+            _SEH2_END;
+
+            if (!IsSameProcess)
+                KeUnstackDetachProcess(&ApcState);
+        }
+        else
+        {
+            /* PostBlock->OwnerProcess should be set to NULL for kernel-mode callers */
+            PostBlock->IoStatusBlock->Status = STATUS_NOTIFY_ENUM_DIR;
+            PostBlock->IoStatusBlock->Information = 0;
+        }
+    }
+
+    /* Signal the event object provided by the user-mode or kernel-mode callers */
+    if (PostBlock->Event)
+    {
+        KeSetEvent(PostBlock->Event, 1, FALSE);
+        ObDereferenceObject(PostBlock->Event);
+        PostBlock->Event = NULL;
+    }
+
+    /* Queue the WorkQueueItem for asynchronous kernel-mode callers */
+    if (PostBlock->WorkQueueItem)
+    {
+        ExQueueWorkItem(PostBlock->WorkQueueItem, PostBlock->WorkQueueType);
+    }
+    else if (PostBlock->UserApc)
+    {
+        /* FIXME: TODO */
+    }
+
+    /* Detach the PostBlock from its NotifyBlock as the wait is complete */
+    RemoveEntryList(&(PostBlock->NotifyList));
+    if (PostBlock->SecondaryBlock)
+    {
+        /* Also detach the PostBlock for the Subordinate key if one was provided */
+        SecondaryPostBlock = CONTAINING_RECORD(PostBlock->SecondaryBlock->PostList.Flink, CMP_POST_BLOCK, NotifyList);
+        RemoveEntryList(&SecondaryPostBlock->NotifyList);
+        /* Free the memory allocated for the SecondaryPostBlock as we don't need it anymore */
+        ExFreePoolWithTag(SecondaryPostBlock, TAG_CM_NOTIFY);
+        ExFreePoolWithTag(PostBlock->SecondaryBlock, TAG_CM_NOTIFY);
+    }
+    ExFreePoolWithTag(PostBlock, TAG_CM_NOTIFY);
+}
+
+/**
+ * @brief Check if @p SubKey is part of @p ParentKey's subtree
+ * 
+ * This is an utility function used by CmpReportNotify to check
+ * if a notification should be send or not when WatchTree flag is set.
+ * 
+ * @param[in] ParentKey The parent key to check against
+ * 
+ * @param[in] SubKey The target key
+ * 
+ * @return TRUE if @p SubKey is a subkey of @p ParentKey, FALSE otherwise
+ */
+BOOLEAN
+NTAPI
+CmpIsKcbSubKey(_In_ PCM_KEY_CONTROL_BLOCK ParentKey,
+               _In_ PCM_KEY_CONTROL_BLOCK SubKey)
+{
+    PCM_KEY_CONTROL_BLOCK SubKeyParent;
+    ULONG Depth = SubKey->TotalLevels - ParentKey->TotalLevels;
+
+    if (Depth <= 0)
+        return FALSE;
+
+    SubKeyParent = SubKey->ParentKcb;
+    while (SubKeyParent != NULL && SubKeyParent != ParentKey && Depth >= 0)
+    {
+        SubKeyParent = SubKeyParent->ParentKcb;
+        Depth--;
+    }
+
+    return SubKeyParent == ParentKey;
+}
+
 /* FUNCTIONS *****************************************************************/
 
+/**
+ * @brief Report a change in a registry key
+ * 
+ * This function is called by CM functions whenever a change occurs in a registry key.
+ * It iterates through all attached CM_NOTIFY_BLOCKs to find one that matches the change
+ * then reports the change to all attached CMP_POST_BLOCKs.
+ * 
+ * @param[in] Kcb The changed registry key
+ * 
+ * @param[in] Hive The registry hive containing the changed key
+ * 
+ * @param[in] Cell Unused
+ * 
+ * @param[in] Filter The type of change, can be REG_NOTIFY_CHANGE_NAME, REG_NOTIFY_CHANGE_ATTRIBUTES, REG_NOTIFY_CHANGE_LAST_SET, or REG_NOTIFY_CHANGE_SECURITY
+ * 
+ */
 VOID
 NTAPI
 CmpReportNotify(IN PCM_KEY_CONTROL_BLOCK Kcb,
@@ -21,8 +157,60 @@ CmpReportNotify(IN PCM_KEY_CONTROL_BLOCK Kcb,
                 IN HCELL_INDEX Cell,
                 IN ULONG Filter)
 {
-    /* FIXME: TODO */
-    return;
+    PCMHIVE KeyHive;
+    PLIST_ENTRY ListHead, NextEntry;
+    PLIST_ENTRY PostListHead, PostNextEntry;
+    PCM_NOTIFY_BLOCK NotifyBlock;
+    PCMP_POST_BLOCK PostBlock;
+
+    KeyHive = CONTAINING_RECORD(Hive, CMHIVE, Hive);
+    ListHead = &(KeyHive->NotifyList);
+    if (IsListEmpty(ListHead)) return;
+
+    NextEntry = ListHead->Flink;
+    while (NextEntry != ListHead)
+    {
+        NotifyBlock = CONTAINING_RECORD(NextEntry, CM_NOTIFY_BLOCK, HiveList);
+        NextEntry = NextEntry->Flink;
+
+        /* Check if this KCB matches to this NotifyBlock */
+        if (NotifyBlock->KeyControlBlock != Kcb && 
+            !(NotifyBlock->WatchTree && CmpIsKcbSubKey(NotifyBlock->KeyControlBlock, Kcb)))
+            continue;
+
+        /* Check the notification filter */
+        if ((NotifyBlock->Filter & Filter) != Filter) 
+            continue;
+
+        PostListHead = &(NotifyBlock->PostList);
+        if (IsListEmpty(PostListHead))
+        {
+            /* A notification block is allocated but no one is watching, so this is a pending notification */
+            NotifyBlock->NotifyPending = TRUE;
+            continue;
+        }
+        PostNextEntry = PostListHead->Flink;
+        while (PostNextEntry != PostListHead)
+        {
+            PostBlock = CONTAINING_RECORD(PostNextEntry, CMP_POST_BLOCK, NotifyList);
+            PostNextEntry = PostNextEntry->Flink;
+
+            if (PostBlock->IsPrimary)
+            {
+                CmpReportNotifyToPostBlock(PostBlock);
+            }
+            else
+            {
+                /* Prevent system from freeing Primary PostBlock's NotifyBlock by locking its KCB */
+                PCM_KEY_CONTROL_BLOCK PrimaryKcb = PostBlock->PrimaryNotifyBlock->KeyControlBlock;
+                CmpAcquireKcbLockShared(PrimaryKcb);
+
+                CmpReportNotifyToPostBlock(PostBlock->PrimaryPostBlock);
+
+                CmpReleaseKcbLock(PrimaryKcb);
+            }
+        }
+    }
 }
 
 VOID

--- a/ntoskrnl/config/cmsysini.c
+++ b/ntoskrnl/config/cmsysini.c
@@ -177,8 +177,9 @@ CmpCloseKeyObject(IN PEPROCESS Process OPTIONAL,
         /* Don't do anything if we don't have a notify block */
         if (!KeyBody->NotifyBlock) return;
 
-        /* This shouldn't happen yet */
-        ASSERT(FALSE);
+        /* Flush NotifyBlock */
+        CmpFlushNotify(KeyBody, FALSE);
+        ASSERT(KeyBody->NotifyBlock == NULL);
     }
 }
 

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -335,6 +335,39 @@ typedef struct _CM_NOTIFY_BLOCK
 } CM_NOTIFY_BLOCK, *PCM_NOTIFY_BLOCK;
 
 //
+// Post Block
+//
+typedef struct _CMP_POST_BLOCK
+{
+    LIST_ENTRY NotifyList; /* Link to CM_NOTIFY_BLOCK->PostList */
+
+    BOOLEAN IsPrimary;
+    union
+    {
+        /* Fields used by the primary PostBlock to report changes to the notification session */
+        struct
+        {
+            PKEVENT Event;
+            PKAPC UserApc;
+            PWORK_QUEUE_ITEM WorkQueueItem;
+            WORK_QUEUE_TYPE WorkQueueType;
+
+            PCM_NOTIFY_BLOCK SecondaryBlock;
+
+            PKPROCESS OwnerProcess;
+            PIO_STATUS_BLOCK IoStatusBlock;
+        };
+
+        /* Fields used by the secondary PostBlock */
+        struct
+        {
+            PCM_NOTIFY_BLOCK PrimaryNotifyBlock;
+            struct _CMP_POST_BLOCK* PrimaryPostBlock;
+        };
+    };
+} CMP_POST_BLOCK, *PCMP_POST_BLOCK;
+
+//
 // Re-map Block
 //
 typedef struct _CM_CELL_REMAP_BLOCK

--- a/sdk/lib/cmlib/cmlib.h
+++ b/sdk/lib/cmlib/cmlib.h
@@ -214,6 +214,7 @@
 #define TAG_CMHIVE         'vHMC'
 #define TAG_CMSD           'DSMC'
 #define TAG_REGISTRY_STACK 'sRMC'
+#define TAG_CM_NOTIFY      'tNMC'
 
 #define CMAPI NTAPI
 


### PR DESCRIPTION
## Purpose

This PR adds basic support needed to implement `NtNotifyChangeMultipleKeys` to the kernel. This PR shouldn't make any change in any part of ReactOS and its behavior, but it implements the needed kernel-mode functionality to implement `NtNotifyChangeMultipleKeys`.

This is part of https://github.com/reactos/reactos/pull/8848 and https://github.com/reactos/reactos/pull/7914 PRs, third one in a series that re-implements the feature using smaller and easy-to-review PRs.

JIRA issue: [CORE-11865](https://jira.reactos.org/browse/CORE-11865)

## Proposed changes

* Initialize `CMHive->NotifyList`, which is used by `CmpReportNotify` to find `CM_NOTIFY_BLOCK` representing a "change notification session".
* Add a call to `CmpFlushNotify` in `CmpCloseKeyObject` instead of asserting `KeyBody->NotifyBlock == NULL`. 
  * The comment `/* This shouldn't happen yet */` implies that this assertion occurs because the functionality is not implemented yet and the `ASSERT(KeyBody->NotifyBlock == NULL)` implies we need to deallocate the NotifyBlock here before closing the KeyObject.
  * The `CmpFlushNotify` is used to signal all the notification listeners and free any resource used for the notification session.
* A definition of `CMP_POST_BLOCK` 
  * This data type represents a notification listener, waiting for a signal. It holds references to signaling objects like `KEVENT` or `WORK_QUEUE_ITEM` and a caller-allocated buffer containing `IO_STATUS_BLOCK` to be used to return the status code to the caller. 
  * There are two types of `CMP_POST_BLOCK`: the primary type or "Master", the secondary type or "Slave" or "Subordinate"
  *  A secondary PostBlock is allocated when `NtNotifyChangeMultipleKeys` wants to watch for changes in two different keys using the same notification session.
  * A new memory tag `TAG_CM_NOTIFY` is added to `cmlib.h` to track memory allocated for `CM_NOTIFY_BLOCK` and `CMP_POST_BLOCK`
* An implementation of an utility function `CmpIsKcbSubKey`, which verifies if a key is subkey of a parent key in the fastest possible way.
  * This function is needed to determine if a change notification should be sent, when `NotifyBlock->WatchTree` flag is set and a change in a subkey occurred.
* An implementation of an utility function `CmpReportNotifyToPostBlock`
  * This function is called by `CmpReportNotify` on each PostBlock attached to `CM_NOTIFY_BLOCK`s, to report notifications to callers.
* An implementation of `CmpReportNotify`, which is called after any change in the registry, to report the change to the listeners.
* An implementation of `CmpFlushNotify`, which is called when a key object is being released.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: