### PR TITLE
[RAPPS] Force download online apps catalog in ID_RESETDB

### DIFF
--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -620,6 +620,9 @@ CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam)
                 CUpdateDatabaseMutex lock;
                 m_Db->RemoveCached();
                 UpdateApplicationsList(SelectedEnumType, bReload);
+                /* Force database update even if "Available apps" view is not active */
+                if (!IsAvailableEnum(SelectedEnumType))
+                    m_Db->UpdateAvailable();
                 break;
             }
 


### PR DESCRIPTION
## Purpose

Since the database is downloaded lazily, clicking on "Update Database" button won't re-download the online catalog if "Available apps" view is not active. This patch forces the download even when the "Installed apps" is active.

<img width="709" height="495" alt="image" src="https://github.com/user-attachments/assets/c0e4f5bb-094b-4f46-b577-c910c65ce1ec" />

JIRA issue: [CORE-20205](https://jira.reactos.org/browse/CORE-20205)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: