### PR TITLE
[MSPAINT] Fix Zoom tool

### DIFF
--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -328,9 +328,10 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
     const INT cItems = (INT)_countof(g_zoomPresets);
     for (INT iItem = 0; iItem < cItems; ++iItem)
     {
-        // Fill background
         RECT rc1 = rects[iItem];
         const INT nItemZoom = g_zoomPresets[iItem];
+
+        // Fill background
         HBRUSH hBrush;
         if (nZoom == nItemZoom * DEFAULT_ZOOM)
         {

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -300,6 +300,17 @@ LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, 
     return 0;
 }
 
+LRESULT CToolSettingsWindow::OnNotify(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    NMHDR *pnmhdr = (NMHDR*)lParam;
+    if (pnmhdr->code == NM_CUSTOMDRAW)
+    {
+        NMCUSTOMDRAW *pCustomDraw = (NMCUSTOMDRAW*)pnmhdr;
+        pCustomDraw->uItemState &= ~CDIS_FOCUS; // Do not draw the focus
+    }
+    return 0;
+}
+
 VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
 {
     INT nCount = (LONG)_countof(g_zoomPresets);
@@ -355,17 +366,6 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
 
     SelectObject(hdc, hFontOld);
     DeleteObject(hFont);
-}
-
-LRESULT CToolSettingsWindow::OnNotify(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
-{
-    NMHDR *pnmhdr = (NMHDR*)lParam;
-    if (pnmhdr->code == NM_CUSTOMDRAW)
-    {
-        NMCUSTOMDRAW *pCustomDraw = (NMCUSTOMDRAW*)pnmhdr;
-        pCustomDraw->uItemState &= ~CDIS_FOCUS; // Do not draw the focus
-    }
-    return 0;
 }
 
 VOID CToolSettingsWindow::calculateTwoBoxes(CRect& rect1, CRect& rect2)

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -330,8 +330,9 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
     {
         // Fill background
         RECT rc1 = rects[iItem];
+        const INT nItemZoom = g_zoomPresets[iItem];
         HBRUSH hBrush;
-        if (nZoom == g_zoomPresets[iItem] * DEFAULT_ZOOM)
+        if (nZoom == nItemZoom * DEFAULT_ZOOM)
         {
             FillRect(hdc, &rc1, (HBRUSH)(COLOR_HIGHLIGHT + 1));
             SetTextColor(hdc, GetSysColor(COLOR_HIGHLIGHTTEXT));
@@ -349,17 +350,16 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
         rc1.left = prc->left + cxMargin;
         rc1.right = (prc->left + prc->right) / 2;
         WCHAR text[16];
-        StringCchPrintfW(text, _countof(text), L"%dx", g_zoomPresets[iItem]);
+        StringCchPrintfW(text, _countof(text), L"%dx", nItemZoom);
         DrawTextW(hdc, text, -1, &rc1, DT_SINGLELINE | DT_CENTER | DT_VCENTER);
 
         // Draw dots on right side
         rc1.left = (prc->left + prc->right) / 2;
         rc1.right = prc->right - cxMargin;
         POINT ptCenter = { (rc1.left + rc1.right) / 2, (rc1.top + rc1.bottom) / 2 };
-        const LONG nZoom = g_zoomPresets[iItem];
-        RECT rc2 = { ptCenter.x - nZoom / 2, ptCenter.y - nZoom / 2 };
-        rc2.right = rc2.left + nZoom;
-        rc2.bottom = rc2.top + nZoom;
+        RECT rc2 = { ptCenter.x - nItemZoom / 2, ptCenter.y - nItemZoom / 2 };
+        rc2.right = rc2.left + nItemZoom;
+        rc2.bottom = rc2.top + nItemZoom;
         FillRect(hdc, &rc2, hBrush);
     }
 

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -293,6 +293,13 @@ static inline INT getZoomRects(RECT *rects, LPCRECT prc, LPPOINT ppt = NULL)
     return getSplitRects(rects, 1, (INT)_countof(g_zoomPresets), prc, ppt);
 }
 
+LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    ::DestroyIcon(m_hNontranspIcon);
+    ::DestroyIcon(m_hTranspIcon);
+    return 0;
+}
+
 VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
 {
     INT nCount = (LONG)_countof(g_zoomPresets);
@@ -348,13 +355,6 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
 
     SelectObject(hdc, hFontOld);
     DeleteObject(hFont);
-}
-
-LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
-{
-    ::DestroyIcon(m_hNontranspIcon);
-    ::DestroyIcon(m_hTranspIcon);
-    return 0;
 }
 
 LRESULT CToolSettingsWindow::OnNotify(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -4,7 +4,7 @@
  * PURPOSE:    Window procedure of the tool settings window
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
  *             Copyright 2018 Stanislav Motylkov <x86corez@gmail.com>
- *             Copyright 2021-2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *             Copyright 2021-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include "precomp.h"
@@ -19,11 +19,10 @@
 #define MARGIN1 3
 #define MARGIN2 2
 
-#define MAX_ZOOM_TRACK 6
-#define MIN_ZOOM_TRACK 0
-#define DEFAULT_ZOOM_TRACK 3
-
 static const BYTE s_AirRadius[4] = { 5, 8, 3, 12 };
+static const INT g_zoomPresets[] = { 1, 2, 6, 8 };
+static const PCWSTR g_zoomStrings[] = { L"1x", L"2x", L"6x", L"8x" };
+C_ASSERT(_countof(g_zoomPresets) == _countof(g_zoomStrings));
 
 CToolSettingsWindow toolSettingsWindow;
 
@@ -286,40 +285,73 @@ LRESULT CToolSettingsWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, B
                                          IMAGE_ICON, CX_TRANS_ICON, CY_TRANS_ICON, LR_DEFAULTCOLOR);
     m_hTranspIcon = (HICON)LoadImageW(g_hinstExe, MAKEINTRESOURCEW(IDI_TRANSPARENT),
                                       IMAGE_ICON, CX_TRANS_ICON, CY_TRANS_ICON, LR_DEFAULTCOLOR);
-
-    CRect trackbarZoomPos, rect2;
-    calculateTwoBoxes(trackbarZoomPos, rect2);
-    trackbarZoomPos.InflateRect(-1, -1);
-
-    trackbarZoom.Create(TRACKBAR_CLASS, m_hWnd, trackbarZoomPos, NULL, WS_CHILD | TBS_VERT | TBS_AUTOTICKS);
-    trackbarZoom.SendMessage(TBM_SETRANGE, TRUE, MAKELPARAM(MIN_ZOOM_TRACK, MAX_ZOOM_TRACK));
-    trackbarZoom.SendMessage(TBM_SETPOS, TRUE, DEFAULT_ZOOM_TRACK);
     return 0;
+}
+
+static inline INT getZoomRects(RECT *rects, LPCRECT prc, LPPOINT ppt = NULL)
+{
+    return getSplitRects(rects, 1, (INT)_countof(g_zoomPresets), prc, ppt);
+}
+
+VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
+{
+    INT nCount = (LONG)_countof(g_zoomPresets);
+
+    RECT rects[_countof(g_zoomPresets)];
+    getZoomRects(rects, prc);
+    LONG cx = (rects[0].right - rects[0].left);
+    LONG dy = (rects[0].bottom - rects[0].top);
+
+    // Create and select font
+    LOGFONTW lf;
+    ZeroMemory(&lf, sizeof(lf));
+    lf.lfHeight = dy * 9 / 10;
+    lf.lfQuality = NONANTIALIASED_QUALITY;
+    lstrcpynW(lf.lfFaceName, L"MS Shell Dlg", _countof(lf.lfFaceName));
+    HFONT hFont = CreateFontIndirectW(&lf);
+    HGDIOBJ hFontOld = SelectObject(hdc, hFont);
+
+    for (LONG iItem = 0, y = 0; iItem < nCount; (y += dy), ++iItem)
+    {
+        // Fill background
+        RECT rc1 = rects[iItem];
+        HBRUSH hBrush;
+        if (nZoom == g_zoomPresets[iItem] * DEFAULT_ZOOM)
+        {
+            FillRect(hdc, &rc1, (HBRUSH)(COLOR_HIGHLIGHT + 1));
+            SetTextColor(hdc, GetSysColor(COLOR_HIGHLIGHTTEXT));
+            hBrush = (HBRUSH)(COLOR_HIGHLIGHTTEXT + 1);
+        }
+        else
+        {
+            FillRect(hdc, &rc1, (HBRUSH)(COLOR_3DFACE + 1));
+            SetTextColor(hdc, GetSysColor(COLOR_WINDOWTEXT));
+            hBrush = (HBRUSH)(COLOR_WINDOWTEXT + 1);
+        }
+
+        // Draw "x1", "x2" etc. on left side
+        SetBkMode(hdc, TRANSPARENT);
+        rc1.right = rc1.left + cx / 2;
+        DrawTextW(hdc, g_zoomStrings[iItem], -1, &rc1, DT_SINGLELINE | DT_CENTER | DT_VCENTER);
+
+        // Draw dots on right side
+        rc1.left = prc->left + cx / 2;
+        rc1.right = prc->left + cx;
+        POINT ptCenter = { (rc1.left + rc1.right) / 2, (rc1.top + rc1.bottom) / 2 };
+        RECT rc2 = { ptCenter.x - g_zoomPresets[iItem] / 2, ptCenter.y - g_zoomPresets[iItem] / 2 };
+        rc2.right = rc2.left + g_zoomPresets[iItem];
+        rc2.bottom = rc2.top + g_zoomPresets[iItem];
+        FillRect(hdc, &rc2, hBrush);
+    }
+
+    SelectObject(hdc, hFontOld);
+    DeleteObject(hFont);
 }
 
 LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     ::DestroyIcon(m_hNontranspIcon);
     ::DestroyIcon(m_hTranspIcon);
-    return 0;
-}
-
-LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
-{
-    INT trackPos = MAX_ZOOM_TRACK - (INT)trackbarZoom.SendMessage(TBM_GETPOS, 0, 0);
-    canvasWindow.zoomTo(MIN_ZOOM << trackPos);
-
-    INT zoomRate = toolsModel.GetZoom();
-
-    CStringW strZoom;
-    if (zoomRate % 10 == 0)
-        strZoom.Format(L"%d%%", zoomRate / 10);
-    else
-        strZoom.Format(L"%d.%d%%", zoomRate / 10, zoomRate % 10);
-
-    ::SendMessageW(g_hStatusBar, SB_SETTEXT, 1, (LPARAM)(LPCWSTR)strZoom);
-
-    OnToolsModelZoomChanged(nMsg, wParam, lParam, bHandled);
     return 0;
 }
 
@@ -356,8 +388,7 @@ LRESULT CToolSettingsWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
     PAINTSTRUCT ps;
     HDC hdc = BeginPaint(&ps);
 
-    if (toolsModel.GetActiveTool() != TOOL_ZOOM)
-        ::DrawEdge(hdc, &rect1, BDR_SUNKENOUTER, BF_RECT | BF_MIDDLE);
+    ::DrawEdge(hdc, &rect1, BDR_SUNKENOUTER, BF_RECT | BF_MIDDLE);
 
     if (toolsModel.GetActiveTool() >= TOOL_RECT)
         ::DrawEdge(hdc, &rect2, BDR_SUNKENOUTER, BF_RECT | BF_MIDDLE);
@@ -399,8 +430,10 @@ LRESULT CToolSettingsWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
                 DeleteObject(hbr);
             }
             break;
-        case TOOL_FILL:
         case TOOL_ZOOM:
+            drawZoom(hdc, &rect1, toolsModel.GetZoom());
+            break;
+        case TOOL_FILL:
         case TOOL_PEN:
             break;
     }
@@ -463,9 +496,16 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
             if (iItem != -1)
                 toolsModel.SetLineWidth(iItem + 1);
             break;
+        case TOOL_ZOOM:
+            iItem = getZoomRects(rects, &rect1, &pt);
+            if (0 <= iItem && iItem < _countof(g_zoomPresets))
+            {
+                toolsModel.SetZoom(g_zoomPresets[iItem] * DEFAULT_ZOOM);
+                toolsModel.SetActiveTool(toolsModel.GetOldActiveTool());
+            }
+            break;
         case TOOL_FILL:
         case TOOL_COLOR:
-        case TOOL_ZOOM:
         case TOOL_PEN:
             break;
     }
@@ -478,7 +518,6 @@ LRESULT CToolSettingsWindow::OnToolsModelToolChanged(UINT nMsg, WPARAM wParam, L
 {
     m_rgbPickColor = CLR_INVALID;
     Invalidate();
-    trackbarZoom.ShowWindow((wParam == TOOL_ZOOM) ? SW_SHOW : SW_HIDE);
     return 0;
 }
 
@@ -497,15 +536,6 @@ LRESULT CToolSettingsWindow::OnToolsModelColorPicked(UINT nMsg, WPARAM wParam, L
 
 LRESULT CToolSettingsWindow::OnToolsModelZoomChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    int tbPos = MIN_ZOOM_TRACK;
-    int tempZoom = toolsModel.GetZoom();
-
-    while (tempZoom > MIN_ZOOM)
-    {
-        tbPos++;
-        tempZoom = tempZoom >> 1;
-    }
-
-    trackbarZoom.SendMessage(TBM_SETPOS, TRUE, MAX_ZOOM_TRACK - tbPos);
+    Invalidate();
     return 0;
 }

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -237,6 +237,11 @@ static inline INT getBoxRects(RECT rects[3], LPCRECT prc, LPPOINT ppt = NULL)
     return getSplitRects(rects, 1, 3, prc, ppt);
 }
 
+static inline INT getZoomRects(RECT *rects, LPCRECT prc, LPPOINT ppt = NULL)
+{
+    return getSplitRects(rects, 1, (INT)_countof(g_zoomPresets), prc, ppt);
+}
+
 VOID CToolSettingsWindow::drawBox(HDC hdc, LPCRECT prc)
 {
     CRect rects[3];
@@ -286,11 +291,6 @@ LRESULT CToolSettingsWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, B
     m_hTranspIcon = (HICON)LoadImageW(g_hinstExe, MAKEINTRESOURCEW(IDI_TRANSPARENT),
                                       IMAGE_ICON, CX_TRANS_ICON, CY_TRANS_ICON, LR_DEFAULTCOLOR);
     return 0;
-}
-
-static inline INT getZoomRects(RECT *rects, LPCRECT prc, LPPOINT ppt = NULL)
-{
-    return getSplitRects(rects, 1, (INT)_countof(g_zoomPresets), prc, ppt);
 }
 
 LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -498,7 +498,7 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
             break;
         case TOOL_ZOOM:
             iItem = getZoomRects(rects, &rect1, &pt);
-            if (0 <= iItem && iItem < _countof(g_zoomPresets))
+            if (0 <= iItem && iItem < (INT)_countof(g_zoomPresets))
             {
                 toolsModel.SetZoom(g_zoomPresets[iItem] * DEFAULT_ZOOM);
                 toolsModel.SetActiveTool(toolsModel.GetOldActiveTool());

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -21,8 +21,6 @@
 
 static const BYTE s_AirRadius[4] = { 5, 8, 3, 12 };
 static const INT g_zoomPresets[] = { 1, 2, 6, 8 };
-static const PCWSTR g_zoomStrings[] = { L"1x", L"2x", L"6x", L"8x" };
-C_ASSERT(_countof(g_zoomPresets) == _countof(g_zoomStrings));
 
 CToolSettingsWindow toolSettingsWindow;
 
@@ -348,12 +346,14 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
 
         // Draw "x1", "x2" etc. on left side
         SetBkMode(hdc, TRANSPARENT);
-        rc1.left += cxMargin;
-        rc1.right = (rc1.left + rc1.right) / 2;
-        DrawTextW(hdc, g_zoomStrings[iItem], -1, &rc1, DT_SINGLELINE | DT_CENTER | DT_VCENTER);
+        rc1.left = prc->left + cxMargin;
+        rc1.right = (prc->left + prc->right) / 2;
+        WCHAR text[8];
+        StringCchPrintfW(text, _countof(text), L"x%d", g_zoomPresets[iItem]);
+        DrawTextW(hdc, text, -1, &rc1, DT_SINGLELINE | DT_CENTER | DT_VCENTER);
 
         // Draw dots on right side
-        rc1.left = (rc1.left + rc1.right) / 2;
+        rc1.left = (prc->left + prc->right) / 2;
         rc1.right = prc->right - cxMargin;
         POINT ptCenter = { (rc1.left + rc1.right) / 2, (rc1.top + rc1.bottom) / 2 };
         const LONG nZoom = g_zoomPresets[iItem];

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -299,19 +299,20 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
 
     RECT rects[_countof(g_zoomPresets)];
     getZoomRects(rects, prc);
-    LONG cx = (rects[0].right - rects[0].left);
-    LONG dy = (rects[0].bottom - rects[0].top);
+    LONG cx = rects[0].right - rects[0].left;
+    LONG cyItem = rects[0].bottom - rects[0].top;
+    const LONG cxMargin = 3;
 
     // Create and select font
     LOGFONTW lf;
     ZeroMemory(&lf, sizeof(lf));
-    lf.lfHeight = dy * 9 / 10;
+    lf.lfHeight = -(cyItem - 2);
     lf.lfQuality = NONANTIALIASED_QUALITY;
     lstrcpynW(lf.lfFaceName, L"MS Shell Dlg", _countof(lf.lfFaceName));
     HFONT hFont = CreateFontIndirectW(&lf);
     HGDIOBJ hFontOld = SelectObject(hdc, hFont);
 
-    for (LONG iItem = 0, y = 0; iItem < nCount; (y += dy), ++iItem)
+    for (LONG iItem = 0, y = 0; iItem < nCount; (y += cyItem), ++iItem)
     {
         // Fill background
         RECT rc1 = rects[iItem];
@@ -331,12 +332,13 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
 
         // Draw "x1", "x2" etc. on left side
         SetBkMode(hdc, TRANSPARENT);
+        rc1.left += cxMargin;
         rc1.right = rc1.left + cx / 2;
         DrawTextW(hdc, g_zoomStrings[iItem], -1, &rc1, DT_SINGLELINE | DT_CENTER | DT_VCENTER);
 
         // Draw dots on right side
         rc1.left = prc->left + cx / 2;
-        rc1.right = prc->left + cx;
+        rc1.right = prc->left + cx - cxMargin;
         POINT ptCenter = { (rc1.left + rc1.right) / 2, (rc1.top + rc1.bottom) / 2 };
         RECT rc2 = { ptCenter.x - g_zoomPresets[iItem] / 2, ptCenter.y - g_zoomPresets[iItem] / 2 };
         rc2.right = rc2.left + g_zoomPresets[iItem];

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -344,12 +344,12 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
             hBrush = (HBRUSH)(COLOR_WINDOWTEXT + 1);
         }
 
-        // Draw "x1", "x2" etc. on left side
+        // Draw "1x", "2x" etc. on left side
         SetBkMode(hdc, TRANSPARENT);
         rc1.left = prc->left + cxMargin;
         rc1.right = (prc->left + prc->right) / 2;
-        WCHAR text[8];
-        StringCchPrintfW(text, _countof(text), L"x%d", g_zoomPresets[iItem]);
+        WCHAR text[16];
+        StringCchPrintfW(text, _countof(text), L"%dx", g_zoomPresets[iItem]);
         DrawTextW(hdc, text, -1, &rc1, DT_SINGLELINE | DT_CENTER | DT_VCENTER);
 
         // Draw dots on right side

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -356,9 +356,10 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
         rc1.left = (rc1.left + rc1.right) / 2;
         rc1.right = prc->right - cxMargin;
         POINT ptCenter = { (rc1.left + rc1.right) / 2, (rc1.top + rc1.bottom) / 2 };
-        RECT rc2 = { ptCenter.x - g_zoomPresets[iItem] / 2, ptCenter.y - g_zoomPresets[iItem] / 2 };
-        rc2.right = rc2.left + g_zoomPresets[iItem];
-        rc2.bottom = rc2.top + g_zoomPresets[iItem];
+        const LONG nZoom = g_zoomPresets[iItem];
+        RECT rc2 = { ptCenter.x - nZoom / 2, ptCenter.y - nZoom / 2 };
+        rc2.right = rc2.left + nZoom;
+        rc2.bottom = rc2.top + nZoom;
         FillRect(hdc, &rc2, hBrush);
     }
 

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -502,8 +502,16 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
             iItem = getZoomRects(rects, &rect1, &pt);
             if (0 <= iItem && iItem < (INT)_countof(g_zoomPresets))
             {
-                toolsModel.SetZoom(g_zoomPresets[iItem] * DEFAULT_ZOOM);
+                INT zoomRatio = g_zoomPresets[iItem] * DEFAULT_ZOOM;
+                toolsModel.SetZoom(zoomRatio);
                 toolsModel.SetActiveTool(toolsModel.GetOldActiveTool());
+
+                CStringW strZoom;
+                if (zoomRatio % 10 == 0)
+                    strZoom.Format(L"%d%%", zoomRatio / 10);
+                else
+                    strZoom.Format(L"%d.%d%%", zoomRatio / 10, zoomRatio % 10);
+                ::SendMessageW(g_hStatusBar, SB_SETTEXT, 1, (LPARAM)(PCWSTR)strZoom);
             }
             break;
         case TOOL_FILL:

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -313,24 +313,22 @@ LRESULT CToolSettingsWindow::OnNotify(UINT nMsg, WPARAM wParam, LPARAM lParam, B
 
 VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
 {
-    const LONG cItems = (LONG)_countof(g_zoomPresets);
-
     RECT rects[_countof(g_zoomPresets)];
     getZoomRects(rects, prc);
-    LONG cx = rects[0].right - rects[0].left;
-    LONG cyItem = rects[0].bottom - rects[0].top;
-    const LONG cxMargin = 3;
 
     // Create and select font
     LOGFONTW lf;
     ZeroMemory(&lf, sizeof(lf));
+    LONG cyItem = rects[0].bottom - rects[0].top;
     lf.lfHeight = -(cyItem - 2);
     lf.lfQuality = NONANTIALIASED_QUALITY;
     lstrcpynW(lf.lfFaceName, L"MS Shell Dlg", _countof(lf.lfFaceName));
     HFONT hFont = CreateFontIndirectW(&lf);
     HGDIOBJ hFontOld = SelectObject(hdc, hFont);
 
-    for (LONG iItem = 0, y = 0; iItem < cItems; (y += cyItem), ++iItem)
+    const LONG cxMargin = 3;
+    const INT cItems = (INT)_countof(g_zoomPresets);
+    for (INT iItem = 0; iItem < cItems; ++iItem)
     {
         // Fill background
         RECT rc1 = rects[iItem];
@@ -351,12 +349,12 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
         // Draw "x1", "x2" etc. on left side
         SetBkMode(hdc, TRANSPARENT);
         rc1.left += cxMargin;
-        rc1.right = rc1.left + cx / 2;
+        rc1.right = (rc1.left + rc1.right) / 2;
         DrawTextW(hdc, g_zoomStrings[iItem], -1, &rc1, DT_SINGLELINE | DT_CENTER | DT_VCENTER);
 
         // Draw dots on right side
-        rc1.left = prc->left + cx / 2;
-        rc1.right = prc->left + cx - cxMargin;
+        rc1.left = (rc1.left + rc1.right) / 2;
+        rc1.right = prc->right - cxMargin;
         POINT ptCenter = { (rc1.left + rc1.right) / 2, (rc1.top + rc1.bottom) / 2 };
         RECT rc2 = { ptCenter.x - g_zoomPresets[iItem] / 2, ptCenter.y - g_zoomPresets[iItem] / 2 };
         rc2.right = rc2.left + g_zoomPresets[iItem];

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -313,7 +313,7 @@ LRESULT CToolSettingsWindow::OnNotify(UINT nMsg, WPARAM wParam, LPARAM lParam, B
 
 VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
 {
-    INT nCount = (LONG)_countof(g_zoomPresets);
+    const LONG cItems = (LONG)_countof(g_zoomPresets);
 
     RECT rects[_countof(g_zoomPresets)];
     getZoomRects(rects, prc);
@@ -330,7 +330,7 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
     HFONT hFont = CreateFontIndirectW(&lf);
     HGDIOBJ hFontOld = SelectObject(hdc, hFont);
 
-    for (LONG iItem = 0, y = 0; iItem < nCount; (y += cyItem), ++iItem)
+    for (LONG iItem = 0, y = 0; iItem < cItems; (y += cyItem), ++iItem)
     {
         // Fill background
         RECT rc1 = rects[iItem];

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -320,7 +320,7 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
     LONG cyItem = rects[0].bottom - rects[0].top;
     lf.lfHeight = -(cyItem - 2);
     lf.lfQuality = NONANTIALIASED_QUALITY;
-    lstrcpynW(lf.lfFaceName, L"MS Shell Dlg", _countof(lf.lfFaceName));
+    StringCchCopyW(lf.lfFaceName, _countof(lf.lfFaceName), L"MS Shell Dlg");
     HFONT hFont = CreateFontIndirectW(&lf);
     HGDIOBJ hFontOld = SelectObject(hdc, hFont);
 

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -504,13 +504,6 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
                 INT zoomRatio = g_zoomPresets[iItem] * DEFAULT_ZOOM;
                 toolsModel.SetZoom(zoomRatio);
                 toolsModel.SetActiveTool(toolsModel.GetOldActiveTool());
-
-                CStringW strZoom;
-                if (zoomRatio % 10 == 0)
-                    strZoom.Format(L"%d%%", zoomRatio / 10);
-                else
-                    strZoom.Format(L"%d.%d%%", zoomRatio / 10, zoomRatio % 10);
-                ::SendMessageW(g_hStatusBar, SB_SETTEXT, 1, (LPARAM)(PCWSTR)strZoom);
             }
             break;
         case TOOL_FILL:

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -343,7 +343,7 @@ VOID CToolSettingsWindow::drawZoom(HDC hdc, LPCRECT prc, INT nZoom)
         }
         else
         {
-            FillRect(hdc, &rc1, (HBRUSH)(COLOR_3DFACE + 1));
+            FillRect(hdc, &rc1, (HBRUSH)(COLOR_WINDOW + 1));
             SetTextColor(hdc, GetSysColor(COLOR_WINDOWTEXT));
             hBrush = (HBRUSH)(COLOR_WINDOWTEXT + 1);
         }

--- a/base/applications/mspaint/toolsettings.h
+++ b/base/applications/mspaint/toolsettings.h
@@ -14,7 +14,6 @@ public:
 
     BEGIN_MSG_MAP(CToolSettingsWindow)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)
-        MESSAGE_HANDLER(WM_VSCROLL, OnVScroll)
         MESSAGE_HANDLER(WM_PAINT, OnPaint)
         MESSAGE_HANDLER(WM_LBUTTONDOWN, OnLButtonDown)
         MESSAGE_HANDLER(WM_NOTIFY, OnNotify)
@@ -28,7 +27,6 @@ public:
     BOOL DoCreate(HWND hwndParent);
 
 private:
-    CWindow trackbarZoom;
     HICON m_hNontranspIcon;
     HICON m_hTranspIcon;
     COLORREF m_rgbPickColor = CLR_INVALID;
@@ -39,11 +37,11 @@ private:
     VOID drawLine(HDC hdc, LPCRECT prc);
     VOID drawBox(HDC hdc, LPCRECT prc);
     VOID drawAirBrush(HDC hdc, LPCRECT prc);
+    VOID drawZoom(HDC hdc, LPCRECT prc, INT nZoom);
     VOID calculateTwoBoxes(CRect& rect1, CRect& rect2);
 
     LRESULT OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
-    LRESULT OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnNotify(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -275,6 +275,7 @@ int ToolsModel::GetZoom() const
 void ToolsModel::SetZoom(int nZoom)
 {
     m_zoom = nZoom;
+
     NotifyZoomChanged();
     SendSetCursor();
 }
@@ -307,6 +308,13 @@ void ToolsModel::NotifyZoomChanged()
         textEditWindow.SendMessage(WM_TOOLSMODELZOOMCHANGED);
     if (canvasWindow.IsWindow())
         canvasWindow.SendMessage(WM_TOOLSMODELZOOMCHANGED);
+
+    CStringW strZoom;
+    if (m_zoom % 10 == 0)
+        strZoom.Format(L"%d%%", m_zoom / 10);
+    else
+        strZoom.Format(L"%d.%d%%", m_zoom / 10, m_zoom % 10);
+    ::SendMessageW(g_hStatusBar, SB_SETTEXT, 2, (LPARAM)(PCWSTR)strZoom);
 }
 
 void ToolsModel::resetTool()

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -275,7 +275,6 @@ int ToolsModel::GetZoom() const
 void ToolsModel::SetZoom(int nZoom)
 {
     m_zoom = nZoom;
-
     NotifyZoomChanged();
     SendSetCursor();
 }


### PR DESCRIPTION
## Purpose
The behavior of Zoom tool (magnifying glass) was different from that of Windows Paint.

JIRA issue: [CORE-19466](https://jira.reactos.org/browse/CORE-19466)

## Proposed changes

- Remove Slider (Trackbar) control from the tool settings window.
- Draw the zoom options (`1x`, `2x`, `6x`, and `8x`) in the tool settings window.
- Allow the user to choose a zoom option by clicking.
- Set status bar text on `ToolsModel::NotifyZoomChanged`.

## Comparison

Windows:
<img width="189" height="253" alt="Win2k3" src="https://github.com/user-attachments/assets/24009d76-5489-4976-9c1f-255a149b1db1" />

ReactOS (BEFORE):
<img width="640" height="480" alt="before" src="https://github.com/user-attachments/assets/0ac59e91-50a7-4c29-9522-66ecf7356961" />

ReactOS (AFTER):
<img width="640" height="480" alt="after" src="https://github.com/user-attachments/assets/f9f08656-fe06-48df-b151-5b347fbf8921" />

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: