### PR TITLE
[KERNEL32_VISTA] Honor dwFlags in InitializeCriticalSectionEx

### DIFF
--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -945,7 +945,6 @@
 @ stdcall RtlInitializeContext(ptr ptr ptr ptr ptr)
 @ stdcall RtlInitializeCriticalSection(ptr)
 @ stdcall RtlInitializeCriticalSectionAndSpinCount(ptr long)
-@ stdcall -version=0x600+ RtlInitializeCriticalSectionEx(ptr long long) ntdll_vista.RtlInitializeCriticalSectionEx
 @ stdcall -stub -version=0x600+ -arch=i386 RtlInitializeExceptionChain(ptr)
 @ stdcall RtlInitializeGenericTable(ptr ptr ptr ptr ptr)
 @ stdcall RtlInitializeGenericTableAvl(ptr ptr ptr ptr ptr)

--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -945,6 +945,7 @@
 @ stdcall RtlInitializeContext(ptr ptr ptr ptr ptr)
 @ stdcall RtlInitializeCriticalSection(ptr)
 @ stdcall RtlInitializeCriticalSectionAndSpinCount(ptr long)
+@ stdcall -version=0x600+ RtlInitializeCriticalSectionEx(ptr long long) ntdll_vista.RtlInitializeCriticalSectionEx
 @ stdcall -stub -version=0x600+ -arch=i386 RtlInitializeExceptionChain(ptr)
 @ stdcall RtlInitializeGenericTable(ptr ptr ptr ptr ptr)
 @ stdcall RtlInitializeGenericTableAvl(ptr ptr ptr ptr ptr)

--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -945,7 +945,6 @@
 @ stdcall RtlInitializeContext(ptr ptr ptr ptr ptr)
 @ stdcall RtlInitializeCriticalSection(ptr)
 @ stdcall RtlInitializeCriticalSectionAndSpinCount(ptr long)
-@ stdcall -version=0x600+ RtlInitializeCriticalSectionEx(ptr long long)
 @ stdcall -stub -version=0x600+ -arch=i386 RtlInitializeExceptionChain(ptr)
 @ stdcall RtlInitializeGenericTable(ptr ptr ptr ptr ptr)
 @ stdcall RtlInitializeGenericTableAvl(ptr ptr ptr ptr ptr)

--- a/dll/ntdll/nt_0600/ntdll_vista.spec
+++ b/dll/ntdll/nt_0600/ntdll_vista.spec
@@ -2,6 +2,7 @@
 @ stdcall LdrUnregisterDllNotification(ptr)
 
 @ stdcall RtlInitializeConditionVariable(ptr)
+@ stdcall RtlInitializeCriticalSectionEx(ptr long long)
 @ stdcall RtlWakeConditionVariable(ptr)
 @ stdcall RtlWakeAllConditionVariable(ptr)
 @ stdcall RtlSleepConditionVariableCS(ptr ptr ptr)

--- a/dll/ntdll/nt_0600/ntdll_vista.spec
+++ b/dll/ntdll/nt_0600/ntdll_vista.spec
@@ -2,7 +2,6 @@
 @ stdcall LdrUnregisterDllNotification(ptr)
 
 @ stdcall RtlInitializeConditionVariable(ptr)
-@ stdcall RtlInitializeCriticalSectionEx(ptr long long)
 @ stdcall RtlWakeConditionVariable(ptr)
 @ stdcall RtlWakeAllConditionVariable(ptr)
 @ stdcall RtlSleepConditionVariableCS(ptr ptr ptr)

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -974,6 +974,7 @@
 @ stdcall -arch=x86_64 RtlDeleteFunctionTable(ptr) ntdll.RtlDeleteFunctionTable
 @ stdcall RtlFillMemory(ptr long long) ntdll.RtlFillMemory
 @ stdcall -arch=x86_64 RtlInstallFunctionTableCallback(double double long ptr ptr ptr) ntdll.RtlInstallFunctionTableCallback
+@ stdcall -version=0x600+ RtlInitializeCriticalSectionEx(ptr long long) kernel32_vista.RtlInitializeCriticalSectionEx
 @ stdcall -arch=x86_64 RtlLookupFunctionEntry(ptr ptr ptr) ntdll.RtlLookupFunctionEntry
 @ stdcall RtlMoveMemory(ptr ptr long) ntdll.RtlMoveMemory
 @ stdcall -arch=x86_64 RtlPcToFileHeader(ptr ptr) ntdll.RtlPcToFileHeader

--- a/dll/win32/kernel32/kernel32_vista/kernel32_vista.spec
+++ b/dll/win32/kernel32/kernel32_vista/kernel32_vista.spec
@@ -19,6 +19,7 @@
 @ stdcall WakeAllConditionVariable(ptr)
 @ stdcall WakeConditionVariable(ptr)
 
+@ stdcall RtlInitializeCriticalSectionEx(ptr long long)
 @ stdcall InitializeCriticalSectionEx(ptr long long)
 
 @ stdcall GetFirmwareEnvironmentVariableExA(str str ptr long long)

--- a/dll/win32/kernel32/kernel32_vista/sync.c
+++ b/dll/win32/kernel32/kernel32_vista/sync.c
@@ -104,18 +104,17 @@ WakeConditionVariable(PCONDITION_VARIABLE ConditionVariable)
 /*
 * @implemented
 */
-BOOL WINAPI InitializeCriticalSectionEx(OUT LPCRITICAL_SECTION lpCriticalSection,
-                                        IN DWORD dwSpinCount,
-                                        IN DWORD flags)
+BOOL
+WINAPI
+InitializeCriticalSectionEx(_Out_ LPCRITICAL_SECTION lpCriticalSection,
+                             _In_ DWORD dwSpinCount,
+                             _In_ DWORD dwFlags)
 {
     NTSTATUS Status;
 
-    /* FIXME: Flags ignored */
-
-    /* Initialize the critical section */
-    Status = RtlInitializeCriticalSectionAndSpinCount(
-        (PRTL_CRITICAL_SECTION)lpCriticalSection,
-        dwSpinCount);
+    Status = RtlInitializeCriticalSectionEx((PRTL_CRITICAL_SECTION)lpCriticalSection,
+                                             dwSpinCount,
+                                             dwFlags);
     if (!NT_SUCCESS(Status))
     {
         /* Set failure code */

--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -3195,6 +3195,15 @@ RtlInitializeCriticalSection(
 NTSYSAPI
 NTSTATUS
 NTAPI
+RtlInitializeCriticalSectionEx(
+    _Out_ PRTL_CRITICAL_SECTION CriticalSection,
+    _In_ ULONG SpinCount,
+    _In_ ULONG Flags
+);
+
+NTSYSAPI
+NTSTATUS
+NTAPI
 RtlInitializeCriticalSectionAndSpinCount(
     _In_ PRTL_CRITICAL_SECTION CriticalSection,
     _In_ ULONG SpinCount


### PR DESCRIPTION
## Purpose

Resolve a FIXME that ignored the flags passed in `InitializeCriticalSectionEx`. Also replace the old IN with SAL2.

JIRA issue: None

## Proposed changes
- Forward `dwFlags` to `RtlInitializeCriticalSectionEx`
- Add a header declaration for `RtlInitializeCriticalSectionEx`
- Change parameters to SAL2

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: