### PR TITLE
[RICHED20] Properly capture \pntext content

### DIFF
--- a/dll/win32/riched20/editor.c
+++ b/dll/win32/riched20/editor.c
@@ -1521,6 +1521,63 @@ static void ME_RTFReadParnumGroup( RTF_Info *info )
     RTFRouteToken( info );     /* feed "}" back to router */
 }
 
+#ifdef __REACTOS__ /* wine-11.11 */
+static void ME_RTFReadPntextGroup( RTF_Info *info )
+{
+    int level = 1;
+    WCHAR buf[256];
+    int buf_len = 0;
+
+    ME_DestroyString( info->pntext );
+    info->pntext = NULL;
+
+    for (;;)
+    {
+        RTFGetToken( info );
+
+        if (info->rtfClass == rtfEOF)
+            return;
+
+        if (RTFCheckCM( info, rtfGroup, rtfBeginGroup ))
+        {
+            level++;
+            continue;
+        }
+
+        if (RTFCheckCM( info, rtfGroup, rtfEndGroup ))
+        {
+            level--;
+            if (level == 0) break;
+            continue;
+        }
+
+        if (buf_len >= ARRAY_SIZE(buf) - 1)
+            continue;
+
+        if (info->rtfClass == rtfText)
+        {
+            buf[buf_len++] = (WCHAR)(unsigned char)info->rtfMajor;
+        }
+        else if (info->rtfClass == rtfControl && info->rtfMajor == rtfSpecialChar)
+        {
+            switch (info->rtfMinor)
+            {
+            case rtfTab:        buf[buf_len++] = '\t'; break;
+            case rtfBullet:     buf[buf_len++] = 0x2022; break;
+            case rtfNoBrkSpace: buf[buf_len++] = 0x00A0; break;
+            case rtfNoBrkHyphen:buf[buf_len++] = 0x2011; break;
+            case rtfOptDest:
+            default: break;
+            }
+        }
+    }
+
+    info->pntext = ME_MakeStringN( buf, buf_len );
+
+    RTFRouteToken( info );
+}
+
+#endif
 static void ME_RTFReadHook(RTF_Info *info)
 {
   switch(info->rtfClass)
@@ -1678,6 +1735,9 @@ static LRESULT ME_StreamIn(ME_TextEditor *editor, DWORD format, EDITSTREAM *stre
       RTFSetDestinationCallback(&parser, rtfPict, ME_RTFReadPictGroup);
       RTFSetDestinationCallback(&parser, rtfObject, ME_RTFReadObjectGroup);
       RTFSetDestinationCallback(&parser, rtfParNumbering, ME_RTFReadParnumGroup);
+#ifdef __REACTOS__ /* wine-11.11 */
+      RTFSetDestinationCallback(&parser, rtfParNumText, ME_RTFReadPntextGroup);
+#endif
       if (!parser.editor->bEmulateVersion10) /* v4.1 */
       {
         RTFSetDestinationCallback(&parser, rtfNoNestTables, RTFSkipGroup);

--- a/dll/win32/riched20/reader.c
+++ b/dll/win32/riched20/reader.c
@@ -150,6 +150,9 @@ RTFDestroy(RTF_Info *info)
 	}
 	RTFDestroyAttrs(info);
 	free(info->cpOutputBuffer);
+#ifdef __REACTOS__ /* wine-11.11 */
+    ME_DestroyString( info->pntext );
+#endif
         while (info->tableDef)
         {
                 RTFTable *tableDef = info->tableDef;
@@ -252,6 +255,9 @@ void RTFInit(RTF_Info *info)
         info->nestingLevel = 0;
         info->canInheritInTbl = FALSE;
         info->borderType = 0;
+#ifdef __REACTOS__ /* wine-11.11 */
+    info->pntext = NULL;
+#endif
 
         memset(&info->fmt, 0, sizeof(info->fmt));
         info->fmt.cbSize = sizeof(info->fmt);
@@ -2497,6 +2503,45 @@ static void SpecialChar (RTF_Info *info)
             break;
 	case rtfPage:
 	case rtfSect:
+#ifdef __REACTOS__ /* wine-11.11 */
+    case rtfPar:
+    {
+        ME_Paragraph *para;
+        RTFFlushOutputBuffer(info);
+        if ((info->fmt.dwMask & PFM_NUMBERING) && !info->pntext)
+            info->fmt.wNumbering = 0;
+
+        if (info->pntext && info->pntext->nLen &&
+            info->pntext->szData[info->pntext->nLen - 1] == '\t')
+        {
+            info->pntext->szData[--info->pntext->nLen] = 0;
+            if ((info->fmt.dwMask & PFM_NUMBERINGTAB) &&
+                info->fmt.wNumberingTab == 0)
+                info->fmt.wNumberingTab = lDefaultTab;
+        }
+
+        editor_set_selection_para_fmt( info->editor, &info->fmt );
+        para = info->editor->pCursors[0].para;
+        memset(&info->fmt, 0, sizeof(info->fmt));
+        info->fmt.cbSize = sizeof(info->fmt);
+        RTFPutUnicodeChar (info, '\r');
+        if (info->editor->bEmulateVersion10) RTFPutUnicodeChar (info, '\n');
+
+        if (info->pntext)
+        {
+            if (info->pntext->nLen && para->fmt.wNumbering)
+            {
+                para_num_clear( &para->para_num );
+                para->para_num.text = info->pntext;
+                info->pntext = NULL;
+                para_mark_rewrap( info->editor, para );
+            }
+            ME_DestroyString( info->pntext );
+            info->pntext = NULL;
+        }
+        break;
+    }
+#else
 	case rtfPar:
                 RTFFlushOutputBuffer(info);
                 editor_set_selection_para_fmt( info->editor, &info->fmt );
@@ -2505,6 +2550,7 @@ static void SpecialChar (RTF_Info *info)
 		RTFPutUnicodeChar (info, '\r');
 		if (info->editor->bEmulateVersion10) RTFPutUnicodeChar (info, '\n');
 		break;
+#endif
 	case rtfNoBrkSpace:
 		RTFPutUnicodeChar (info, 0x00A0);
 		break;

--- a/dll/win32/riched20/rtf.h
+++ b/dll/win32/riched20/rtf.h
@@ -1175,6 +1175,9 @@ struct _RTF_Info {
     int borderType; /* value corresponds to the RTFBorder constants. */
 
     PARAFORMAT2 fmt; /* Accumulated para fmt for current paragraph. */
+#ifdef __REACTOS__ /* wine-11.11 */
+    ME_String *pntext; /* Explicit paragraph number text from \pntext destination. */
+#endif
 };
 
 


### PR DESCRIPTION
## Purpose

Import the following patch from Wine 11.11: https://gitlab.winehq.org/wine/wine/-/merge_requests/10952

<img width="648" height="502" alt="image" src="https://github.com/user-attachments/assets/4e40b315-ec98-480f-a168-356173476b24" />

JIRA issue: [CORE-20483](https://jira.reactos.org/browse/CORE-20483)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: