### PR TITLE
[SHCORE] IsOS(OS_XPORGREATER) should return TRUE on 6.0+

### DIFF
--- a/dll/win32/shcore/main.c
+++ b/dll/win32/shcore/main.c
@@ -2464,7 +2464,11 @@ BOOL WINAPI IsOS(DWORD feature)
     case OS_MEORGREATER:
         ISOS_RETURN(platform == VER_PLATFORM_WIN32_WINDOWS && minorv >= 90);
     case OS_XPORGREATER:
+#ifdef __REACTOS__
+        ISOS_RETURN(platform == VER_PLATFORM_WIN32_NT && ((majorv >= 5 && minorv >= 1) || majorv >= 6));
+#else
         ISOS_RETURN(platform == VER_PLATFORM_WIN32_NT && majorv >= 5 && minorv >= 1);
+#endif /* __REACTOS__ */
     case OS_HOME:
         ISOS_RETURN(platform == VER_PLATFORM_WIN32_NT && majorv >= 5 && minorv >= 1);
     case OS_PROFESSIONAL:

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND SOURCE
     AssocQueryString.c
     CharUpperNoDBCS.cpp
     IShellFolderHelpers.cpp
+    IsOS.c
     IsQSForward.cpp
     IStreamPidl.cpp
     MapWin32ErrorToSTG.c

--- a/modules/rostests/apitests/shlwapi/IsOS.c
+++ b/modules/rostests/apitests/shlwapi/IsOS.c
@@ -1,0 +1,76 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for IsOS
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include <apitest.h>
+#include <shlwapi.h>
+#include <versionhelpers.h>
+
+#ifndef OS_WIN32SORGREATER
+#define OS_WIN32SORGREATER 0x00
+#endif
+
+typedef struct
+{
+    DWORD Value;
+    PCSTR Name;
+} ISOS_ENTRY;
+
+typedef BOOL (WINAPI *PFNISOS)(DWORD);
+
+START_TEST(IsOS)
+{
+    HMODULE hShlwapi;
+    PFNISOS pIsOS;
+    size_t i;
+
+#define ISOS_ENTRY_LEVEL(level) { level, #level }
+    const ISOS_ENTRY FALSE_OS_Levels[] =
+    {
+        ISOS_ENTRY_LEVEL(OS_WIN32SORGREATER),
+        ISOS_ENTRY_LEVEL(OS_WIN95ORGREATER),
+        ISOS_ENTRY_LEVEL(OS_WIN98ORGREATER),
+        ISOS_ENTRY_LEVEL(OS_MEORGREATER),
+        ISOS_ENTRY_LEVEL(OS_WIN95_GOLD),
+        ISOS_ENTRY_LEVEL(OS_WIN98_GOLD),
+    };
+
+    const ISOS_ENTRY TRUE_OS_Levels[] =
+    {
+        ISOS_ENTRY_LEVEL(OS_NT),
+        ISOS_ENTRY_LEVEL(OS_NT4ORGREATER),
+        ISOS_ENTRY_LEVEL(OS_WIN2000ORGREATER),
+        ISOS_ENTRY_LEVEL(OS_XPORGREATER),
+        ISOS_ENTRY_LEVEL(OS_FASTUSERSWITCHING),
+    };
+#undef ISOS_ENTRY_LEVEL
+
+    hShlwapi = GetModuleHandleW(L"shlwapi.dll");
+    if (!hShlwapi)
+    {
+        skip(FALSE, "shlwapi.dll is not available\n");
+        return;
+    }
+
+    pIsOS = (PFNISOS)GetProcAddress(hShlwapi, "IsOS");
+    if (!pIsOS && !IsWindowsVistaOrGreater())
+        pIsOS = (PFNISOS)GetProcAddress(hShlwapi, (LPCSTR)437);
+    if (!pIsOS)
+    {
+        skip(FALSE, "IsOS is not available\n");
+        return;
+    }
+
+    for (i = 0; i < _countof(FALSE_OS_Levels); i++)
+    {
+        ok(pIsOS(FALSE_OS_Levels[i].Value) == FALSE, "Expected IsOS(%s) to return FALSE, got TRUE\n", FALSE_OS_Levels[i].Name);
+    }
+
+    for (i = 0; i < _countof(TRUE_OS_Levels); i++)
+    {
+        ok(pIsOS(TRUE_OS_Levels[i].Value) == TRUE, "Expected IsOS(%s) to return TRUE, got FALSE\n", TRUE_OS_Levels[i].Name);
+    }
+}

--- a/modules/rostests/apitests/shlwapi/testlist.c
+++ b/modules/rostests/apitests/shlwapi/testlist.c
@@ -4,13 +4,14 @@
 extern void func_AssocQueryKey(void);
 extern void func_AssocQueryString(void);
 extern void func_CharUpperNoDBCS(void);
-extern void func_PathFileExistsDefExtAndAttributesW(void);
-extern void func_PathFindOnPath(void);
 extern void func_IShellFolderHelpers(void);
+extern void func_IsOS(void);
 extern void func_IsQSForward(void);
 extern void func_IStreamPidl(void);
-extern void func_MapWin32ErrorToSTG(void); 
+extern void func_MapWin32ErrorToSTG(void);
 extern void func_NextPath(void);
+extern void func_PathFileExistsDefExtAndAttributesW(void);
+extern void func_PathFindOnPath(void);
 extern void func_PathIsUNC(void);
 extern void func_PathIsUNCServer(void);
 extern void func_PathIsUNCServerShare(void);
@@ -33,13 +34,14 @@ const struct test winetest_testlist[] =
     { "AssocQueryKey", func_AssocQueryKey },
     { "AssocQueryString", func_AssocQueryString },
     { "CharUpperNoDBCS", func_CharUpperNoDBCS },
-    { "PathFileExistsDefExtAndAttributesW", func_PathFileExistsDefExtAndAttributesW },
-    { "PathFindOnPath", func_PathFindOnPath },
     { "IShellFolderHelpers", func_IShellFolderHelpers },
+    { "IsOS", func_IsOS },
     { "IsQSForward", func_IsQSForward },
     { "IStreamPidl", func_IStreamPidl },
     { "MapWin32ErrorToSTG", func_MapWin32ErrorToSTG },
     { "NextPath", func_NextPath },
+    { "PathFileExistsDefExtAndAttributesW", func_PathFileExistsDefExtAndAttributesW },
+    { "PathFindOnPath", func_PathFindOnPath },
     { "PathIsUNC", func_PathIsUNC },
     { "PathIsUNCServer", func_PathIsUNCServer },
     { "PathIsUNCServerShare", func_PathIsUNCServerShare },


### PR DESCRIPTION
## Purpose

Even though the [official documentation](https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-isos) says `IsOS(OS_XPORGREATER)` always returns false, the tests show otherwise and there are app compatibility issues already, so we would need this patch.

JIRA issue: [CORE-20577](https://jira.reactos.org/browse/CORE-20577)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: