### PR TITLE
[NTOS:OB] Get handle attributes

### DIFF
--- a/ntoskrnl/ob/obref.c
+++ b/ntoskrnl/ob/obref.c
@@ -263,8 +263,7 @@ ObReferenceFileObjectForWrite(IN HANDLE Handle,
 
             HandleInformation->GrantedAccess = GrantedAccess;
 
-            /* FIXME: Get handle attributes */
-            HandleInformation->HandleAttributes = 0;
+            HandleInformation->HandleAttributes = HandleEntry->ObAttributes & OBJ_HANDLE_ATTRIBUTES;
 
             /* Do granted and desired access match? */
             if (GrantedAccess & DesiredAccess)


### PR DESCRIPTION
## Purpose

Resolve a FIXME in ObReferenceFileObjectForWrite (getting the handle attributes)

JIRA issue: None

## Proposed changes
- Delete the FIXME line
- Read `HandleEntry->ObAttributes & OBJ_HANDLE_ATTRIBUTES` into `HandleInformation->HandleAttributes`

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: