### PR TITLE
[WIN32SS:NTUSER] Fix DrawText ellipsification bug

### DIFF
--- a/win32ss/user/rtl/text.c
+++ b/win32ss/user/rtl/text.c
@@ -287,7 +287,11 @@ static void TEXT_PathEllipsify (HDC hdc, WCHAR *str, unsigned int max_len,
     lastFwdSlash = strrchrW (str, FORWARD_SLASH);
 #endif
     lastSlash = lastBkSlash > lastFwdSlash ? lastBkSlash : lastFwdSlash;
+#ifdef __REACTOS__
+    if (!lastSlash) lastSlash = str + *len_str;
+#else
     if (!lastSlash) lastSlash = str;
+#endif
     len_trailing = *len_str - (lastSlash - str);
 
     /* overlap-safe movement to the right */


### PR DESCRIPTION
## Purpose

This PR imports the following commit from Wine master branch: https://gitlab.winehq.org/wine/wine/-/commit/5909e9070f2fba8f6231e6a2b1459dadce524b4b

Without the patch:
<img width="284" height="172" alt="image" src="https://github.com/user-attachments/assets/a6650234-82ae-4df1-befe-f06f11aced5f" />

After the patch:
<img width="314" height="198" alt="image" src="https://github.com/user-attachments/assets/b23db86d-38c1-48cc-b9a7-dca66281bbe3" />

JIRA issue: [CORE-20581](https://jira.reactos.org/browse/CORE-20581)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: