### PR TITLE
[USER32] Implement IsServerSideWindow (Retry of #7577)

### DIFF
--- a/modules/rostests/apitests/user32/CMakeLists.txt
+++ b/modules/rostests/apitests/user32/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND SOURCE
     GetWindowPlacement.c
     GW_ENABLEDPOPUP.c
     InitializeLpkHooks.c
+    IsServerSideWindow.c
     KbdLayout.c
     keybd_event.c
     LoadImage.c

--- a/modules/rostests/apitests/user32/IsServerSideWindow.c
+++ b/modules/rostests/apitests/user32/IsServerSideWindow.c
@@ -1,0 +1,104 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Test for IsServerSideWindow
+ * COPYRIGHT:   Copyright 2024 Oleg Dubinskiy <oleg.dubinskiy@reactos.org>
+ *              Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "precomp.h"
+
+static const WCHAR WndClass[] = L"window class";
+
+static LRESULT
+CALLBACK
+Test_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg)
+    {
+        case WM_PAINT:
+            return 0;
+
+        case WM_DESTROY:
+            PostQuitMessage(0);
+            return 0;
+    }
+
+    return DefWindowProcW(hWnd, msg, wParam, lParam);
+}
+
+START_TEST(IsServerSideWindow)
+{
+    HWND hWnd;
+    WNDCLASSEXW wcx;
+    BOOL ret;
+
+    ZeroMemory(&wcx, sizeof(wcx));
+    wcx.cbSize = sizeof(wcx);
+    wcx.lpfnWndProc = Test_WndProc;
+    wcx.hInstance = GetModuleHandleW(NULL);
+    wcx.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+    wcx.lpszClassName = WndClass;
+
+    if (!RegisterClassExW(&wcx))
+    {
+        skip("RegisterClassExW failed with error %lu\n", GetLastError());
+        return;
+    }
+
+    /* 1. Invalid window */
+    hWnd = (HWND)(UINT_PTR)0xdeadbeef;
+    SetLastError(0xfeedfab1);
+    ret = IsServerSideWindow(hWnd);
+    ok(!ret, "The window %p is invalid but IsServerSideWindow() returned TRUE\n", hWnd);
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_WINDOW_HANDLE);
+
+    /* 2. Window with a kernel-mode WndProc.
+     * ScrollBar is an example of a server-side window that can be created from user-mode code. */
+    hWnd = CreateWindowExW(0,
+                           L"ScrollBar",
+                           NULL,
+                           SBS_HORZ | WS_VISIBLE,
+                           CW_USEDEFAULT, CW_USEDEFAULT,
+                           400, 100,
+                           NULL, 0,
+                           wcx.hInstance, NULL);
+    if (!hWnd)
+    {
+        skip("CreateWindowExW failed with error %lu\n", GetLastError());
+        goto Quit;
+    }
+
+    SetLastError(0xfeedfab1);
+    ret = IsServerSideWindow(hWnd);
+    ok(ret, "The window %p is invalid or doesn't have a valid kernel-mode WndProc\n", hWnd);
+    ok_eq_ulong(GetLastError(), 0xfeedfab1); // The last-error shouldn't change.
+
+    DestroyWindow(hWnd);
+
+    /* 3. Window with a user-mode WndProc */
+    hWnd = CreateWindowExW(0,
+                           WndClass,
+                           NULL,
+                           WS_CAPTION | WS_SYSMENU,
+                           CW_USEDEFAULT, CW_USEDEFAULT,
+                           400, 100,
+                           NULL, 0,
+                           wcx.hInstance, NULL);
+    if (!hWnd)
+    {
+        skip("CreateWindowExW failed with error %lu\n", GetLastError());
+        goto Quit;
+    }
+
+    SetLastError(0xfeedfab1);
+    ret = IsServerSideWindow(hWnd);
+    ok(!ret, "The window %p has a valid kernel-mode WndProc when it should not\n", hWnd);
+    ok_eq_ulong(GetLastError(), 0xfeedfab1); // The last-error shouldn't change.
+
+    DestroyWindow(hWnd);
+
+Quit:
+    UnregisterClassW(WndClass, wcx.hInstance);
+    return;
+}

--- a/modules/rostests/apitests/user32/testlist.c
+++ b/modules/rostests/apitests/user32/testlist.c
@@ -29,6 +29,7 @@ extern void func_GetUserObjectInformation(void);
 extern void func_GetWindowPlacement(void);
 extern void func_GW_ENABLEDPOPUP(void);
 extern void func_InitializeLpkHooks(void);
+extern void func_IsServerSideWindow(void);
 extern void func_KbdLayout(void);
 extern void func_keybd_event(void);
 extern void func_LoadImage(void);
@@ -94,6 +95,7 @@ const struct test winetest_testlist[] =
     { "GetWindowPlacement", func_GetWindowPlacement },
     { "GW_ENABLEDPOPUP", func_GW_ENABLEDPOPUP },
     { "InitializeLpkHooks", func_InitializeLpkHooks },
+    { "IsServerSideWindow", func_IsServerSideWindow },
     { "KbdLayout", func_KbdLayout },
     { "keybd_event", func_keybd_event },
     { "LoadImage", func_LoadImage },

--- a/sdk/include/reactos/undocuser.h
+++ b/sdk/include/reactos/undocuser.h
@@ -212,6 +212,7 @@ CliImmSetHotKey(
                     !(IME_HOTKEY_DSWITCH_FIRST <= dwHotKeyId &&
                       dwHotKeyId <= IME_HOTKEY_DSWITCH_LAST), _Null_) HKL hKL);
 
+BOOL WINAPI IsServerSideWindow(HWND);
 HWND WINAPI SetTaskmanWindow(HWND);
 HWND WINAPI GetTaskmanWindow(VOID);
 HWND WINAPI GetProgmanWindow(VOID);

--- a/win32ss/user/user32/misc/stubs.c
+++ b/win32ss/user/user32/misc/stubs.c
@@ -435,15 +435,6 @@ WORD WINAPI InitializeWin32EntryTable(UCHAR* EntryTablePlus0x1000)
 /*
  * @unimplemented
  */
-BOOL WINAPI IsServerSideWindow(HWND wnd)
-{
-  UNIMPLEMENTED;
-  return FALSE;
-}
-
-/*
- * @unimplemented
- */
 VOID WINAPI AllowForegroundActivation(VOID)
 {
   UNIMPLEMENTED;

--- a/win32ss/user/user32/windows/window.c
+++ b/win32ss/user/user32/windows/window.c
@@ -1510,6 +1510,30 @@ IsIconic(HWND hWnd)
 }
 
 
+/**
+ * @brief
+ * Checks whether a window has a window procedure that resides in kernel mode.
+ *
+ * @param[in]   hWnd
+ * A handle to the window to be checked.
+ *
+ * @return
+ * TRUE if the window has a window procedure that resides in kernel mode,
+ * FALSE otherwise.
+ *
+ * @remarks
+ * Undocumented, see https://undoc.airesoft.co.uk/user32.dll/IsServerSideWindow.php
+ **/
+BOOL
+WINAPI
+IsServerSideWindow(
+    _In_ HWND hWnd)
+{
+    PWND Wnd = ValidateHwnd(hWnd);
+    return Wnd && (Wnd->state & WNDS_SERVERSIDEWINDOWPROC);
+}
+
+
 /*
  * @implemented
  */


### PR DESCRIPTION
## Purpose

This PR implements `IsServerSideWindow` undocumented function, which is needed by original `uxtheme.dll` implementation from Windows.

This is a retry of #7577, it imports commits from the old PR while addressing merge conflicts and review comments.

<img width="1204" height="686" alt="image" src="https://github.com/user-attachments/assets/80a5274d-a46b-4732-841d-6843deb3fbea" />

<img width="721" height="498" alt="image" src="https://github.com/user-attachments/assets/ac98ad38-28bc-48d4-903c-af6ebe6ba818" />

JIRA issue: [CORE-19946](https://jira.reactos.org/browse/CORE-19946)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108821,108826
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108820,108827