### PR TITLE
[COMCTL32] Pass a couple of window messages to the active page of property sheets

### DIFF
--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -3767,6 +3767,7 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
          HWND hwndPage = psInfo->proppage[i].hwndPage;
          SendMessageW(hwndPage, uMsg, wParam, lParam);
       }
+      SendDlgItemMessageW(hwnd, IDC_TABCONTROL, uMsg, wParam, lParam);
       return FALSE;
     }
 #endif

--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -3772,6 +3772,37 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     }
 #endif
 
+#ifdef __REACTOS__
+    case WM_ENABLE:
+    case WM_QUERYENDSESSION:
+    case WM_ENDSESSION:
+    case WM_DEVICECHANGE:
+    {
+        /* Send to the tab control, before forwarding it to the active page */
+        SendDlgItemMessageW(hwnd, IDC_TABCONTROL, uMsg, wParam, lParam);
+        __fallthrough;
+    }
+    case WM_ACTIVATE:
+    case WM_ACTIVATEAPP:
+    {
+        PropSheetInfo* psInfo = GetPropW(hwnd, PropSheetInfoStr);
+        if (!psInfo)
+            return FALSE;
+
+        /* Forward notification to active page */
+        if (psInfo->activeValid && psInfo->active_page != -1)
+        {
+            HWND hwndPage = psInfo->proppage[psInfo->active_page].hwndPage;
+            LRESULT msgResult = SendMessageW(hwndPage, uMsg, wParam, lParam);
+            /* The message is handled, set the dialog return value
+             * to whatever the page returned */
+            SetWindowLongPtrW(hwnd, DWLP_MSGRESULT, msgResult);
+            return TRUE;
+        }
+        return FALSE;
+    }
+#endif // __REACTOS__
+
     case PSM_GETCURRENTPAGEHWND:
     {
       PropSheetInfo* psInfo = GetPropW(hwnd, PropSheetInfoStr);


### PR DESCRIPTION
## Purpose

Pass a couple of window messages to the active page of property sheets

JIRA issue: [CORE-20681](https://jira.reactos.org/browse/CORE-20681)

## Proposed changes

- ### `Pass WM_SYSCOLORCHANGE/WM_DISPLAYCHANGE/WM_WININICHANGE also to the property sheet tab control`

  Addendum to commit d09c3d0af8.

- ### `Pass a couple of window messages to the active page of property sheets`

  Send `WM_ACTIVATE` and `WM_ACTIVATEAPP` to the property sheet active page.
  And do the same with `WM_ENABLE`, `WM_QUERYENDSESSION`, `WM_ENDSESSION`, and `WM_DEVICECHANGE`, after sending them to the tab control first.

  Similar in spirit to commit d09c3d0af8.

----

In particular, handling the `WM_ACTIVATE` will allow the 1st-stage ReactOS GUI Setup to halt its final countdown, whenever another interactive window is made active, and resume the countdown when the Setup wizard is made focused again.

## Tests

### On ReactOS (patched):

  https://github.com/user-attachments/assets/992f7b3f-c8f7-4988-80a6-f90dc5b2861f

### On Windows 2003:

  https://github.com/user-attachments/assets/e7fb4fbc-0def-4e4c-b36a-00327b02e71e

### Verification of messages ordering on Win2003:

- ReactOS setup wizard windows tree:

  <img width="1025" height="769" alt="Win2003_GuiSetup_WM_ACTIVATE_windowstree" src="https://github.com/user-attachments/assets/fc7de554-2b70-4186-a005-a8b90cb77925" />

- Spy++ capture settings:

  The tested window messages: `WM_SYSCOLORCHANGE` and `WM_DISPLAYCHANGE` (note: `WM_WININICHANGE` not available in Spy++); as well as:
  `WM_ENABLE`, `WM_QUERYENDSESSION`, `WM_ENDSESSION` (not directly tested in what follows), and:
  `WM_DEVICECHANGE`, `WM_ACTIVATE`, `WM_ACTIVATEAPP`.

  <img width="490" height="360" alt="Win2003_spyxx_capture_settings" src="https://github.com/user-attachments/assets/54af72b2-c05a-4122-a01e-588010c12540" />

- Messages monitoring results:

  [ROS_setup_propsheet_messages_on_Win2003.txt](https://github.com/user-attachments/files/29859758/ROS_setup_propsheet_messages_on_Win2003.txt)

- Activating and deactivating the setup wizard:
```
Activating the Install Wizard window
====================================

(Aux.windows):
<00001> 0004005E S WM_ACTIVATEAPP fActive:True dwThreadID:00000000 [wParam:00000001 lParam:00000000]
<00002> 000200BA S WM_ACTIVATEAPP fActive:True dwThreadID:00000000 [wParam:00000001 lParam:00000000]

Main window:
<00003> 000200BE S WM_ACTIVATEAPP fActive:True dwThreadID:00000000 [wParam:00000001 lParam:00000000]
Current page:
<00004> 00030074 S WM_ACTIVATEAPP fActive:True dwThreadID:00000000 [wParam:00000001 lParam:00000000]

Main window:
<00005> 000200BE S WM_ACTIVATE fActive:WA_CLICKACTIVE fMinimized:False hwndPrevious:(null) [wParam:00000002 lParam:00000000]
Current page:
<00006> 00030074 S WM_ACTIVATE fActive:WA_CLICKACTIVE fMinimized:False hwndPrevious:(null) [wParam:00000002 lParam:00000000]


Deactivating the Install Wizard window
======================================

Main window:
<00007> 000200BE S WM_ACTIVATE fActive:WA_INACTIVE fMinimized:False hwndPrevious:(null) [wParam:00000000 lParam:00000000]
Current page:
<00008> 00030074 S WM_ACTIVATE fActive:WA_INACTIVE fMinimized:False hwndPrevious:(null) [wParam:00000000 lParam:00000000]

(Aux.windows):
<00009> 0004005E S WM_ACTIVATEAPP fActive:False dwThreadID:000002C4 [wParam:00000000 lParam:000002C4]
<00010> 000200BA S WM_ACTIVATEAPP fActive:False dwThreadID:000002C4 [wParam:00000000 lParam:000002C4]

Main window:
<00011> 000200BE S WM_ACTIVATEAPP fActive:False dwThreadID:000002C4 [wParam:00000000 lParam:000002C4]
Current page:
<00012> 00030074 S WM_ACTIVATEAPP fActive:False dwThreadID:000002C4 [wParam:00000000 lParam:000002C4]
```

  We observe that, first, the main wizard window is notified, and then only the current wizard page.
  Note that no other wizard page, neither the internal wizard tab control container, are notified there.

- Changing the screen resolution only:
```
Changing the screen resolution
==============================

(Aux.windows):
<00013> 0004005E S WM_DISPLAYCHANGE cBitsPerPixel:32 cxScreen:1024 cyScreen:768 [wParam:00000020 lParam:03000400]
<00014> 000200BA S WM_DISPLAYCHANGE cBitsPerPixel:32 cxScreen:1024 cyScreen:768 [wParam:00000020 lParam:03000400]

Main window:
<00015> 000200BE S WM_DISPLAYCHANGE cBitsPerPixel:32 cxScreen:1024 cyScreen:768 [wParam:00000020 lParam:03000400]

Other page 1:
<00016> 000200A6 S WM_DISPLAYCHANGE cBitsPerPixel:32 cxScreen:1024 cyScreen:768 [wParam:00000020 lParam:03000400]
Other page 2:
<00017> 00020072 S WM_DISPLAYCHANGE cBitsPerPixel:32 cxScreen:1024 cyScreen:768 [wParam:00000020 lParam:03000400]
Current page:
<00018> 00030074 S WM_DISPLAYCHANGE cBitsPerPixel:32 cxScreen:1024 cyScreen:768 [wParam:00000020 lParam:03000400]

SysTabControl32:
<00019> 000400AA S WM_DISPLAYCHANGE cBitsPerPixel:32 cxScreen:1024 cyScreen:768 [wParam:00000020 lParam:03000400]
```

  We observe that, first, the main wizard window is notified, then all the tabs one after the order in order ("Other page 1, 2, and Current page are respectively: "Intro", "Install type", and "Abort" pages).
  Only then, the internal wizard tab control container is notified.

- Changing the screen depth colors:
```
Changing the color depth (from 32bpp to 16bpp)
==============================================

(Aux.windows):
<00032> 0004005E S WM_DISPLAYCHANGE cBitsPerPixel:16 cxScreen:1024 cyScreen:768 [wParam:00000010 lParam:03000400]
<00033> 000200BA S WM_DISPLAYCHANGE cBitsPerPixel:16 cxScreen:1024 cyScreen:768 [wParam:00000010 lParam:03000400]

Main window:
<00034> 000200BE S WM_DISPLAYCHANGE cBitsPerPixel:16 cxScreen:1024 cyScreen:768 [wParam:00000010 lParam:03000400]

Other page 1:
<00035> 000200A6 S WM_DISPLAYCHANGE cBitsPerPixel:16 cxScreen:1024 cyScreen:768 [wParam:00000010 lParam:03000400]
Other page 2:
<00036> 00020072 S WM_DISPLAYCHANGE cBitsPerPixel:16 cxScreen:1024 cyScreen:768 [wParam:00000010 lParam:03000400]
Current page:
<00037> 00030074 S WM_DISPLAYCHANGE cBitsPerPixel:16 cxScreen:1024 cyScreen:768 [wParam:00000010 lParam:03000400]

SysTabControl32:
<00038> 000400AA S WM_DISPLAYCHANGE cBitsPerPixel:16 cxScreen:1024 cyScreen:768 [wParam:00000010 lParam:03000400]

(Aux.windows):
<00039> 0004005E S WM_SYSCOLORCHANGE wParam:00000000 lParam:00000000
<00040> 000200BA S WM_SYSCOLORCHANGE wParam:00000000 lParam:00000000

Main window:
<00041> 000200BE S WM_SYSCOLORCHANGE wParam:00000000 lParam:00000000

Other page 1:
<00042> 000200A6 S WM_SYSCOLORCHANGE wParam:00000000 lParam:00000000
Other page 2:
<00043> 00020072 S WM_SYSCOLORCHANGE wParam:00000000 lParam:00000000
Current page:
<00044> 00030074 S WM_SYSCOLORCHANGE wParam:00000000 lParam:00000000

SysTabControl32:
<00045> 000400AA S WM_SYSCOLORCHANGE wParam:00000000 lParam:00000000
```

  We first get a `WM_DISPLAYCHANGE` message, followed by `WM_SYSCOLORCHANGE`. For that latter message also, the main wizard window is first notified, then all the wizard pages in order, and only then the internal wizard tab control container.
