### PR TITLE
[RICHED20] Fix crash on copy

### DIFF
--- a/dll/win32/riched20/writer.c
+++ b/dll/win32/riched20/writer.c
@@ -686,8 +686,13 @@ static BOOL stream_out_para_props( ME_TextEditor *editor, ME_OutStream *pStream,
             /* Word bar tab (vertical bar). Handled below */
             break;
         }
+#ifdef __REACTOS__
+        if ((ULONG)fmt->rgxTabs[i] >> 28 <= 5)
+          strcat(props, leader[(ULONG)fmt->rgxTabs[i] >> 28]);
+#else
         if (fmt->rgxTabs[i] >> 28 <= 5)
           strcat(props, leader[fmt->rgxTabs[i] >> 28]);
+#endif
         sprintf(props+strlen(props), "\\tx%ld", fmt->rgxTabs[i]&0x00FFFFFF);
       }
     }

--- a/dll/win32/riched20/writer.c
+++ b/dll/win32/riched20/writer.c
@@ -686,7 +686,7 @@ static BOOL stream_out_para_props( ME_TextEditor *editor, ME_OutStream *pStream,
             /* Word bar tab (vertical bar). Handled below */
             break;
         }
-#ifdef __REACTOS__
+#ifdef __REACTOS__ /* Import fix from Wine-11.3 */
         if ((ULONG)fmt->rgxTabs[i] >> 28 <= 5)
           strcat(props, leader[(ULONG)fmt->rgxTabs[i] >> 28]);
 #else


### PR DESCRIPTION
## Purpose

This PR imports this patch from Wine 11.3: https://github.com/wine-mirror/wine/commit/bb4ef1fbf7d8dae627025ea698c740cca8d15a06 (https://gitlab.winehq.org/wine/wine/-/merge_requests/9776)

<img width="837" height="672" alt="image" src="https://github.com/user-attachments/assets/12e0e97a-df84-4165-b006-781badee2fcd" />

JIRA issue: [CORE-20482](https://jira.reactos.org/browse/CORE-20482)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: