### PR TITLE
[SERIAL] Implement device state handler

### DIFF
--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -359,9 +359,6 @@ SerialPnp(
 		IRP_MN_QUERY_DEVICE_RELATIONS / RemovalRelations (optional) 0x7
 		IRP_MN_QUERY_INTERFACE (optional) 0x8
 		IRP_MN_QUERY_CAPABILITIES (optional) 0x9
-		IRP_MN_FILTER_RESOURCE_REQUIREMENTS (optional) 0xd
-		IRP_MN_QUERY_PNP_DEVICE_STATE (optional) 0x14
-		IRP_MN_DEVICE_USAGE_NOTIFICATION (required or optional) 0x16
 		IRP_MN_SURPRISE_REMOVAL 0x17
 		*/
 		case IRP_MN_START_DEVICE: /* 0x0 */
@@ -413,6 +410,77 @@ SerialPnp(
 		{
 			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_FILTER_RESOURCE_REQUIREMENTS\n");
 			return ForwardIrpAndForget(DeviceObject, Irp);
+		}
+		case IRP_MN_QUERY_PNP_DEVICE_STATE: /* (optional) 0x14 */
+		{
+			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_QUERY_PNP_DEVICE_STATE\n");
+
+			DeviceExtension = DeviceObject->DeviceExtension;
+
+			if (IoForwardIrpSynchronously(DeviceExtension->LowerDevice, Irp))
+			{
+				Status = Irp->IoStatus.Status;
+			}
+			else
+			{
+				Status = STATUS_UNSUCCESSFUL;
+			}
+
+			if (NT_SUCCESS(Status))
+			{
+				if (KdComPortInUse == ULongToPtr(DeviceExtension->BaseAddress))
+				{
+					Information |= PNP_DEVICE_NOT_DISABLEABLE;
+				}
+			}
+
+			break;
+		}
+		case IRP_MN_DEVICE_USAGE_NOTIFICATION: /* (required or optional) 0x16 */
+		{
+			BOOLEAN InPath = Stack->Parameters.UsageNotification.InPath;
+
+			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_DEVICE_USAGE_NOTIFICATION\n");
+
+			DeviceExtension = DeviceObject->DeviceExtension;
+
+			if (IoForwardIrpSynchronously(DeviceExtension->LowerDevice, Irp))
+			{
+				Status = Irp->IoStatus.Status;
+			}
+			else
+			{
+				Status = STATUS_UNSUCCESSFUL;
+			}
+
+			if (NT_SUCCESS(Status))
+			{
+				switch (Stack->Parameters.UsageNotification.Type)
+				{
+					case DeviceUsageTypePaging:
+						InPath ? DeviceExtension->PagingCount++ : DeviceExtension->PagingCount--;
+						break;
+					case DeviceUsageTypeHibernation:
+						InPath ? DeviceExtension->HibernateCount++ : DeviceExtension->HibernateCount--;
+						break;
+					case DeviceUsageTypeDumpFile:
+						InPath ? DeviceExtension->DumpCount++ : DeviceExtension->DumpCount--;
+						break;
+					default:
+						break;
+				}
+
+				if (DeviceExtension->PagingCount + DeviceExtension->HibernateCount + DeviceExtension->DumpCount > 0)
+				{
+					DeviceObject->Flags &= ~DO_POWER_PAGABLE;
+				}
+				else
+				{
+					DeviceObject->Flags |= DO_POWER_PAGABLE;
+				}
+			}
+
+			break;
 		}
 		default:
 		{

--- a/drivers/serial/serial/pnp.c
+++ b/drivers/serial/serial/pnp.c
@@ -436,52 +436,6 @@ SerialPnp(
 
 			break;
 		}
-		case IRP_MN_DEVICE_USAGE_NOTIFICATION: /* (required or optional) 0x16 */
-		{
-			BOOLEAN InPath = Stack->Parameters.UsageNotification.InPath;
-
-			TRACE_(SERIAL, "IRP_MJ_PNP / IRP_MN_DEVICE_USAGE_NOTIFICATION\n");
-
-			DeviceExtension = DeviceObject->DeviceExtension;
-
-			if (IoForwardIrpSynchronously(DeviceExtension->LowerDevice, Irp))
-			{
-				Status = Irp->IoStatus.Status;
-			}
-			else
-			{
-				Status = STATUS_UNSUCCESSFUL;
-			}
-
-			if (NT_SUCCESS(Status))
-			{
-				switch (Stack->Parameters.UsageNotification.Type)
-				{
-					case DeviceUsageTypePaging:
-						InPath ? DeviceExtension->PagingCount++ : DeviceExtension->PagingCount--;
-						break;
-					case DeviceUsageTypeHibernation:
-						InPath ? DeviceExtension->HibernateCount++ : DeviceExtension->HibernateCount--;
-						break;
-					case DeviceUsageTypeDumpFile:
-						InPath ? DeviceExtension->DumpCount++ : DeviceExtension->DumpCount--;
-						break;
-					default:
-						break;
-				}
-
-				if (DeviceExtension->PagingCount + DeviceExtension->HibernateCount + DeviceExtension->DumpCount > 0)
-				{
-					DeviceObject->Flags &= ~DO_POWER_PAGABLE;
-				}
-				else
-				{
-					DeviceObject->Flags |= DO_POWER_PAGABLE;
-				}
-			}
-
-			break;
-		}
 		default:
 		{
 			TRACE_(SERIAL, "Unknown minor function 0x%x\n", MinorFunction);

--- a/drivers/serial/serial/serial.h
+++ b/drivers/serial/serial/serial.h
@@ -4,7 +4,7 @@
  * FILE:            drivers/dd/serial/serial.h
  * PURPOSE:         Serial driver header
  *
- * PROGRAMMERS:     Hervé Poussineau (hpoussin@reactos.org)
+ * PROGRAMMERS:     HervÃ© Poussineau (hpoussin@reactos.org)
  */
 
 #ifndef _SERIAL_PCH_
@@ -78,6 +78,10 @@ typedef struct _SERIAL_DEVICE_EXTENSION
 	KSPIN_LOCK OutputBufferLock;
 
 	UNICODE_STRING SerialInterfaceName;
+
+	ULONG PagingCount;
+	ULONG HibernateCount;
+	ULONG DumpCount;
 
 	/* Current values */
 	UCHAR MCR; /* Base+4, Modem Control Register */

--- a/drivers/serial/serial/serial.h
+++ b/drivers/serial/serial/serial.h
@@ -79,10 +79,6 @@ typedef struct _SERIAL_DEVICE_EXTENSION
 
 	UNICODE_STRING SerialInterfaceName;
 
-	ULONG PagingCount;
-	ULONG HibernateCount;
-	ULONG DumpCount;
-
 	/* Current values */
 	UCHAR MCR; /* Base+4, Modem Control Register */
 	UCHAR MSR; /* Base+6, Modem Status Register */


### PR DESCRIPTION
## Purpose
Implements the device state handler.

JIRA issue: [CORE-20666](https://jira.reactos.org/browse/CORE-20666)

## Proposed changes
- Implement `IRP_MN_QUERY_PNP_DEVICE_STATE` (forwards synchronously, then sets `PNP_DEVICE_NOT_DISABLEABLE` if the port is being used by the kernel debugger)

NOTE: `IRP_MN_FILTER_RESOURCE_REQUIREMENTS` left unchanged because serial doesn't need to modify the resource list, and `IRP_MN_DEVICE_USAGE_NOTIFICATION` has no implementation either since a serial port is not a storage device.

## Testbot runs (Filled in by Devs)
- [ ] KVM x86:
- [ ] KVM x64: