### PR TITLE
[FLOPPY] Fix double-free of the interrupt object on init failure

### DIFF
--- a/drivers/storage/floppy/floppy/floppy.c
+++ b/drivers/storage/floppy/floppy/floppy.c
@@ -1019,6 +1019,7 @@ AddControllers(PDRIVER_OBJECT DriverObject)
         {
             WARN_(FLOPPY, "AddControllers: unable to allocate an adapter object\n");
             IoDisconnectInterrupt(gControllerInfo[i].InterruptObject);
+            gControllerInfo[i].InterruptObject = NULL;
             continue;
         }
 
@@ -1027,6 +1028,7 @@ AddControllers(PDRIVER_OBJECT DriverObject)
         {
             WARN_(FLOPPY, "AddControllers(): Unable to set up controller %d - initialization failed\n", i);
             IoDisconnectInterrupt(gControllerInfo[i].InterruptObject);
+            gControllerInfo[i].InterruptObject = NULL;
             continue;
         }
 
@@ -1067,6 +1069,7 @@ AddControllers(PDRIVER_OBJECT DriverObject)
             {
                 WARN_(FLOPPY, "AddControllers: unable to register a Device object\n");
                 IoDisconnectInterrupt(gControllerInfo[i].InterruptObject);
+                gControllerInfo[i].InterruptObject = NULL;
                 continue; /* continue on to next drive */
             }
 


### PR DESCRIPTION
AddControllers already disconnects the controller interrupt on its error paths but left InterruptObject pointing at the freed object. 

Now that DriverEntry runs Cleanup on failure (and Unload() routes through it too), that stale pointer is handed to IoDisconnectInterrupt a second time, bugchecking with BAD_POOL_HEADER.

Clear InterruptObject right after disconnecting so Cleanup() skips it.

Jira issue: [CORE-20669](https://jira.reactos.org/browse/CORE-20669)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108704,108708 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108705,108709 LGTM