### PR TITLE
[RICHED20] Mask out ENM_CHANGE during WM_SETTEXT

### DIFF
--- a/dll/win32/riched20/editor.c
+++ b/dll/win32/riched20/editor.c
@@ -3636,10 +3636,7 @@ LRESULT editor_handle_message( ME_TextEditor *editor, UINT msg, WPARAM wParam,
     ME_Cursor cursor;
 #if __REACTOS__
     int oldEventMask = editor->nEventMask;
-    if (editor->nEventMask & ENM_CHANGE)
-    {
-      editor->nEventMask &= ~ENM_CHANGE;
-    }
+    editor->nEventMask &= ~ENM_CHANGE;
 #endif
     ME_SetCursorToStart(editor, &cursor);
     ME_InternalDeleteText(editor, &cursor, ME_GetTextLength(editor), FALSE);

--- a/dll/win32/riched20/editor.c
+++ b/dll/win32/riched20/editor.c
@@ -3634,7 +3634,7 @@ LRESULT editor_handle_message( ME_TextEditor *editor, UINT msg, WPARAM wParam,
   case WM_SETTEXT:
   {
     ME_Cursor cursor;
-#if __REACTOS__
+#ifdef __REACTOS__
     int oldEventMask = editor->nEventMask;
     editor->nEventMask &= ~ENM_CHANGE;
 #endif

--- a/dll/win32/riched20/editor.c
+++ b/dll/win32/riched20/editor.c
@@ -3634,6 +3634,13 @@ LRESULT editor_handle_message( ME_TextEditor *editor, UINT msg, WPARAM wParam,
   case WM_SETTEXT:
   {
     ME_Cursor cursor;
+#if __REACTOS__
+    int oldEventMask = editor->nEventMask;
+    if (editor->nEventMask & ENM_CHANGE)
+    {
+      editor->nEventMask &= ~ENM_CHANGE;
+    }
+#endif
     ME_SetCursorToStart(editor, &cursor);
     ME_InternalDeleteText(editor, &cursor, ME_GetTextLength(editor), FALSE);
     if (lParam)
@@ -3657,6 +3664,9 @@ LRESULT editor_handle_message( ME_TextEditor *editor, UINT msg, WPARAM wParam,
     ME_CommitUndo(editor);
     ME_EmptyUndoStack(editor);
     ME_UpdateRepaint(editor, FALSE);
+#ifdef __REACTOS__
+    editor->nEventMask = oldEventMask;
+#endif
     return 1;
   }
   case EM_CANPASTE:


### PR DESCRIPTION
## Purpose

According to documentations (https://learn.microsoft.com/en-us/windows/win32/controls/en-change#remarks) the `EN_CHANGE` notification is not sent when the text is changed through `WM_SETTEXT`.
The current RICHED20 implementation doesn't respect this specification, causing compatibility issues and making apps like Word Flood 2.0 crash. The patch provided by this PR fixes this issue by preventing RICHED20 from sending `EN_CHANGE` notifications while handling `WM_TEXT` messages.

<img width="833" height="659" alt="image" src="https://github.com/user-attachments/assets/ea2491e7-d6ee-47d9-a7a2-583c594f4154" />

JIRA issue: [CORE-20101](https://jira.reactos.org/browse/CORE-20101)

## Proposed changes

Mask out `ENM_CHANGE` from `editor->nEventMask` inside `WM_SETTEXT` and restore it to its previous state when returning.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: