### PR TITLE
[SERIAL] Implement IRP_MN_QUERY_REMOVE_DEVICE and IRP_MN_CANCEL_REMOV…

### DIFF
--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -391,6 +391,13 @@ SerialPnp(
 			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_QUERY_REMOVE_DEVICE\n");
 
 			DeviceExtension = DeviceObject->DeviceExtension;
+
+			if (DeviceExtension->IsOpened)
+			{
+				Status = STATUS_UNSUCCESSFUL;
+				break;
+			}
+
 			DeviceExtension->OldPnpState = DeviceExtension->PnpState;
 			DeviceExtension->PnpState = dsRemovePending;
 			Status = STATUS_SUCCESS;

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -340,7 +340,6 @@ SerialPnp(
 	switch (MinorFunction)
 	{
 		/* FIXME: do all these minor functions
-		IRP_MN_QUERY_REMOVE_DEVICE 0x1
 		IRP_MN_REMOVE_DEVICE 0x2
 		{
 			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_REMOVE_DEVICE\n");
@@ -351,7 +350,6 @@ SerialPnp(
 			IoDeleteDevice(Fdo) and/or IoDetachDevice
 			break;
 		}
-		IRP_MN_CANCEL_REMOVE_DEVICE 0x3
 		IRP_MN_STOP_DEVICE 0x4
 		IRP_MN_QUERY_STOP_DEVICE 0x5
 		IRP_MN_CANCEL_STOP_DEVICE 0x6
@@ -387,6 +385,27 @@ SerialPnp(
 			}
 
 			break;
+		}
+		case IRP_MN_QUERY_REMOVE_DEVICE: /* 0x1 */
+		{
+			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_QUERY_REMOVE_DEVICE\n");
+
+			DeviceExtension = DeviceObject->DeviceExtension;
+			DeviceExtension->OldPnpState = DeviceExtension->PnpState;
+			DeviceExtension->PnpState = dsRemovePending;
+			Status = STATUS_SUCCESS;
+
+			return ForwardIrpAndForget(DeviceObject, Irp);
+		}
+		case IRP_MN_CANCEL_REMOVE_DEVICE: /* 0x3 */
+		{
+			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_CANCEL_REMOVE_DEVICE\n");
+
+			DeviceExtension = DeviceObject->DeviceExtension;
+			DeviceExtension->PnpState = DeviceExtension->OldPnpState;
+			Status = STATUS_SUCCESS;
+
+			return ForwardIrpAndForget(DeviceObject, Irp);
 		}
 		case IRP_MN_QUERY_DEVICE_RELATIONS: /* (optional) 0x7 */
 		{

--- a/drivers/serial/serial/serial.h
+++ b/drivers/serial/serial/serial.h
@@ -4,7 +4,7 @@
  * FILE:            drivers/dd/serial/serial.h
  * PURPOSE:         Serial driver header
  *
- * PROGRAMMERS:     Herv� Poussineau (hpoussin@reactos.org)
+ * PROGRAMMERS:     Hervé Poussineau (hpoussin@reactos.org)
  */
 
 #ifndef _SERIAL_PCH_
@@ -22,7 +22,7 @@ typedef enum
   dsStopped,
   dsStarted,
   dsPaused,
-	dsRemovePending,
+  dsRemovePending,
   dsRemoved,
   dsSurpriseRemoved
 } SERIAL_DEVICE_STATE;
@@ -77,6 +77,7 @@ typedef struct _SERIAL_DEVICE_EXTENSION
 	KSPIN_LOCK InputBufferLock;
 	CIRCULAR_BUFFER OutputBuffer;
 	KSPIN_LOCK OutputBufferLock;
+
 	SERIAL_DEVICE_STATE OldPnpState;
 	UNICODE_STRING SerialInterfaceName;
 

--- a/drivers/serial/serial/serial.h
+++ b/drivers/serial/serial/serial.h
@@ -4,7 +4,7 @@
  * FILE:            drivers/dd/serial/serial.h
  * PURPOSE:         Serial driver header
  *
- * PROGRAMMERS:     Hervé Poussineau (hpoussin@reactos.org)
+ * PROGRAMMERS:     Hervï¿½ Poussineau (hpoussin@reactos.org)
  */
 
 #ifndef _SERIAL_PCH_
@@ -22,6 +22,7 @@ typedef enum
   dsStopped,
   dsStarted,
   dsPaused,
+	dsRemovePending,
   dsRemoved,
   dsSurpriseRemoved
 } SERIAL_DEVICE_STATE;
@@ -76,7 +77,7 @@ typedef struct _SERIAL_DEVICE_EXTENSION
 	KSPIN_LOCK InputBufferLock;
 	CIRCULAR_BUFFER OutputBuffer;
 	KSPIN_LOCK OutputBufferLock;
-
+	SERIAL_DEVICE_STATE OldPnpState;
 	UNICODE_STRING SerialInterfaceName;
 
 	/* Current values */


### PR DESCRIPTION
…E_DEVICE

## Purpose
Implement two PnP minor functions in the serial driver (IRP_MN_QUERY_REMOVE_DEVICE and IRP_MN_CANCEL_REMOVE_DEVICE), or 0x1 and 0x3.

JIRA issue: [CORE-20666](https://jira.reactos.org/browse/CORE-20666)

## Proposed changes
- Add `OldPnpState` to `SERIAL_DEVICE_EXTENSION` and `dsRemovePending` to  `SERIAL_DEVICE_STATE` in `serial.h`
- Implement `IRP_MN_QUERY_REMOVE_DEVICE` (saves current PnP state to `OldPnpState`, transitions to `dsRemovePending`, and forwards the IRP down the stack)
- Implement `IRP_MN_CANCEL_REMOVE_DEVICE` (restores `OldPnpState` and forwards the IRP down the stack)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: