### PR TITLE
[NTOS:CM] Detect NEC PC-98 alternative system architecture dynamically

### DIFF
--- a/ntoskrnl/config/cmconfig.c
+++ b/ntoskrnl/config/cmconfig.c
@@ -411,7 +411,7 @@ CmpInitializeHardwareConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
             {
                 /* Running on a NEC PC-9800 or compatible */
                 KeI386MachineType |= 0x100; /* Should probably be one of MACHINE_TYPE_* consts */
-                SharedUserData->AlternativeArchitecture = NEC98x86;
+                SetNEC_98;
             }
         }
 #endif

--- a/ntoskrnl/config/cmconfig.c
+++ b/ntoskrnl/config/cmconfig.c
@@ -411,7 +411,7 @@ CmpInitializeHardwareConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
             {
                 /* Running on a NEC PC-9800 or compatible */
                 KeI386MachineType |= 0x100; /* Should probably be one of MACHINE_TYPE_* consts */
-                SetNEC_98;
+                SharedUserData->AlternativeArchitecture = NEC98x86;
             }
         }
 #endif

--- a/ntoskrnl/config/cmconfig.c
+++ b/ntoskrnl/config/cmconfig.c
@@ -334,11 +334,6 @@ CmpInitializeHardwareConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     ULONG Disposition;
     UNICODE_STRING KeyName;
 
-    /* Set the alternative system architecture information */
-#if defined(SARCH_PC98)
-    SharedUserData->AlternativeArchitecture = NEC98x86;
-#endif
-
     /* Setup the key name */
     RtlInitUnicodeString(&KeyName,
                          L"\\Registry\\Machine\\Hardware\\DeviceMap");
@@ -399,6 +394,30 @@ CmpInitializeHardwareConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     /* Check if we got anything from NTLDR */
     if (LoaderBlock->ConfigurationRoot)
     {
+#ifdef _M_IX86
+        /* Set the alternative system architecture information */
+        const CHAR SystemId_PC98[] = "NEC PC-98";
+
+        PCONFIGURATION_COMPONENT_DATA ConfigData;
+        ConfigData = KeFindConfigurationEntry(LoaderBlock->ConfigurationRoot,
+                                              SystemClass,
+                                              MaximumType,
+                                              NULL);
+        if (ConfigData)
+        {
+            /* Check if the system identifier starts with a known string.
+             * Set kernel flags and initialize variables accordingly. */
+            if (RtlCompareMemory(ConfigData->ComponentEntry.Identifier,
+                                 SystemId_PC98,
+                                 sizeof(SystemId_PC98) - 1) == sizeof(SystemId_PC98) - 1)
+            {
+                /* Running on a NEC PC-9800 or compatible */
+                KeI386MachineType |= 0x100; /* Should probably be one of MACHINE_TYPE_* consts */
+                SharedUserData->AlternativeArchitecture = NEC98x86;
+            }
+        }
+#endif
+
         /* Setup the configuration tree */
         Status = CmpSetupConfigurationTree(LoaderBlock->ConfigurationRoot,
                                            KeyHandle,

--- a/ntoskrnl/config/cmconfig.c
+++ b/ntoskrnl/config/cmconfig.c
@@ -395,10 +395,8 @@ CmpInitializeHardwareConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     if (LoaderBlock->ConfigurationRoot)
     {
 #ifdef _M_IX86
-        /* Set the alternative system architecture information */
-        const CHAR SystemId_PC98[] = "NEC PC-98";
-
         PCONFIGURATION_COMPONENT_DATA ConfigData;
+        
         ConfigData = KeFindConfigurationEntry(LoaderBlock->ConfigurationRoot,
                                               SystemClass,
                                               MaximumType,
@@ -407,9 +405,9 @@ CmpInitializeHardwareConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
         {
             /* Check if the system identifier starts with a known string.
              * Set kernel flags and initialize variables accordingly. */
-            if (RtlCompareMemory(ConfigData->ComponentEntry.Identifier,
-                                 SystemId_PC98,
-                                 sizeof(SystemId_PC98) - 1) == sizeof(SystemId_PC98) - 1)
+            if (!strncmp(ConfigData->ComponentEntry.Identifier,
+                         "NEC PC-98",
+                         sizeof("NEC PC-98") - 1))
             {
                 /* Running on a NEC PC-9800 or compatible */
                 KeI386MachineType |= 0x100; /* Should probably be one of MACHINE_TYPE_* consts */

--- a/ntoskrnl/include/internal/i386/ke.h
+++ b/ntoskrnl/include/internal/i386/ke.h
@@ -732,6 +732,7 @@ extern ULONG KeI386FxsrPresent;
 extern ULONG KiMXCsrMask;
 extern ULONG KeI386CpuType;
 extern ULONG KeI386CpuStep;
+extern ULONG KeI386MachineType;
 extern ULONG KiFastSystemCallDisable;
 extern UCHAR KiDebugRegisterTrapOffsets[9];
 extern UCHAR KiDebugRegisterContextOffsets[9];


### PR DESCRIPTION
Perform detection by matching system identifier passed from the loader block, similarly to how FreeLoader detects the boot video driver: https://github.com/reactos/reactos/blob/332331ce1b7a71b0227b9ec3d4449272b28a84f6/boot/freeldr/freeldr/ntldr/winldr.c#L653

Windows checks if the identifier starts with a known string and then sets additional flags for the drivers.

Follow up of commit 8df1b535080 (PR #5136).

JIRA issue: [CORE-17977](https://jira.reactos.org/browse/CORE-17977)

## Testbot runs

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108561,108563
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108562,108564