### PR TITLE
[DBGHELP] Fix a warning

### DIFF
--- a/dll/win32/dbghelp/type.c
+++ b/dll/win32/dbghelp/type.c
@@ -22,7 +22,9 @@
  * upon which full support for datatype handling will eventually be built.
  */
 
+#if !defined(__REACTOS__) || !defined(NONAMELESSUNION) /* Required to avoid a warning when NOT CMAKE_CROSSCOMPILING */
 #define NONAMELESSUNION
+#endif
 
 #include <stdlib.h>
 #include <stdarg.h>


### PR DESCRIPTION
## Purpose

Fix
`/srv/buildbot/worker_data/Build_GCCLin_x86/build/dll/win32/dbghelp/type.c:25: warning: "NONAMELESSUNION" redefined`

JIRA issue: [CORE-18933](https://jira.reactos.org/browse/CORE-18933)
Addendum to 212a1a5c7457b11c5d1caa9813914e98f9f332a2.

## Proposed changes

- Add an `#if ...`.