### PR TITLE
[MCIAVI32] Sync to Wine 11.11

### DIFF
--- a/dll/directx/wine/d3dxof/parsing.c
+++ b/dll/directx/wine/d3dxof/parsing.c
@@ -81,15 +81,6 @@ WINE_DEFAULT_DEBUG_CHANNEL(d3dxof_parsing);
 
 #define CLSIDFMT "<%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X>"
 
-/* FOURCC to string conversion for debug messages */
-static const char *debugstr_fourcc(DWORD fourcc)
-{
-    if (!fourcc) return "'null'";
-    return wine_dbg_sprintf ("\'%c%c%c%c\'",
-        (char)(fourcc), (char)(fourcc >> 8),
-        (char)(fourcc >> 16), (char)(fourcc >> 24));
-}
-
 static const char* get_primitive_string(DWORD token)
 {
   switch(token)

--- a/dll/directx/wine/dmusic/dmobject.c
+++ b/dll/directx/wine/dmusic/dmobject.c
@@ -36,15 +36,6 @@ WINE_DECLARE_DEBUG_CHANNEL(dmfile);
 /* RIFF format parsing */
 #define CHUNK_HDR_SIZE (sizeof(FOURCC) + sizeof(DWORD))
 
-#ifndef __REACTOS__
-static inline const char *debugstr_fourcc(DWORD fourcc)
-{
-    if (!fourcc) return "''";
-    return wine_dbg_sprintf("'%c%c%c%c'", (char)(fourcc), (char)(fourcc >> 8),
-            (char)(fourcc >> 16), (char)(fourcc >> 24));
-}
-#endif
-
 const char *debugstr_chunk(const struct chunk_entry *chunk)
 {
     const char *type = "";

--- a/dll/directx/wine/dmusic/dmusic_main.c
+++ b/dll/directx/wine/dmusic/dmusic_main.c
@@ -215,14 +215,6 @@ int even_or_odd (DWORD number) {
 	return (number & 0x1); /* basically, check if bit 0 is set ;) */
 }
 
-/* FOURCC to string conversion for debug messages */
-const char *debugstr_fourcc (DWORD fourcc) {
-    if (!fourcc) return "'null'";
-    return wine_dbg_sprintf ("\'%c%c%c%c\'",
-		(char)(fourcc), (char)(fourcc >> 8),
-        (char)(fourcc >> 16), (char)(fourcc >> 24));
-}
-
 /* DMUS_VERSION struct to string conversion for debug messages */
 static const char *debugstr_dmversion(const DMUS_VERSION *version)
 {

--- a/dll/directx/wine/dmusic/dmusic_private.h
+++ b/dll/directx/wine/dmusic/dmusic_private.h
@@ -260,8 +260,6 @@ extern void Patch2MIDILOCALE (DWORD dwPatch, LPMIDILOCALE pLocale) DECLSPEC_HIDD
 
 /* check whether the given DWORD is even (return 0) or odd (return 1) */
 extern int even_or_odd (DWORD number) DECLSPEC_HIDDEN;
-/* FOURCC to string conversion for debug messages */
-extern const char *debugstr_fourcc (DWORD fourcc) DECLSPEC_HIDDEN;
 /* returns name of given GUID */
 extern const char *debugstr_dmguid (const GUID *id) DECLSPEC_HIDDEN;
 /* Dump whole DMUS_OBJECTDESC struct */

--- a/dll/win32/mciavi32/CMakeLists.txt
+++ b/dll/win32/mciavi32/CMakeLists.txt
@@ -14,8 +14,8 @@ add_library(mciavi32 MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/mciavi32.def)
 
 set_module_type(mciavi32 win32dll)
-target_link_libraries(mciavi32 wine)
-add_importlibs(mciavi32 msvfw32 winmm user32 gdi32 msvcrt kernel32 ntdll)
+target_link_libraries(mciavi32 wine oldnames)
+add_importlibs(mciavi32 msvfw32 winmm user32 gdi32 msvcrt kernel32_vista kernel32 ntdll)
 add_pch(mciavi32 precomp.h SOURCE)
 add_cd_file(TARGET mciavi32 DESTINATION reactos/system32 FOR all)
 set_wine_module(mciavi32)

--- a/dll/win32/mciavi32/info.c
+++ b/dll/win32/mciavi32/info.c
@@ -39,9 +39,9 @@ static DWORD MCIAVI_ConvertFrameToTimeFormat(WINE_MCIAVI* wma, DWORD val, LPDWOR
 	ret = val;
 	break;
     default:
-	WARN("Bad time format %u!\n", wma->dwMciTimeFormat);
+	WARN("Bad time format %lu!\n", wma->dwMciTimeFormat);
     }
-    TRACE("val=%u=0x%08x [tf=%u] => ret=%u\n", val, val, wma->dwMciTimeFormat, ret);
+    TRACE("val=%lu=0x%08lx [tf=%lu] => ret=%lu\n", val, val, wma->dwMciTimeFormat, ret);
     *lpRet = 0;
     return ret;
 }
@@ -61,9 +61,9 @@ DWORD 	MCIAVI_ConvertTimeFormatToFrame(WINE_MCIAVI* wma, DWORD val)
 	ret = val;
 	break;
     default:
-	WARN("Bad time format %u!\n", wma->dwMciTimeFormat);
+	WARN("Bad time format %lu!\n", wma->dwMciTimeFormat);
     }
-    TRACE("val=%u=0x%08x [tf=%u] => ret=%u\n", val, val, wma->dwMciTimeFormat, ret);
+    TRACE("val=%lu=0x%08lx [tf=%lu] => ret=%lu\n", val, val, wma->dwMciTimeFormat, ret);
     return ret;
 }
 
@@ -75,7 +75,7 @@ DWORD	MCIAVI_mciGetDevCaps(UINT wDevID, DWORD dwFlags,  LPMCI_GETDEVCAPS_PARMS l
     WINE_MCIAVI*	wma = MCIAVI_mciGetOpenDev(wDevID);
     DWORD		ret = MCIERR_UNSUPPORTED_FUNCTION;
 
-    TRACE("(%04x, %08X, %p)\n", wDevID, dwFlags, lpParms);
+    TRACE("(%04x, %08lX, %p)\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL) 	return MCIERR_NULL_PARAMETER_BLOCK;
     if (wma == NULL)		return MCIERR_INVALID_DEVICE_ID;
@@ -173,7 +173,7 @@ DWORD	MCIAVI_mciGetDevCaps(UINT wDevID, DWORD dwFlags,  LPMCI_GETDEVCAPS_PARMS l
 	    break;
 	/* w2k does not know MAX_WINDOWS or MAX/MINIMUM_RATE */
 	default:
-            FIXME("Unknown capability (%08x) !\n", lpParms->dwItem);
+            FIXME("Unknown capability (%08lx) !\n", lpParms->dwItem);
             break;
 	}
     }
@@ -190,32 +190,29 @@ DWORD	MCIAVI_mciInfo(UINT wDevID, DWORD dwFlags, LPMCI_DGV_INFO_PARMSW lpParms)
     LPCWSTR		str = 0;
     WINE_MCIAVI*	wma = MCIAVI_mciGetOpenDev(wDevID);
     DWORD		ret = 0;
-    static const WCHAR wszAviPlayer[] = {'W','i','n','e','\'','s',' ','A','V','I',' ','p','l','a','y','e','r',0};
-    static const WCHAR wszVersion[] = {'1','.','1',0};
 
     if (lpParms == NULL || lpParms->lpstrReturn == NULL)
 	return MCIERR_NULL_PARAMETER_BLOCK;
     if (wma == NULL) return MCIERR_INVALID_DEVICE_ID;
     if (dwFlags & MCI_TEST)	return 0;
 
-    TRACE("buf=%p, len=%u\n", lpParms->lpstrReturn, lpParms->dwRetSize);
+    TRACE("buf=%p, len=%lu\n", lpParms->lpstrReturn, lpParms->dwRetSize);
 
     EnterCriticalSection(&wma->cs);
 
     if (dwFlags & MCI_INFO_PRODUCT)
-	str = wszAviPlayer;
+	str = L"Wine's AVI player";
     else if (dwFlags & MCI_INFO_VERSION)
-	str = wszVersion;
+	str = L"1.1";
     else if (dwFlags & MCI_INFO_FILE)
 	str = wma->lpFileName;
     else {
-	WARN("Don't know this info command (%u)\n", dwFlags);
+	WARN("Don't know this info command (%lu)\n", dwFlags);
 	ret = MCIERR_UNRECOGNIZED_COMMAND;
     }
     if (!ret) {
-	WCHAR zero = 0;
 	/* Only mciwave, mciseq and mcicda set dwRetSize (since NT). */
-	lstrcpynW(lpParms->lpstrReturn, str ? str : &zero, lpParms->dwRetSize);
+	lstrcpynW(lpParms->lpstrReturn, str ? str : L"", lpParms->dwRetSize);
     }
     LeaveCriticalSection(&wma->cs);
     return ret;
@@ -245,7 +242,7 @@ DWORD	MCIAVI_mciSet(UINT wDevID, DWORD dwFlags, LPMCI_DGV_SET_PARMS lpParms)
 	    wma->dwMciTimeFormat = MCI_FORMAT_FRAMES;
 	    break;
 	default:
-            WARN("Bad time format %u!\n", lpParms->dwTimeFormat);
+            WARN("Bad time format %lu!\n", lpParms->dwTimeFormat);
             LeaveCriticalSection(&wma->cs);
 	    return MCIERR_BAD_TIME_FORMAT;
 	}
@@ -287,7 +284,7 @@ DWORD	MCIAVI_mciSet(UINT wDevID, DWORD dwFlags, LPMCI_DGV_SET_PARMS lpParms)
 		break;
 	    default:
 		szAudio = " audio unknown";
-		WARN("Unknown audio channel %u\n", lpParms->dwAudio);
+		WARN("Unknown audio channel %lu\n", lpParms->dwAudio);
 		break;
 	    }
 	}
@@ -322,7 +319,7 @@ DWORD	MCIAVI_mciSet(UINT wDevID, DWORD dwFlags, LPMCI_DGV_SET_PARMS lpParms)
 		break;
 	    default:
 		szAudio = " audio unknown";
-		WARN("Unknown audio channel %u\n", lpParms->dwAudio);
+		WARN("Unknown audio channel %lu\n", lpParms->dwAudio);
 		break;
 	    }
 	}
@@ -345,12 +342,12 @@ DWORD	MCIAVI_mciSet(UINT wDevID, DWORD dwFlags, LPMCI_DGV_SET_PARMS lpParms)
 	case MCI_DGV_FF_MPEG: 	FIXME("Setting file format (%s) to 'MPEG'\n", str); 	break;
 	case MCI_DGV_FF_RDIB:	FIXME("Setting file format (%s) to 'RLE DIB'\n", str);	break;
 	case MCI_DGV_FF_RJPEG: 	FIXME("Setting file format (%s) to 'RJPEG'\n", str);	break;
-	default:		FIXME("Setting unknown file format (%s): %d\n", str, lpParms->dwFileFormat);
+	default:		FIXME("Setting unknown file format (%s): %ld\n", str, lpParms->dwFileFormat);
 	}
     }
 
     if (dwFlags & MCI_DGV_SET_SPEED) {
-	FIXME("Setting speed to %d\n", lpParms->dwSpeed);
+	FIXME("Setting speed to %ld\n", lpParms->dwSpeed);
     }
 
     LeaveCriticalSection(&wma->cs);
@@ -376,7 +373,7 @@ DWORD	MCIAVI_mciStatus(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STATUS_PARMSW lpPar
 	switch (lpParms->dwItem) {
 	case MCI_STATUS_CURRENT_TRACK:
 	    lpParms->dwReturn = 1;
-	    TRACE("MCI_STATUS_CURRENT_TRACK => %lu\n", lpParms->dwReturn);
+	    TRACE("MCI_STATUS_CURRENT_TRACK => %Iu\n", lpParms->dwReturn);
 	    break;
 	case MCI_STATUS_LENGTH:
 	    if (!wma->hFile) {
@@ -386,7 +383,7 @@ DWORD	MCIAVI_mciStatus(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STATUS_PARMSW lpPar
 	    }
 	    /* only one track in file is currently handled, so don't take care of MCI_TRACK flag */
 	    lpParms->dwReturn = MCIAVI_ConvertFrameToTimeFormat(wma, wma->mah.dwTotalFrames, &ret);
-	    TRACE("MCI_STATUS_LENGTH => %lu\n", lpParms->dwReturn);
+	    TRACE("MCI_STATUS_LENGTH => %Iu\n", lpParms->dwReturn);
 	    break;
 	case MCI_STATUS_MODE:
  	    lpParms->dwReturn = MAKEMCIRESOURCE(wma->dwStatus, wma->dwStatus);
@@ -400,7 +397,7 @@ DWORD	MCIAVI_mciStatus(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STATUS_PARMSW lpPar
 	    break;
 	case MCI_STATUS_NUMBER_OF_TRACKS:
 	    lpParms->dwReturn = 1;
-	    TRACE("MCI_STATUS_NUMBER_OF_TRACKS => %lu\n", lpParms->dwReturn);
+	    TRACE("MCI_STATUS_NUMBER_OF_TRACKS => %Iu\n", lpParms->dwReturn);
 	    break;
 	case MCI_STATUS_POSITION:
 	    if (!wma->hFile) {
@@ -412,7 +409,7 @@ DWORD	MCIAVI_mciStatus(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STATUS_PARMSW lpPar
 	    lpParms->dwReturn = MCIAVI_ConvertFrameToTimeFormat(wma,
 							     (dwFlags & MCI_STATUS_START) ? 0 : wma->dwCurrVideoFrame,
 							     &ret);
-	    TRACE("MCI_STATUS_POSITION %s => %lu\n",
+	    TRACE("MCI_STATUS_POSITION %s => %Iu\n",
 		  (dwFlags & MCI_STATUS_START) ? "start" : "current", lpParms->dwReturn);
 	    break;
 	case MCI_STATUS_READY:
@@ -461,11 +458,11 @@ DWORD	MCIAVI_mciStatus(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STATUS_PARMSW lpPar
 #endif
 	case MCI_DGV_STATUS_BITSPERPEL:
 	    lpParms->dwReturn = wma->inbih->biBitCount;
-	    TRACE("MCI_DGV_STATUS_BITSPERPEL => %lu\n", lpParms->dwReturn);
+	    TRACE("MCI_DGV_STATUS_BITSPERPEL => %Iu\n", lpParms->dwReturn);
 	    break;
 	case MCI_DGV_STATUS_HPAL:
 	    lpParms->dwReturn = 0;
-	    TRACE("MCI_DGV_STATUS_HPAL => %lx\n", lpParms->dwReturn);
+	    TRACE("MCI_DGV_STATUS_HPAL => %Ix\n", lpParms->dwReturn);
 	    break;
 	case MCI_DGV_STATUS_HWND:
            lpParms->dwReturn = (DWORD_PTR)wma->hWndPaint;
@@ -491,12 +488,12 @@ DWORD	MCIAVI_mciStatus(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STATUS_PARMSW lpPar
 	    break;
 	case MCI_DGV_STATUS_SPEED:
 	    lpParms->dwReturn = 1000;
-	    TRACE("MCI_DGV_STATUS_SPEED = %lu\n", lpParms->dwReturn);
+	    TRACE("MCI_DGV_STATUS_SPEED = %Iu\n", lpParms->dwReturn);
 	    break;
 	case MCI_DGV_STATUS_FRAME_RATE:
 	    /* FIXME: 1000 is a settable speed multiplier */
 	    lpParms->dwReturn = MulDiv(1000000,1000,wma->mah.dwMicroSecPerFrame);
-	    TRACE("MCI_DGV_STATUS_FRAME_RATE = %lu\n", lpParms->dwReturn);
+	    TRACE("MCI_DGV_STATUS_FRAME_RATE = %Iu\n", lpParms->dwReturn);
 	    break;
 	case MCI_DGV_STATUS_FORWARD:
 	    lpParms->dwReturn = MAKEMCIRESOURCE(TRUE, MCI_TRUE);
@@ -514,7 +511,7 @@ DWORD	MCIAVI_mciStatus(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STATUS_PARMSW lpPar
 	    break;
 	case MCI_DGV_STATUS_AUDIO_STREAM:
 	   lpParms->dwReturn = wma->audio_stream_n;
-	   TRACE("MCI_DGV_STATUS_AUDIO_STREAM => %lu\n", lpParms->dwReturn);
+	   TRACE("MCI_DGV_STATUS_AUDIO_STREAM => %Iu\n", lpParms->dwReturn);
 	   break;
 #if 0
 	case MCI_DGV_STATUS_KEY_COLOR:
@@ -539,15 +536,15 @@ DWORD	MCIAVI_mciStatus(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STATUS_PARMSW lpPar
 	case MCI_DGV_STATUS_VOLUME:
 #endif
 	default:
-            FIXME("Unknown command %08X !\n", lpParms->dwItem);
-            TRACE("(%04x, %08X, %p)\n", wDevID, dwFlags, lpParms);
+            FIXME("Unknown command %08lX !\n", lpParms->dwItem);
+            TRACE("(%04x, %08lX, %p)\n", wDevID, dwFlags, lpParms);
             LeaveCriticalSection(&wma->cs);
 	    return MCIERR_UNSUPPORTED_FUNCTION;
 	}
     }
 
     if (dwFlags & MCI_NOTIFY) {
-	TRACE("MCI_NOTIFY_SUCCESSFUL %08lX !\n", lpParms->dwCallback);
+	TRACE("MCI_NOTIFY_SUCCESSFUL %08IX !\n", lpParms->dwCallback);
 	mciDriverNotify(HWND_32(LOWORD(lpParms->dwCallback)),
                        wDevID, MCI_NOTIFY_SUCCESSFUL);
     }

--- a/dll/win32/mciavi32/mciavi.c
+++ b/dll/win32/mciavi32/mciavi.c
@@ -71,7 +71,6 @@ BOOL WINAPI DllMain(HINSTANCE hInstDLL, DWORD fdwReason, LPVOID fImpLoad)
 static	DWORD	MCIAVI_drvOpen(LPCWSTR str, LPMCI_OPEN_DRIVER_PARMSW modp)
 {
     WINE_MCIAVI*	wma;
-    static const WCHAR mciAviWStr[] = {'M','C','I','A','V','I',0};
 
     TRACE("%s, %p\n", debugstr_w(str), modp);
 
@@ -80,15 +79,15 @@ static	DWORD	MCIAVI_drvOpen(LPCWSTR str, LPMCI_OPEN_DRIVER_PARMSW modp)
 
     if (!MCIAVI_RegisterClass()) return 0;
 
-    wma = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WINE_MCIAVI));
+    wma = calloc(1, sizeof(WINE_MCIAVI));
     if (!wma)
 	return 0;
 
-    InitializeCriticalSection(&wma->cs);
+    InitializeCriticalSectionEx(&wma->cs, 0, RTL_CRITICAL_SECTION_FLAG_FORCE_DEBUG_INFO);
     wma->cs.DebugInfo->Spare[0] = (DWORD_PTR)(__FILE__ ": WINE_MCIAVI.cs");
     wma->hStopEvent = CreateEventW(NULL, FALSE, FALSE, NULL);
     wma->wDevID = modp->wDeviceID;
-    wma->wCommandTable = mciLoadCommandResource(MCIAVI_hInstance, mciAviWStr, 0);
+    wma->wCommandTable = mciLoadCommandResource(MCIAVI_hInstance, L"MCIAVI", 0);
     wma->dwStatus = MCI_MODE_NOT_READY;
     modp->wCustomCommandTable = wma->wCommandTable;
     modp->wType = MCI_DEVTYPE_DIGITAL_VIDEO;
@@ -104,7 +103,7 @@ static	DWORD	MCIAVI_drvClose(DWORD dwDevID)
 {
     WINE_MCIAVI *wma;
 
-    TRACE("%04x\n", dwDevID);
+    TRACE("%04lx\n", dwDevID);
 
     /* finish all outstanding things */
     MCIAVI_mciClose(dwDevID, MCI_WAIT, NULL);
@@ -125,8 +124,8 @@ static	DWORD	MCIAVI_drvClose(DWORD dwDevID)
         wma->cs.DebugInfo->Spare[0] = 0;
         DeleteCriticalSection(&wma->cs);
 
-	HeapFree(GetProcessHeap(), 0, wma);
-	return 1;
+        free(wma);
+        return 1;
     }
     return (dwDevID == 0xFFFFFFFF) ? 1 : 0;
 }
@@ -138,7 +137,7 @@ static	DWORD	MCIAVI_drvConfigure(DWORD dwDevID)
 {
     WINE_MCIAVI *wma;
 
-    TRACE("%04x\n", dwDevID);
+    TRACE("%04lx\n", dwDevID);
 
     MCIAVI_mciStop(dwDevID, MCI_WAIT, NULL);
 
@@ -173,30 +172,32 @@ static void MCIAVI_CleanUp(WINE_MCIAVI* wma)
 	mmioClose(wma->hFile, 0);
 	wma->hFile = 0;
 
-        HeapFree(GetProcessHeap(), 0, wma->lpFileName);
+        free(wma->lpFileName);
         wma->lpFileName = NULL;
 
-        HeapFree(GetProcessHeap(), 0, wma->lpVideoIndex);
-	wma->lpVideoIndex = NULL;
-        HeapFree(GetProcessHeap(), 0, wma->lpAudioIndex);
-	wma->lpAudioIndex = NULL;
-	if (wma->hic)		ICClose(wma->hic);
-	wma->hic = 0;
-        HeapFree(GetProcessHeap(), 0, wma->inbih);
-	wma->inbih = NULL;
-        HeapFree(GetProcessHeap(), 0, wma->outbih);
-	wma->outbih = NULL;
-        HeapFree(GetProcessHeap(), 0, wma->indata);
-	wma->indata = NULL;
-        HeapFree(GetProcessHeap(), 0, wma->outdata);
-	wma->outdata = NULL;
-    	if (wma->hbmFrame)	DeleteObject(wma->hbmFrame);
-	wma->hbmFrame = 0;
-	if (wma->hWnd)		DestroyWindow(wma->hWnd);
-	wma->hWnd = 0;
+        DrawDibClose(wma->hdd);
 
-        HeapFree(GetProcessHeap(), 0, wma->lpWaveFormat);
-	wma->lpWaveFormat = 0;
+        free(wma->lpVideoIndex);
+        wma->lpVideoIndex = NULL;
+        free(wma->lpAudioIndex);
+        wma->lpAudioIndex = NULL;
+        if (wma->hic) ICClose(wma->hic);
+        wma->hic = 0;
+        free(wma->inbih);
+        wma->inbih = NULL;
+        free(wma->outbih);
+        wma->outbih = NULL;
+        free(wma->indata);
+        wma->indata = NULL;
+        free(wma->outdata);
+        wma->outdata = NULL;
+        if (wma->hbmFrame) DeleteObject(wma->hbmFrame);
+        wma->hbmFrame = 0;
+        if (wma->hWnd) DestroyWindow(wma->hWnd);
+        wma->hWnd = 0;
+
+        free(wma->lpWaveFormat);
+        wma->lpWaveFormat = 0;
 
 	memset(&wma->mah, 0, sizeof(wma->mah));
 	memset(&wma->ash_video, 0, sizeof(wma->ash_video));
@@ -215,7 +216,7 @@ static	DWORD	MCIAVI_mciOpen(UINT wDevID, DWORD dwFlags,
     WINE_MCIAVI *wma;
     LRESULT		dwRet = 0;
 
-    TRACE("(%04x, %08X, %p)\n", wDevID, dwFlags, lpOpenParms);
+    TRACE("(%04x, %08lX, %p)\n", wDevID, dwFlags, lpOpenParms);
 
     if (lpOpenParms == NULL) 		return MCIERR_NULL_PARAMETER_BLOCK;
 
@@ -252,8 +253,7 @@ static	DWORD	MCIAVI_mciOpen(UINT wDevID, DWORD dwFlags,
 	    /* FIXME : what should be done id wma->hFile is already != 0, or the driver is playin' */
 	    TRACE("MCI_OPEN_ELEMENT %s!\n", debugstr_w(lpOpenParms->lpstrElementName));
 
-            wma->lpFileName = HeapAlloc(GetProcessHeap(), 0, (lstrlenW(lpOpenParms->lpstrElementName) + 1) * sizeof(WCHAR));
-            lstrcpyW(wma->lpFileName, lpOpenParms->lpstrElementName);
+	    wma->lpFileName = wcsdup(lpOpenParms->lpstrElementName);
 
 	    if (lpOpenParms->lpstrElementName[0] == '@') {
 		/* The file name @11223344 encodes an AVIFile handle in decimal notation
@@ -307,7 +307,7 @@ DWORD MCIAVI_mciClose(UINT wDevID, DWORD dwFlags, LPMCI_GENERIC_PARMS lpParms)
     WINE_MCIAVI *wma;
     DWORD		dwRet = 0;
 
-    TRACE("(%04x, %08X, %p)\n", wDevID, dwFlags, lpParms);
+    TRACE("(%04x, %08lX, %p)\n", wDevID, dwFlags, lpParms);
 
     wma = MCIAVI_mciGetOpenDev(wDevID);
     if (wma == NULL) 	return MCIERR_INVALID_DEVICE_ID;
@@ -367,7 +367,7 @@ static	DWORD	MCIAVI_player(WINE_MCIAVI *wma, DWORD dwFlags, LPMCI_PLAY_PARMS lpP
        if (MCIAVI_OpenAudio(wma, &nHdr, &waveHdr) != 0)
         {
             /* can't play audio */
-            HeapFree(GetProcessHeap(), 0, wma->lpWaveFormat);
+            free(wma->lpWaveFormat);
             wma->lpWaveFormat = NULL;
         }
        else
@@ -463,7 +463,7 @@ static	DWORD	MCIAVI_player(WINE_MCIAVI *wma, DWORD dwFlags, LPMCI_PLAY_PARMS lpP
     dwRet = 0;
 
     if (wma->lpWaveFormat) {
-	HeapFree(GetProcessHeap(), 0, waveHdr);
+	free(waveHdr);
 
 	if (wma->hWave) {
 	    LeaveCriticalSection(&wma->cs);
@@ -478,7 +478,7 @@ mci_play_done:
     wma->dwStatus = MCI_MODE_STOP;
 
     if (dwFlags & MCI_NOTIFY) {
-	TRACE("MCI_NOTIFY_SUCCESSFUL %08lX !\n", lpParms->dwCallback);
+	TRACE("MCI_NOTIFY_SUCCESSFUL %08IX !\n", lpParms->dwCallback);
 	mciDriverNotify(HWND_32(LOWORD(lpParms->dwCallback)),
                        wma->wDevID, MCI_NOTIFY_SUCCESSFUL);
     }
@@ -504,11 +504,11 @@ static DWORD WINAPI MCIAVI_mciPlay_thread(LPVOID arg)
     struct MCIAVI_play_data *data = (struct MCIAVI_play_data *)arg;
     DWORD ret;
 
-    TRACE("In thread before async play command (id %u, flags %08x)\n", data->wma->wDevID, data->flags);
+    TRACE("In thread before async play command (id %u, flags %08lx)\n", data->wma->wDevID, data->flags);
     ret = MCIAVI_player(data->wma, data->flags, &data->params);
-    TRACE("In thread after async play command (id %u, flags %08x)\n", data->wma->wDevID, data->flags);
+    TRACE("In thread after async play command (id %u, flags %08lx)\n", data->wma->wDevID, data->flags);
 
-    HeapFree(GetProcessHeap(), 0, data);
+    free(data);
     return ret;
 }
 
@@ -518,7 +518,7 @@ static DWORD WINAPI MCIAVI_mciPlay_thread(LPVOID arg)
 static DWORD MCIAVI_mciPlay_async(WINE_MCIAVI *wma, DWORD dwFlags, LPMCI_PLAY_PARMS lpParams)
 {
     HANDLE handle;
-    struct MCIAVI_play_data *data = HeapAlloc(GetProcessHeap(), 0, sizeof(struct MCIAVI_play_data));
+    struct MCIAVI_play_data *data = malloc(sizeof(struct MCIAVI_play_data));
 
     if (!data) return MCIERR_OUT_OF_MEMORY;
 
@@ -546,7 +546,7 @@ static	DWORD	MCIAVI_mciPlay(UINT wDevID, DWORD dwFlags, LPMCI_PLAY_PARMS lpParms
     DWORD		dwRet;
     DWORD		dwFromFrame, dwToFrame;
 
-    TRACE("(%04x, %08X, %p)\n", wDevID, dwFlags, lpParms);
+    TRACE("(%04x, %08lX, %p)\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
 
@@ -556,7 +556,7 @@ static	DWORD	MCIAVI_mciPlay(UINT wDevID, DWORD dwFlags, LPMCI_PLAY_PARMS lpParms
     if (dwFlags & MCI_TEST)	return 0;
 
     if (dwFlags & (MCI_MCIAVI_PLAY_WINDOW|MCI_MCIAVI_PLAY_FULLBY2))
-	FIXME("Unsupported flag %08x\n", dwFlags);
+	FIXME("Unsupported flag %08lx\n", dwFlags);
 
     EnterCriticalSection(&wma->cs);
 
@@ -572,7 +572,7 @@ static	DWORD	MCIAVI_mciPlay(UINT wDevID, DWORD dwFlags, LPMCI_PLAY_PARMS lpParms
     }
 
     dwFromFrame = wma->dwCurrVideoFrame;
-    dwToFrame = wma->dwPlayableVideoFrames - 1;
+    dwToFrame = wma->dwPlayableVideoFrames;
 
     if (dwFlags & MCI_FROM) {
 	dwFromFrame = MCIAVI_ConvertTimeFormatToFrame(wma, lpParms->dwFrom);
@@ -580,10 +580,13 @@ static	DWORD	MCIAVI_mciPlay(UINT wDevID, DWORD dwFlags, LPMCI_PLAY_PARMS lpParms
     if (dwFlags & MCI_TO) {
 	dwToFrame = MCIAVI_ConvertTimeFormatToFrame(wma, lpParms->dwTo);
     }
-    if (dwToFrame >= wma->dwPlayableVideoFrames)
-	dwToFrame = wma->dwPlayableVideoFrames - 1;
+    if (dwToFrame > wma->dwPlayableVideoFrames)
+    {
+        LeaveCriticalSection(&wma->cs);
+        return MCIERR_OUTOFRANGE;
+    }
 
-    TRACE("Playing from frame=%u to frame=%u\n", dwFromFrame, dwToFrame);
+    TRACE("Playing from frame=%lu to frame=%lu\n", dwFromFrame, dwToFrame);
 
     wma->dwCurrVideoFrame = dwFromFrame;
     wma->dwToVideoFrame = dwToFrame;
@@ -638,7 +641,7 @@ static	DWORD	MCIAVI_mciStop(UINT wDevID, DWORD dwFlags, LPMCI_GENERIC_PARMS lpPa
     WINE_MCIAVI *wma;
     DWORD		dwRet = 0;
 
-    TRACE("(%04x, %08X, %p)\n", wDevID, dwFlags, lpParms);
+    TRACE("(%04x, %08lX, %p)\n", wDevID, dwFlags, lpParms);
 
     wma = MCIAVI_mciGetOpenDev(wDevID);
     if (wma == NULL)		return MCIERR_INVALID_DEVICE_ID;
@@ -646,7 +649,7 @@ static	DWORD	MCIAVI_mciStop(UINT wDevID, DWORD dwFlags, LPMCI_GENERIC_PARMS lpPa
 
     EnterCriticalSection(&wma->cs);
 
-    TRACE("current status %04x\n", wma->dwStatus);
+    TRACE("current status %04lx\n", wma->dwStatus);
 
     switch (wma->dwStatus) {
     case MCI_MODE_PLAY:
@@ -673,7 +676,7 @@ static	DWORD	MCIAVI_mciStop(UINT wDevID, DWORD dwFlags, LPMCI_GENERIC_PARMS lpPa
 	break;
 
     case MCI_MODE_NOT_READY:
-        break;        
+        break;
     }
 
     if ((dwFlags & MCI_NOTIFY) && lpParms) {
@@ -691,7 +694,7 @@ static	DWORD	MCIAVI_mciPause(UINT wDevID, DWORD dwFlags, LPMCI_GENERIC_PARMS lpP
 {
     WINE_MCIAVI *wma;
 
-    TRACE("(%04x, %08X, %p)\n", wDevID, dwFlags, lpParms);
+    TRACE("(%04x, %08lX, %p)\n", wDevID, dwFlags, lpParms);
 
     wma = MCIAVI_mciGetOpenDev(wDevID);
     if (wma == NULL)		return MCIERR_INVALID_DEVICE_ID;
@@ -718,7 +721,7 @@ static	DWORD	MCIAVI_mciResume(UINT wDevID, DWORD dwFlags, LPMCI_GENERIC_PARMS lp
 {
     WINE_MCIAVI *wma;
 
-    TRACE("(%04x, %08X, %p)\n", wDevID, dwFlags, lpParms);
+    TRACE("(%04x, %08lX, %p)\n", wDevID, dwFlags, lpParms);
 
     wma = MCIAVI_mciGetOpenDev(wDevID);
     if (wma == NULL)		return MCIERR_INVALID_DEVICE_ID;
@@ -746,7 +749,7 @@ static	DWORD	MCIAVI_mciSeek(UINT wDevID, DWORD dwFlags, LPMCI_SEEK_PARMS lpParms
     WINE_MCIAVI *wma;
     DWORD position;
 
-    TRACE("(%04x, %08X, %p)\n", wDevID, dwFlags, lpParms);
+    TRACE("(%04x, %08lX, %p)\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
 
@@ -759,12 +762,12 @@ static	DWORD	MCIAVI_mciSeek(UINT wDevID, DWORD dwFlags, LPMCI_SEEK_PARMS lpParms
 
     if (dwFlags & MCI_TO) {
 	position = MCIAVI_ConvertTimeFormatToFrame(wma, lpParms->dwTo);
-	if (position >= wma->dwPlayableVideoFrames)
+	if (position > wma->dwPlayableVideoFrames)
 	    return MCIERR_OUTOFRANGE;
     } else if (dwFlags & MCI_SEEK_TO_START) {
 	position = 0;
     } else {
-	position = wma->dwPlayableVideoFrames - 1;
+	position = wma->dwPlayableVideoFrames;
     }
     if (dwFlags & MCI_TEST)	return 0;
 
@@ -773,7 +776,7 @@ static	DWORD	MCIAVI_mciSeek(UINT wDevID, DWORD dwFlags, LPMCI_SEEK_PARMS lpParms
     EnterCriticalSection(&wma->cs);
 
     wma->dwCurrVideoFrame = position;
-    TRACE("Seeking to frame=%u\n", wma->dwCurrVideoFrame);
+    TRACE("Seeking to frame=%lu\n", wma->dwCurrVideoFrame);
 
     if (dwFlags & MCI_NOTIFY) {
 	mciDriverNotify(HWND_32(LOWORD(lpParms->dwCallback)),
@@ -790,7 +793,7 @@ static DWORD	MCIAVI_mciLoad(UINT wDevID, DWORD dwFlags, LPMCI_DGV_LOAD_PARMSW lp
 {
     WINE_MCIAVI *wma;
 
-    FIXME("(%04x, %08x, %p) : stub\n", wDevID, dwFlags, lpParms);
+    FIXME("(%04x, %08lx, %p) : stub\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
 
@@ -807,7 +810,7 @@ static	DWORD	MCIAVI_mciRealize(UINT wDevID, DWORD dwFlags, LPMCI_GENERIC_PARMS l
 {
     WINE_MCIAVI *wma;
 
-    FIXME("(%04x, %08x, %p) : stub\n", wDevID, dwFlags, lpParms);
+    FIXME("(%04x, %08lx, %p) : stub\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
 
@@ -825,7 +828,7 @@ static	DWORD	MCIAVI_mciUpdate(UINT wDevID, DWORD dwFlags, LPMCI_DGV_UPDATE_PARMS
 {
     WINE_MCIAVI *wma;
 
-    TRACE("%04x, %08x, %p\n", wDevID, dwFlags, lpParms);
+    TRACE("%04x, %08lx, %p\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
 
@@ -852,7 +855,7 @@ static	DWORD	MCIAVI_mciStep(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STEP_PARMS lpP
     DWORD position;
     int delta = 1;
 
-    TRACE("(%04x, %08x, %p)\n", wDevID, dwFlags, lpParms);
+    TRACE("(%04x, %08lx, %p)\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
 
@@ -862,7 +865,7 @@ static	DWORD	MCIAVI_mciStep(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STEP_PARMS lpP
     if (dwFlags & MCI_DGV_STEP_FRAMES)  delta = lpParms->dwFrames;
     if (dwFlags & MCI_DGV_STEP_REVERSE) delta = -delta;
     position = wma->dwCurrVideoFrame + delta;
-    if (position >= wma->dwPlayableVideoFrames) return MCIERR_OUTOFRANGE;
+    if (position > wma->dwPlayableVideoFrames) return MCIERR_OUTOFRANGE;
     if (dwFlags & MCI_TEST)	return 0;
 
     MCIAVI_mciStop(wDevID, MCI_WAIT, NULL);
@@ -870,7 +873,7 @@ static	DWORD	MCIAVI_mciStep(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STEP_PARMS lpP
     EnterCriticalSection(&wma->cs);
 
     wma->dwCurrVideoFrame = position;
-    TRACE("Stepping to frame=%u\n", wma->dwCurrVideoFrame);
+    TRACE("Stepping to frame=%lu\n", wma->dwCurrVideoFrame);
 
     if (dwFlags & MCI_NOTIFY) {
 	mciDriverNotify(HWND_32(LOWORD(lpParms->dwCallback)),
@@ -887,7 +890,7 @@ static	DWORD	MCIAVI_mciCue(UINT wDevID, DWORD dwFlags, LPMCI_DGV_CUE_PARMS lpPar
 {
     WINE_MCIAVI *wma;
 
-    FIXME("(%04x, %08x, %p) : stub\n", wDevID, dwFlags, lpParms);
+    FIXME("(%04x, %08lx, %p) : stub\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
 
@@ -906,7 +909,7 @@ static	DWORD	MCIAVI_mciBreak(UINT wDevID, DWORD dwFlags, LPMCI_BREAK_PARMS lpPar
 {
     WINE_MCIAVI *wma;
 
-    TRACE("(%04x, %08x, %p)\n", wDevID, dwFlags, lpParms);
+    TRACE("(%04x, %08lx, %p)\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
 
@@ -932,7 +935,7 @@ static	DWORD	MCIAVI_mciSetAudio(UINT wDevID, DWORD dwFlags, LPMCI_DGV_SETAUDIO_P
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
 
-    FIXME("(%04x, %08x, %p) Item %04x: stub\n", wDevID, dwFlags, lpParms, dwFlags & MCI_DGV_SETAUDIO_ITEM ? lpParms->dwItem : 0);
+    FIXME("(%04x, %08lx, %p) Item %04lx: stub\n", wDevID, dwFlags, lpParms, dwFlags & MCI_DGV_SETAUDIO_ITEM ? lpParms->dwItem : 0);
 
     wma = MCIAVI_mciGetOpenDev(wDevID);
     if (wma == NULL)		return MCIERR_INVALID_DEVICE_ID;
@@ -947,7 +950,7 @@ static	DWORD	MCIAVI_mciSignal(UINT wDevID, DWORD dwFlags, LPMCI_DGV_SIGNAL_PARMS
 {
     WINE_MCIAVI *wma;
 
-    FIXME("(%04x, %08x, %p) : stub\n", wDevID, dwFlags, lpParms);
+    FIXME("(%04x, %08lx, %p) : stub\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
 
@@ -966,7 +969,7 @@ static	DWORD	MCIAVI_mciSetVideo(UINT wDevID, DWORD dwFlags, LPMCI_DGV_SETVIDEO_P
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
 
-    FIXME("(%04x, %08x, %p) Item %04x: stub\n", wDevID, dwFlags, lpParms, dwFlags & MCI_DGV_SETVIDEO_ITEM ? lpParms->dwItem : 0);
+    FIXME("(%04x, %08lx, %p) Item %04lx: stub\n", wDevID, dwFlags, lpParms, dwFlags & MCI_DGV_SETVIDEO_ITEM ? lpParms->dwItem : 0);
 
     wma = MCIAVI_mciGetOpenDev(wDevID);
     if (wma == NULL)		return MCIERR_INVALID_DEVICE_ID;
@@ -981,7 +984,7 @@ static	DWORD	MCIAVI_mciConfigure(UINT wDevID, DWORD dwFlags, LPMCI_GENERIC_PARMS
 {
     WINE_MCIAVI *wma;
 
-    FIXME("(%04x, %08x, %p) : stub\n", wDevID, dwFlags, lpParms);
+    FIXME("(%04x, %08lx, %p) : stub\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
 
@@ -1002,7 +1005,7 @@ static	DWORD	MCIAVI_mciConfigure(UINT wDevID, DWORD dwFlags, LPMCI_GENERIC_PARMS
 LRESULT CALLBACK MCIAVI_DriverProc(DWORD_PTR dwDevID, HDRVR hDriv, UINT wMsg,
                                    LPARAM dwParam1, LPARAM dwParam2)
 {
-    TRACE("(%08lX, %p, %08X, %08lX, %08lX)\n",
+    TRACE("(%08IX, %p, %08X, %08IX, %08IX)\n",
 	  dwDevID, hDriv, wMsg, dwParam1, dwParam2);
 
     switch (wMsg) {
@@ -1064,11 +1067,11 @@ LRESULT CALLBACK MCIAVI_DriverProc(DWORD_PTR dwDevID, HDRVR hDriv, UINT wMsg,
     case MCI_SAVE:
     case MCI_UNDO:
     case MCI_UNFREEZE:
-	TRACE("Unsupported function [0x%x] flags=%08x\n", wMsg, (DWORD)dwParam1);
+	TRACE("Unsupported function [0x%x] flags=%08Ix\n", wMsg, dwParam1);
 	return MCIERR_UNSUPPORTED_FUNCTION;
     case MCI_SPIN:
     case MCI_ESCAPE:
-	WARN("Unsupported command [0x%x] %08x\n", wMsg, (DWORD)dwParam1);
+	WARN("Unsupported command [0x%x] %08Ix\n", wMsg, dwParam1);
 	break;
     case MCI_OPEN:
     case MCI_CLOSE:

--- a/dll/win32/mciavi32/mciavi_res.rc
+++ b/dll/win32/mciavi32/mciavi_res.rc
@@ -22,11 +22,7 @@
 #include "mmddk.h"
 #include "digitalv.h"
 
-#ifdef MCI_INTEGER64
-#define MCI_DWORD_PTR MCI_INTEGER64
-#else
-#define MCI_DWORD_PTR MCI_INTEGER
-#endif
+#define MCI_DWORD_PTR 13 /* MCI_INTEGER64 */
 
 MCIAVI RCDATA
 BEGIN

--- a/dll/win32/mciavi32/mmoutput.c
+++ b/dll/win32/mciavi32/mmoutput.c
@@ -28,28 +28,22 @@ static BOOL MCIAVI_GetInfoAudio(WINE_MCIAVI* wma, const MMCKINFO* mmckList, MMCK
 {
     MMCKINFO	mmckInfo;
 
-    TRACE("ash.fccType='%c%c%c%c'\n", 		LOBYTE(LOWORD(wma->ash_audio.fccType)),
-	                                        HIBYTE(LOWORD(wma->ash_audio.fccType)),
-	                                        LOBYTE(HIWORD(wma->ash_audio.fccType)),
-	                                        HIBYTE(HIWORD(wma->ash_audio.fccType)));
+    TRACE("ash.fccType=%s\n",			debugstr_fourcc(wma->ash_audio.fccType));
     if (wma->ash_audio.fccHandler) /* not all streams specify a handler */
-        TRACE("ash.fccHandler='%c%c%c%c'\n",	LOBYTE(LOWORD(wma->ash_audio.fccHandler)),
-	                                        HIBYTE(LOWORD(wma->ash_audio.fccHandler)),
-	                                        LOBYTE(HIWORD(wma->ash_audio.fccHandler)),
-	                                        HIBYTE(HIWORD(wma->ash_audio.fccHandler)));
+        TRACE("ash.fccHandler=%s\n",		debugstr_fourcc(wma->ash_audio.fccHandler));
     else
         TRACE("ash.fccHandler=0, no handler specified\n");
-    TRACE("ash.dwFlags=%d\n", 			wma->ash_audio.dwFlags);
+    TRACE("ash.dwFlags=%ld\n", 			wma->ash_audio.dwFlags);
     TRACE("ash.wPriority=%d\n", 		wma->ash_audio.wPriority);
     TRACE("ash.wLanguage=%d\n", 		wma->ash_audio.wLanguage);
-    TRACE("ash.dwInitialFrames=%d\n", 		wma->ash_audio.dwInitialFrames);
-    TRACE("ash.dwScale=%d\n", 			wma->ash_audio.dwScale);
-    TRACE("ash.dwRate=%d\n", 			wma->ash_audio.dwRate);
-    TRACE("ash.dwStart=%d\n", 			wma->ash_audio.dwStart);
-    TRACE("ash.dwLength=%d\n", 		wma->ash_audio.dwLength);
-    TRACE("ash.dwSuggestedBufferSize=%d\n", 	wma->ash_audio.dwSuggestedBufferSize);
-    TRACE("ash.dwQuality=%d\n", 		wma->ash_audio.dwQuality);
-    TRACE("ash.dwSampleSize=%d\n", 		wma->ash_audio.dwSampleSize);
+    TRACE("ash.dwInitialFrames=%ld\n", 		wma->ash_audio.dwInitialFrames);
+    TRACE("ash.dwScale=%ld\n", 			wma->ash_audio.dwScale);
+    TRACE("ash.dwRate=%ld\n", 			wma->ash_audio.dwRate);
+    TRACE("ash.dwStart=%ld\n", 			wma->ash_audio.dwStart);
+    TRACE("ash.dwLength=%ld\n", 		wma->ash_audio.dwLength);
+    TRACE("ash.dwSuggestedBufferSize=%ld\n", 	wma->ash_audio.dwSuggestedBufferSize);
+    TRACE("ash.dwQuality=%ld\n", 		wma->ash_audio.dwQuality);
+    TRACE("ash.dwSampleSize=%ld\n", 		wma->ash_audio.dwSampleSize);
     TRACE("ash.rcFrame=(%d,%d,%d,%d)\n", 	wma->ash_audio.rcFrame.top, wma->ash_audio.rcFrame.left,
 	  wma->ash_audio.rcFrame.bottom, wma->ash_audio.rcFrame.right);
 
@@ -62,10 +56,10 @@ static BOOL MCIAVI_GetInfoAudio(WINE_MCIAVI* wma, const MMCKINFO* mmckList, MMCK
 	return FALSE;
     }
     if (mmckInfo.cksize < sizeof(WAVEFORMAT)) {
-	WARN("Size of strf chunk (%d) < audio format struct\n", mmckInfo.cksize);
+	WARN("Size of strf chunk (%ld) < audio format struct\n", mmckInfo.cksize);
 	return FALSE;
     }
-    wma->lpWaveFormat = HeapAlloc(GetProcessHeap(), 0, mmckInfo.cksize);
+    wma->lpWaveFormat = malloc(mmckInfo.cksize);
     if (!wma->lpWaveFormat) {
 	WARN("Can't alloc WaveFormat\n");
 	return FALSE;
@@ -75,8 +69,8 @@ static BOOL MCIAVI_GetInfoAudio(WINE_MCIAVI* wma, const MMCKINFO* mmckList, MMCK
 
     TRACE("waveFormat.wFormatTag=%d\n",		wma->lpWaveFormat->wFormatTag);
     TRACE("waveFormat.nChannels=%d\n", 		wma->lpWaveFormat->nChannels);
-    TRACE("waveFormat.nSamplesPerSec=%d\n",	wma->lpWaveFormat->nSamplesPerSec);
-    TRACE("waveFormat.nAvgBytesPerSec=%d\n",	wma->lpWaveFormat->nAvgBytesPerSec);
+    TRACE("waveFormat.nSamplesPerSec=%ld\n",	wma->lpWaveFormat->nSamplesPerSec);
+    TRACE("waveFormat.nAvgBytesPerSec=%ld\n",	wma->lpWaveFormat->nAvgBytesPerSec);
     TRACE("waveFormat.nBlockAlign=%d\n",	wma->lpWaveFormat->nBlockAlign);
     TRACE("waveFormat.wBitsPerSample=%d\n",	wma->lpWaveFormat->wBitsPerSample);
     if (mmckInfo.cksize >= sizeof(WAVEFORMATEX))
@@ -89,25 +83,19 @@ static BOOL MCIAVI_GetInfoVideo(WINE_MCIAVI* wma, const MMCKINFO* mmckList, MMCK
 {
     MMCKINFO	mmckInfo;
 
-    TRACE("ash.fccType='%c%c%c%c'\n", 		LOBYTE(LOWORD(wma->ash_video.fccType)),
-	                                        HIBYTE(LOWORD(wma->ash_video.fccType)),
-	                                        LOBYTE(HIWORD(wma->ash_video.fccType)),
-	                                        HIBYTE(HIWORD(wma->ash_video.fccType)));
-    TRACE("ash.fccHandler='%c%c%c%c'\n",	LOBYTE(LOWORD(wma->ash_video.fccHandler)),
-	                                        HIBYTE(LOWORD(wma->ash_video.fccHandler)),
-	                                        LOBYTE(HIWORD(wma->ash_video.fccHandler)),
-	                                        HIBYTE(HIWORD(wma->ash_video.fccHandler)));
-    TRACE("ash.dwFlags=%d\n", 			wma->ash_video.dwFlags);
+    TRACE("ash.fccType=%s\n",			debugstr_fourcc(wma->ash_video.fccType));
+    TRACE("ash.fccHandler=%s\n",		debugstr_fourcc(wma->ash_video.fccHandler));
+    TRACE("ash.dwFlags=%ld\n", 			wma->ash_video.dwFlags);
     TRACE("ash.wPriority=%d\n", 		wma->ash_video.wPriority);
     TRACE("ash.wLanguage=%d\n", 		wma->ash_video.wLanguage);
-    TRACE("ash.dwInitialFrames=%d\n", 		wma->ash_video.dwInitialFrames);
-    TRACE("ash.dwScale=%d\n", 			wma->ash_video.dwScale);
-    TRACE("ash.dwRate=%d\n", 			wma->ash_video.dwRate);
-    TRACE("ash.dwStart=%d\n", 			wma->ash_video.dwStart);
-    TRACE("ash.dwLength=%d\n", 		wma->ash_video.dwLength);
-    TRACE("ash.dwSuggestedBufferSize=%d\n", 	wma->ash_video.dwSuggestedBufferSize);
-    TRACE("ash.dwQuality=%d\n", 		wma->ash_video.dwQuality);
-    TRACE("ash.dwSampleSize=%d\n", 		wma->ash_video.dwSampleSize);
+    TRACE("ash.dwInitialFrames=%ld\n", 		wma->ash_video.dwInitialFrames);
+    TRACE("ash.dwScale=%ld\n", 			wma->ash_video.dwScale);
+    TRACE("ash.dwRate=%ld\n", 			wma->ash_video.dwRate);
+    TRACE("ash.dwStart=%ld\n", 			wma->ash_video.dwStart);
+    TRACE("ash.dwLength=%ld\n", 		wma->ash_video.dwLength);
+    TRACE("ash.dwSuggestedBufferSize=%ld\n", 	wma->ash_video.dwSuggestedBufferSize);
+    TRACE("ash.dwQuality=%ld\n", 		wma->ash_video.dwQuality);
+    TRACE("ash.dwSampleSize=%ld\n", 		wma->ash_video.dwSampleSize);
     TRACE("ash.rcFrame=(%d,%d,%d,%d)\n", 	wma->ash_video.rcFrame.top, wma->ash_video.rcFrame.left,
 	  wma->ash_video.rcFrame.bottom, wma->ash_video.rcFrame.right);
 
@@ -120,7 +108,7 @@ static BOOL MCIAVI_GetInfoVideo(WINE_MCIAVI* wma, const MMCKINFO* mmckList, MMCK
 	return FALSE;
     }
 
-    wma->inbih = HeapAlloc(GetProcessHeap(), 0, mmckInfo.cksize);
+    wma->inbih = malloc(mmckInfo.cksize);
     if (!wma->inbih) {
 	WARN("Can't alloc input BIH\n");
 	return FALSE;
@@ -128,17 +116,17 @@ static BOOL MCIAVI_GetInfoVideo(WINE_MCIAVI* wma, const MMCKINFO* mmckList, MMCK
 
     mmioRead(wma->hFile, (LPSTR)wma->inbih, mmckInfo.cksize);
 
-    TRACE("bih.biSize=%d\n", 		wma->inbih->biSize);
-    TRACE("bih.biWidth=%d\n", 		wma->inbih->biWidth);
-    TRACE("bih.biHeight=%d\n", 	wma->inbih->biHeight);
+    TRACE("bih.biSize=%ld\n", 		wma->inbih->biSize);
+    TRACE("bih.biWidth=%ld\n", 		wma->inbih->biWidth);
+    TRACE("bih.biHeight=%ld\n", 	wma->inbih->biHeight);
     TRACE("bih.biPlanes=%d\n", 		wma->inbih->biPlanes);
     TRACE("bih.biBitCount=%d\n", 	wma->inbih->biBitCount);
-    TRACE("bih.biCompression=%x\n", 	wma->inbih->biCompression);
-    TRACE("bih.biSizeImage=%d\n", 	wma->inbih->biSizeImage);
-    TRACE("bih.biXPelsPerMeter=%d\n", 	wma->inbih->biXPelsPerMeter);
-    TRACE("bih.biYPelsPerMeter=%d\n", 	wma->inbih->biYPelsPerMeter);
-    TRACE("bih.biClrUsed=%d\n", 	wma->inbih->biClrUsed);
-    TRACE("bih.biClrImportant=%d\n", 	wma->inbih->biClrImportant);
+    TRACE("bih.biCompression=%lx\n", 	wma->inbih->biCompression);
+    TRACE("bih.biSizeImage=%ld\n", 	wma->inbih->biSizeImage);
+    TRACE("bih.biXPelsPerMeter=%ld\n", 	wma->inbih->biXPelsPerMeter);
+    TRACE("bih.biYPelsPerMeter=%ld\n", 	wma->inbih->biYPelsPerMeter);
+    TRACE("bih.biClrUsed=%ld\n", 	wma->inbih->biClrUsed);
+    TRACE("bih.biClrImportant=%ld\n", 	wma->inbih->biClrImportant);
 
     SetRect(&wma->source, 0, 0, wma->inbih->biWidth, wma->inbih->biHeight);
     wma->dest = wma->source;
@@ -175,7 +163,7 @@ static BOOL	MCIAVI_AddFrame(WINE_MCIAVI* wma, LPMMCKINFO mmck,
     stream_n <<= 4;
     stream_n |= (p[1] <= '9') ? (p[1] - '0') : (tolower(p[1]) - 'a' + 10);
 
-    TRACE("ckid %4.4s (stream #%d)\n", (LPSTR)&mmck->ckid, stream_n);
+    TRACE("ckid %4.4s (stream #%ld)\n", (LPSTR)&mmck->ckid, stream_n);
 
     /* Some (rare?) AVI files have video streams name XXYY where XX = stream number and YY = TWOCC
      * of the last 2 characters of the biCompression member of the BITMAPINFOHEADER structure.
@@ -197,11 +185,11 @@ static BOOL	MCIAVI_AddFrame(WINE_MCIAVI* wma, LPMMCKINFO mmck,
     case cktypePALchange:
         if (stream_n != wma->video_stream_n)
         {
-            TRACE("data belongs to another video stream #%d\n", stream_n);
+            TRACE("data belongs to another video stream #%ld\n", stream_n);
             return FALSE;
         }
 
-	TRACE("Adding video frame[%d]: %d bytes\n",
+	TRACE("Adding video frame[%ld]: %ld bytes\n",
 	      alb->numVideoFrames, mmck->cksize);
 
 	if (alb->numVideoFrames < wma->dwPlayableVideoFrames) {
@@ -217,21 +205,18 @@ static BOOL	MCIAVI_AddFrame(WINE_MCIAVI* wma, LPMMCKINFO mmck,
     case cktypeWAVEbytes:
         if (stream_n != wma->audio_stream_n)
         {
-            TRACE("data belongs to another audio stream #%d\n", stream_n);
+            TRACE("data belongs to another audio stream #%ld\n", stream_n);
             return FALSE;
         }
 
-	TRACE("Adding audio frame[%d]: %d bytes\n",
+	TRACE("Adding audio frame[%ld]: %ld bytes\n",
 	      alb->numAudioBlocks, mmck->cksize);
 	if (wma->lpWaveFormat) {
 	    if (alb->numAudioBlocks >= alb->numAudioAllocated) {
                 DWORD newsize = alb->numAudioAllocated + 32;
                 struct MMIOPos* newindex;
 
-                if (!wma->lpAudioIndex)
-                    newindex = HeapAlloc(GetProcessHeap(), 0, newsize * sizeof(struct MMIOPos));
-                else
-                    newindex = HeapReAlloc(GetProcessHeap(), 0, wma->lpAudioIndex, newsize * sizeof(struct MMIOPos));
+                newindex = realloc(wma->lpAudioIndex, newsize * sizeof(struct MMIOPos));
                 if (!newindex) return FALSE;
                 alb->numAudioAllocated = newsize;
                 wma->lpAudioIndex = newindex;
@@ -286,16 +271,16 @@ BOOL MCIAVI_GetInfo(WINE_MCIAVI* wma)
 
     mmioRead(wma->hFile, (LPSTR)&wma->mah, sizeof(wma->mah));
 
-    TRACE("mah.dwMicroSecPerFrame=%d\n", 	wma->mah.dwMicroSecPerFrame);
-    TRACE("mah.dwMaxBytesPerSec=%d\n", 	wma->mah.dwMaxBytesPerSec);
-    TRACE("mah.dwPaddingGranularity=%d\n", 	wma->mah.dwPaddingGranularity);
-    TRACE("mah.dwFlags=%d\n", 			wma->mah.dwFlags);
-    TRACE("mah.dwTotalFrames=%d\n", 		wma->mah.dwTotalFrames);
-    TRACE("mah.dwInitialFrames=%d\n", 		wma->mah.dwInitialFrames);
-    TRACE("mah.dwStreams=%d\n", 		wma->mah.dwStreams);
-    TRACE("mah.dwSuggestedBufferSize=%d\n",	wma->mah.dwSuggestedBufferSize);
-    TRACE("mah.dwWidth=%d\n", 			wma->mah.dwWidth);
-    TRACE("mah.dwHeight=%d\n", 		wma->mah.dwHeight);
+    TRACE("mah.dwMicroSecPerFrame=%ld\n", 	wma->mah.dwMicroSecPerFrame);
+    TRACE("mah.dwMaxBytesPerSec=%ld\n", 	wma->mah.dwMaxBytesPerSec);
+    TRACE("mah.dwPaddingGranularity=%ld\n", 	wma->mah.dwPaddingGranularity);
+    TRACE("mah.dwFlags=%ld\n", 			wma->mah.dwFlags);
+    TRACE("mah.dwTotalFrames=%ld\n", 		wma->mah.dwTotalFrames);
+    TRACE("mah.dwInitialFrames=%ld\n", 		wma->mah.dwInitialFrames);
+    TRACE("mah.dwStreams=%ld\n", 		wma->mah.dwStreams);
+    TRACE("mah.dwSuggestedBufferSize=%ld\n",	wma->mah.dwSuggestedBufferSize);
+    TRACE("mah.dwWidth=%ld\n", 			wma->mah.dwWidth);
+    TRACE("mah.dwHeight=%ld\n", 		wma->mah.dwHeight);
 
     mmioAscend(wma->hFile, &mmckInfo, 0);
 
@@ -320,7 +305,7 @@ BOOL MCIAVI_GetInfo(WINE_MCIAVI* wma)
 
         mmioRead(wma->hFile, (LPSTR)&strh, sizeof(strh));
 
-        TRACE("Stream #%d fccType %4.4s\n", stream_n, (LPSTR)&strh.fccType);
+        TRACE("Stream #%ld fccType %4.4s\n", stream_n, (LPSTR)&strh.fccType);
 
         if (strh.fccType == streamtypeVIDEO)
         {
@@ -371,8 +356,7 @@ BOOL MCIAVI_GetInfo(WINE_MCIAVI* wma)
     }
 
     wma->dwPlayableVideoFrames = wma->mah.dwTotalFrames;
-    wma->lpVideoIndex = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY,
-				  wma->dwPlayableVideoFrames * sizeof(struct MMIOPos));
+    wma->lpVideoIndex = calloc(wma->dwPlayableVideoFrames, sizeof(struct MMIOPos));
     if (!wma->lpVideoIndex) {
 	WARN("Can't alloc video index array\n");
 	return FALSE;
@@ -408,22 +392,22 @@ BOOL MCIAVI_GetInfo(WINE_MCIAVI* wma)
 #endif
 
     if (alb.numVideoFrames != wma->dwPlayableVideoFrames) {
-	WARN("AVI header says %d frames, we found %d video frames, reducing playable frames\n",
+	WARN("AVI header says %ld frames, we found %ld video frames, reducing playable frames\n",
 	     wma->dwPlayableVideoFrames, alb.numVideoFrames);
 	wma->dwPlayableVideoFrames = alb.numVideoFrames;
     }
     wma->dwPlayableAudioBlocks = alb.numAudioBlocks;
 
     if (alb.inVideoSize > wma->ash_video.dwSuggestedBufferSize) {
-	WARN("inVideoSize=%d suggestedSize=%d\n", alb.inVideoSize, wma->ash_video.dwSuggestedBufferSize);
+	WARN("inVideoSize=%ld suggestedSize=%ld\n", alb.inVideoSize, wma->ash_video.dwSuggestedBufferSize);
 	wma->ash_video.dwSuggestedBufferSize = alb.inVideoSize;
     }
     if (alb.inAudioSize > wma->ash_audio.dwSuggestedBufferSize) {
-	WARN("inAudioSize=%d suggestedSize=%d\n", alb.inAudioSize, wma->ash_audio.dwSuggestedBufferSize);
+	WARN("inAudioSize=%ld suggestedSize=%ld\n", alb.inAudioSize, wma->ash_audio.dwSuggestedBufferSize);
 	wma->ash_audio.dwSuggestedBufferSize = alb.inAudioSize;
     }
 
-    wma->indata = HeapAlloc(GetProcessHeap(), 0, wma->ash_video.dwSuggestedBufferSize);
+    wma->indata = malloc(wma->ash_video.dwSuggestedBufferSize);
     if (!wma->indata) {
 	WARN("Can't alloc input buffer\n");
 	return FALSE;
@@ -462,7 +446,7 @@ BOOL    MCIAVI_OpenVideo(WINE_MCIAVI* wma)
 
     outSize = sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD);
 
-    wma->outbih = HeapAlloc(GetProcessHeap(), 0, outSize);
+    wma->outbih = malloc(outSize);
     if (!wma->outbih) {
 	WARN("Can't alloc output BIH\n");
 	return FALSE;
@@ -472,19 +456,19 @@ BOOL    MCIAVI_OpenVideo(WINE_MCIAVI* wma)
 	return FALSE;
     }
 
-    TRACE("bih.biSize=%d\n", 		wma->outbih->biSize);
-    TRACE("bih.biWidth=%d\n", 		wma->outbih->biWidth);
-    TRACE("bih.biHeight=%d\n", 	wma->outbih->biHeight);
+    TRACE("bih.biSize=%ld\n", 		wma->outbih->biSize);
+    TRACE("bih.biWidth=%ld\n", 		wma->outbih->biWidth);
+    TRACE("bih.biHeight=%ld\n", 	wma->outbih->biHeight);
     TRACE("bih.biPlanes=%d\n", 		wma->outbih->biPlanes);
     TRACE("bih.biBitCount=%d\n", 	wma->outbih->biBitCount);
-    TRACE("bih.biCompression=%x\n", 	wma->outbih->biCompression);
-    TRACE("bih.biSizeImage=%d\n", 	wma->outbih->biSizeImage);
-    TRACE("bih.biXPelsPerMeter=%d\n", 	wma->outbih->biXPelsPerMeter);
-    TRACE("bih.biYPelsPerMeter=%d\n", 	wma->outbih->biYPelsPerMeter);
-    TRACE("bih.biClrUsed=%d\n", 	wma->outbih->biClrUsed);
-    TRACE("bih.biClrImportant=%d\n", 	wma->outbih->biClrImportant);
+    TRACE("bih.biCompression=%lx\n", 	wma->outbih->biCompression);
+    TRACE("bih.biSizeImage=%ld\n", 	wma->outbih->biSizeImage);
+    TRACE("bih.biXPelsPerMeter=%ld\n", 	wma->outbih->biXPelsPerMeter);
+    TRACE("bih.biYPelsPerMeter=%ld\n", 	wma->outbih->biYPelsPerMeter);
+    TRACE("bih.biClrUsed=%ld\n", 	wma->outbih->biClrUsed);
+    TRACE("bih.biClrImportant=%ld\n", 	wma->outbih->biClrImportant);
 
-    wma->outdata = HeapAlloc(GetProcessHeap(), 0, wma->outbih->biSizeImage);
+    wma->outdata = malloc(wma->outbih->biSizeImage);
     if (!wma->outdata) {
 	WARN("Can't alloc output buffer\n");
 	return FALSE;
@@ -497,6 +481,14 @@ BOOL    MCIAVI_OpenVideo(WINE_MCIAVI* wma)
     }
 
 paint_frame:
+    if (!(wma->hdd = DrawDibOpen()))
+    {
+	ERR("DrawDibOpen() failed.\n");
+	free(wma->outdata);
+	wma->outdata = NULL;
+	return FALSE;
+    }
+
     hDC = wma->hWndPaint ? GetDC(wma->hWndPaint) : 0;
     if (hDC)
     {
@@ -521,7 +513,7 @@ static void CALLBACK MCIAVI_waveCallback(HWAVEOUT hwo, UINT uMsg, DWORD_PTR dwIn
 	break;
     case WOM_DONE:
 	InterlockedIncrement(&wma->dwEventCount);
-	TRACE("Returning waveHdr=%lx\n", dwParam1);
+	TRACE("Returning waveHdr=%Ix\n", dwParam1);
 	SetEvent(wma->hEvent);
 	break;
     default:
@@ -540,7 +532,7 @@ DWORD MCIAVI_OpenAudio(WINE_MCIAVI* wma, unsigned* nHdr, LPWAVEHDR* pWaveHdr)
     dwRet = waveOutOpen((HWAVEOUT *)&wma->hWave, WAVE_MAPPER, wma->lpWaveFormat,
                        (DWORD_PTR)MCIAVI_waveCallback, wma->wDevID, CALLBACK_FUNCTION);
     if (dwRet != 0) {
-	TRACE("Can't open low level audio device %d\n", dwRet);
+	TRACE("Can't open low level audio device %ld\n", dwRet);
 	dwRet = MCIERR_DEVICE_OPEN;
 	wma->hWave = 0;
 	goto cleanUp;
@@ -550,8 +542,7 @@ DWORD MCIAVI_OpenAudio(WINE_MCIAVI* wma, unsigned* nHdr, LPWAVEHDR* pWaveHdr)
      * to be used...
      */
     *nHdr = 7;
-    waveHdr = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY,
-			*nHdr * (sizeof(WAVEHDR) + wma->ash_audio.dwSuggestedBufferSize));
+    waveHdr = calloc(*nHdr, sizeof(WAVEHDR) + wma->ash_audio.dwSuggestedBufferSize);
     if (!waveHdr) {
 	TRACE("Can't alloc wave headers\n");
 	dwRet = MCIERR_DEVICE_OPEN;
@@ -585,7 +576,7 @@ void MCIAVI_PlayAudioBlocks(WINE_MCIAVI* wma, unsigned nHdr, LPWAVEHDR waveHdr)
 {
     if (!wma->lpAudioIndex) 
         return;
-    TRACE("%d (ec=%u)\n", wma->lpAudioIndex[wma->dwCurrAudioBlock].dwOffset, wma->dwEventCount);
+    TRACE("%ld (ec=%lu)\n", wma->lpAudioIndex[wma->dwCurrAudioBlock].dwOffset, wma->dwEventCount);
 
     /* push as many blocks as possible => audio gets priority */
     while (wma->dwStatus != MCI_MODE_STOP && wma->dwStatus != MCI_MODE_NOT_READY &&
@@ -614,13 +605,19 @@ double MCIAVI_PaintFrame(WINE_MCIAVI* wma, HDC hDC)
 {
     void* 		pBitmapData;
     LPBITMAPINFO	pBitmapInfo;
+    DWORD		frame;
 
     if (!hDC || !wma->inbih)
 	return 0;
 
-    TRACE("Painting frame %u (cached %u)\n", wma->dwCurrVideoFrame, wma->dwCachedFrame);
+    if (wma->dwCurrVideoFrame >= wma->dwPlayableVideoFrames)
+        frame = wma->dwPlayableVideoFrames - 1;
+    else
+        frame = wma->dwCurrVideoFrame;
 
-    if (wma->dwCurrVideoFrame != wma->dwCachedFrame)
+    TRACE("Painting frame %lu (cached %lu)\n", frame, wma->dwCachedFrame);
+
+    if (frame != wma->dwCachedFrame)
     {
 #ifdef __REACTOS__
         if (wma->dwCurrVideoFrame >= wma->dwPlayableVideoFrames) {
@@ -628,16 +625,15 @@ double MCIAVI_PaintFrame(WINE_MCIAVI* wma, HDC hDC)
             return 0;
         }
 #endif
-
-        if (!wma->lpVideoIndex[wma->dwCurrVideoFrame].dwOffset)
+        if (!wma->lpVideoIndex[frame].dwOffset)
 	    return 0;
 
-        if (wma->lpVideoIndex[wma->dwCurrVideoFrame].dwSize)
+        if (wma->lpVideoIndex[frame].dwSize)
         {
-            mmioSeek(wma->hFile, wma->lpVideoIndex[wma->dwCurrVideoFrame].dwOffset, SEEK_SET);
-            mmioRead(wma->hFile, wma->indata, wma->lpVideoIndex[wma->dwCurrVideoFrame].dwSize);
+            mmioSeek(wma->hFile, wma->lpVideoIndex[frame].dwOffset, SEEK_SET);
+            mmioRead(wma->hFile, wma->indata, wma->lpVideoIndex[frame].dwSize);
 
-            wma->inbih->biSizeImage = wma->lpVideoIndex[wma->dwCurrVideoFrame].dwSize;
+            wma->inbih->biSizeImage = wma->lpVideoIndex[frame].dwSize;
 
             if (wma->hic && ICDecompress(wma->hic, 0, wma->inbih, wma->indata,
                                          wma->outbih, wma->outdata) != ICERR_OK)
@@ -647,7 +643,7 @@ double MCIAVI_PaintFrame(WINE_MCIAVI* wma, HDC hDC)
             }
         }
 
-        wma->dwCachedFrame = wma->dwCurrVideoFrame;
+        wma->dwCachedFrame = frame;
     }
 
     if (wma->hic) {
@@ -658,12 +654,9 @@ double MCIAVI_PaintFrame(WINE_MCIAVI* wma, HDC hDC)
         pBitmapInfo = (LPBITMAPINFO)wma->inbih;
     }
 
-    StretchDIBits(hDC,
-                  wma->dest.left, wma->dest.top,
-                  wma->dest.right - wma->dest.left, wma->dest.bottom - wma->dest.top,
-                  wma->source.left, wma->source.top,
-                  wma->source.right - wma->source.left, wma->source.bottom - wma->source.top,
-                  pBitmapData, pBitmapInfo, DIB_RGB_COLORS, SRCCOPY);
+    DrawDibDraw(wma->hdd, hDC, wma->dest.left, wma->dest.top, wma->dest.right - wma->dest.left, wma->dest.bottom - wma->dest.top,
+                &pBitmapInfo->bmiHeader, pBitmapData,
+                wma->source.left, wma->source.top, wma->source.right - wma->source.left, wma->source.bottom - wma->source.top, 0);
 
     return (wma->ash_video.dwScale / (double)wma->ash_video.dwRate) * 1000000;
 }

--- a/dll/win32/mciavi32/private_mciavi.h
+++ b/dll/win32/mciavi32/private_mciavi.h
@@ -84,34 +84,36 @@ typedef struct {
     /* data for the background mechanism */
     CRITICAL_SECTION	cs;
     HANDLE              hStopEvent;
+    /* data for presentation */
+    HDRAWDIB            hdd;
 } WINE_MCIAVI;
 
-extern HINSTANCE MCIAVI_hInstance DECLSPEC_HIDDEN;
+extern HINSTANCE MCIAVI_hInstance;
 
 /* info.c */
-DWORD 	MCIAVI_ConvertTimeFormatToFrame(WINE_MCIAVI* wma, DWORD val) DECLSPEC_HIDDEN;
-DWORD	MCIAVI_mciGetDevCaps(UINT wDevID, DWORD dwFlags,  LPMCI_GETDEVCAPS_PARMS lpParms) DECLSPEC_HIDDEN;
-DWORD	MCIAVI_mciInfo(UINT wDevID, DWORD dwFlags, LPMCI_DGV_INFO_PARMSW lpParms) DECLSPEC_HIDDEN;
-DWORD	MCIAVI_mciSet(UINT wDevID, DWORD dwFlags, LPMCI_DGV_SET_PARMS lpParms) DECLSPEC_HIDDEN;
-DWORD	MCIAVI_mciStatus(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STATUS_PARMSW lpParms) DECLSPEC_HIDDEN;
+DWORD 	MCIAVI_ConvertTimeFormatToFrame(WINE_MCIAVI* wma, DWORD val);
+DWORD	MCIAVI_mciGetDevCaps(UINT wDevID, DWORD dwFlags,  LPMCI_GETDEVCAPS_PARMS lpParms);
+DWORD	MCIAVI_mciInfo(UINT wDevID, DWORD dwFlags, LPMCI_DGV_INFO_PARMSW lpParms);
+DWORD	MCIAVI_mciSet(UINT wDevID, DWORD dwFlags, LPMCI_DGV_SET_PARMS lpParms);
+DWORD	MCIAVI_mciStatus(UINT wDevID, DWORD dwFlags, LPMCI_DGV_STATUS_PARMSW lpParms);
 
 /* mmoutput.c */
-BOOL	MCIAVI_GetInfo(WINE_MCIAVI* wma) DECLSPEC_HIDDEN;
-DWORD	MCIAVI_OpenAudio(WINE_MCIAVI* wma, unsigned* nHdr, LPWAVEHDR* pWaveHdr) DECLSPEC_HIDDEN;
-BOOL	MCIAVI_OpenVideo(WINE_MCIAVI* wma) DECLSPEC_HIDDEN;
-void	MCIAVI_PlayAudioBlocks(WINE_MCIAVI* wma, unsigned nHdr, LPWAVEHDR waveHdr) DECLSPEC_HIDDEN;
-double	MCIAVI_PaintFrame(WINE_MCIAVI* wma, HDC hDC) DECLSPEC_HIDDEN;
+BOOL	MCIAVI_GetInfo(WINE_MCIAVI* wma);
+DWORD	MCIAVI_OpenAudio(WINE_MCIAVI* wma, unsigned* nHdr, LPWAVEHDR* pWaveHdr);
+BOOL	MCIAVI_OpenVideo(WINE_MCIAVI* wma);
+void	MCIAVI_PlayAudioBlocks(WINE_MCIAVI* wma, unsigned nHdr, LPWAVEHDR waveHdr);
+double	MCIAVI_PaintFrame(WINE_MCIAVI* wma, HDC hDC);
 
 /* mciavi.c */
-WINE_MCIAVI*	MCIAVI_mciGetOpenDev(UINT wDevID) DECLSPEC_HIDDEN;
-DWORD MCIAVI_mciClose(UINT, DWORD, LPMCI_GENERIC_PARMS) DECLSPEC_HIDDEN;
+WINE_MCIAVI*	MCIAVI_mciGetOpenDev(UINT wDevID);
+DWORD MCIAVI_mciClose(UINT, DWORD, LPMCI_GENERIC_PARMS);
 
 /* wnd.c */
-BOOL    MCIAVI_RegisterClass(void) DECLSPEC_HIDDEN;
-BOOL    MCIAVI_UnregisterClass(void) DECLSPEC_HIDDEN;
-BOOL    MCIAVI_CreateWindow(WINE_MCIAVI* wma, DWORD dwFlags, LPMCI_DGV_OPEN_PARMSW lpOpenParms) DECLSPEC_HIDDEN;
-DWORD	MCIAVI_mciPut(UINT wDevID, DWORD dwFlags, LPMCI_DGV_PUT_PARMS lpParms) DECLSPEC_HIDDEN;
-DWORD	MCIAVI_mciWhere(UINT wDevID, DWORD dwFlags, LPMCI_DGV_RECT_PARMS lpParms) DECLSPEC_HIDDEN;
-DWORD	MCIAVI_mciWindow(UINT wDevID, DWORD dwFlags, LPMCI_DGV_WINDOW_PARMSW lpParms) DECLSPEC_HIDDEN;
+BOOL    MCIAVI_RegisterClass(void);
+BOOL    MCIAVI_UnregisterClass(void);
+BOOL    MCIAVI_CreateWindow(WINE_MCIAVI* wma, DWORD dwFlags, LPMCI_DGV_OPEN_PARMSW lpOpenParms);
+DWORD	MCIAVI_mciPut(UINT wDevID, DWORD dwFlags, LPMCI_DGV_PUT_PARMS lpParms);
+DWORD	MCIAVI_mciWhere(UINT wDevID, DWORD dwFlags, LPMCI_DGV_RECT_PARMS lpParms);
+DWORD	MCIAVI_mciWindow(UINT wDevID, DWORD dwFlags, LPMCI_DGV_WINDOW_PARMSW lpParms);
 
 #endif  /* __WINE_PRIVATE_MCIAVI_H */

--- a/dll/win32/mciavi32/wnd.c
+++ b/dll/win32/mciavi32/wnd.c
@@ -25,11 +25,9 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(mciavi);
 
-static const WCHAR mciaviW[] = {'M','C','I','A','V','I',0};
-
 static LRESULT WINAPI MCIAVI_WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-    TRACE("hwnd=%p msg=%x wparam=%lx lparam=%lx\n", hWnd, uMsg, wParam, lParam);
+    TRACE("hwnd=%p msg=%x wparam=%Ix lparam=%Ix\n", hWnd, uMsg, wParam, lParam);
 
     switch (uMsg) {
     case WM_CREATE:
@@ -80,6 +78,20 @@ static LRESULT WINAPI MCIAVI_WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
         }
        return 1;
 
+       case WM_SIZE:
+        {
+            WINE_MCIAVI *wma = (WINE_MCIAVI *)mciGetDriverData(GetWindowLongW(hWnd, 0));
+
+            if (!wma)
+                return DefWindowProcW(hWnd, uMsg, wParam, lParam);
+
+            EnterCriticalSection(&wma->cs);
+            wma->dest.right = LOWORD(lParam);
+            wma->dest.bottom = HIWORD(lParam);
+            LeaveCriticalSection(&wma->cs);
+            return DefWindowProcW(hWnd, uMsg, wParam, lParam);
+        }
+
     default:
         return DefWindowProcW(hWnd, uMsg, wParam, lParam);
     }
@@ -87,7 +99,7 @@ static LRESULT WINAPI MCIAVI_WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
 
 BOOL MCIAVI_UnregisterClass(void)
 {
-    return UnregisterClassW(mciaviW, MCIAVI_hInstance);
+    return UnregisterClassW(L"MCIAVI", MCIAVI_hInstance);
 }
 
 BOOL MCIAVI_RegisterClass(void)
@@ -101,7 +113,7 @@ BOOL MCIAVI_RegisterClass(void)
     wndClass.hInstance     = MCIAVI_hInstance;
     wndClass.hCursor       = LoadCursorW(0, (LPCWSTR)IDC_ARROW);
     wndClass.hbrBackground = (HBRUSH)(COLOR_3DFACE + 1);
-    wndClass.lpszClassName = mciaviW;
+    wndClass.lpszClassName = L"MCIAVI";
 
     if (RegisterClassW(&wndClass)) return TRUE;
     if (GetLastError() == ERROR_CLASS_ALREADY_EXISTS) return TRUE;
@@ -111,7 +123,6 @@ BOOL MCIAVI_RegisterClass(void)
 
 BOOL    MCIAVI_CreateWindow(WINE_MCIAVI* wma, DWORD dwFlags, LPMCI_DGV_OPEN_PARMSW lpParms)
 {
-    static const WCHAR captionW[] = {'W','i','n','e',' ','M','C','I','-','A','V','I',' ','p','l','a','y','e','r',0};
     HWND	hParent = 0;
     DWORD	dwStyle = WS_OVERLAPPEDWINDOW;
     RECT        rc;
@@ -135,14 +146,12 @@ BOOL    MCIAVI_CreateWindow(WINE_MCIAVI* wma, DWORD dwFlags, LPMCI_DGV_OPEN_PARM
         rc.left = rc.top = CW_USEDEFAULT;
     }
 
-    wma->hWnd = CreateWindowW(mciaviW, captionW,
-                              dwStyle, rc.left, rc.top,
-                              rc.right, rc.bottom,
-                              hParent, 0, MCIAVI_hInstance,
+    wma->hWnd = CreateWindowW(L"MCIAVI", L"Wine MCI-AVI player", dwStyle, rc.left, rc.top,
+                              rc.right, rc.bottom, hParent, 0, MCIAVI_hInstance,
                               ULongToPtr(wma->wDevID));
     wma->hWndPaint = wma->hWnd;
 
-    TRACE("(%04x, %08X, %p, style %x, parent %p, dimensions %dx%d, hwnd %p)\n", wma->wDevID,
+    TRACE("(%04x, %08lX, %p, style %lx, parent %p, dimensions %ldx%ld, hwnd %p)\n", wma->wDevID,
           dwFlags, lpParms, dwStyle, hParent, rc.right - rc.left, rc.bottom - rc.top, wma->hWnd);
     return wma->hWnd != 0;
 }
@@ -155,7 +164,7 @@ DWORD	MCIAVI_mciPut(UINT wDevID, DWORD dwFlags, LPMCI_DGV_PUT_PARMS lpParms)
     WINE_MCIAVI*	wma = MCIAVI_mciGetOpenDev(wDevID);
     RECT		rc;
 
-    TRACE("(%04x, %08X, %p)\n", wDevID, dwFlags, lpParms);
+    TRACE("(%04x, %08lX, %p)\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
     if (wma == NULL)		return MCIERR_INVALID_DEVICE_ID;
@@ -211,7 +220,7 @@ DWORD	MCIAVI_mciWhere(UINT wDevID, DWORD dwFlags, LPMCI_DGV_RECT_PARMS lpParms)
     WINE_MCIAVI*	wma = MCIAVI_mciGetOpenDev(wDevID);
     RECT		rc;
 
-    TRACE("(%04x, %08x, %p)\n", wDevID, dwFlags, lpParms);
+    TRACE("(%04x, %08lx, %p)\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
     if (wma == NULL)		return MCIERR_INVALID_DEVICE_ID;
@@ -278,7 +287,7 @@ DWORD	MCIAVI_mciWindow(UINT wDevID, DWORD dwFlags, LPMCI_DGV_WINDOW_PARMSW lpPar
 {
     WINE_MCIAVI*	wma = MCIAVI_mciGetOpenDev(wDevID);
 
-    TRACE("(%04x, %08X, %p)\n", wDevID, dwFlags, lpParms);
+    TRACE("(%04x, %08lX, %p)\n", wDevID, dwFlags, lpParms);
 
     if (lpParms == NULL)	return MCIERR_NULL_PARAMETER_BLOCK;
     if (wma == NULL)		return MCIERR_INVALID_DEVICE_ID;

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -103,7 +103,7 @@ dll/win32/jsproxy             # Synced to WineStaging-4.18
 dll/win32/loadperf            # Synced to WineStaging-4.18
 dll/win32/lz32                # Synced to WineStaging-3.3
 dll/win32/mapi32              # Synced to WineStaging-4.18
-dll/win32/mciavi32            # Synced to WineStaging-4.18
+dll/win32/mciavi32            # Synced to Wine-11.11
 dll/win32/mcicda              # Synced to WineStaging-3.3
 dll/win32/mciqtz32            # Synced to WineStaging-4.18
 dll/win32/mciseq              # Synced to WineStaging-4.18

--- a/sdk/include/wine/debug.h
+++ b/sdk/include/wine/debug.h
@@ -178,6 +178,18 @@ static __inline const char *wine_dbgstr_guid( const GUID *id )
                              id->Data4[4], id->Data4[5], id->Data4[6], id->Data4[7] );
 }
 
+#ifdef __REACTOS__ /* wine-8.18 */
+static inline const char *wine_dbgstr_fourcc( unsigned int fourcc )
+{
+    char str[4] = { (char)fourcc, (char)(fourcc >> 8), (char)(fourcc >> 16), (char)(fourcc >> 24) };
+    if (!fourcc)
+        return "''";
+    if (isprint( str[0] ) && isprint( str[1] ) && isprint( str[2] ) && isprint( str[3] ))
+        return wine_dbg_sprintf( "'%.4s'", str );
+    return wine_dbg_sprintf( "0x%08x", fourcc );
+}
+#endif
+
 static __inline const char *wine_dbgstr_point( const POINT *pt )
 {
     if (!pt) return "(null)";
@@ -360,6 +372,9 @@ static inline const char *wine_dbgstr_variant( const VARIANT *v )
 static __inline const char *debugstr_an( const char * s, int n ) { return wine_dbgstr_an( s, n ); }
 static __inline const char *debugstr_wn( const WCHAR *s, int n ) { return wine_dbgstr_wn( s, n ); }
 static __inline const char *debugstr_guid( const struct _GUID *id ) { return wine_dbgstr_guid(id); }
+#ifdef __REACTOS__ /* wine-8.18 */
+static inline const char *debugstr_fourcc( unsigned int cc ) { return wine_dbgstr_fourcc( cc ); }
+#endif
 static __inline const char *debugstr_a( const char *s )  { return wine_dbgstr_an( s, -1 ); }
 static __inline const char *debugstr_w( const WCHAR *s ) { return wine_dbgstr_wn( s, -1 ); }
 


### PR DESCRIPTION
## Purpose

**Note:** These two changes were not available in upstream:
* `mmoutput.c:386`
```
#ifdef __REACTOS__
    /* Empty file */
    if (alb.numVideoFrames == 0) {
        WARN("NumVideoFrames: %u, Empty or possibly corrupt video file");
        return FALSE;
    }
#endif
```
* `mmoutput.c:622`
```
#ifdef __REACTOS__
        if (wma->dwCurrVideoFrame >= wma->dwPlayableVideoFrames) {
            ERR("Invalid frame requested. Current : %u Total Playable %u\n", wma->dwCurrVideoFrame, wma->dwPlayableVideoFrames);
            return 0;
        }
#endif
```

<img width="839" height="670" alt="image" src="https://github.com/user-attachments/assets/f5974d92-bdc5-45ca-885f-2481018f321d" />

JIRA issue: [CORE-20515](https://jira.reactos.org/browse/CORE-20515)

## Proposed changes

* Import `debugstr_fourcc` as it was needed by the new `mmoutput`.
* Remove `debugstr_fourcc` from `d3ddxof` and `dmusic` since we have it in `debug.h` now.
* Sync MCIAVI32 to Wine 11.11

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: