### PR TITLE
[IMM32] Fix C4334 and C4267 warnings

### DIFF
--- a/win32ss/user/imm32/candidate.c
+++ b/win32ss/user/imm32/candidate.c
@@ -458,6 +458,6 @@ ImmSetCandidateWindow(
     ImmUnlockIMC(hIMC);
 
     Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0, IMC_SETCANDIDATEPOS,
-                       IMN_SETCANDIDATEPOS, (1 << (BYTE)lpCandidate->dwIndex));
+                       IMN_SETCANDIDATEPOS, (DWORD)(1 << (BYTE)lpCandidate->dwIndex));
     return TRUE;
 }

--- a/win32ss/user/imm32/imemenu.c
+++ b/win32ss/user/imm32/imemenu.c
@@ -127,7 +127,7 @@ Imm32WriteHBitmapToNode(
             break;
         default:
             nodeExtraSize = sizeof(BITMAPINFOHEADER);
-            nodeExtraSize += (1 << pBmih->biBitCount) * sizeof(RGBQUAD);
+            nodeExtraSize += ((DWORD)(1 << pBmih->biBitCount)) * sizeof(RGBQUAD);
             break;
     }
 

--- a/win32ss/user/imm32/install.c
+++ b/win32ss/user/imm32/install.c
@@ -281,13 +281,13 @@ Imm32WriteImeLayout(
         goto Failure;
 
     /* Write "Ime File" */
-    cbData = (wcslen(pchFileTitle) + 1) * sizeof(WCHAR);
+    cbData = (DWORD)((wcslen(pchFileTitle) + 1) * sizeof(WCHAR));
     lError = RegSetValueExW(hkeyIME, L"Ime File", 0, REG_SZ, (LPBYTE)pchFileTitle, cbData);
     if (IS_ERROR_UNEXPECTEDLY(lError))
         goto Failure;
 
     /* Write "Layout Text" */
-    cbData = (wcslen(pszLayoutText) + 1) * sizeof(WCHAR);
+    cbData = (DWORD)((wcslen(pszLayoutText) + 1) * sizeof(WCHAR));
     lError = RegSetValueExW(hkeyIME, L"Layout Text", 0, REG_SZ, (LPBYTE)pszLayoutText, cbData);
     if (IS_ERROR_UNEXPECTEDLY(lError))
         goto Failure;
@@ -302,7 +302,7 @@ Imm32WriteImeLayout(
     }
 
     /* Write "Layout File" */
-    cbData = (wcslen(pszLayoutFile) + 1) * sizeof(WCHAR);
+    cbData = (DWORD)((wcslen(pszLayoutFile) + 1) * sizeof(WCHAR));
     lError = RegSetValueExW(hkeyIME, L"Layout File", 0, REG_SZ, (LPBYTE)pszLayoutFile, cbData);
     if (IS_ERROR_UNEXPECTEDLY(lError))
         goto Failure;
@@ -337,7 +337,7 @@ Imm32WriteImeLayout(
 #undef MAX_PRELOAD
 
     /* Write the IME key to the preload number */
-    cbData = (wcslen(szImeKey) + 1) * sizeof(WCHAR);
+    cbData = (DWORD)((wcslen(szImeKey) + 1) * sizeof(WCHAR));
     lError = RegSetValueExW(hkeyPreload, szPreloadNumber, 0, REG_SZ, (LPBYTE)szImeKey, cbData);
     RegCloseKey(hkeyPreload);
     return lError == ERROR_SUCCESS;

--- a/win32ss/user/imm32/keymsg.c
+++ b/win32ss/user/imm32/keymsg.c
@@ -403,7 +403,7 @@ Imm32ProcessRequest(HIMC hIMC, PWND pWnd, DWORD dwCommand, LPVOID pData, BOOL bA
         return 0; /* Out of range */
     }
 
-    dwSize = acbData[bAnsiAPI * 7 + dwCommand - 1];
+    dwSize = (DWORD)acbData[bAnsiAPI * 7 + dwCommand - 1];
     if (pData && IsBadWritePtr(pData, dwSize))
     {
         ERR("\n");

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -1456,7 +1456,7 @@ WINNLSTranslateMessageJ(
                         LPARAM lParam = pCurrent->lParam;
                         for (DWORD iCandForm = 0; iCandForm < MAX_CANDIDATEFORM; ++iCandForm)
                         {
-                            if (!(lParam & (1 << iCandForm)))
+                            if (!(lParam & (DWORD)(1 << iCandForm)))
                                 continue;
 
                             CandForm.dwIndex = iCandForm;


### PR DESCRIPTION
## Purpose

Kill the warnings.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Add type casts to `DWORD`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108561,108654
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108562,108660