### PR TITLE
[NTDLL] Fix dynamic TLS registration

### DIFF
--- a/dll/ntdll/include/ntdllp.h
+++ b/dll/ntdll/include/ntdllp.h
@@ -26,6 +26,7 @@
 typedef struct _LDRP_TLS_DATA
 {
     LIST_ENTRY TlsLinks;
+    PLDR_DATA_TABLE_ENTRY LdrEntry;
     IMAGE_TLS_DIRECTORY TlsDirectory;
 } LDRP_TLS_DATA, *PLDRP_TLS_DATA;
 
@@ -71,7 +72,8 @@ extern PVOID g_pfnSE_ProcessDying;
 NTSTATUS NTAPI LdrpRunInitializeRoutines(IN PCONTEXT Context OPTIONAL);
 VOID NTAPI LdrpInitializeThread(IN PCONTEXT Context);
 NTSTATUS NTAPI LdrpInitializeTls(VOID);
-NTSTATUS NTAPI LdrpHandleTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry);
+NTSTATUS NTAPI LdrpHandleTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry, IN BOOLEAN ProcessInit);
+VOID NTAPI LdrpReleaseTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry);
 NTSTATUS NTAPI LdrpAllocateTls(VOID);
 VOID NTAPI LdrpFreeTls(VOID);
 VOID NTAPI LdrpCallTlsInitializers(IN PLDR_DATA_TABLE_ENTRY LdrEntry, IN ULONG Reason);

--- a/dll/ntdll/include/ntdllp.h
+++ b/dll/ntdll/include/ntdllp.h
@@ -71,6 +71,7 @@ extern PVOID g_pfnSE_ProcessDying;
 NTSTATUS NTAPI LdrpRunInitializeRoutines(IN PCONTEXT Context OPTIONAL);
 VOID NTAPI LdrpInitializeThread(IN PCONTEXT Context);
 NTSTATUS NTAPI LdrpInitializeTls(VOID);
+NTSTATUS NTAPI LdrpHandleTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry);
 NTSTATUS NTAPI LdrpAllocateTls(VOID);
 VOID NTAPI LdrpFreeTls(VOID);
 VOID NTAPI LdrpCallTlsInitializers(IN PLDR_DATA_TABLE_ENTRY LdrEntry, IN ULONG Reason);

--- a/dll/ntdll/ldr/ldrapi.c
+++ b/dll/ntdll/ldr/ldrapi.c
@@ -1468,6 +1468,13 @@ LdrUnloadDll(
             /* Call the entrypoint */
             _SEH2_TRY
             {
+                /* Check if it has TLS */
+                if (LdrEntry->TlsIndex)
+                {
+                    /* Call TLS */
+                    LdrpCallTlsInitializers(LdrEntry, DLL_PROCESS_DETACH);
+                }
+
                 LdrpCallInitRoutine(LdrEntry->EntryPoint,
                                     LdrEntry->DllBase,
                                     DLL_PROCESS_DETACH,
@@ -1483,6 +1490,9 @@ LdrUnloadDll(
             /* Release the context */
             RtlDeactivateActivationContextUnsafeFast(&ActCtx);
         }
+
+        /* Release static TLS data before the image is unmapped */
+        LdrpReleaseTlsData(LdrEntry);
 
         /* Remove it from the list */
         RemoveEntryList(&CurrentEntry->InLoadOrderLinks);

--- a/dll/ntdll/ldr/ldrinit.c
+++ b/dll/ntdll/ldr/ldrinit.c
@@ -725,9 +725,7 @@ LdrpRunInitializeRoutines(IN PCONTEXT Context OPTIONAL)
                 if (!NT_SUCCESS(Status))
                 {
                     if (LdrRootEntry != LocalArray)
-                    {
                         RtlFreeHeap(LdrpHeap, 0, LdrRootEntry);
-                    }
 
                     return Status;
                 }
@@ -1283,7 +1281,6 @@ typedef struct _LDRP_TEB_TLS_BLOCK
 
 static
 NTSTATUS
-NTAPI
 LdrpAllocateTlsBlock(IN PIMAGE_TLS_DIRECTORY TlsDirectory,
                      OUT PVOID *TlsBlock)
 {
@@ -1293,21 +1290,17 @@ LdrpAllocateTlsBlock(IN PIMAGE_TLS_DIRECTORY TlsDirectory,
                   TlsDirectory->StartAddressOfRawData;
     TlsDataSize = RawDataSize + TlsDirectory->SizeOfZeroFill;
 
-    *TlsBlock = RtlAllocateHeap(RtlGetProcessHeap(),
-                                HEAP_ZERO_MEMORY,
-                                TlsDataSize);
-    if (!*TlsBlock) return STATUS_NO_MEMORY;
+    *TlsBlock = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, TlsDataSize);
+    if (!*TlsBlock)
+        return STATUS_NO_MEMORY;
 
-    RtlCopyMemory(*TlsBlock,
-                  (PVOID)TlsDirectory->StartAddressOfRawData,
-                  RawDataSize);
+    RtlCopyMemory(*TlsBlock, (PVOID)TlsDirectory->StartAddressOfRawData, RawDataSize);
 
     return STATUS_SUCCESS;
 }
 
 static
 NTSTATUS
-NTAPI
 LdrpGetCurrentProcessTebs(OUT PTEB **ThreadTebs,
                           OUT PULONG ThreadCount)
 {
@@ -1327,12 +1320,10 @@ LdrpGetCurrentProcessTebs(OUT PTEB **ThreadTebs,
     do
     {
         ProcessInfo = RtlAllocateHeap(RtlGetProcessHeap(), 0, BufferSize);
-        if (!ProcessInfo) return STATUS_NO_MEMORY;
+        if (!ProcessInfo)
+            return STATUS_NO_MEMORY;
 
-        Status = NtQuerySystemInformation(SystemProcessInformation,
-                                          ProcessInfo,
-                                          BufferSize,
-                                          &ReturnLength);
+        Status = NtQuerySystemInformation(SystemProcessInformation, ProcessInfo, BufferSize, &ReturnLength);
         if ((Status == STATUS_INFO_LENGTH_MISMATCH) ||
             (Status == STATUS_BUFFER_OVERFLOW) ||
             (Status == STATUS_BUFFER_TOO_SMALL))
@@ -1359,14 +1350,10 @@ LdrpGetCurrentProcessTebs(OUT PTEB **ThreadTebs,
             return STATUS_UNSUCCESSFUL;
         }
 
-        CurrentProcessInfo = (PSYSTEM_PROCESS_INFORMATION)
-                             ((ULONG_PTR)CurrentProcessInfo +
-                              CurrentProcessInfo->NextEntryOffset);
+        CurrentProcessInfo = (PSYSTEM_PROCESS_INFORMATION)((ULONG_PTR)CurrentProcessInfo + CurrentProcessInfo->NextEntryOffset);
     }
 
-    Tebs = RtlAllocateHeap(RtlGetProcessHeap(),
-                           0,
-                           CurrentProcessInfo->NumberOfThreads * sizeof(*Tebs));
+    Tebs = RtlAllocateHeap(RtlGetProcessHeap(), 0, CurrentProcessInfo->NumberOfThreads * sizeof(*Tebs));
     if (!Tebs)
     {
         RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
@@ -1383,10 +1370,7 @@ LdrpGetCurrentProcessTebs(OUT PTEB **ThreadTebs,
             continue;
         }
 
-        Status = NtOpenThread(&ThreadHandle,
-                              THREAD_QUERY_INFORMATION,
-                              &ObjectAttributes,
-                              &ThreadInfo->ClientId);
+        Status = NtOpenThread(&ThreadHandle, THREAD_QUERY_INFORMATION, &ObjectAttributes, &ThreadInfo->ClientId);
         if (!NT_SUCCESS(Status))
         {
             if ((Status == STATUS_INVALID_CID) ||
@@ -1400,11 +1384,7 @@ LdrpGetCurrentProcessTebs(OUT PTEB **ThreadTebs,
             return Status;
         }
 
-        Status = NtQueryInformationThread(ThreadHandle,
-                                          ThreadBasicInformation,
-                                          &ThreadBasicInfo,
-                                          sizeof(ThreadBasicInfo),
-                                          NULL);
+        Status = NtQueryInformationThread(ThreadHandle, ThreadBasicInformation, &ThreadBasicInfo, sizeof(ThreadBasicInfo), NULL);
         NtClose(ThreadHandle);
         if (!NT_SUCCESS(Status))
         {
@@ -1434,7 +1414,6 @@ LdrpGetCurrentProcessTebs(OUT PTEB **ThreadTebs,
 
 static
 NTSTATUS
-NTAPI
 LdrpAppendTlsDataToThread(IN PTEB Teb,
                           IN PLDRP_TLS_DATA TlsData,
                           IN ULONG Index,
@@ -1448,33 +1427,26 @@ LdrpAppendTlsDataToThread(IN PTEB Teb,
     *TlsBlock = NULL;
 
     Status = LdrpAllocateTlsBlock(&TlsData->TlsDirectory, &Block);
-    if (!NT_SUCCESS(Status)) return Status;
+    if (!NT_SUCCESS(Status))
+        return Status;
 
     OldTlsVector = Teb->ThreadLocalStoragePointer;
     if (OldTlsVector)
     {
         if (Teb == NtCurrentTeb())
         {
-            TlsVector = RtlReAllocateHeap(RtlGetProcessHeap(),
-                                          0,
-                                          OldTlsVector,
-                                          TlsVectorSize);
+            TlsVector = RtlReAllocateHeap(RtlGetProcessHeap(), 0, OldTlsVector, TlsVectorSize);
         }
         else
         {
-            TlsVector = RtlReAllocateHeap(RtlGetProcessHeap(),
-                                          HEAP_REALLOC_IN_PLACE_ONLY,
-                                          OldTlsVector,
-                                          TlsVectorSize);
+            TlsVector = RtlReAllocateHeap(RtlGetProcessHeap(), HEAP_REALLOC_IN_PLACE_ONLY, OldTlsVector, TlsVectorSize);
             if (!TlsVector)
             {
                 /*
                  * Static TLS reads do not take the loader lock, so keep the old
                  * vector valid if the target thread needs a moved vector.
                  */
-                TlsVector = RtlAllocateHeap(RtlGetProcessHeap(),
-                                            HEAP_ZERO_MEMORY,
-                                            TlsVectorSize);
+                TlsVector = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, TlsVectorSize);
                 if (TlsVector)
                 {
                     RtlCopyMemory(TlsVector, OldTlsVector, Index * sizeof(PVOID));
@@ -1484,9 +1456,7 @@ LdrpAppendTlsDataToThread(IN PTEB Teb,
     }
     else
     {
-        TlsVector = RtlAllocateHeap(RtlGetProcessHeap(),
-                                    HEAP_ZERO_MEMORY,
-                                    TlsVectorSize);
+        TlsVector = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, TlsVectorSize);
     }
 
     if (!TlsVector)
@@ -1504,7 +1474,6 @@ LdrpAppendTlsDataToThread(IN PTEB Teb,
 
 static
 NTSTATUS
-NTAPI
 LdrpAppendTlsDataToProcessThreads(IN PLDRP_TLS_DATA TlsData,
                                   IN ULONG Index)
 {
@@ -1514,11 +1483,10 @@ LdrpAppendTlsDataToProcessThreads(IN PLDRP_TLS_DATA TlsData,
     ULONG i, Count, BlockCount = 0;
 
     Status = LdrpGetCurrentProcessTebs(&Tebs, &Count);
-    if (!NT_SUCCESS(Status)) return Status;
+    if (!NT_SUCCESS(Status))
+        return Status;
 
-    Blocks = RtlAllocateHeap(RtlGetProcessHeap(),
-                             HEAP_ZERO_MEMORY,
-                             Count * sizeof(*Blocks));
+    Blocks = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, Count * sizeof(*Blocks));
     if (!Blocks)
     {
         RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
@@ -1528,10 +1496,7 @@ LdrpAppendTlsDataToProcessThreads(IN PLDRP_TLS_DATA TlsData,
     for (i = 0; i < Count; i++)
     {
         Blocks[BlockCount].Teb = Tebs[i];
-        Status = LdrpAppendTlsDataToThread(Tebs[i],
-                                           TlsData,
-                                           Index,
-                                           &Blocks[BlockCount].TlsBlock);
+        Status = LdrpAppendTlsDataToThread(Tebs[i], TlsData, Index, &Blocks[BlockCount].TlsBlock);
         if (!NT_SUCCESS(Status))
         {
             while (BlockCount)
@@ -1540,7 +1505,8 @@ LdrpAppendTlsDataToProcessThreads(IN PLDRP_TLS_DATA TlsData,
 
                 BlockCount--;
                 TlsVector = Blocks[BlockCount].Teb->ThreadLocalStoragePointer;
-                if (TlsVector) TlsVector[Index] = NULL;
+                if (TlsVector)
+                    TlsVector[Index] = NULL;
                 RtlFreeHeap(RtlGetProcessHeap(), 0, Blocks[BlockCount].TlsBlock);
             }
 
@@ -1571,10 +1537,7 @@ LdrpHandleTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry,
         return STATUS_SUCCESS;
 
     /* Check for a TLS directory */
-    TlsDirectory = RtlImageDirectoryEntryToData(LdrEntry->DllBase,
-                                                TRUE,
-                                                IMAGE_DIRECTORY_ENTRY_TLS,
-                                                &Size);
+    TlsDirectory = RtlImageDirectoryEntryToData(LdrEntry->DllBase, TRUE, IMAGE_DIRECTORY_ENTRY_TLS, &Size);
     if (!TlsDirectory)
         return STATUS_SUCCESS;
 
@@ -1588,7 +1551,8 @@ LdrpHandleTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry,
 
     /* Cache the directory and assign the module its TLS index */
     TlsData = RtlAllocateHeap(RtlGetProcessHeap(), 0, sizeof(LDRP_TLS_DATA));
-    if (!TlsData) return STATUS_NO_MEMORY;
+    if (!TlsData)
+        return STATUS_NO_MEMORY;
 
     TlsData->LdrEntry = LdrEntry;
     TlsData->TlsDirectory = *TlsDirectory;
@@ -1616,7 +1580,7 @@ LdrpHandleTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry,
     *(PLONG)TlsData->TlsDirectory.AddressOfIndex = Index;
     LdrpNumberOfTlsEntries++;
 
-    if (!LdrpImageHasTls) LdrpImageHasTls = TRUE;
+    LdrpImageHasTls = TRUE;
 
     return STATUS_SUCCESS;
 }
@@ -1630,7 +1594,8 @@ LdrpReleaseTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry)
     PTEB *Tebs;
     ULONG i, Count;
 
-    if (!LdrEntry->TlsIndex) return;
+    if (!LdrEntry->TlsIndex)
+        return;
 
     ListHead = &LdrpTlsList;
     NextEntry = ListHead->Flink;
@@ -1698,7 +1663,8 @@ LdrpInitializeTls(VOID)
         NextEntry = NextEntry->Flink;
 
         Status = LdrpHandleTlsData(LdrEntry, TRUE);
-        if (!NT_SUCCESS(Status)) return Status;
+        if (!NT_SUCCESS(Status))
+            return Status;
     }
 
     /* Done setting up TLS, allocate entries */
@@ -1720,10 +1686,9 @@ LdrpAllocateTls(VOID)
         return STATUS_SUCCESS;
 
     /* Allocate the vector array */
-    TlsVector = RtlAllocateHeap(RtlGetProcessHeap(),
-                                    HEAP_ZERO_MEMORY,
-                                    LdrpNumberOfTlsEntries * sizeof(PVOID));
-    if (!TlsVector) return STATUS_NO_MEMORY;
+    TlsVector = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, LdrpNumberOfTlsEntries * sizeof(PVOID));
+    if (!TlsVector)
+        return STATUS_NO_MEMORY;
     Teb->ThreadLocalStoragePointer = TlsVector;
 
     /* Loop the TLS Array */
@@ -1739,9 +1704,7 @@ LdrpAllocateTls(VOID)
         RawDataSize = TlsData->TlsDirectory.EndAddressOfRawData -
                       TlsData->TlsDirectory.StartAddressOfRawData;
         TlsDataSize = RawDataSize + TlsData->TlsDirectory.SizeOfZeroFill;
-        TlsVector[TlsData->TlsDirectory.Characteristics] = RtlAllocateHeap(RtlGetProcessHeap(),
-                                                                           HEAP_ZERO_MEMORY,
-                                                                           TlsDataSize);
+        TlsVector[TlsData->TlsDirectory.Characteristics] = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, TlsDataSize);
         if (!TlsVector[TlsData->TlsDirectory.Characteristics])
         {
             /* Out of memory */
@@ -1760,9 +1723,7 @@ LdrpAllocateTls(VOID)
         }
 
         /* Copy the initialized raw data */
-        RtlCopyMemory(TlsVector[TlsData->TlsDirectory.Characteristics],
-                      (PVOID)TlsData->TlsDirectory.StartAddressOfRawData,
-                      RawDataSize);
+        RtlCopyMemory(TlsVector[TlsData->TlsDirectory.Characteristics], (PVOID)TlsData->TlsDirectory.StartAddressOfRawData, RawDataSize);
     }
 
     /* Done */

--- a/dll/ntdll/ldr/ldrinit.c
+++ b/dll/ntdll/ldr/ldrinit.c
@@ -721,6 +721,17 @@ LdrpRunInitializeRoutines(IN PCONTEXT Context OPTIONAL)
             /* Check flags */
             if (!(LdrEntry->Flags & LDRP_ENTRY_PROCESSED))
             {
+                Status = LdrpHandleTlsData(LdrEntry);
+                if (!NT_SUCCESS(Status))
+                {
+                    if (LdrRootEntry != LocalArray)
+                    {
+                        RtlFreeHeap(LdrpHeap, 0, LdrRootEntry);
+                    }
+
+                    return Status;
+                }
+
                 /* Setup the Cookie for the DLL */
                 LdrpInitSecurityCookie(LdrEntry);
 
@@ -1264,20 +1275,97 @@ LdrShutdownThread(VOID)
     return STATUS_SUCCESS;
 }
 
+/*
+ * Register a module's TLS directory and, when the current thread already has
+ * a TLS vector, make the new slot usable before the module initializer runs.
+ */
+NTSTATUS
+NTAPI
+LdrpHandleTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry)
+{
+    PIMAGE_TLS_DIRECTORY TlsDirectory;
+    PLDRP_TLS_DATA TlsData;
+    PTEB Teb = NtCurrentTeb();
+    PVOID *TlsVector;
+    SIZE_T RawDataSize, BlockSize;
+    ULONG Index, Size;
+
+    /* Nothing to do if this module is already registered */
+    if (LdrEntry->TlsIndex)
+        return STATUS_SUCCESS;
+
+    /* Check for a TLS directory */
+    TlsDirectory = RtlImageDirectoryEntryToData(LdrEntry->DllBase,
+                                                TRUE,
+                                                IMAGE_DIRECTORY_ENTRY_TLS,
+                                                &Size);
+    if (!TlsDirectory)
+        return STATUS_SUCCESS;
+
+    /* Remember that the process uses TLS */
+    if (!LdrpImageHasTls) LdrpImageHasTls = TRUE;
+
+    /* Show debug message */
+    if (ShowSnaps)
+    {
+        DPRINT1("LDR: Tls Found in %wZ at %p\n",
+                &LdrEntry->BaseDllName,
+                TlsDirectory);
+    }
+
+    /* Cache the directory and assign the module its TLS index */
+    TlsData = RtlAllocateHeap(RtlGetProcessHeap(), 0, sizeof(LDRP_TLS_DATA));
+    if (!TlsData) return STATUS_NO_MEMORY;
+
+    LdrEntry->LoadCount = -1;
+    LdrEntry->TlsIndex = -1;
+    TlsData->TlsDirectory = *TlsDirectory;
+    InsertTailList(&LdrpTlsList, &TlsData->TlsLinks);
+
+    Index = LdrpNumberOfTlsEntries++;
+    *(PLONG)TlsData->TlsDirectory.AddressOfIndex = Index;
+    TlsData->TlsDirectory.Characteristics = Index;
+
+    /* LdrpAllocateTls() will allocate the vector during process startup. */
+    if (!Teb->ThreadLocalStoragePointer)
+        return STATUS_SUCCESS;
+
+    /* Grow the running thread's vector so the new index is addressable */
+    TlsVector = RtlReAllocateHeap(RtlGetProcessHeap(),
+                                  0,
+                                  Teb->ThreadLocalStoragePointer,
+                                  LdrpNumberOfTlsEntries * sizeof(PVOID));
+    if (!TlsVector) return STATUS_NO_MEMORY;
+    Teb->ThreadLocalStoragePointer = TlsVector;
+
+    /* Allocate the raw TLS data plus the image's zero-fill area. */
+    RawDataSize = TlsDirectory->EndAddressOfRawData -
+                  TlsDirectory->StartAddressOfRawData;
+    BlockSize = RawDataSize + TlsDirectory->SizeOfZeroFill;
+    TlsVector[Index] = RtlAllocateHeap(RtlGetProcessHeap(),
+                                       HEAP_ZERO_MEMORY,
+                                       BlockSize);
+    if (!TlsVector[Index]) return STATUS_NO_MEMORY;
+
+    RtlCopyMemory(TlsVector[Index],
+                  (PVOID)TlsDirectory->StartAddressOfRawData,
+                  RawDataSize);
+
+    return STATUS_SUCCESS;
+}
+
 NTSTATUS
 NTAPI
 LdrpInitializeTls(VOID)
 {
     PLIST_ENTRY NextEntry, ListHead;
     PLDR_DATA_TABLE_ENTRY LdrEntry;
-    PIMAGE_TLS_DIRECTORY TlsDirectory;
-    PLDRP_TLS_DATA TlsData;
-    ULONG Size;
+    NTSTATUS Status;
 
     /* Initialize the TLS List */
     InitializeListHead(&LdrpTlsList);
 
-    /* Loop all the modules */
+    /* Register the TLS of every module already loaded */
     ListHead = &NtCurrentPeb()->Ldr->InLoadOrderModuleList;
     NextEntry = ListHead->Flink;
     while (ListHead != NextEntry)
@@ -1286,41 +1374,8 @@ LdrpInitializeTls(VOID)
         LdrEntry = CONTAINING_RECORD(NextEntry, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
         NextEntry = NextEntry->Flink;
 
-        /* Get the TLS directory */
-        TlsDirectory = RtlImageDirectoryEntryToData(LdrEntry->DllBase,
-                                                    TRUE,
-                                                    IMAGE_DIRECTORY_ENTRY_TLS,
-                                                    &Size);
-
-        /* Check if we have a directory */
-        if (!TlsDirectory) continue;
-
-        /* Check if the image has TLS */
-        if (!LdrpImageHasTls) LdrpImageHasTls = TRUE;
-
-        /* Show debug message */
-        if (ShowSnaps)
-        {
-            DPRINT1("LDR: Tls Found in %wZ at %p\n",
-                    &LdrEntry->BaseDllName,
-                    TlsDirectory);
-        }
-
-        /* Allocate an entry */
-        TlsData = RtlAllocateHeap(RtlGetProcessHeap(), 0, sizeof(LDRP_TLS_DATA));
-        if (!TlsData) return STATUS_NO_MEMORY;
-
-        /* Lock the DLL and mark it for TLS Usage */
-        LdrEntry->LoadCount = -1;
-        LdrEntry->TlsIndex = -1;
-
-        /* Save the cached TLS data */
-        TlsData->TlsDirectory = *TlsDirectory;
-        InsertTailList(&LdrpTlsList, &TlsData->TlsLinks);
-
-        /* Update the index */
-        *(PLONG)TlsData->TlsDirectory.AddressOfIndex = LdrpNumberOfTlsEntries;
-        TlsData->TlsDirectory.Characteristics = LdrpNumberOfTlsEntries++;
+        Status = LdrpHandleTlsData(LdrEntry);
+        if (!NT_SUCCESS(Status)) return Status;
     }
 
     /* Done setting up TLS, allocate entries */
@@ -1334,7 +1389,7 @@ LdrpAllocateTls(VOID)
     PTEB Teb = NtCurrentTeb();
     PLIST_ENTRY NextEntry, ListHead;
     PLDRP_TLS_DATA TlsData;
-    SIZE_T TlsDataSize;
+    SIZE_T RawDataSize, TlsDataSize;
     PVOID *TlsVector;
 
     /* Check if we have any entries */
@@ -1357,11 +1412,12 @@ LdrpAllocateTls(VOID)
         TlsData = CONTAINING_RECORD(NextEntry, LDRP_TLS_DATA, TlsLinks);
         NextEntry = NextEntry->Flink;
 
-        /* Allocate this vector */
-        TlsDataSize = TlsData->TlsDirectory.EndAddressOfRawData -
+        /* Allocate the initial TLS data and zero-fill tail. */
+        RawDataSize = TlsData->TlsDirectory.EndAddressOfRawData -
                       TlsData->TlsDirectory.StartAddressOfRawData;
+        TlsDataSize = RawDataSize + TlsData->TlsDirectory.SizeOfZeroFill;
         TlsVector[TlsData->TlsDirectory.Characteristics] = RtlAllocateHeap(RtlGetProcessHeap(),
-                                                                           0,
+                                                                           HEAP_ZERO_MEMORY,
                                                                            TlsDataSize);
         if (!TlsVector[TlsData->TlsDirectory.Characteristics])
         {
@@ -1380,10 +1436,10 @@ LdrpAllocateTls(VOID)
                     TlsVector[TlsData->TlsDirectory.Characteristics]);
         }
 
-        /* Copy the data */
+        /* Copy the initialized raw data */
         RtlCopyMemory(TlsVector[TlsData->TlsDirectory.Characteristics],
                       (PVOID)TlsData->TlsDirectory.StartAddressOfRawData,
-                      TlsDataSize);
+                      RawDataSize);
     }
 
     /* Done */

--- a/dll/ntdll/ldr/ldrinit.c
+++ b/dll/ntdll/ldr/ldrinit.c
@@ -1273,12 +1273,6 @@ LdrShutdownThread(VOID)
     return STATUS_SUCCESS;
 }
 
-typedef struct _LDRP_TEB_TLS_BLOCK
-{
-    PTEB Teb;
-    PVOID TlsBlock;
-} LDRP_TEB_TLS_BLOCK, *PLDRP_TEB_TLS_BLOCK;
-
 static
 NTSTATUS
 LdrpAllocateTlsBlock(IN PIMAGE_TLS_DIRECTORY TlsDirectory,
@@ -1310,44 +1304,43 @@ LdrpGetCurrentProcessTebs(OUT PTEB **ThreadTebs,
     PSYSTEM_PROCESS_INFORMATION ProcessInfo, CurrentProcessInfo;
     PSYSTEM_THREAD_INFORMATION ThreadInfo;
     THREAD_BASIC_INFORMATION ThreadBasicInfo;
-    PTEB *Tebs;
+    PTEB *Tebs = NULL;
     ULONG BufferSize = 0x8000, ReturnLength = 0;
     ULONG i, Count = 0;
 
     *ThreadTebs = NULL;
     *ThreadCount = 0;
 
-    do
+    /* Query the system process list, growing the buffer until it fits */
+    for (;;)
     {
         ProcessInfo = RtlAllocateHeap(RtlGetProcessHeap(), 0, BufferSize);
         if (!ProcessInfo)
             return STATUS_NO_MEMORY;
 
         Status = NtQuerySystemInformation(SystemProcessInformation, ProcessInfo, BufferSize, &ReturnLength);
-        if ((Status == STATUS_INFO_LENGTH_MISMATCH) ||
-            (Status == STATUS_BUFFER_OVERFLOW) ||
-            (Status == STATUS_BUFFER_TOO_SMALL))
+        if ((Status != STATUS_INFO_LENGTH_MISMATCH) &&
+            (Status != STATUS_BUFFER_OVERFLOW) &&
+            (Status != STATUS_BUFFER_TOO_SMALL))
         {
-            RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
-            BufferSize = ReturnLength ? ReturnLength + PAGE_SIZE : BufferSize * 2;
+            break;
         }
-    } while ((Status == STATUS_INFO_LENGTH_MISMATCH) ||
-             (Status == STATUS_BUFFER_OVERFLOW) ||
-             (Status == STATUS_BUFFER_TOO_SMALL));
 
-    if (!NT_SUCCESS(Status))
-    {
         RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
-        return Status;
+        BufferSize = ReturnLength ? ReturnLength + PAGE_SIZE : BufferSize * 2;
     }
 
+    if (!NT_SUCCESS(Status))
+        goto Quickie;
+
+    /* Locate our own process in the list */
     CurrentProcessInfo = ProcessInfo;
     while (CurrentProcessInfo->UniqueProcessId != NtCurrentTeb()->ClientId.UniqueProcess)
     {
         if (!CurrentProcessInfo->NextEntryOffset)
         {
-            RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
-            return STATUS_UNSUCCESSFUL;
+            Status = STATUS_UNSUCCESSFUL;
+            goto Quickie;
         }
 
         CurrentProcessInfo = (PSYSTEM_PROCESS_INFORMATION)((ULONG_PTR)CurrentProcessInfo + CurrentProcessInfo->NextEntryOffset);
@@ -1356,10 +1349,11 @@ LdrpGetCurrentProcessTebs(OUT PTEB **ThreadTebs,
     Tebs = RtlAllocateHeap(RtlGetProcessHeap(), 0, CurrentProcessInfo->NumberOfThreads * sizeof(*Tebs));
     if (!Tebs)
     {
-        RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
-        return STATUS_NO_MEMORY;
+        Status = STATUS_NO_MEMORY;
+        goto Quickie;
     }
 
+    /* Resolve every thread's client ID to its TEB base address */
     InitializeObjectAttributes(&ObjectAttributes, NULL, 0, NULL, NULL);
     ThreadInfo = (PSYSTEM_THREAD_INFORMATION)(CurrentProcessInfo + 1);
     for (i = 0; i < CurrentProcessInfo->NumberOfThreads; i++, ThreadInfo++)
@@ -1379,9 +1373,7 @@ LdrpGetCurrentProcessTebs(OUT PTEB **ThreadTebs,
                 continue;
             }
 
-            RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
-            RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
-            return Status;
+            goto Quickie;
         }
 
         Status = NtQueryInformationThread(ThreadHandle, ThreadBasicInformation, &ThreadBasicInfo, sizeof(ThreadBasicInfo), NULL);
@@ -1394,9 +1386,7 @@ LdrpGetCurrentProcessTebs(OUT PTEB **ThreadTebs,
                 continue;
             }
 
-            RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
-            RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
-            return Status;
+            goto Quickie;
         }
 
         if (ThreadBasicInfo.TebBaseAddress)
@@ -1410,6 +1400,11 @@ LdrpGetCurrentProcessTebs(OUT PTEB **ThreadTebs,
     *ThreadTebs = Tebs;
     *ThreadCount = Count;
     return STATUS_SUCCESS;
+
+Quickie:
+    RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
+    RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
+    return Status;
 }
 
 static
@@ -1479,8 +1474,8 @@ LdrpAppendTlsDataToProcessThreads(IN PLDRP_TLS_DATA TlsData,
 {
     NTSTATUS Status;
     PTEB *Tebs;
-    PLDRP_TEB_TLS_BLOCK Blocks;
-    ULONG i, Count, BlockCount = 0;
+    PVOID *Blocks;
+    ULONG i, Count;
 
     Status = LdrpGetCurrentProcessTebs(&Tebs, &Count);
     if (!NT_SUCCESS(Status))
@@ -1495,27 +1490,25 @@ LdrpAppendTlsDataToProcessThreads(IN PLDRP_TLS_DATA TlsData,
 
     for (i = 0; i < Count; i++)
     {
-        Blocks[BlockCount].Teb = Tebs[i];
-        Status = LdrpAppendTlsDataToThread(Tebs[i], TlsData, Index, &Blocks[BlockCount].TlsBlock);
+        Status = LdrpAppendTlsDataToThread(Tebs[i], TlsData, Index, &Blocks[i]);
         if (!NT_SUCCESS(Status))
         {
-            while (BlockCount)
+            /* Roll back the blocks already appended to earlier threads */
+            while (i)
             {
                 PVOID *TlsVector;
 
-                BlockCount--;
-                TlsVector = Blocks[BlockCount].Teb->ThreadLocalStoragePointer;
+                i--;
+                TlsVector = Tebs[i]->ThreadLocalStoragePointer;
                 if (TlsVector)
                     TlsVector[Index] = NULL;
-                RtlFreeHeap(RtlGetProcessHeap(), 0, Blocks[BlockCount].TlsBlock);
+                RtlFreeHeap(RtlGetProcessHeap(), 0, Blocks[i]);
             }
 
             RtlFreeHeap(RtlGetProcessHeap(), 0, Blocks);
             RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
             return Status;
         }
-
-        BlockCount++;
     }
 
     RtlFreeHeap(RtlGetProcessHeap(), 0, Blocks);
@@ -1556,9 +1549,9 @@ LdrpHandleTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry,
 
     TlsData->LdrEntry = LdrEntry;
     TlsData->TlsDirectory = *TlsDirectory;
-    TlsData->TlsDirectory.Characteristics = LdrpNumberOfTlsEntries;
 
-    Index = TlsData->TlsDirectory.Characteristics;
+    Index = LdrpNumberOfTlsEntries;
+    TlsData->TlsDirectory.Characteristics = Index;
     if (!ProcessInit)
     {
         NTSTATUS Status;
@@ -1591,7 +1584,7 @@ LdrpReleaseTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry)
 {
     PLIST_ENTRY ListHead, NextEntry;
     PLDRP_TLS_DATA TlsData;
-    PTEB *Tebs;
+    PTEB LocalTebs[1], *Tebs;
     ULONG i, Count;
 
     if (!LdrEntry->TlsIndex)
@@ -1608,24 +1601,18 @@ LdrpReleaseTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry)
         {
             ULONG Index = TlsData->TlsDirectory.Characteristics;
 
-            if (NT_SUCCESS(LdrpGetCurrentProcessTebs(&Tebs, &Count)))
+            /* Free this module's block from every thread; if the thread
+             * enumeration fails, fall back to the current thread alone */
+            if (!NT_SUCCESS(LdrpGetCurrentProcessTebs(&Tebs, &Count)))
             {
-                for (i = 0; i < Count; i++)
-                {
-                    PVOID *TlsVector = Tebs[i]->ThreadLocalStoragePointer;
-
-                    if (TlsVector && TlsVector[Index])
-                    {
-                        RtlFreeHeap(RtlGetProcessHeap(), 0, TlsVector[Index]);
-                        TlsVector[Index] = NULL;
-                    }
-                }
-
-                RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
+                LocalTebs[0] = NtCurrentTeb();
+                Tebs = LocalTebs;
+                Count = 1;
             }
-            else
+
+            for (i = 0; i < Count; i++)
             {
-                PVOID *TlsVector = NtCurrentTeb()->ThreadLocalStoragePointer;
+                PVOID *TlsVector = Tebs[i]->ThreadLocalStoragePointer;
 
                 if (TlsVector && TlsVector[Index])
                 {
@@ -1633,6 +1620,9 @@ LdrpReleaseTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry)
                     TlsVector[Index] = NULL;
                 }
             }
+
+            if (Tebs != LocalTebs)
+                RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
 
             RemoveEntryList(&TlsData->TlsLinks);
             RtlFreeHeap(RtlGetProcessHeap(), 0, TlsData);
@@ -1678,8 +1668,9 @@ LdrpAllocateTls(VOID)
     PTEB Teb = NtCurrentTeb();
     PLIST_ENTRY NextEntry, ListHead;
     PLDRP_TLS_DATA TlsData;
-    SIZE_T RawDataSize, TlsDataSize;
+    NTSTATUS Status;
     PVOID *TlsVector;
+    ULONG Index;
 
     /* Check if we have any entries */
     if (!LdrpNumberOfTlsEntries)
@@ -1700,30 +1691,22 @@ LdrpAllocateTls(VOID)
         TlsData = CONTAINING_RECORD(NextEntry, LDRP_TLS_DATA, TlsLinks);
         NextEntry = NextEntry->Flink;
 
-        /* Allocate the initial TLS data and zero-fill tail. */
-        RawDataSize = TlsData->TlsDirectory.EndAddressOfRawData -
-                      TlsData->TlsDirectory.StartAddressOfRawData;
-        TlsDataSize = RawDataSize + TlsData->TlsDirectory.SizeOfZeroFill;
-        TlsVector[TlsData->TlsDirectory.Characteristics] = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, TlsDataSize);
-        if (!TlsVector[TlsData->TlsDirectory.Characteristics])
-        {
-            /* Out of memory */
-            return STATUS_NO_MEMORY;
-        }
+        /* Allocate and initialize this module's TLS block */
+        Index = TlsData->TlsDirectory.Characteristics;
+        Status = LdrpAllocateTlsBlock(&TlsData->TlsDirectory, &TlsVector[Index]);
+        if (!NT_SUCCESS(Status))
+            return Status;
 
         /* Show debug message */
         if (ShowSnaps)
         {
             DPRINT1("LDR: TlsVector %p Index %lu = %p copied from %x to %p\n",
                     TlsVector,
-                    TlsData->TlsDirectory.Characteristics,
-                    &TlsVector[TlsData->TlsDirectory.Characteristics],
+                    Index,
+                    &TlsVector[Index],
                     TlsData->TlsDirectory.StartAddressOfRawData,
-                    TlsVector[TlsData->TlsDirectory.Characteristics]);
+                    TlsVector[Index]);
         }
-
-        /* Copy the initialized raw data */
-        RtlCopyMemory(TlsVector[TlsData->TlsDirectory.Characteristics], (PVOID)TlsData->TlsDirectory.StartAddressOfRawData, RawDataSize);
     }
 
     /* Done */

--- a/dll/ntdll/ldr/ldrinit.c
+++ b/dll/ntdll/ldr/ldrinit.c
@@ -721,7 +721,7 @@ LdrpRunInitializeRoutines(IN PCONTEXT Context OPTIONAL)
             /* Check flags */
             if (!(LdrEntry->Flags & LDRP_ENTRY_PROCESSED))
             {
-                Status = LdrpHandleTlsData(LdrEntry);
+                Status = LdrpHandleTlsData(LdrEntry, Context != NULL);
                 if (!NT_SUCCESS(Status))
                 {
                     if (LdrRootEntry != LocalArray)
@@ -853,7 +853,7 @@ LdrpRunInitializeRoutines(IN PCONTEXT Context OPTIONAL)
             _SEH2_TRY
             {
                 /* Check if it has TLS */
-                if (LdrEntry->TlsIndex && Context)
+                if (LdrEntry->TlsIndex)
                 {
                     /* Call TLS */
                     LdrpCallTlsInitializers(LdrEntry, DLL_PROCESS_ATTACH);
@@ -1275,19 +1275,295 @@ LdrShutdownThread(VOID)
     return STATUS_SUCCESS;
 }
 
-/*
- * Register a module's TLS directory and, when the current thread already has
- * a TLS vector, make the new slot usable before the module initializer runs.
- */
+typedef struct _LDRP_TEB_TLS_BLOCK
+{
+    PTEB Teb;
+    PVOID TlsBlock;
+} LDRP_TEB_TLS_BLOCK, *PLDRP_TEB_TLS_BLOCK;
+
+static
 NTSTATUS
 NTAPI
-LdrpHandleTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry)
+LdrpAllocateTlsBlock(IN PIMAGE_TLS_DIRECTORY TlsDirectory,
+                     OUT PVOID *TlsBlock)
+{
+    SIZE_T RawDataSize, TlsDataSize;
+
+    RawDataSize = TlsDirectory->EndAddressOfRawData -
+                  TlsDirectory->StartAddressOfRawData;
+    TlsDataSize = RawDataSize + TlsDirectory->SizeOfZeroFill;
+
+    *TlsBlock = RtlAllocateHeap(RtlGetProcessHeap(),
+                                HEAP_ZERO_MEMORY,
+                                TlsDataSize);
+    if (!*TlsBlock) return STATUS_NO_MEMORY;
+
+    RtlCopyMemory(*TlsBlock,
+                  (PVOID)TlsDirectory->StartAddressOfRawData,
+                  RawDataSize);
+
+    return STATUS_SUCCESS;
+}
+
+static
+NTSTATUS
+NTAPI
+LdrpGetCurrentProcessTebs(OUT PTEB **ThreadTebs,
+                          OUT PULONG ThreadCount)
+{
+    HANDLE ThreadHandle;
+    NTSTATUS Status;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    PSYSTEM_PROCESS_INFORMATION ProcessInfo, CurrentProcessInfo;
+    PSYSTEM_THREAD_INFORMATION ThreadInfo;
+    THREAD_BASIC_INFORMATION ThreadBasicInfo;
+    PTEB *Tebs;
+    ULONG BufferSize = 0x8000, ReturnLength = 0;
+    ULONG i, Count = 0;
+
+    *ThreadTebs = NULL;
+    *ThreadCount = 0;
+
+    do
+    {
+        ProcessInfo = RtlAllocateHeap(RtlGetProcessHeap(), 0, BufferSize);
+        if (!ProcessInfo) return STATUS_NO_MEMORY;
+
+        Status = NtQuerySystemInformation(SystemProcessInformation,
+                                          ProcessInfo,
+                                          BufferSize,
+                                          &ReturnLength);
+        if ((Status == STATUS_INFO_LENGTH_MISMATCH) ||
+            (Status == STATUS_BUFFER_OVERFLOW) ||
+            (Status == STATUS_BUFFER_TOO_SMALL))
+        {
+            RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
+            BufferSize = ReturnLength ? ReturnLength + PAGE_SIZE : BufferSize * 2;
+        }
+    } while ((Status == STATUS_INFO_LENGTH_MISMATCH) ||
+             (Status == STATUS_BUFFER_OVERFLOW) ||
+             (Status == STATUS_BUFFER_TOO_SMALL));
+
+    if (!NT_SUCCESS(Status))
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
+        return Status;
+    }
+
+    CurrentProcessInfo = ProcessInfo;
+    while (CurrentProcessInfo->UniqueProcessId != NtCurrentTeb()->ClientId.UniqueProcess)
+    {
+        if (!CurrentProcessInfo->NextEntryOffset)
+        {
+            RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
+            return STATUS_UNSUCCESSFUL;
+        }
+
+        CurrentProcessInfo = (PSYSTEM_PROCESS_INFORMATION)
+                             ((ULONG_PTR)CurrentProcessInfo +
+                              CurrentProcessInfo->NextEntryOffset);
+    }
+
+    Tebs = RtlAllocateHeap(RtlGetProcessHeap(),
+                           0,
+                           CurrentProcessInfo->NumberOfThreads * sizeof(*Tebs));
+    if (!Tebs)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
+        return STATUS_NO_MEMORY;
+    }
+
+    InitializeObjectAttributes(&ObjectAttributes, NULL, 0, NULL, NULL);
+    ThreadInfo = (PSYSTEM_THREAD_INFORMATION)(CurrentProcessInfo + 1);
+    for (i = 0; i < CurrentProcessInfo->NumberOfThreads; i++, ThreadInfo++)
+    {
+        if (ThreadInfo->ClientId.UniqueThread == NtCurrentTeb()->ClientId.UniqueThread)
+        {
+            Tebs[Count++] = NtCurrentTeb();
+            continue;
+        }
+
+        Status = NtOpenThread(&ThreadHandle,
+                              THREAD_QUERY_INFORMATION,
+                              &ObjectAttributes,
+                              &ThreadInfo->ClientId);
+        if (!NT_SUCCESS(Status))
+        {
+            if ((Status == STATUS_INVALID_CID) ||
+                (Status == STATUS_THREAD_IS_TERMINATING))
+            {
+                continue;
+            }
+
+            RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
+            RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
+            return Status;
+        }
+
+        Status = NtQueryInformationThread(ThreadHandle,
+                                          ThreadBasicInformation,
+                                          &ThreadBasicInfo,
+                                          sizeof(ThreadBasicInfo),
+                                          NULL);
+        NtClose(ThreadHandle);
+        if (!NT_SUCCESS(Status))
+        {
+            if ((Status == STATUS_INVALID_CID) ||
+                (Status == STATUS_THREAD_IS_TERMINATING))
+            {
+                continue;
+            }
+
+            RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
+            RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
+            return Status;
+        }
+
+        if (ThreadBasicInfo.TebBaseAddress)
+        {
+            Tebs[Count++] = ThreadBasicInfo.TebBaseAddress;
+        }
+    }
+
+    RtlFreeHeap(RtlGetProcessHeap(), 0, ProcessInfo);
+
+    *ThreadTebs = Tebs;
+    *ThreadCount = Count;
+    return STATUS_SUCCESS;
+}
+
+static
+NTSTATUS
+NTAPI
+LdrpAppendTlsDataToThread(IN PTEB Teb,
+                          IN PLDRP_TLS_DATA TlsData,
+                          IN ULONG Index,
+                          OUT PVOID *TlsBlock)
+{
+    NTSTATUS Status;
+    PVOID Block;
+    PVOID *OldTlsVector, *TlsVector;
+    SIZE_T TlsVectorSize = (Index + 1) * sizeof(PVOID);
+
+    *TlsBlock = NULL;
+
+    Status = LdrpAllocateTlsBlock(&TlsData->TlsDirectory, &Block);
+    if (!NT_SUCCESS(Status)) return Status;
+
+    OldTlsVector = Teb->ThreadLocalStoragePointer;
+    if (OldTlsVector)
+    {
+        if (Teb == NtCurrentTeb())
+        {
+            TlsVector = RtlReAllocateHeap(RtlGetProcessHeap(),
+                                          0,
+                                          OldTlsVector,
+                                          TlsVectorSize);
+        }
+        else
+        {
+            TlsVector = RtlReAllocateHeap(RtlGetProcessHeap(),
+                                          HEAP_REALLOC_IN_PLACE_ONLY,
+                                          OldTlsVector,
+                                          TlsVectorSize);
+            if (!TlsVector)
+            {
+                /*
+                 * Static TLS reads do not take the loader lock, so keep the old
+                 * vector valid if the target thread needs a moved vector.
+                 */
+                TlsVector = RtlAllocateHeap(RtlGetProcessHeap(),
+                                            HEAP_ZERO_MEMORY,
+                                            TlsVectorSize);
+                if (TlsVector)
+                {
+                    RtlCopyMemory(TlsVector, OldTlsVector, Index * sizeof(PVOID));
+                }
+            }
+        }
+    }
+    else
+    {
+        TlsVector = RtlAllocateHeap(RtlGetProcessHeap(),
+                                    HEAP_ZERO_MEMORY,
+                                    TlsVectorSize);
+    }
+
+    if (!TlsVector)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, Block);
+        return STATUS_NO_MEMORY;
+    }
+
+    TlsVector[Index] = Block;
+    Teb->ThreadLocalStoragePointer = TlsVector;
+    *TlsBlock = Block;
+
+    return STATUS_SUCCESS;
+}
+
+static
+NTSTATUS
+NTAPI
+LdrpAppendTlsDataToProcessThreads(IN PLDRP_TLS_DATA TlsData,
+                                  IN ULONG Index)
+{
+    NTSTATUS Status;
+    PTEB *Tebs;
+    PLDRP_TEB_TLS_BLOCK Blocks;
+    ULONG i, Count, BlockCount = 0;
+
+    Status = LdrpGetCurrentProcessTebs(&Tebs, &Count);
+    if (!NT_SUCCESS(Status)) return Status;
+
+    Blocks = RtlAllocateHeap(RtlGetProcessHeap(),
+                             HEAP_ZERO_MEMORY,
+                             Count * sizeof(*Blocks));
+    if (!Blocks)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
+        return STATUS_NO_MEMORY;
+    }
+
+    for (i = 0; i < Count; i++)
+    {
+        Blocks[BlockCount].Teb = Tebs[i];
+        Status = LdrpAppendTlsDataToThread(Tebs[i],
+                                           TlsData,
+                                           Index,
+                                           &Blocks[BlockCount].TlsBlock);
+        if (!NT_SUCCESS(Status))
+        {
+            while (BlockCount)
+            {
+                PVOID *TlsVector;
+
+                BlockCount--;
+                TlsVector = Blocks[BlockCount].Teb->ThreadLocalStoragePointer;
+                if (TlsVector) TlsVector[Index] = NULL;
+                RtlFreeHeap(RtlGetProcessHeap(), 0, Blocks[BlockCount].TlsBlock);
+            }
+
+            RtlFreeHeap(RtlGetProcessHeap(), 0, Blocks);
+            RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
+            return Status;
+        }
+
+        BlockCount++;
+    }
+
+    RtlFreeHeap(RtlGetProcessHeap(), 0, Blocks);
+    RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+NTAPI
+LdrpHandleTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry,
+                  IN BOOLEAN ProcessInit)
 {
     PIMAGE_TLS_DIRECTORY TlsDirectory;
     PLDRP_TLS_DATA TlsData;
-    PTEB Teb = NtCurrentTeb();
-    PVOID *TlsVector;
-    SIZE_T RawDataSize, BlockSize;
     ULONG Index, Size;
 
     /* Nothing to do if this module is already registered */
@@ -1302,9 +1578,6 @@ LdrpHandleTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry)
     if (!TlsDirectory)
         return STATUS_SUCCESS;
 
-    /* Remember that the process uses TLS */
-    if (!LdrpImageHasTls) LdrpImageHasTls = TRUE;
-
     /* Show debug message */
     if (ShowSnaps)
     {
@@ -1317,41 +1590,91 @@ LdrpHandleTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry)
     TlsData = RtlAllocateHeap(RtlGetProcessHeap(), 0, sizeof(LDRP_TLS_DATA));
     if (!TlsData) return STATUS_NO_MEMORY;
 
-    LdrEntry->LoadCount = -1;
-    LdrEntry->TlsIndex = -1;
+    TlsData->LdrEntry = LdrEntry;
     TlsData->TlsDirectory = *TlsDirectory;
+    TlsData->TlsDirectory.Characteristics = LdrpNumberOfTlsEntries;
+
+    Index = TlsData->TlsDirectory.Characteristics;
+    if (!ProcessInit)
+    {
+        NTSTATUS Status;
+
+        Status = LdrpAppendTlsDataToProcessThreads(TlsData, Index);
+        if (!NT_SUCCESS(Status))
+        {
+            RtlFreeHeap(RtlGetProcessHeap(), 0, TlsData);
+            return Status;
+        }
+    }
+    else
+    {
+        LdrEntry->LoadCount = -1;
+    }
+
+    LdrEntry->TlsIndex = -1;
     InsertTailList(&LdrpTlsList, &TlsData->TlsLinks);
-
-    Index = LdrpNumberOfTlsEntries++;
     *(PLONG)TlsData->TlsDirectory.AddressOfIndex = Index;
-    TlsData->TlsDirectory.Characteristics = Index;
+    LdrpNumberOfTlsEntries++;
 
-    /* LdrpAllocateTls() will allocate the vector during process startup. */
-    if (!Teb->ThreadLocalStoragePointer)
-        return STATUS_SUCCESS;
-
-    /* Grow the running thread's vector so the new index is addressable */
-    TlsVector = RtlReAllocateHeap(RtlGetProcessHeap(),
-                                  0,
-                                  Teb->ThreadLocalStoragePointer,
-                                  LdrpNumberOfTlsEntries * sizeof(PVOID));
-    if (!TlsVector) return STATUS_NO_MEMORY;
-    Teb->ThreadLocalStoragePointer = TlsVector;
-
-    /* Allocate the raw TLS data plus the image's zero-fill area. */
-    RawDataSize = TlsDirectory->EndAddressOfRawData -
-                  TlsDirectory->StartAddressOfRawData;
-    BlockSize = RawDataSize + TlsDirectory->SizeOfZeroFill;
-    TlsVector[Index] = RtlAllocateHeap(RtlGetProcessHeap(),
-                                       HEAP_ZERO_MEMORY,
-                                       BlockSize);
-    if (!TlsVector[Index]) return STATUS_NO_MEMORY;
-
-    RtlCopyMemory(TlsVector[Index],
-                  (PVOID)TlsDirectory->StartAddressOfRawData,
-                  RawDataSize);
+    if (!LdrpImageHasTls) LdrpImageHasTls = TRUE;
 
     return STATUS_SUCCESS;
+}
+
+VOID
+NTAPI
+LdrpReleaseTlsData(IN PLDR_DATA_TABLE_ENTRY LdrEntry)
+{
+    PLIST_ENTRY ListHead, NextEntry;
+    PLDRP_TLS_DATA TlsData;
+    PTEB *Tebs;
+    ULONG i, Count;
+
+    if (!LdrEntry->TlsIndex) return;
+
+    ListHead = &LdrpTlsList;
+    NextEntry = ListHead->Flink;
+    while (NextEntry != ListHead)
+    {
+        TlsData = CONTAINING_RECORD(NextEntry, LDRP_TLS_DATA, TlsLinks);
+        NextEntry = NextEntry->Flink;
+
+        if (TlsData->LdrEntry == LdrEntry)
+        {
+            ULONG Index = TlsData->TlsDirectory.Characteristics;
+
+            if (NT_SUCCESS(LdrpGetCurrentProcessTebs(&Tebs, &Count)))
+            {
+                for (i = 0; i < Count; i++)
+                {
+                    PVOID *TlsVector = Tebs[i]->ThreadLocalStoragePointer;
+
+                    if (TlsVector && TlsVector[Index])
+                    {
+                        RtlFreeHeap(RtlGetProcessHeap(), 0, TlsVector[Index]);
+                        TlsVector[Index] = NULL;
+                    }
+                }
+
+                RtlFreeHeap(RtlGetProcessHeap(), 0, Tebs);
+            }
+            else
+            {
+                PVOID *TlsVector = NtCurrentTeb()->ThreadLocalStoragePointer;
+
+                if (TlsVector && TlsVector[Index])
+                {
+                    RtlFreeHeap(RtlGetProcessHeap(), 0, TlsVector[Index]);
+                    TlsVector[Index] = NULL;
+                }
+            }
+
+            RemoveEntryList(&TlsData->TlsLinks);
+            RtlFreeHeap(RtlGetProcessHeap(), 0, TlsData);
+            LdrEntry->TlsIndex = 0;
+            return;
+        }
+    }
 }
 
 NTSTATUS
@@ -1374,7 +1697,7 @@ LdrpInitializeTls(VOID)
         LdrEntry = CONTAINING_RECORD(NextEntry, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
         NextEntry = NextEntry->Flink;
 
-        Status = LdrpHandleTlsData(LdrEntry);
+        Status = LdrpHandleTlsData(LdrEntry, TRUE);
         if (!NT_SUCCESS(Status)) return Status;
     }
 
@@ -1398,7 +1721,7 @@ LdrpAllocateTls(VOID)
 
     /* Allocate the vector array */
     TlsVector = RtlAllocateHeap(RtlGetProcessHeap(),
-                                    0,
+                                    HEAP_ZERO_MEMORY,
                                     LdrpNumberOfTlsEntries * sizeof(PVOID));
     if (!TlsVector) return STATUS_NO_MEMORY;
     Teb->ThreadLocalStoragePointer = TlsVector;


### PR DESCRIPTION
This fixes some heap corruption I hit while experimenting with SwiftShader in ReactOS.

The issue was that static TLS was only registered for modules present during process startup. A DLL loaded later through LdrLoadDll() could keep _tls_index at 0, so its TLS accesses reused another module's TLS block and could overwrite heap metadata.

The fix registers TLS directories for dynamically loaded modules before their initializers run, allocates the new TLS slot for existing threads, calls TLS callbacks for LoadLibrary loads, and keeps those DLLs unloadable. It also sizes each TLS block to include SizeOfZeroFill.

## TODO

- [ ] test under amd64

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: