### PR TITLE
[SERIAL] Implement some more query functions

### DIFF
--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -395,8 +395,8 @@ SerialPnp(
 					TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_QUERY_DEVICE_RELATIONS / BusRelations\n");
 
 					DeviceRelations = ExAllocatePoolWithTag(PagedPool,
-																									FIELD_OFFSET(DEVICE_RELATIONS, Objects),
-																									SERIAL_TAG);
+															FIELD_OFFSET(DEVICE_RELATIONS, Objects),
+															SERIAL_TAG);
 
 					if (!DeviceRelations)
 					{
@@ -416,8 +416,8 @@ SerialPnp(
 					TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_QUERY_DEVICE_RELATIONS / RemovalRelations\n");
 
 					DeviceRelations = ExAllocatePoolWithTag(PagedPool,
-																									FIELD_OFFSET(DEVICE_RELATIONS, Objects),
-																									SERIAL_TAG);
+															FIELD_OFFSET(DEVICE_RELATIONS, Objects),
+															SERIAL_TAG);
 
 					if (!DeviceRelations)
 					{

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -418,7 +418,6 @@ SerialPnp(
 					DeviceRelations = ExAllocatePoolWithTag(PagedPool,
 															FIELD_OFFSET(DEVICE_RELATIONS, Objects),
 															SERIAL_TAG);
-
 					if (!DeviceRelations)
 					{
 						Status = STATUS_INSUFFICIENT_RESOURCES;

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -397,7 +397,6 @@ SerialPnp(
 					DeviceRelations = ExAllocatePoolWithTag(PagedPool,
 															FIELD_OFFSET(DEVICE_RELATIONS, Objects),
 															SERIAL_TAG);
-
 					if (!DeviceRelations)
 					{
 						Status = STATUS_INSUFFICIENT_RESOURCES;

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -355,10 +355,6 @@ SerialPnp(
 		IRP_MN_STOP_DEVICE 0x4
 		IRP_MN_QUERY_STOP_DEVICE 0x5
 		IRP_MN_CANCEL_STOP_DEVICE 0x6
-		IRP_MN_QUERY_DEVICE_RELATIONS / BusRelations (optional) 0x7
-		IRP_MN_QUERY_DEVICE_RELATIONS / RemovalRelations (optional) 0x7
-		IRP_MN_QUERY_INTERFACE (optional) 0x8
-		IRP_MN_QUERY_CAPABILITIES (optional) 0x9
 		IRP_MN_FILTER_RESOURCE_REQUIREMENTS (optional) 0xd
 		IRP_MN_QUERY_PNP_DEVICE_STATE (optional) 0x14
 		IRP_MN_DEVICE_USAGE_NOTIFICATION (required or optional) 0x16
@@ -394,19 +390,73 @@ SerialPnp(
 			{
 				case BusRelations:
 				{
+					PDEVICE_RELATIONS DeviceRelations;
+
 					TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_QUERY_DEVICE_RELATIONS / BusRelations\n");
-					return ForwardIrpAndForget(DeviceObject, Irp);
+
+					DeviceRelations = ExAllocatePoolWithTag(PagedPool,
+																									FIELD_OFFSET(DEVICE_RELATIONS, Objects),
+																									SERIAL_TAG);
+
+					if (!DeviceRelations)
+					{
+						Status = STATUS_INSUFFICIENT_RESOURCES;
+						break;
+					}
+
+					DeviceRelations->Count = 0;
+					Information = (ULONG_PTR)DeviceRelations;
+					Status = STATUS_SUCCESS;
+					break;
 				}
 				case RemovalRelations:
 				{
+					PDEVICE_RELATIONS DeviceRelations;
+
 					TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_QUERY_DEVICE_RELATIONS / RemovalRelations\n");
-					return ForwardIrpAndForget(DeviceObject, Irp);
+
+					DeviceRelations = ExAllocatePoolWithTag(PagedPool,
+																									FIELD_OFFSET(DEVICE_RELATIONS, Objects),
+																									SERIAL_TAG);
+
+					if (!DeviceRelations)
+					{
+						Status = STATUS_INSUFFICIENT_RESOURCES;
+						break;
+					}
+
+					DeviceRelations->Count = 0;
+					Information = (ULONG_PTR)DeviceRelations;
+					Status = STATUS_SUCCESS;
+					break;
 				}
 				default:
 					TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_QUERY_DEVICE_RELATIONS / Unknown type 0x%lx\n",
 						Stack->Parameters.QueryDeviceRelations.Type);
 					return ForwardIrpAndForget(DeviceObject, Irp);
 			}
+			break;
+		}
+		case IRP_MN_QUERY_INTERFACE: /* (optional) 0x8 */
+		{
+			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_QUERY_INTERFACE\n");
+			return ForwardIrpAndForget(DeviceObject, Irp);
+		}
+		case IRP_MN_QUERY_CAPABILITIES: /* (optional) 0x9 */
+		{
+			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_QUERY_CAPABILITIES\n");
+
+			DeviceExtension = DeviceObject->DeviceExtension;
+
+			if (IoForwardIrpSynchronously(DeviceExtension->LowerDevice, Irp))
+			{
+				Status = Irp->IoStatus.Status;
+			}
+			else
+			{
+				Status = STATUS_UNSUCCESSFUL;
+			}
+
 			break;
 		}
 		case IRP_MN_FILTER_RESOURCE_REQUIREMENTS: /* (optional) 0xd */


### PR DESCRIPTION
## Purpose

Implement quite a few query functions, including: `BusRelations` and `RemovalRelations` cases in `IRP_MN_QUERY_DEVICE_RELATIONS`, `IRP_MN_QUERY_INTERFACE` handler and `IRP_MN_QUERY_CAPABILITIES` handler.

JIRA issue: [CORE-20666](https://jira.reactos.org/browse/CORE-20666)

## Proposed changes
- Implement `BusRelations` and `RemovalRelations` in `IRP_MN_QUERY_DEVICE_RELATIONS` (returns a empty `DEVICE_RELATIONS`  with `Count=0` for both, because serial has no child devices)
- Implement `IRP_MN_QUERY_INTERFACE` (forwards the IRP down the stack)
- Implement `IRP_MN_QUERY_CAPABILITIES` (forwards the IRP synchronously to the lower driver and uses its returned status)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: