### PR TITLE
[DC21X4] Improve MII link status indication

### DIFF
--- a/drivers/network/dd/dc21x4/media.c
+++ b/drivers/network/dd/dc21x4/media.c
@@ -145,13 +145,10 @@ MediaMiiCheckLink(
     BOOLEAN FullDuplex, Speed100;
 
     /* The link status is a latched-low bit, read it twice */
+    MiiRead(Adapter, Adapter->PhyAddress, MII_STATUS, &MiiStatus);
     if (!MiiRead(Adapter, Adapter->PhyAddress, MII_STATUS, &MiiStatus))
     {
         goto NoLink;
-    }
-    if (!(MiiStatus & MII_SR_LINK_STATUS))
-    {
-        MiiRead(Adapter, Adapter->PhyAddress, MII_STATUS, &MiiStatus);
     }
     TRACE("MII Status %04lx\n", MiiStatus);
 


### PR DESCRIPTION
## Purpose

This code should be generic for all MII PHYs so always read the BMSR register twice.

JIRA issue: none
## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: