### PR TITLE
[MSPAINT] Fix unzooming coordinate conversion

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -196,17 +196,17 @@ VOID CCanvasWindow::ImageToCanvas(RECT& rc)
     ::OffsetRect(&rc, GRIP_SIZE - GetScrollPos(SB_HORZ), GRIP_SIZE - GetScrollPos(SB_VERT));
 }
 
-VOID CCanvasWindow::CanvasToImage(POINT& pt)
+VOID CCanvasWindow::CanvasToImage(POINT& pt, BOOL bRound)
 {
     pt.x -= GRIP_SIZE - GetScrollPos(SB_HORZ);
     pt.y -= GRIP_SIZE - GetScrollPos(SB_VERT);
-    UnZoomed(pt);
+    UnZoomed(pt, bRound);
 }
 
-VOID CCanvasWindow::CanvasToImage(RECT& rc)
+VOID CCanvasWindow::CanvasToImage(RECT& rc, BOOL bRound)
 {
     ::OffsetRect(&rc, GetScrollPos(SB_HORZ) - GRIP_SIZE, GetScrollPos(SB_VERT) - GRIP_SIZE);
-    UnZoomed(rc);
+    UnZoomed(rc, bRound);
 }
 
 VOID CCanvasWindow::GetImageRect(RECT& rc)
@@ -531,7 +531,7 @@ LRESULT CCanvasWindow::OnButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
 LRESULT CCanvasWindow::OnButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
-    CanvasToImage(pt);
+    CanvasToImage(pt, TRUE);
 
     m_drawing = FALSE;
     ::ReleaseCapture();
@@ -557,7 +557,7 @@ LRESULT CCanvasWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
         return 0;
     }
 
-    CanvasToImage(pt);
+    CanvasToImage(pt, TRUE);
 
     if (toolsModel.GetActiveTool() == TOOL_ZOOM)
         Invalidate();
@@ -672,7 +672,7 @@ LRESULT CCanvasWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
 LRESULT CCanvasWindow::OnButtonUp(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
-    CanvasToImage(pt);
+    CanvasToImage(pt, TRUE);
 
     ::ReleaseCapture();
 

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -475,7 +475,7 @@ LRESULT CCanvasWindow::OnButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
     if (hitSelection != HIT_NONE)
     {
         m_drawing = TRUE;
-        CanvasToImage(pt);
+        CanvasToImage(pt, TRUE);
         SetCapture();
         toolsModel.OnButtonDown(bLeftButton, pt.x, pt.y, FALSE);
         Invalidate();
@@ -507,7 +507,7 @@ LRESULT CCanvasWindow::OnButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
         return 0;
     }
 
-    CanvasToImage(pt);
+    CanvasToImage(pt, TRUE);
 
     if (hit == HIT_INNER)
     {

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -81,8 +81,8 @@ public:
 
     VOID ImageToCanvas(POINT& pt);
     VOID ImageToCanvas(RECT& rc);
-    VOID CanvasToImage(POINT& pt);
-    VOID CanvasToImage(RECT& rc);
+    VOID CanvasToImage(POINT& pt, BOOL bRound = FALSE);
+    VOID CanvasToImage(RECT& rc, BOOL bRound = FALSE);
     VOID GetImageRect(RECT& rc);
     VOID getNewZoomRect(CRect& rcView, INT newZoom, CPoint ptTarget);
     VOID zoomTo(INT newZoom, LONG left = 0, LONG top = 0);

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -172,9 +172,11 @@ static inline int Zoomed(int xy)
     return MulDiv(xy, toolsModel.GetZoom(), DEFAULT_ZOOM);
 }
 
-static inline int UnZoomed(int xy)
+static inline int UnZoomed(int xy, BOOL bRound = FALSE)
 {
-    return MulDiv(xy, DEFAULT_ZOOM, toolsModel.GetZoom());
+    if (bRound)
+        return MulDiv(xy, DEFAULT_ZOOM, toolsModel.GetZoom());
+    return xy * DEFAULT_ZOOM / toolsModel.GetZoom();
 }
 
 static inline void Zoomed(POINT& pt)
@@ -187,12 +189,12 @@ static inline void Zoomed(RECT& rc)
     rc = { Zoomed(rc.left), Zoomed(rc.top), Zoomed(rc.right), Zoomed(rc.bottom) };
 }
 
-static inline void UnZoomed(POINT& pt)
+static inline void UnZoomed(POINT& pt, BOOL bRound = FALSE)
 {
-    pt = { UnZoomed(pt.x), UnZoomed(pt.y) };
+    pt = { UnZoomed(pt.x, bRound), UnZoomed(pt.y, bRound) };
 }
 
-static inline void UnZoomed(RECT& rc)
+static inline void UnZoomed(RECT& rc, BOOL bRound = FALSE)
 {
-    rc = { UnZoomed(rc.left), UnZoomed(rc.top), UnZoomed(rc.right), UnZoomed(rc.bottom) };
+    rc = { UnZoomed(rc.left, bRound), UnZoomed(rc.top, bRound), UnZoomed(rc.right, bRound), UnZoomed(rc.bottom, bRound) };
 }

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -196,5 +196,6 @@ static inline void UnZoomed(POINT& pt, BOOL bRound = FALSE)
 
 static inline void UnZoomed(RECT& rc, BOOL bRound = FALSE)
 {
-    rc = { UnZoomed(rc.left, bRound), UnZoomed(rc.top, bRound), UnZoomed(rc.right, bRound), UnZoomed(rc.bottom, bRound) };
+    rc = { UnZoomed(rc.left, bRound), UnZoomed(rc.top, bRound),
+           UnZoomed(rc.right, bRound), UnZoomed(rc.bottom, bRound) };
 }


### PR DESCRIPTION
## Purpose

Always rounding of unzooming coordinate values had caused display glitch (e.g. black line on top edge in zooming).

(BEFORE)
<img width="545" height="380" alt="image" src="https://github.com/user-attachments/assets/13c89f65-edb7-4ae8-aefe-ff8700f29fdc" />

JIRA issue: [CORE-19466](https://jira.reactos.org/browse/CORE-19466)

## Proposed changes

- Add `bRound` parameter to `UnZoomed` function. If `bRound` is `TRUE`, then do round by `kernel32!MulDiv` function. Otherwise don't round.
- Add `bRound` parameter to `CCanvasWindow::CanvasToImage`.
- Make `bRound = FALSE` default.
- Use `bRound = TRUE` for `CCanvasWindow::OnButtonDown`, `CCanvasWindow::OnButtonDblClk`, `CCanvasWindow::OnMouseMove`, and `CCanvasWindow::OnButtonUp`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108848,108852
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108849,108853