### PR TITLE
[CRT][UCRT][MSVCRT] intrinsic functions: Fix MSVC build (Retry #9157)

### DIFF
--- a/dll/win32/msvcrt/string.c
+++ b/dll/win32/msvcrt/string.c
@@ -39,7 +39,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 #ifdef _MSC_VER
 #pragma function(_strset,memchr,memcmp,memcpy,memset,strcat,strcmp,strcpy,strlen)
 #ifdef __REACTOS__
-#if defined(_M_ARM) || _MSC_VER >= 1932 // VS2022 version 17.2 and later
+#if defined(_M_ARM) || _MSC_VER >= 1950
 #pragma function(strncmp,strncpy)
 #endif
 #endif

--- a/dll/win32/msvcrt/wcs.c
+++ b/dll/win32/msvcrt/wcs.c
@@ -36,7 +36,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 #ifdef _MSC_VER
 #pragma function(_wcsset,wcscat,wcscmp,wcscpy,wcslen)
 #ifdef __REACTOS__
-#if defined(_M_ARM) || _MSC_VER >= 1932 // VS2022 version 17.2 and later
+#if defined(_M_ARM) || _MSC_VER >= 1950
 #pragma function(wcsncmp,wcsncpy)
 #endif
 #endif

--- a/sdk/lib/crt/string/tcsncmp.h
+++ b/sdk/lib/crt/string/tcsncmp.h
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <tchar.h>
 
-#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1932) // VS2022 version 17.2 and later
+#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1950)
 #pragma function(_tcsncmp)
 #endif /* _MSC_VER */
 

--- a/sdk/lib/crt/string/tcsncpy.h
+++ b/sdk/lib/crt/string/tcsncpy.h
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <tchar.h>
 
-#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1932) // VS2022 version 17.2 and later
+#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1950)
 #pragma function(_tcsncpy)
 #endif /* _MSC_VER */
 

--- a/sdk/lib/ucrt/string/strncmp.c
+++ b/sdk/lib/ucrt/string/strncmp.c
@@ -11,7 +11,7 @@
 
 #include <string.h>
 
-#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1932) // VS2022 version 17.2 and later
+#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1950)
     #pragma function(strncmp)
 #endif
 

--- a/sdk/lib/ucrt/string/strncpy.c
+++ b/sdk/lib/ucrt/string/strncpy.c
@@ -10,7 +10,7 @@
 
 #include <string.h>
 
-#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1932) // VS2022 version 17.2 and later
+#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1950)
     #pragma function(strncpy)
 #endif
 

--- a/sdk/lib/ucrt/string/wcsncmp.cpp
+++ b/sdk/lib/ucrt/string/wcsncmp.cpp
@@ -19,7 +19,7 @@
 
 
 
-#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1932) // VS2022 version 17.2 and later
+#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1950)
     #pragma function(wcsncmp)
 #endif
 

--- a/sdk/lib/ucrt/string/wcsncpy.cpp
+++ b/sdk/lib/ucrt/string/wcsncpy.cpp
@@ -12,7 +12,7 @@
 #pragma warning(disable:__WARNING_POSTCONDITION_NULLTERMINATION_VIOLATION) // 26036
 
 
-#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1932) // VS2022 version 17.2 and later
+#if defined(_MSC_VER) && (defined(_M_ARM) || _MSC_VER >= 1950)
     #pragma function(wcsncpy)
 #endif
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-20617](https://jira.reactos.org/browse/CORE-20617)

@learn-more found #9157 breaks the build as follows:

> error C2220: the following warning is treated as an error
> warning C4163: 'strncmp': not available as an intrinsic function
> warning C4163: 'strncpy': not available as an intrinsic function

`_MSC_VER=1932` was not the version that the intrinsic functions (`strncmp`,`strncpy`,`wcsncmp`,`wcsncpy`) added.
Using Compiler Explorer could detect the correct version: `_MSC_VER=1950`.
Tested on x86, x64, and arm64 msvc.

Test code  on Compiler Explorer (with `/WX` option):
```c
#include <stdio.h>
#include <string.h>
#pragma function(strncmp,strncpy,wcsncmp,wcsncpy)
int main() { printf("%X", _MSC_VER); return 0; }
```

## Proposed changes

- Change target version to `_MSC_VER=1950`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: