### PR TITLE
[SERIAL] Implement the STOP minor function handlers

### DIFF
--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -352,9 +352,6 @@ SerialPnp(
 			break;
 		}
 		IRP_MN_CANCEL_REMOVE_DEVICE 0x3
-		IRP_MN_STOP_DEVICE 0x4
-		IRP_MN_QUERY_STOP_DEVICE 0x5
-		IRP_MN_CANCEL_STOP_DEVICE 0x6
 		IRP_MN_QUERY_DEVICE_RELATIONS / BusRelations (optional) 0x7
 		IRP_MN_QUERY_DEVICE_RELATIONS / RemovalRelations (optional) 0x7
 		IRP_MN_QUERY_INTERFACE (optional) 0x8
@@ -387,6 +384,58 @@ SerialPnp(
 			}
 
 			break;
+		}
+		case IRP_MN_STOP_DEVICE: /* 0x4 */
+		{
+			WCHAR LinkNameBuffer[32];
+			UNICODE_STRING LinkName;
+
+			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_STOP_DEVICE\n");
+
+			DeviceExtension = DeviceObject->DeviceExtension;
+
+			IoSetDeviceInterfaceState(&DeviceExtension->SerialInterfaceName, FALSE);
+
+			if (DeviceExtension->Interrupt)
+			{
+				IoDisconnectInterrupt(DeviceExtension->Interrupt);
+				DeviceExtension->Interrupt = NULL;
+		  }
+
+			_swprintf(LinkNameBuffer, L"\\DosDevices\\COM%lu", DeviceExtension->ComPort);
+			RtlInitUnicodeString(&LinkName, LinkNameBuffer);
+			IoDeleteSymbolicLink(&LinkName);
+			DeviceExtension->PnpState = dsStopped;
+
+			return ForwardIrpAndForget(DeviceObject, Irp);
+		}
+		case IRP_MN_QUERY_STOP_DEVICE: /* 0x5 */
+		{
+			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_QUERY_STOP_DEVICE\n");
+
+			DeviceExtension = DeviceObject->DeviceExtension;
+
+			if (DeviceExtension->IsOpened)
+			{
+				Status = STATUS_UNSUCCESSFUL;
+				break;
+			}
+
+			DeviceExtension->OldPnpState = DeviceExtension->PnpState;
+			DeviceExtension->PnpState = dsStopPending;
+			Status = STATUS_SUCCESS;
+
+			return ForwardIrpAndForget(DeviceObject, Irp);
+		}
+		case IRP_MN_CANCEL_STOP_DEVICE: /* 0x6 */
+		{
+			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_CANCEL_STOP_DEVICE\n");
+
+			DeviceExtension = DeviceObject->DeviceExtension;
+			DeviceExtension->PnpState = DeviceExtension->OldPnpState;
+			Status = STATUS_SUCCESS;
+
+			return ForwardIrpAndForget(DeviceObject, Irp);
 		}
 		case IRP_MN_QUERY_DEVICE_RELATIONS: /* (optional) 0x7 */
 		{

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -400,7 +400,7 @@ SerialPnp(
 			{
 				IoDisconnectInterrupt(DeviceExtension->Interrupt);
 				DeviceExtension->Interrupt = NULL;
-		  }
+		    }
 
 			_swprintf(LinkNameBuffer, L"\\DosDevices\\COM%lu", DeviceExtension->ComPort);
 			RtlInitUnicodeString(&LinkName, LinkNameBuffer);

--- a/drivers/serial/serial/serial.h
+++ b/drivers/serial/serial/serial.h
@@ -4,7 +4,7 @@
  * FILE:            drivers/dd/serial/serial.h
  * PURPOSE:         Serial driver header
  *
- * PROGRAMMERS:     Hervé Poussineau (hpoussin@reactos.org)
+ * PROGRAMMERS:     HervÃ© Poussineau (hpoussin@reactos.org)
  */
 
 #ifndef _SERIAL_PCH_
@@ -22,7 +22,9 @@ typedef enum
   dsStopped,
   dsStarted,
   dsPaused,
+	dsRemovePending,
   dsRemoved,
+	dsStopPending,
   dsSurpriseRemoved
 } SERIAL_DEVICE_STATE;
 
@@ -76,6 +78,7 @@ typedef struct _SERIAL_DEVICE_EXTENSION
 	KSPIN_LOCK InputBufferLock;
 	CIRCULAR_BUFFER OutputBuffer;
 	KSPIN_LOCK OutputBufferLock;
+	SERIAL_DEVICE_STATE OldPnpState;
 
 	UNICODE_STRING SerialInterfaceName;
 

--- a/drivers/serial/serial/serial.h
+++ b/drivers/serial/serial/serial.h
@@ -22,9 +22,9 @@ typedef enum
   dsStopped,
   dsStarted,
   dsPaused,
-	dsRemovePending,
+  dsRemovePending,
   dsRemoved,
-	dsStopPending,
+  dsStopPending,
   dsSurpriseRemoved
 } SERIAL_DEVICE_STATE;
 
@@ -78,8 +78,8 @@ typedef struct _SERIAL_DEVICE_EXTENSION
 	KSPIN_LOCK InputBufferLock;
 	CIRCULAR_BUFFER OutputBuffer;
 	KSPIN_LOCK OutputBufferLock;
-	SERIAL_DEVICE_STATE OldPnpState;
 
+	SERIAL_DEVICE_STATE OldPnpState;
 	UNICODE_STRING SerialInterfaceName;
 
 	/* Current values */


### PR DESCRIPTION
## Purpose

Implement the STOP device minor functions handlers:

1. IRP_MN_STOP_DEVICE (0x4)
2. IRP_MN_QUERY_STOP_DEVICE (0x5)
3. IRP_MN_CANCEL_STOP_DEVICE (0x6)

JIRA issue: [CORE-20666](https://jira.reactos.org/browse/CORE-20666)

## Proposed changes
- Add `dsStopPending` in `SERIAL_DEVICE_STATE`
- Implement `IRP_MN_QUERY_STOP_DEVICE` handler (fails if the device is open, or else saves current PnP state to `OldPnpState`, changes to `dsStopPending`, and forwards the IRP down the stack)
- Implement `IRP_MN_CANCEL_STOP_DEVICE` handler (restores `OldPnpState` and forwards the IRP down the stack)
- Implement `IRP_MN_STOP_DEVICE` handler (disables the device interface, disconnects the interrupt, deletes the DOS symlink, changes to `dsStopped`, and forwards the IRP down the stack)

## Testbot runs (Filled in by Devs)
- [ ] KVM x86:
- [ ] KVM x64: