### PR TITLE
[RICHED20] Fix crash when calling WM_SETTEXT with lParam=NULL

### DIFF
--- a/dll/win32/riched20/txthost.c
+++ b/dll/win32/riched20/txthost.c
@@ -1457,6 +1457,11 @@ static LRESULT RichEditWndProc_common( HWND hwnd, UINT msg, WPARAM wparam,
         WCHAR *text = (WCHAR *)lparam;
         int len;
 
+#ifdef __REACTOS__
+        if (!lparam || !*text || !*textA)
+            return 0;
+#endif
+
         if (!unicode && textA && strncmp( textA, "{\\rtf", 5 ) && strncmp( textA, "{\\urtf", 6 ))
             text = ME_ToUnicode( CP_ACP, textA, &len );
         hr = ITextServices_TxSendMessage( host->text_srv, msg, wparam, (LPARAM)text, &res );


### PR DESCRIPTION
## Purpose

This PR imports a patch provided by I_Kill_Bugs in https://jira.reactos.org/secure/attachment/71734/71734_richedit.patch

The patch fixes a null-reference exception in WordFlood 2.0 application.

<img width="1058" height="596" alt="image" src="https://github.com/user-attachments/assets/f3bfb376-db40-4871-b834-c71868dfa947" />

JIRA issue: [CORE-20101](https://jira.reactos.org/browse/CORE-20101)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: