### PR TITLE
[KERNEL32][APITESTS:KERNEL32] Implement SetSearchPathMode

### DIFF
--- a/dll/win32/kernel32/client/path.c
+++ b/dll/win32/kernel32/client/path.c
@@ -80,6 +80,8 @@ BASE_SEARCH_PATH_TYPE BaseProcessOrder[BaseSearchPathMax] =
 
 BASE_CURRENT_DIR_PLACEMENT BasepDllCurrentDirPlacement = BaseCurrentDirPlacementInvalid;
 
+DWORD BasepSearchPathModeFlags = BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE;
+
 extern UNICODE_STRING BasePathVariableName;
 
 /* PRIVATE FUNCTIONS **********************************************************/
@@ -394,10 +396,14 @@ LPWSTR
 WINAPI
 BaseComputeProcessSearchPath(VOID)
 {
+    BASE_CURRENT_DIR_PLACEMENT CurDirPlacement;
     DPRINT("Computing Process Search path\n");
 
+    CurDirPlacement = BasepSearchPathModeFlags & BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE ?
+                      BaseCurrentDirPlacementSafe : BaseCurrentDirPlacementDefault;
+
     /* Compute the path using default process order */
-    return BasepComputeProcessPath(BaseProcessOrder, NULL, NULL);
+    return BasepComputeProcessPath(BaseDllOrderCurrent[CurDirPlacement], NULL, NULL);
 }
 
 LPWSTR
@@ -1113,6 +1119,35 @@ GetFullPathNameW(IN LPCWSTR lpFileName,
                                 nBufferLength * sizeof(WCHAR),
                                 lpBuffer,
                                 lpFilePart) / sizeof(WCHAR);
+}
+
+/*
+ * @implemented
+ */
+BOOL
+WINAPI
+SetSearchPathMode(_In_ DWORD dwFlags)
+{
+    switch (dwFlags)
+    {
+        /* There are only 3 valid parameters */
+        case BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE:
+        case BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE:
+            if (BasepSearchPathModeFlags & BASE_SEARCH_PATH_PERMANENT)
+            {
+                /* Return with ERROR_ACCESS_DENIED if permanent flag is set */
+                SetLastError(ERROR_ACCESS_DENIED);
+                return FALSE;
+            }
+            __fallthrough;
+        case BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE | BASE_SEARCH_PATH_PERMANENT:
+            BasepSearchPathModeFlags = dwFlags;
+            return TRUE;
+
+        default:
+            SetLastError(ERROR_INVALID_PARAMETER);
+            return FALSE;
+    }
 }
 
 /*

--- a/dll/win32/kernel32/client/path.c
+++ b/dll/win32/kernel32/client/path.c
@@ -80,7 +80,7 @@ BASE_SEARCH_PATH_TYPE BaseProcessOrder[BaseSearchPathMax] =
 
 BASE_CURRENT_DIR_PLACEMENT BasepDllCurrentDirPlacement = BaseCurrentDirPlacementInvalid;
 
-DWORD BasepSearchPathModeFlags = BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE;
+DWORD BasepSearchPathModeFlags = BASE_SEARCH_PATH_INVALID_FLAGS;
 
 extern UNICODE_STRING BasePathVariableName;
 
@@ -397,7 +397,50 @@ WINAPI
 BaseComputeProcessSearchPath(VOID)
 {
     BASE_CURRENT_DIR_PLACEMENT CurDirPlacement;
+    UNICODE_STRING KeyName = RTL_CONSTANT_STRING(L"\\Registry\\MACHINE\\System\\CurrentControlSet\\Control\\Session Manager");
+    UNICODE_STRING ValueName = RTL_CONSTANT_STRING(L"SafeProcessSearchMode");
+    OBJECT_ATTRIBUTES ObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&KeyName, OBJ_CASE_INSENSITIVE);
+    CHAR PartialInfoBuffer[FIELD_OFFSET(KEY_VALUE_PARTIAL_INFORMATION, Data) + sizeof(DWORD)];
+    HANDLE KeyHandle;
+    NTSTATUS Status;
+    ULONG ResultLength;
+
     DPRINT("Computing Process Search path\n");
+
+    /* No flag is set, read from registry */
+    if (BasepSearchPathModeFlags == BASE_SEARCH_PATH_INVALID_FLAGS)
+    {
+        /* Open the configuration key */
+        Status = NtOpenKey(&KeyHandle, KEY_QUERY_VALUE, &ObjectAttributes);
+        if (NT_SUCCESS(Status))
+        {
+            /* Query if safe search is enabled */
+            Status = NtQueryValueKey(KeyHandle,
+                                     &ValueName,
+                                     KeyValuePartialInformation,
+                                     PartialInfoBuffer,
+                                     sizeof(PartialInfoBuffer),
+                                     &ResultLength);
+            if (NT_SUCCESS(Status))
+            {
+                /* Read the value if the size is OK */
+                if (ResultLength == sizeof(PartialInfoBuffer))
+                {
+                    PKEY_VALUE_PARTIAL_INFORMATION PartialInfo = (PKEY_VALUE_PARTIAL_INFORMATION)PartialInfoBuffer;
+                    /* 0 means disabled and 1 means enabled */
+                    BasepSearchPathModeFlags = *(PDWORD)PartialInfo->Data == 1 ? 
+                                               BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE : BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE;
+                }
+            }
+            /* Close the handle */
+            NtClose(KeyHandle);
+        }
+    }
+    /* Fallback to default value if couldn't read from registry */
+    if (BasepSearchPathModeFlags == BASE_SEARCH_PATH_INVALID_FLAGS)
+    {
+        BasepSearchPathModeFlags = BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE;
+    }
 
     CurDirPlacement = BasepSearchPathModeFlags & BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE ?
                       BaseCurrentDirPlacementSafe : BaseCurrentDirPlacementDefault;

--- a/dll/win32/kernel32/client/path.c
+++ b/dll/win32/kernel32/client/path.c
@@ -1181,20 +1181,31 @@ WINAPI
 SetSearchPathMode(
     _In_ DWORD dwFlags)
 {
+    LONG OldFlags, CurrentFlags;
+
     switch (dwFlags)
     {
         /* There are only 3 valid parameters */
         case BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE:
         case BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE:
-            if (BasepSearchPathModeFlags & BASE_SEARCH_PATH_PERMANENT)
-            {
-                /* Return with ERROR_ACCESS_DENIED if permanent flag is set */
-                SetLastError(ERROR_ACCESS_DENIED);
-                return FALSE;
-            }
-            __fallthrough;
         case BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE | BASE_SEARCH_PATH_PERMANENT:
-            BasepSearchPathModeFlags = dwFlags;
+            CurrentFlags = InterlockedCompareExchange((PLONG)&BasepSearchPathModeFlags, 0, 0);
+            do
+            {
+                if ((CurrentFlags & BASE_SEARCH_PATH_PERMANENT) &&
+                    dwFlags != CurrentFlags)
+                {
+                    /* Return with ERROR_ACCESS_DENIED if permanent flag is set */
+                    SetLastError(ERROR_ACCESS_DENIED);
+                    return FALSE;
+                }
+
+                OldFlags = CurrentFlags;
+                CurrentFlags = InterlockedCompareExchange((PLONG)&BasepSearchPathModeFlags,
+                                                          (LONG)dwFlags,
+                                                          OldFlags);
+            } while (CurrentFlags != OldFlags);
+
             return TRUE;
 
         default:

--- a/dll/win32/kernel32/client/path.c
+++ b/dll/win32/kernel32/client/path.c
@@ -80,7 +80,7 @@ BASE_SEARCH_PATH_TYPE BaseProcessOrder[BaseSearchPathMax] =
 
 BASE_CURRENT_DIR_PLACEMENT BasepDllCurrentDirPlacement = BaseCurrentDirPlacementInvalid;
 
-DWORD BasepSearchPathModeFlags = BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE;
+DWORD BasepSearchPathModeFlags = BASE_SEARCH_PATH_INVALID_FLAGS;
 
 extern UNICODE_STRING BasePathVariableName;
 
@@ -397,9 +397,61 @@ WINAPI
 BaseComputeProcessSearchPath(VOID)
 {
     BASE_CURRENT_DIR_PLACEMENT CurDirPlacement;
+    DWORD CurrentModeFlags, OldCurrentModeFlags;
+    UNICODE_STRING KeyName = RTL_CONSTANT_STRING(L"\\Registry\\MACHINE\\System\\CurrentControlSet\\Control\\Session Manager");
+    UNICODE_STRING ValueName = RTL_CONSTANT_STRING(L"SafeProcessSearchMode");
+    OBJECT_ATTRIBUTES ObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&KeyName, OBJ_CASE_INSENSITIVE);
+    CHAR PartialInfoBuffer[FIELD_OFFSET(KEY_VALUE_PARTIAL_INFORMATION, Data) + sizeof(DWORD)];
+    HANDLE KeyHandle;
+    NTSTATUS Status;
+    ULONG ResultLength;
+
     DPRINT("Computing Process Search path\n");
 
-    CurDirPlacement = BasepSearchPathModeFlags & BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE ?
+    CurrentModeFlags = BasepSearchPathModeFlags;
+    /* No flag is set, read from registry */
+    if (CurrentModeFlags == BASE_SEARCH_PATH_INVALID_FLAGS)
+    {
+        /* Open the configuration key */
+        Status = NtOpenKey(&KeyHandle, KEY_QUERY_VALUE, &ObjectAttributes);
+        if (NT_SUCCESS(Status))
+        {
+            /* Query if safe search is enabled */
+            Status = NtQueryValueKey(KeyHandle,
+                                     &ValueName,
+                                     KeyValuePartialInformation,
+                                     PartialInfoBuffer,
+                                     sizeof(PartialInfoBuffer),
+                                     &ResultLength);
+            if (NT_SUCCESS(Status))
+            {
+                /* Read the value if the size is OK */
+                if (ResultLength == sizeof(PartialInfoBuffer))
+                {
+                    PKEY_VALUE_PARTIAL_INFORMATION PartialInfo = (PKEY_VALUE_PARTIAL_INFORMATION)PartialInfoBuffer;
+                    /* 0 means disabled and 1 means enabled */
+                    CurrentModeFlags = *(PDWORD)PartialInfo->Data == 1
+                                       ? BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE
+                                       : BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE;
+                }
+            }
+            /* Close the handle */
+            NtClose(KeyHandle);
+        }
+
+        /* Fallback to default value if couldn't read from registry */
+        if (CurrentModeFlags == BASE_SEARCH_PATH_INVALID_FLAGS)
+            CurrentModeFlags = BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE;
+
+        /* Update the flag and read the old one */
+        OldCurrentModeFlags = InterlockedCompareExchange((PLONG)&BasepSearchPathModeFlags,
+                                                         CurrentModeFlags,
+                                                         BASE_SEARCH_PATH_INVALID_FLAGS);
+        if (OldCurrentModeFlags != BASE_SEARCH_PATH_INVALID_FLAGS)
+            CurrentModeFlags = OldCurrentModeFlags;
+    }
+
+    CurDirPlacement = CurrentModeFlags & BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE ?
                       BaseCurrentDirPlacementSafe : BaseCurrentDirPlacementDefault;
 
     /* Compute the path using default process order */
@@ -1126,7 +1178,8 @@ GetFullPathNameW(IN LPCWSTR lpFileName,
  */
 BOOL
 WINAPI
-SetSearchPathMode(_In_ DWORD dwFlags)
+SetSearchPathMode(
+    _In_ DWORD dwFlags)
 {
     switch (dwFlags)
     {

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -1102,6 +1102,7 @@
 @ stdcall SetProcessShutdownParameters(long long)
 @ stdcall SetProcessWorkingSetSize(long long long)
 @ stdcall SetProcessWorkingSetSizeEx(long long long long)
+@ stdcall SetSearchPathMode(long)
 @ stdcall SetStdHandle(long long)
 @ stub -version=0x600+ SetStdHandleEx
 @ stdcall SetSystemFileCacheSize(long long long)

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -1093,6 +1093,7 @@
 @ stdcall SetProcessShutdownParameters(long long)
 @ stdcall SetProcessWorkingSetSize(long long long)
 @ stdcall SetProcessWorkingSetSizeEx(long long long long)
+@ stdcall SetSearchPathMode(long)
 @ stdcall SetStdHandle(long long)
 @ stub -version=0x600+ SetStdHandleEx
 @ stdcall SetSystemFileCacheSize(long long long)

--- a/modules/rostests/apitests/kernel32/CMakeLists.txt
+++ b/modules/rostests/apitests/kernel32/CMakeLists.txt
@@ -41,6 +41,7 @@ list(APPEND SOURCE
     SetComputerNameExW.c
     SetConsoleWindowInfo.c
     SetCurrentDirectory.c
+    SetSearchPathMode.c
     SetUnhandledExceptionFilter.c
     SystemFirmware.c
     TerminateProcess.c

--- a/modules/rostests/apitests/kernel32/CMakeLists.txt
+++ b/modules/rostests/apitests/kernel32/CMakeLists.txt
@@ -42,6 +42,7 @@ list(APPEND SOURCE
     SetComputerNameExW.c
     SetConsoleWindowInfo.c
     SetCurrentDirectory.c
+    SetSearchPathMode.c
     SetUnhandledExceptionFilter.c
     SystemFirmware.c
     TerminateProcess.c

--- a/modules/rostests/apitests/kernel32/SetSearchPathMode.c
+++ b/modules/rostests/apitests/kernel32/SetSearchPathMode.c
@@ -1,0 +1,86 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for SetSearchPathMode
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include <apitest.h>
+#include <winbase.h>
+
+START_TEST(SetSearchPathMode)
+{
+    BOOL Ret;
+
+    /* Testing invalid flags */
+
+    SetLastError(0xdeadbeef);
+    Ret = SetSearchPathMode(0x0);
+    ok(!Ret, "SetSearchPathMode unexpectedly succeeded with invalid parameter\n");
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_PARAMETER);
+
+    SetLastError(0xdeadbeef);
+    Ret = SetSearchPathMode(0xdeadbeef);
+    ok(!Ret, "SetSearchPathMode unexpectedly succeeded with invalid parameter\n");
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_PARAMETER);
+
+    SetLastError(0xdeadbeef);
+    Ret = SetSearchPathMode(BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE |
+                            BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE);
+    ok(!Ret, "SetSearchPathMode unexpectedly succeeded with invalid parameter\n");
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_PARAMETER);
+
+    SetLastError(0xdeadbeef);
+    Ret = SetSearchPathMode(BASE_SEARCH_PATH_PERMANENT);
+    ok(!Ret, "SetSearchPathMode unexpectedly succeeded with invalid parameter\n");
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_PARAMETER);
+
+    SetLastError(0xdeadbeef);
+    Ret = SetSearchPathMode(BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE |
+                            BASE_SEARCH_PATH_PERMANENT);
+    ok(!Ret, "SetSearchPathMode unexpectedly succeeded with invalid parameter\n");
+    ok_eq_ulong(GetLastError(), ERROR_INVALID_PARAMETER);
+
+    /* Enabling and disabling safe search mode */
+
+    SetLastError(0xdeadbeef);
+    Ret = SetSearchPathMode(BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE);
+    ok(Ret, "ENABLE_SAFE_SEARCHMODE failed\n");
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+
+    SetLastError(0xdeadbeef);
+    Ret = SetSearchPathMode(BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE);
+    ok(Ret, "DISABLE_SAFE_SEARCHMODE failed\n");
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+
+    SetLastError(0xdeadbeef);
+    Ret = SetSearchPathMode(BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE);
+    ok(Ret, "ENABLE_SAFE_SEARCHMODE failed (second call)\n");
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+    ok(Ret, "ENABLE_SAFE_SEARCHMODE failed (second call)\n");
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+
+    /* Testing permanent mode */
+
+    SetLastError(0xdeadbeef);
+    Ret = SetSearchPathMode(BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE |
+                            BASE_SEARCH_PATH_PERMANENT);
+    ok(Ret, "Permanent mode failed\n");
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+
+    SetLastError(0xdeadbeef);
+    Ret = SetSearchPathMode(BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE);
+    ok(!Ret, "ENABLE unexpectedly succeeded after permanent mode\n");
+    ok_eq_ulong(GetLastError(), ERROR_ACCESS_DENIED);
+
+    SetLastError(0xdeadbeef);
+    Ret = SetSearchPathMode(BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE);
+    ok(!Ret, "DISABLE unexpectedly succeeded after permanent mode\n");
+    ok_eq_ulong(GetLastError(), ERROR_ACCESS_DENIED);
+
+    SetLastError(0xdeadbeef);
+    Ret = SetSearchPathMode(BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE |
+                            BASE_SEARCH_PATH_PERMANENT);
+    ok(Ret, "Calling permanent mode again should succeed\n");
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+}

--- a/sdk/include/psdk/winbase.h
+++ b/sdk/include/psdk/winbase.h
@@ -3039,6 +3039,7 @@ BOOL WINAPI SetProcessAffinityMask(_In_ HANDLE, _In_ DWORD_PTR);
 BOOL WINAPI SetProcessPriorityBoost(_In_ HANDLE, _In_ BOOL);
 BOOL WINAPI SetProcessShutdownParameters(DWORD,DWORD);
 BOOL WINAPI SetProcessWorkingSetSize(_In_ HANDLE, _In_ SIZE_T, _In_ SIZE_T);
+BOOL WINAPI SetSearchPathMode(_In_ DWORD);
 #if (_WIN32_WINNT >= 0x0600)
 VOID WINAPI SetSecurityAccessMask(SECURITY_INFORMATION,LPDWORD);
 #endif


### PR DESCRIPTION
## Purpose

This PR implements SetSearchPathMode based on [official documentations](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setsearchpathmode) from Microsoft and Wine tests.

This is different from #3665 since it updates `SearchPathW` to use the configured Search Path Mode, while the older PR only introduces `SetSearchPathMode` with desired outputs per input.

Wine tests result:

<img width="791" height="563" alt="image" src="https://github.com/user-attachments/assets/36e9d232-81a2-49e0-9f44-f6b85e05280a" />

All SetSearchPathMode related tests are passing, previously skipping.

KeePassX:

<img width="768" height="559" alt="image" src="https://github.com/user-attachments/assets/c5515f2f-e352-4129-ba57-8aeedffc8813" />

JIRA issue: [CORE-17586](https://jira.reactos.org/browse/CORE-17586)

## Proposed changes

* A new global `BasepSearchPathModeFlags` to hold "SearchPath mode" flags.
* Update `BaseComputeProcessSearchPath` to use a mode based on configured "SearchPath mode" flags using [registry key](https://learn.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-searchpathw#remarks) or value set by `SetSearchPathMode`
* A definition for `SetSearchPathMode` in `winbase.h` and `kernel32.spec` files, and an implementation in `path.c` file

## Testbot runs (Filled in by Devs)

In all cases:
`SetSearchPathMode: 26 tests executed (0 marked as todo, 0 failures), 0 skipped.`
and `kernel32:path` gets one more test running, without more errors than before.

- [x] ✅ KVM x86: https://reactos.org/testman/compare.php?ids=109933,109937
- [x] ✅ KVM x64: https://reactos.org/testman/compare.php?ids=109934,109938
- [x] ✅ Windows Server 2003 - Build 3790 SP2 - i386: https://reactos.org/testman/compare.php?ids=109875,109941
- [x] ✅ Windows Server 2008 - Build 6003 SP2 - AMD64: https://reactos.org/testman/compare.php?ids=109932,109935
