### PR TITLE
[NTGDI][GDI32_APITEST] Allow calling NtGdiCreateHalftonePalette with HDC=NULL

### DIFF
--- a/modules/rostests/apitests/gdi32/CMakeLists.txt
+++ b/modules/rostests/apitests/gdi32/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND SOURCE
     CreateDIBPatternBrush.c
     CreateFont.c
     CreateFontIndirect.c
+    CreateHalftonePalette.c
     CreateIconIndirect.c
     CreatePen.c
     CreateRectRgn.c

--- a/modules/rostests/apitests/gdi32/CreateHalftonePalette.c
+++ b/modules/rostests/apitests/gdi32/CreateHalftonePalette.c
@@ -1,0 +1,47 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Test for CreateHalftonePalette
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include <apitest.h>
+#include <wingdi.h>
+
+START_TEST(CreateHalftonePalette)
+{
+    HPALETTE hPal;
+    UINT entries;
+    BOOL ret;
+    PALETTEENTRY pe[256];
+    PALETTEENTRY sysPal[20];
+
+    hPal = CreateHalftonePalette(NULL);
+    ok(hPal != NULL, "CreateHalftonePalette(NULL) failed, LastError=%lu\n", GetLastError());
+    if (!hPal)
+    {
+        skip("CreateHalftonePalette(NULL) failed, skipping test\n");
+        return;
+    }
+
+    /* Validate the palette */
+    entries = GetPaletteEntries(hPal, 0, _countof(pe), pe);
+    ok(entries == _countof(pe), "Unexpected number of palette entries: %u\n", entries);
+    /* Get system default palette */
+    entries = GetPaletteEntries(GetStockObject(DEFAULT_PALETTE), 0, 20, sysPal);
+    ok(entries == _countof(sysPal), "Unexpected number of system palette entries: %u\n", entries);
+    /* First and last ten entries are default ones */
+    for (int i = 0; i < 10; i++)
+    {
+        ok(pe[i].peRed == sysPal[i].peRed && 
+           pe[i].peGreen == sysPal[i].peGreen &&
+           pe[i].peBlue == sysPal[i].peBlue, "Unexpected color at index %d\n", i);
+
+        ok(pe[246 + i].peRed == sysPal[10 + i].peRed && 
+           pe[246 + i].peGreen == sysPal[10 + i].peGreen &&
+           pe[246 + i].peBlue == sysPal[10 + i].peBlue, "Unexpected color at index %d\n", 246 + i);
+    }
+
+    ret = DeleteObject(hPal);
+    ok(ret != FALSE, "DeleteObject(hPal) failed\n");
+}

--- a/win32ss/gdi/ntgdi/palette.c
+++ b/win32ss/gdi/ntgdi/palette.c
@@ -531,13 +531,7 @@ NtGdiCreateHalftonePalette(HDC  hDC)
     PPALETTE ppal;
     PDC pdc;
     HPALETTE hpal = NULL;
-
-    pdc = DC_LockDc(hDC);
-    if (!pdc)
-    {
-        EngSetLastError(ERROR_INVALID_HANDLE);
-        return NULL;
-    }
+    BOOL UseDefaultPalette = TRUE;
 
     RtlZeroMemory(PalEntries, sizeof(PalEntries));
 
@@ -553,13 +547,33 @@ NtGdiCreateHalftonePalette(HDC  hDC)
         PalEntries[246 + i].peBlue = g_sysPalTemplate[10 + i].peBlue;
     }
 
-    ppal = PALETTE_ShareLockPalette(pdc->dclevel.hpal);
-    if (ppal && (ppal->flFlags & PAL_INDEXED))
+    if (hDC)
     {
-        /* FIXME: optimize the palette for the current palette */
-        UNIMPLEMENTED;
+        pdc = DC_LockDc(hDC);
+        if (!pdc)
+        {
+            EngSetLastError(ERROR_INVALID_HANDLE);
+            return NULL;
+        }
+
+        ppal = PALETTE_ShareLockPalette(pdc->dclevel.hpal);
+        if (ppal)
+        {
+            if (ppal->flFlags & PAL_INDEXED)
+            {
+                UseDefaultPalette = FALSE;
+
+                /* FIXME: optimize the palette for the current palette */
+                UNIMPLEMENTED;
+            }
+
+            PALETTE_ShareUnlockPalette(ppal);
+        }
+
+        DC_UnlockDc(pdc);
     }
-    else
+
+    if (UseDefaultPalette)
     {
         for (r = 0; r < 6; r++)
         {
@@ -583,11 +597,6 @@ NtGdiCreateHalftonePalette(HDC  hDC)
             PalEntries[i].peBlue = v;
         }
     }
-
-    if (ppal)
-        PALETTE_ShareUnlockPalette(ppal);
-
-    DC_UnlockDc(pdc);
 
     ppal = PALETTE_AllocPalWithHandle(PAL_INDEXED, 256, PalEntries, 0, 0, 0);
     if (ppal)
@@ -778,7 +787,7 @@ IntGdiRealizePalette(HDC hDC)
 
     ASSERT(ppalDC->flFlags & PAL_INDEXED);
 
-    DPRINT1("RealizePalette unimplemented for %s\n", 
+    DPRINT1("RealizePalette unimplemented for %s\n",
             (pdc->dctype == DCTYPE_MEMORY ? "memory managed DCs" : "device DCs"));
 
 cleanup:


### PR DESCRIPTION
## Purpose

Currently ReactOS doesn't allow calling `CreateHalftonePalette(HDC)` with NULL, while tests show this is allowed on Windows and even Wine. Also, SDK headers provided by Microsoft [here](https://github.com/microsoft/win32metadata/blob/00506a453b49a9a6e8947f69c00ae1c1ec4cbb41/generation/WinSDK/RecompiledIdlHeaders/um/wingdi.h#L5117) indicates that `CreateHalftonePalette`'s parameter is optional, and can be NULL.

This behavior causes compatibility issues, breaking applications like *Internet Explorer 8.0* and *Microsoft Encarta*.

This PR imports a patch provided by simonelombardo in Jira which allows `NtGdiCreateHalftonePalette` to run with NULL HDC, and also adds APITEST for CreateHalftonePalette.

The test result without the patch:

<img width="694" height="476" alt="image" src="https://github.com/user-attachments/assets/781da3c8-113f-418c-9dea-b64f61e6f0ff" />

The test result after applying the patch:

<img width="689" height="462" alt="image" src="https://github.com/user-attachments/assets/57a884c4-0db7-491e-83c4-d1ecf0a3a34f" />

Test result on other platforms:

<img width="920" height="548" alt="image" src="https://github.com/user-attachments/assets/b5d94397-d3d4-4565-bf83-d7ff369e584b" />

<img width="1216" height="700" alt="image" src="https://github.com/user-attachments/assets/7068ae27-df58-4e67-bd64-1d6b9e636f08" />


JIRA issue: [CORE-20231](https://jira.reactos.org/browse/CORE-20231)

## Proposed changes

* Add APITEST for CreateHalftonePalette: The test calls `CreateHalftonePalette(NULL)` and verifies it returns a valid palette
* Make `NtGdiCreateHalftonePalette` accept NULL: Don't fail when HDC was NULL and only lock it when it's not

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108741,108754
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108742,108755