### PR TITLE
[SERIAL] Implement surprise removal handler

### DIFF
--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -415,28 +415,28 @@ SerialPnp(
 		}
 		case IRP_MN_SURPRISE_REMOVAL: /* 0x17 */
 		{
-				WCHAR LinkNameBuffer[32];
-				UNICODE_STRING LinkName;
+			WCHAR LinkNameBuffer[32];
+			UNICODE_STRING LinkName;
 
-				TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_SURPRISE_REMOVAL\n");
+			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_SURPRISE_REMOVAL\n");
 
-				DeviceExtension = DeviceObject->DeviceExtension;
-				DeviceExtension->PnpState = dsSurpriseRemoved;
+			DeviceExtension = DeviceObject->DeviceExtension;
+			DeviceExtension->PnpState = dsSurpriseRemoved;
 
-				IoSetDeviceInterfaceState(&DeviceExtension->SerialInterfaceName, FALSE);
+			IoSetDeviceInterfaceState(&DeviceExtension->SerialInterfaceName, FALSE);
 
-				if (DeviceExtension->Interrupt)
-				{
-						IoDisconnectInterrupt(DeviceExtension->Interrupt);
-						DeviceExtension->Interrupt = NULL;
-				}
+			if (DeviceExtension->Interrupt)
+			{
+				IoDisconnectInterrupt(DeviceExtension->Interrupt);
+				DeviceExtension->Interrupt = NULL;
+			}
 
-				_swprintf(LinkNameBuffer, L"\\DosDevices\\COM%lu", DeviceExtension->ComPort);
-				RtlInitUnicodeString(&LinkName, LinkNameBuffer);
-				IoDeleteSymbolicLink(&LinkName);
+			_swprintf(LinkNameBuffer, L"\\DosDevices\\COM%lu", DeviceExtension->ComPort);
+			RtlInitUnicodeString(&LinkName, LinkNameBuffer);
+			IoDeleteSymbolicLink(&LinkName);
 
-				Status = STATUS_SUCCESS;
-				return ForwardIrpAndForget(DeviceObject, Irp);
+			Status = STATUS_SUCCESS;
+			return ForwardIrpAndForget(DeviceObject, Irp);
 		}
 		default:
 		{

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -416,7 +416,11 @@ SerialPnp(
 		case IRP_MN_SURPRISE_REMOVAL: /* 0x17 */
 		{
 			WCHAR LinkNameBuffer[32];
+			WCHAR DeviceNameBuffer[32];
 			UNICODE_STRING LinkName;
+			UNICODE_STRING DeviceName;
+			OBJECT_ATTRIBUTES ObjectAttributes;
+			HANDLE hKey;
 
 			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_SURPRISE_REMOVAL\n");
 
@@ -434,6 +438,17 @@ SerialPnp(
 			_swprintf(LinkNameBuffer, L"\\DosDevices\\COM%lu", DeviceExtension->ComPort);
 			RtlInitUnicodeString(&LinkName, LinkNameBuffer);
 			IoDeleteSymbolicLink(&LinkName);
+
+			_swprintf(DeviceNameBuffer, L"\\Device\\Serial%lu", DeviceExtension->SerialPortNumber);
+			RtlInitUnicodeString(&DeviceName, DeviceNameBuffer);
+			RtlInitUnicodeString(&KeyName, L"\\Registry\\Machine\\HARDWARE\\DeviceMap\\SERIALCOMM");
+			InitializeObjectAttributes(&ObjectAttributes, &KeyName, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
+
+			if (NT_SUCCESS(ZwOpenKey(&hKey, KEY_SET_VALUE, &ObjectAttributes)))
+			{
+					ZwDeleteValueKey(hKey, &DeviceName);
+					ZwClose(hKey);
+			}
 
 			return ForwardIrpAndForget(DeviceObject, Irp);
 		}

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -433,7 +433,7 @@ SerialPnp(
 
 				_swprintf(LinkNameBuffer, L"\\DosDevices\\COM%lu", DeviceExtension->ComPort);
 				RtlInitUnicodeString(&LinkName, LinkNameBuffer);
-				IoDeleteSymbolicLink(%LinkName);
+				IoDeleteSymbolicLink(&LinkName);
 
 				Status = STATUS_SUCCESS;
 				return ForwardIrpAndForget(DeviceObject, Irp);

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -446,8 +446,8 @@ SerialPnp(
 
 			if (NT_SUCCESS(ZwOpenKey(&hKey, KEY_SET_VALUE, &ObjectAttributes)))
 			{
-					ZwDeleteValueKey(hKey, &DeviceName);
-					ZwClose(hKey);
+				ZwDeleteValueKey(hKey, &DeviceName);
+				ZwClose(hKey);
 			}
 
 			return ForwardIrpAndForget(DeviceObject, Irp);

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -362,7 +362,6 @@ SerialPnp(
 		IRP_MN_FILTER_RESOURCE_REQUIREMENTS (optional) 0xd
 		IRP_MN_QUERY_PNP_DEVICE_STATE (optional) 0x14
 		IRP_MN_DEVICE_USAGE_NOTIFICATION (required or optional) 0x16
-		IRP_MN_SURPRISE_REMOVAL 0x17
 		*/
 		case IRP_MN_START_DEVICE: /* 0x0 */
 		{
@@ -413,6 +412,31 @@ SerialPnp(
 		{
 			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_FILTER_RESOURCE_REQUIREMENTS\n");
 			return ForwardIrpAndForget(DeviceObject, Irp);
+		}
+		case IRP_MN_SURPRISE_REMOVAL: /* 0x17 */
+		{
+				WCHAR LinkNameBuffer[32];
+				UNICODE_STRING LinkName;
+
+				TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_SURPRISE_REMOVAL\n");
+
+				DeviceExtension = DeviceObject->DeviceExtension;
+				DeviceExtension->PnpState = dsSurpriseRemoved;
+
+				IoSetDeviceInterfaceState(&DeviceExtension->SerialInterfaceName, FALSE);
+
+				if (DeviceExtension->Interrupt)
+				{
+						IoDisconnectInterrupt(DeviceExtension->Interrupt);
+						DeviceExtension->Interrupt = NULL;
+				}
+
+				_swprintf(LinkNameBuffer, L"\\DosDevices\\COM%lu", DeviceExtension->ComPort);
+				RtlInitUnicodeString(&LinkName, LinkNameBuffer);
+				IoDeleteSymbolicLink(%LinkName);
+
+				Status = STATUS_SUCCESS;
+				return ForwardIrpAndForget(DeviceObject, Irp);
 		}
 		default:
 		{

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -435,7 +435,6 @@ SerialPnp(
 			RtlInitUnicodeString(&LinkName, LinkNameBuffer);
 			IoDeleteSymbolicLink(&LinkName);
 
-			Status = STATUS_SUCCESS;
 			return ForwardIrpAndForget(DeviceObject, Irp);
 		}
 		default:

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -419,6 +419,7 @@ SerialPnp(
 			WCHAR DeviceNameBuffer[32];
 			UNICODE_STRING LinkName;
 			UNICODE_STRING DeviceName;
+            UNICODE_STRING KeyName;
 			OBJECT_ATTRIBUTES ObjectAttributes;
 			HANDLE hKey;
 


### PR DESCRIPTION
## Purpose

Implement the `IRP_MN_SURPRISE_REMOVAL` minor function handler in `pnp.c`

JIRA issue: [CORE-20666](https://jira.reactos.org/browse/CORE-20666)

## Proposed changes
- Add a case for `IRP_MN_SURPRISE_REMOVAL` in SerialPnp (changes to `dsSurpriseRemoved`, disables the device interface, disconnects the DOS symlink and forwards the IRP down the stack.)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: