### PR TITLE
[SMSS] sminit.c: Check DirInfo is non-null

### DIFF
--- a/base/system/smss/sminit.c
+++ b/base/system/smss/sminit.c
@@ -928,9 +928,12 @@ SmpTranslateSystemPartitionInformation(VOID)
          * NOTE: This has been introduced in a post-SP1 Windows 7 update. */
         if (Status != STATUS_NO_MORE_ENTRIES)
             return;
-        DirInfo->Name.Buffer = DirInfoBuffer.Buffer;
-        DirInfo->Name.Buffer[0] = SharedUserData->NtSystemRoot[0];
-        DirInfo->Name.Buffer[1] = SharedUserData->NtSystemRoot[1]; // == L':';
+        if (DirInfo)
+        {
+            DirInfo->Name.Buffer = DirInfoBuffer.Buffer;
+            DirInfo->Name.Buffer[0] = SharedUserData->NtSystemRoot[0];
+            DirInfo->Name.Buffer[1] = SharedUserData->NtSystemRoot[1]; // == L':';
+        }
 #else
         return;
 #endif


### PR DESCRIPTION
## Purpose
Based on @xmine64's comment.
OK: `reactos-livecd-0.4.17-dev-237-g93bd77f-x86-gcc-lin-dbg`
BAD: `reactos-livecd-0.4.17-dev-238-g3b3e1ff-x86-gcc-lin-dbg`

JIRA issue: [CORE-20678](https://jira.reactos.org/browse/CORE-20678)

## Proposed changes

- Check `DirInfo` is non-nulll.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: