### PR TITLE
[ROSAUTOTEST] Misc fixes

### DIFF
--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -189,7 +189,6 @@ target_link_libraries(kmtest ${PSEH_LIB})
 add_importlibs(kmtest fltlib advapi32 ws2_32 msvcrt kernel32 ntdll)
 target_compile_definitions(kmtest PRIVATE KMT_USER_MODE NTDDI_VERSION=NTDDI_WS03SP1)
 #add_pch(kmtest include/kmt_test.h)
-set_target_properties(kmtest PROPERTIES OUTPUT_NAME "kmtest_")
 add_rostests_file(TARGET kmtest)
 
 #

--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -46,9 +46,6 @@ CWineTest::~CWineTest()
 {
     if(m_hFind)
         FindClose(m_hFind);
-
-    if(m_ListBuffer)
-        delete m_ListBuffer;
 }
 
 /**
@@ -154,45 +151,46 @@ CWineTest::GetNextFile()
 DWORD
 CWineTest::DoListCommand()
 {
-    DWORD BytesAvailable;
-    DWORD Temp;
+    DWORD BytesRead;
     wstring CommandLine;
     CPipe Pipe;
+    CHAR TempBuffer[1024];
+    DWORD ret;
+
+    m_ListString.clear();
 
     /* Build the command line */
     CommandLine = m_TestPath;
     CommandLine += m_CurrentFile;
     CommandLine += L" --list";
 
-    {
-        /* Start the process for getting all available tests */
-        CPipedProcess Process(CommandLine, Pipe);
+    /* Start the process for getting all available tests */
+    CPipedProcess Process(CommandLine, Pipe);
 
-        /* Wait till this process ended */
-        if(WaitForSingleObject(Process.GetProcessHandle(), ListTimeout) == WAIT_FAILED)
-            TESTEXCEPTION("WaitForSingleObject failed for the test list\n");
+    for (;;)
+    {
+        /* Try to read from the pipe */
+        ret = Pipe.Read(TempBuffer, ARRAYSIZE(TempBuffer), &BytesRead, ListTimeout);
+
+        /* If the pipe is broken, the process terminated */
+        if (ret == ERROR_BROKEN_PIPE)
+            break;
+
+        /* Timeout, the process might not be responding */
+        if (ret == WAIT_TIMEOUT)
+            break;
+
+        if (ret != ERROR_SUCCESS)
+            TESTEXCEPTION("Unexpected error\n");
+
+        m_ListString.append(TempBuffer, BytesRead);
     }
 
-    /* Read the output data into a buffer */
-    if(!Pipe.Peek(NULL, 0, NULL, &BytesAvailable))
-        TESTEXCEPTION("CPipe::Peek failed for the test list\n");
+    if (WaitForSingleObject(Process.GetProcessHandle(), ListTimeout) != ERROR_SUCCESS)
+        TESTEXCEPTION("WaitForSingleObject failed for the test list\n");
 
-    /* Check if we got any */
-    if(!BytesAvailable)
-    {
-        stringstream ss;
-
-        ss << "The --list command did not return any data for " << UnicodeToAscii(m_CurrentFile) << endl;
-        TESTEXCEPTION(ss.str());
-    }
-
-    /* Read the data */
-    m_ListBuffer = new char[BytesAvailable];
-
-    if(Pipe.Read(m_ListBuffer, BytesAvailable, &Temp, INFINITE) != ERROR_SUCCESS)
-        TESTEXCEPTION("CPipe::Read failed\n");
-
-    return BytesAvailable;
+    m_ListBuffer = (PCHAR)m_ListString.c_str();
+    return (DWORD)m_ListString.size();
 }
 
 /**
@@ -225,8 +223,8 @@ CWineTest::GetNextTest()
         m_CurrentFile.clear();
 
         /* Also free the memory for the list buffer */
-        delete[] m_ListBuffer;
         m_ListBuffer = NULL;
+        m_ListString.clear();
 
         return false;
     }
@@ -234,8 +232,12 @@ CWineTest::GetNextTest()
     /* Get start and end of this test name */
     pEnd = pStart;
 
-    while(*pEnd != '\r')
+    while (*pEnd != '\r')
+    {
+        if (*pEnd == '\0')
+            TESTEXCEPTION("Unexpected test list format\n");
         ++pEnd;
+    }
 
     /* Store the test name */
     m_CurrentTest = string(pStart, pEnd);
@@ -314,7 +316,7 @@ CWineTest::GetNextTestInfo()
             StringOut(e.GetMessage());
             StringOut("\n");
             m_CurrentFile.clear();
-            delete[] m_ListBuffer;
+            m_ListString.clear();
         }
     }
 

--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -90,18 +90,29 @@ CWineTest::GetNextFile()
     {
         /* Start searching for test files */
         wstring FindPath = m_TestPath;
+        wstring Module = Configuration.GetModule();
 
         /* Did the user specify a module? */
-        if(Configuration.GetModule().empty())
+        if(Module.empty())
         {
-            /* No module, so search for all files in that directory */
-            FindPath += L"*.exe";
+            /* No module, so search for all "*test.exe" files in that directory */
+            FindPath += L"*test.exe";
         }
         else
         {
-            /* Search for files with the pattern "modulename_*" */
-            FindPath += Configuration.GetModule();
-            FindPath += L"_*.exe";
+            /* Check for 'special' tests (e.g. "kmtest") or full test name ("ntdll_winetest") */
+            if (Module.substr(Module.length() - 4, 4) == L"test")
+            {
+                /* Search for files with the pattern "modulename.exe" */
+                FindPath += Configuration.GetModule();
+                FindPath += L".exe";
+            }
+            else
+            {
+                /* Search for files with the pattern "modulename_*test.exe" */
+                FindPath += Configuration.GetModule();
+                FindPath += L"_*test.exe";
+            }
         }
 
         /* Search for the first file and check whether we got one */

--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -279,10 +279,10 @@ CWineTest::GetNextTestInfo()
 
                     if(UnderscorePosition == m_CurrentFile.npos)
                     {
-                        stringstream ss;
-
-                        ss << "Invalid test file name: " << UnicodeToAscii(m_CurrentFile) << endl;
-                        SSEXCEPTION;
+                        /* Use the entire name (without .exe extendion) */
+                        UnderscorePosition = m_CurrentFile.find_first_of('.');
+                        if(UnderscorePosition == m_CurrentFile.npos)
+                            UnderscorePosition = m_CurrentFile.length();
                     }
 
                     TestInfo->Module = UnicodeToAscii(m_CurrentFile.substr(0, UnderscorePosition));

--- a/modules/rostests/rosautotest/CWineTest.h
+++ b/modules/rostests/rosautotest/CWineTest.h
@@ -9,6 +9,7 @@ class CWineTest : public CTest
 {
 private:
     HANDLE m_hFind;
+    std::string m_ListString;
     PCHAR m_ListBuffer;
     string m_CurrentTest;
     wstring m_CurrentFile;

--- a/sdk/include/xdk/ntbasedef.h
+++ b/sdk/include/xdk/ntbasedef.h
@@ -689,16 +689,16 @@ typedef struct _GROUP_AFFINITY {
 
 #define RTL_NUMBER_OF_V1(A) (sizeof(A)/sizeof((A)[0]))
 
-#ifdef __GNUC__
- #define RTL_NUMBER_OF_V2(A) \
-     (({ int _check_array_type[__builtin_types_compatible_p(typeof(A), typeof(&A[0])) ? -1 : 1]; (void)_check_array_type; }), \
-     RTL_NUMBER_OF_V1(A))
-#elif defined(__cplusplus)
+#if defined(__cplusplus)
 extern "C++" {
  template <typename T, size_t N>
  static char (& SAFE_RTL_NUMBER_OF(T (&)[N]))[N];
 }
  #define RTL_NUMBER_OF_V2(A) sizeof(SAFE_RTL_NUMBER_OF(A))
+#elif defined(__GNUC__)
+ #define RTL_NUMBER_OF_V2(A) \
+     (({ int _check_array_type[__builtin_types_compatible_p(typeof(A), typeof(&A[0])) ? -1 : 1]; (void)_check_array_type; }), \
+     RTL_NUMBER_OF_V1(A))
 #else
  #define RTL_NUMBER_OF_V2(A) RTL_NUMBER_OF_V1(A)
 #endif


### PR DESCRIPTION
## Purpose

Fix rosautotest

## Proposed changes

- Handle test executables without an underscore (e.g. kmtest.exe)
- Rename kmtest_.exe back to kmtest.exe
- Don't run random executables in the bin folder. Instead only run *test.exe.
- Fix reading of test list. Fixes large test lists, that previously got truncated and could result in a crash.
- Prevent crash on parsing invalid test lists.
- Use an std::string for the list storage.

<img width="800" height="600" alt="ReactOS - rosautotest" src="https://github.com/user-attachments/assets/f3c384b4-c83b-467f-9858-079454ce6a9e" />


## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108795,108802
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108796,108801