### PR TITLE
[RTL_UNITTEST] Add RtlpInitialize

### DIFF
--- a/modules/rostests/apitests/rtl/CMakeLists.txt
+++ b/modules/rostests/apitests/rtl/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 
 list(APPEND SOURCE
+    rtlinit.c
     RtlIntSafe.c
 )
 
@@ -43,9 +44,10 @@ endif()
 
 # RTL tests with static linkage (called unittest, so it won't run in rosautotest)
 add_executable(rtl_unittest
+    rtlinit.c
     testlist.c
     ldrstubs.c)
-target_compile_definitions(rtl_unittest PRIVATE _RTL_TEST _NTSYSTEM_)
+target_compile_definitions(rtl_unittest PRIVATE _RTL_TEST _NTSYSTEM_ TEST_STATIC)
 target_link_libraries(rtl_unittest rtl_test_lib rtl rtl_um rtl_vista wine uuid ${PSEH_LIB})
 set_module_type(rtl_unittest win32cui)
 add_importlibs(rtl_unittest msvcrt advapi32 kernel32 ntdll)

--- a/modules/rostests/apitests/rtl/rtlinit.c
+++ b/modules/rostests/apitests/rtl/rtlinit.c
@@ -1,0 +1,19 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Initialization for RTL unit test
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include <rtltests.h>
+
+VOID NTAPI RtlpInitializeVectoredExceptionHandling(VOID);
+
+VOID
+NTAPI
+RtlpInitialize(VOID)
+{
+#ifdef TEST_STATIC
+    RtlpInitializeVectoredExceptionHandling();
+#endif
+}

--- a/modules/rostests/apitests/rtl/rtltests.h
+++ b/modules/rostests/apitests/rtl/rtltests.h
@@ -10,3 +10,7 @@
 #include <apitest.h>
 #include <ndk/ntndk.h>
 #include <strsafe.h>
+
+VOID
+NTAPI
+RtlpInitialize(VOID);


### PR DESCRIPTION
## Purpose

Add RtlpInitialize for RTL unit test.
This will be compiled as a dummy in the test library, but in the unit test it will actually initialize the required RTL things. For now it is only RtlpInitializeVectoredExceptionHandling. This prevents a problem with the RtlVirtualUnwind test.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108792,108795,108799
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108793,108796,108798