### PR TITLE
[SERIAL] Implement device removal handler

### DIFF
--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -341,16 +341,6 @@ SerialPnp(
 	{
 		/* FIXME: do all these minor functions
 		IRP_MN_QUERY_REMOVE_DEVICE 0x1
-		IRP_MN_REMOVE_DEVICE 0x2
-		{
-			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_REMOVE_DEVICE\n");
-			IoAcquireRemoveLock
-			IoReleaseRemoveLockAndWait
-			pass request to DeviceExtension-LowerDriver
-			disable interface
-			IoDeleteDevice(Fdo) and/or IoDetachDevice
-			break;
-		}
 		IRP_MN_CANCEL_REMOVE_DEVICE 0x3
 		IRP_MN_STOP_DEVICE 0x4
 		IRP_MN_QUERY_STOP_DEVICE 0x5

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -388,6 +388,45 @@ SerialPnp(
 
 			break;
 		}
+		case IRP_MN_REMOVE_DEVICE: /* 0x2 */
+		{
+			WCHAR LinkNameBuffer[32];
+			UNICODE_STRING LinkName;
+
+			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_REMOVE_DEVICE\n");
+
+			DeviceExtension = DeviceObject->DeviceExtension;
+
+			IoAcquireRemoveLock(&DeviceExtension->RemoveLock, Irp);
+
+			if (DeviceExtension->PnpState == dsStarted)
+			{
+				IoSetDeviceInterfaceState(&DeviceExtension->SerialInterfaceName, FALSE);
+
+				if (DeviceExtension->Interrupt)
+				{
+					IoDisconnectInterrupt(DeviceExtension->Interrupt);
+					DeviceExtension->Interrupt = NULL;
+				}
+
+				_swprintf(LinkNameBuffer, L"\\DosDevices\\COM%lu", DeviceExtension->ComPort);
+				RtlInitUnicodeString(&LinkName, LinkNameBuffer);
+				IoDeleteSymbolicLink(&LinkName);
+			}
+
+			DeviceExtension->PnpState = dsRemoved;
+
+			Irp->IoStatus.Status = STATUS_SUCCESS;
+			IoSkipCurrentIrpStackLocation(Irp);
+			Status = IoCallDriver(DeviceExtension->LowerDevice, Irp);
+
+			IoReleaseRemoveLockAndWait(&DeviceExtension->RemoveLock, Irp);
+
+			IoDetachDevice(DeviceExtension->LowerDevice);
+			IoDeleteDevice(DeviceObject);
+
+			return Status;
+		}
 		case IRP_MN_QUERY_DEVICE_RELATIONS: /* (optional) 0x7 */
 		{
 			switch (Stack->Parameters.QueryDeviceRelations.Type)


### PR DESCRIPTION
## Purpose

The missing piece that went alongside `IRP_MN_SURPRISE_REMOVAL`. Implements `IRP_MN_REMOVE_DEVICE` handler.

JIRA issue: [CORE-20666](https://jira.reactos.org/browse/CORE-20666)

## Proposed changes
- Implement `IRP_MN_REMOVE_DEVICE` (acquires the remove lock, conditionally cleans up the interface, interrupt, and DOS symlink if the device was started, changes to `dsRemoved`, forwards the IRP, waits for queued I/O with `IoReleaseRemoveLockAndWait`, then detaches and deletes the device object.)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: