### PR TITLE
[SYSSETUP] Fix use of uninitialized variable

### DIFF
--- a/dll/win32/syssetup/addons.c
+++ b/dll/win32/syssetup/addons.c
@@ -135,7 +135,7 @@ HRESULT
 InstallOptionalComponents(
     _In_ PITEMSDATA pItemsData)
 {
-    HRESULT hr;
+    HRESULT hr = S_OK;
     PSETUPDATA pSetupData;
     REGISTRATIONNOTIFY Notify = { 0 };
     RappsConsent Consent = NOT_ASKED;


### PR DESCRIPTION
## Purpose

Fix use of uninitialized variable

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
