### PR TITLE
[NTOS][RTL] Thread creation and context fixes

### DIFF
--- a/dll/win32/kernel32/client/utils.c
+++ b/dll/win32/kernel32/client/utils.c
@@ -588,7 +588,7 @@ BaseInitializeContext(IN PCONTEXT Context,
     /* Setup the Initial Win32 Thread Context */
     Context->Rcx = (ULONG_PTR)StartAddress;
     Context->Rdx = (ULONG_PTR)Parameter;
-    Context->Rsp = (ULONG_PTR)StackAddress - 5 * sizeof(PVOID);
+    Context->Rsp = (ULONG_PTR)StackAddress;
 
     /* Setup the Segments */
     Context->SegGs = KGDT64_R3_DATA | RPL_MASK;

--- a/ntoskrnl/ke/amd64/context.c
+++ b/ntoskrnl/ke/amd64/context.c
@@ -88,7 +88,7 @@ KeContextToTrapFrame(IN PCONTEXT Context,
         TrapFrame->Rsp = Context->Rsp;
         TrapFrame->EFlags = Context->EFlags;
 
-        if ((Context->SegCs & MODE_MASK) == KernelMode)
+        if (PreviousMode == KernelMode)
         {
             /* Set valid selectors */
             TrapFrame->SegCs = KGDT64_R0_CODE;
@@ -118,7 +118,7 @@ KeContextToTrapFrame(IN PCONTEXT Context,
     if (ContextFlags & CONTEXT_SEGMENTS)
     {
         /* Check if this was a Kernel Trap */
-        if ((Context->SegCs & MODE_MASK) == KernelMode)
+        if (PreviousMode == KernelMode)
         {
             /* Set valid selectors */
             TrapFrame->SegDs = KGDT64_R3_DATA | RPL_MASK;
@@ -147,7 +147,7 @@ KeContextToTrapFrame(IN PCONTEXT Context,
         TrapFrame->Dr6 = Context->Dr6;
         TrapFrame->Dr7 = Context->Dr7;
 
-        if ((Context->SegCs & MODE_MASK) != KernelMode)
+        if (PreviousMode != KernelMode)
         {
             if (TrapFrame->Dr0 > (ULONG64)MmHighestUserAddress)
                 TrapFrame->Dr0 = 0;

--- a/ntoskrnl/ke/amd64/thrdini.c
+++ b/ntoskrnl/ke/amd64/thrdini.c
@@ -116,10 +116,15 @@ KiInitializeContextThread(IN PKTHREAD Thread,
                              CONTEXT_AMD64 | ContextFlags,
                              UserMode);
 
-        /* Set SS, DS, ES's RPL Mask properly */
-        TrapFrame->SegSs |= RPL_MASK;
-        TrapFrame->SegDs |= RPL_MASK;
-        TrapFrame->SegEs |= RPL_MASK;
+        /* Set user mode segment selectors */
+        TrapFrame->SegDs = KGDT64_R3_DATA | RPL_MASK;
+        TrapFrame->SegEs = KGDT64_R3_DATA | RPL_MASK;
+        TrapFrame->SegFs = KGDT64_R3_CMTEB | RPL_MASK;
+        TrapFrame->SegGs = KGDT64_R3_DATA | RPL_MASK;
+        TrapFrame->SegCs = KGDT64_R3_CODE | RPL_MASK;
+        TrapFrame->SegSs = KGDT64_R3_DATA | RPL_MASK;
+
+        /* Clear DR7 */
         TrapFrame->Dr7 = 0;
 
         /* Set the previous mode as user */
@@ -133,6 +138,9 @@ KiInitializeContextThread(IN PKTHREAD Thread,
 
         /* KiUserThreadStartupExit returns to KiServiceExit3 */
         InitFrame->ExceptionFrame.Return = (ULONG64)KiServiceExit3;
+
+        /* Allocate home space on the stack */
+        TrapFrame->Rsp -= 5 * sizeof(PVOID);
     }
     else
     {

--- a/ntoskrnl/ke/amd64/thrdini.c
+++ b/ntoskrnl/ke/amd64/thrdini.c
@@ -46,6 +46,7 @@ KiInitializeContextThread(IN PKTHREAD Thread,
     PKSTART_FRAME StartFrame;
     PKSWITCH_FRAME CtxSwitchFrame;
     PKTRAP_FRAME TrapFrame;
+    PKEXCEPTION_FRAME ExceptionFrame;
     ULONG ContextFlags;
     PVOID InitialStack;
 
@@ -102,19 +103,37 @@ KiInitializeContextThread(IN PKTHREAD Thread,
         ASSERT((Context->ContextFlags & CONTEXT_CONTROL) == CONTEXT_CONTROL);
         ContextFlags = Context->ContextFlags & ~CONTEXT_DEBUG_REGISTERS;
 
-        /* Setup the Trap Frame */
+        /* Zero-initialize the Trap Frame and exception frame */
         TrapFrame = &InitFrame->TrapFrame;
-
-        /* Zero out the trap frame */
         RtlZeroMemory(TrapFrame, sizeof(KTRAP_FRAME));
-        RtlZeroMemory(&InitFrame->ExceptionFrame, sizeof(KEXCEPTION_FRAME));
+        ExceptionFrame = &InitFrame->ExceptionFrame;
+        RtlZeroMemory(ExceptionFrame, sizeof(KEXCEPTION_FRAME));
 
-        /* Set up a trap frame from the context. */
-        KeContextToTrapFrame(Context,
-                             &InitFrame->ExceptionFrame,
-                             TrapFrame,
-                             CONTEXT_AMD64 | ContextFlags,
-                             UserMode);
+        /* Copy integer registers */
+        TrapFrame->Rax = Context->Rax;
+        TrapFrame->Rcx = Context->Rcx;
+        TrapFrame->Rdx = Context->Rdx;
+        TrapFrame->Rbp = 0; // Context->Rbp; // 0 on Vista, copied on Win 10
+        TrapFrame->R8 = Context->R8;
+        TrapFrame->R9 = Context->R9;
+        TrapFrame->R10 = Context->R10;
+        TrapFrame->R11 = Context->R11;
+        ExceptionFrame->Rbx = Context->Rbx;
+        ExceptionFrame->Rsi = Context->Rsi;
+        ExceptionFrame->Rdi = Context->Rdi;
+        ExceptionFrame->R12 = Context->R12;
+        ExceptionFrame->R13 = Context->R13;
+        ExceptionFrame->R14 = Context->R14;
+        ExceptionFrame->R15 = Context->R15;
+
+        /* Copy RIP, RSP, EFLAGS */
+        TrapFrame->Rip = Context->Rip;
+        TrapFrame->Rsp = Context->Rsp;
+        TrapFrame->EFlags = Context->EFlags;
+
+        /* Sanitize EFLAGS */
+        TrapFrame->EFlags &= EFLAGS_USER_THREAD_SANITIZE;
+        TrapFrame->EFlags |= EFLAGS_INTERRUPT_MASK;
 
         /* Set user mode segment selectors */
         TrapFrame->SegDs = KGDT64_R3_DATA | RPL_MASK;
@@ -127,6 +146,9 @@ KiInitializeContextThread(IN PKTHREAD Thread,
         /* Clear DR7 */
         TrapFrame->Dr7 = 0;
 
+        /* Initialize floating point state */
+        TrapFrame->MxCsr = INITIAL_MXCSR;
+
         /* Set the previous mode as user */
         TrapFrame->PreviousMode = UserMode;
 
@@ -137,7 +159,7 @@ KiInitializeContextThread(IN PKTHREAD Thread,
         StartFrame->Return = (ULONG64)KiUserThreadStartupExit;
 
         /* KiUserThreadStartupExit returns to KiServiceExit3 */
-        InitFrame->ExceptionFrame.Return = (ULONG64)KiServiceExit3;
+        ExceptionFrame->Return = (ULONG64)KiServiceExit3;
 
         /* Allocate home space on the stack */
         TrapFrame->Rsp -= 5 * sizeof(PVOID);

--- a/ntoskrnl/ke/amd64/usercall.c
+++ b/ntoskrnl/ke/amd64/usercall.c
@@ -108,9 +108,8 @@ KiInitializeUserApc(
     TrapFrame->SegGs = KGDT64_R3_DATA | RPL_MASK;
     TrapFrame->SegSs = KGDT64_R3_DATA | RPL_MASK;
 
-    /* Sanitize EFLAGS, enable interrupts */
-    TrapFrame->EFlags &= EFLAGS_USER_SANITIZE;
-    TrapFrame->EFlags |= EFLAGS_INTERRUPT_MASK;
+    /* Initialize EFLAGS */
+    TrapFrame->EFlags = EFLAGS_INTERRUPT_MASK;
 }
 
 /*

--- a/sdk/include/ndk/amd64/ketypes.h
+++ b/sdk/include/ndk/amd64/ketypes.h
@@ -191,10 +191,15 @@ typedef enum
 // EFlags
 //
 #define EFLAGS_CF               0x01L
+#define EFLAGS_RESERVED1        0x02L
+#define EFLAGS_PF               0x04L
+#define EFLAGS_AF               0x10L
 #define EFLAGS_ZF               0x40L
+#define EFLAGS_SF               0x80L
 #define EFLAGS_TF               0x100L
 #define EFLAGS_INTERRUPT_MASK   0x200L
 #define EFLAGS_DF               0x400L
+#define EFLAGS_OF               0x800L
 #define EFLAGS_IOPL             0x3000L
 #define EFLAGS_NESTED_TASK      0x4000L
 //#define EFLAGS_NF               0x4000
@@ -212,6 +217,7 @@ typedef enum
 #define EFLAGS_ID_MASK          0x200000
 #define EFLAGS_IF_MASK          0x0200
 #define EFLAGS_IF_SHIFT         0x0009
+#define EFLAGS_USER_THREAD_SANITIZE 0x200FD5 /* Allowed flags: ID|OF|DF|IF|TF|SF|ZF|AF|PF|CF */
 
 //
 // MXCSR Floating Control/Status Bit Masks

--- a/sdk/lib/rtl/amd64/stubs.c
+++ b/sdk/lib/rtl/amd64/stubs.c
@@ -27,16 +27,15 @@ RtlInitializeContext(
     _In_ PTHREAD_START_ROUTINE ThreadStartAddress,
     _In_ PVOID StackBase)
 {
-    /* Initialize everything to 0 */
-    RtlZeroMemory(ThreadContext, sizeof(*ThreadContext));
+    /* Make sure the stack is aligned */
+    if (((ULONG_PTR)StackBase & 0xF) != 0)
+    {
+        RtlRaiseStatus(STATUS_BAD_INITIAL_STACK);
+    }
 
     /* Initialize StartAddress and Stack */
     ThreadContext->Rip = (ULONG64)ThreadStartAddress;
-    ThreadContext->Rsp = (ULONG64)StackBase - 6 * sizeof(PVOID);
-
-    /* Align stack by 16 and substract 8 (unaligned on function entry) */
-    ThreadContext->Rsp &= ~15;
-    ThreadContext->Rsp -= 8;
+    ThreadContext->Rsp = (ULONG64)StackBase;
 
     /* Enable Interrupts */
     ThreadContext->EFlags = EFLAGS_INTERRUPT_MASK;
@@ -44,35 +43,29 @@ RtlInitializeContext(
     /* Set start parameter */
     ThreadContext->Rcx = (ULONG64)ThreadStartParam;
 
-    /* Set the Selectors */
-    if ((LONG64)ThreadStartAddress < 0)
-    {
-        /* Initialize kernel mode segments */
-        ThreadContext->SegCs = KGDT64_R0_CODE;
-        ThreadContext->SegDs = KGDT64_R3_DATA;
-        ThreadContext->SegEs = KGDT64_R3_DATA;
-        ThreadContext->SegFs = KGDT64_R3_CMTEB;
-        ThreadContext->SegGs = KGDT64_R3_DATA;
-        ThreadContext->SegSs = KGDT64_R0_DATA;
-    }
-    else
-    {
-        /* Initialize user mode segments */
-        ThreadContext->SegCs = KGDT64_R3_CODE |  RPL_MASK;
-        ThreadContext->SegDs = KGDT64_R3_DATA |  RPL_MASK;
-        ThreadContext->SegEs = KGDT64_R3_DATA |  RPL_MASK;
-        ThreadContext->SegFs = KGDT64_R3_CMTEB |  RPL_MASK;
-        ThreadContext->SegGs = KGDT64_R3_DATA |  RPL_MASK;
-        ThreadContext->SegSs = KGDT64_R3_DATA |  RPL_MASK;
-    }
-
+    /* Initialize floating point and SSE state */
+    RtlZeroMemory(&ThreadContext->FltSave, sizeof(ThreadContext->FltSave));
     ThreadContext->MxCsr = INITIAL_MXCSR;
+    ThreadContext->FltSave.MxCsr = INITIAL_MXCSR;
+    ThreadContext->FltSave.ControlWord = INITIAL_FPCSR;
 
-    /* Only the basic Context is initialized */
-    ThreadContext->ContextFlags = CONTEXT_CONTROL |
-                                  CONTEXT_INTEGER |
-                                  CONTEXT_SEGMENTS |
-                                  CONTEXT_FLOATING_POINT;
+    /* Initialize integer registers */
+    ThreadContext->Rbp = 0x0000000000000000ull;
+    ThreadContext->Rax = 0x0000000000000000ull;
+    ThreadContext->Rbx = 0x0000000000000001ull;
+    ThreadContext->Rsi = 0x0000000000000004ull;
+    ThreadContext->Rdi = 0x0000000000000005ull;
+    ThreadContext->R8  = 0x0000000000000008ull;
+    ThreadContext->R9  = 0xF0E0D0C0A0908070ull;
+    ThreadContext->R10 = 0x000000000000000Aull;
+    ThreadContext->R11 = 0x000000000000000Bull;
+    ThreadContext->R12 = 0x000000000000000Cull;
+    ThreadContext->R13 = 0x000000000000000Dull;
+    ThreadContext->R14 = 0x000000000000000Eull;
+    ThreadContext->R15 = 0x000000000000000Full;
+
+    /* Set the context flags */
+    ThreadContext->ContextFlags = CONTEXT_FULL;
 
     return;
 }


### PR DESCRIPTION
## Purpose

Fix thread creation and context initialization on x64.

## Proposed changes
* [NTOS:KE/x64] Fix KeContextToTrapFrame
* [RTL/x64][NTOS:KE/x64] Fix RtlInitializeContext
* [NTOS:KE/x64] Fix KiInitializeUserApc
* [NTOS:KE/x64] Fix KiInitializeContextThread

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109126,109135
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109133,109136
