### PR TITLE
[KERNEL32] Implement Data Execution Prevention functions

### DIFF
--- a/dll/win32/kernel32/CMakeLists.txt
+++ b/dll/win32/kernel32/CMakeLists.txt
@@ -2,7 +2,8 @@
 add_subdirectory(kernel32_vista)
 
 add_definitions(-D_KERNEL32_)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/subsys)
+include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/subsys
+                    ${REACTOS_SOURCE_DIR}/dll/win32/kernelbase/wine)
 spec2def(kernel32.dll kernel32.spec ADD_IMPORTLIB)
 
 # Shared between kernel32 and kernel32_vista
@@ -104,6 +105,7 @@ list(APPEND SOURCE
     winnls/string/lstring.c
     winnls/string/nls.c
     winnls/string/sortkey.c
+    dep.c
     k32.h)
 
 if(MSVC)

--- a/dll/win32/kernel32/dep.c
+++ b/dll/win32/kernel32/dep.c
@@ -1,0 +1,84 @@
+/*
+ * PROJECT:     ReactOS Win32 Base API
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Data Execution Prevention (DEP) functions from Wine (dlls/kernel32/process.c)
+ * COPYRIGHT:   Copyright 2010 Detlef Riekenberg <wine.dev@web.de>
+ *              Copyright 2010, 2011 Austin English <austinenglish@gmail.com>
+ *              Copyright 2014 Sebastian Lackner <sebastian@fds-team.de>
+ *              Copyright 2019 Alexandre Julliard <julliard@winehq.org>
+ *              Copyright 2021 Zebediah Figura <z.figura12@gmail.com>
+ *              Copyright 2022 Eric Pouech <eric.pouech@gmail.com>
+ *              Copyright 2026 Earldridge Jazzed Pineda <earldridgejazzedpineda@gmail.com>
+ */
+
+#include <ndk/mmtypes.h>
+#include <ndk/psfuncs.h>
+#include <ndk/rtlfuncs.h>
+#include <windef.h>
+#include <winbase.h>
+#include <kernelbase.h>
+#include <wine/debug.h>
+WINE_DEFAULT_DEBUG_CHANNEL(dep);
+ 
+#define PROCESS_DEP_ENABLE 1
+#define PROCESS_DEP_DISABLE_ATL_THUNK_EMULATION 2
+
+/**********************************************************************
+ *           GetProcessDEPPolicy     (KERNEL32.@)
+ */
+BOOL WINAPI GetProcessDEPPolicy(HANDLE process, LPDWORD flags, PBOOL permanent)
+{
+    ULONG dep_flags;
+
+    TRACE("(%p %p %p)\n", process, flags, permanent);
+
+#if __REACTOS__
+    if (!set_ntstatus( NtQueryInformationProcess( process, ProcessExecuteFlags,
+#else
+    if (!set_ntstatus( NtQueryInformationProcess( GetCurrentProcess(), ProcessExecuteFlags,
+#endif
+                                                  &dep_flags, sizeof(dep_flags), NULL )))
+        return FALSE;
+
+    if (flags)
+	{
+	    *flags = 0;
+        if (dep_flags & MEM_EXECUTE_OPTION_DISABLE)
+            *flags |= PROCESS_DEP_ENABLE;
+        if (dep_flags & MEM_EXECUTE_OPTION_DISABLE_THUNK_EMULATION)
+            *flags |= PROCESS_DEP_DISABLE_ATL_THUNK_EMULATION;
+    }
+	
+	if (permanent) *permanent = (dep_flags & MEM_EXECUTE_OPTION_PERMANENT) != 0;
+    return TRUE;
+}
+
+/**********************************************************************
+ *           GetSystemDEPPolicy     (KERNEL32.@)
+ */
+DEP_SYSTEM_POLICY_TYPE WINAPI GetSystemDEPPolicy(void)
+{
+#if __REACTOS__
+    return SharedUserData->NXSupportPolicy;
+#else
+    return user_shared_data->NXSupportPolicy;
+#endif
+}	
+
+/**********************************************************************
+ *           SetProcessDEPPolicy     (KERNEL32.@)
+ */
+BOOL WINAPI SetProcessDEPPolicy( DWORD flags )
+{
+    ULONG dep_flags = 0;
+
+    TRACE("%#lx\n", flags);
+
+    if (flags & PROCESS_DEP_ENABLE)
+        dep_flags |= MEM_EXECUTE_OPTION_DISABLE | MEM_EXECUTE_OPTION_PERMANENT;
+    if (flags & PROCESS_DEP_DISABLE_ATL_THUNK_EMULATION)
+        dep_flags |= MEM_EXECUTE_OPTION_DISABLE_THUNK_EMULATION;
+
+    return set_ntstatus( NtSetInformationProcess( GetCurrentProcess(), ProcessExecuteFlags,
+                                                  &dep_flags, sizeof(dep_flags) ) );
+}

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -561,7 +561,7 @@
 @ stdcall GetPrivateProfileStructW(wstr wstr ptr long wstr)
 @ stdcall GetProcAddress(long str)
 @ stdcall GetProcessAffinityMask(long ptr ptr)
-@ stub -version=0x600+ GetProcessDEPPolicy
+@ stdcall -version=0x501,0x600+ GetProcessDEPPolicy(long ptr ptr)
 @ stdcall GetProcessHandleCount(long ptr)
 @ stdcall -norelay GetProcessHeap()
 @ stdcall GetProcessHeaps(long ptr)
@@ -593,7 +593,7 @@
 @ stdcall GetStringTypeExA(long long str long ptr)
 @ stdcall GetStringTypeExW(long long wstr long ptr)
 @ stdcall GetStringTypeW(long wstr long ptr)
-@ stub -version=0x600+ GetSystemDEPPolicy
+@ stdcall -version=0x501,0x600+ GetSystemDEPPolicy()
 @ stdcall GetSystemDefaultLCID()
 @ stdcall GetSystemDefaultLangID()
 @ stdcall -stub -version=0x600+ GetSystemDefaultLocaleName(ptr long)
@@ -1088,7 +1088,7 @@
 @ stdcall SetPriorityClass(long long)
 @ stdcall SetProcessAffinityMask(long long)
 @ stub -version=0x600+ SetProcessAffinityUpdateMode
-@ stub -version=0x600+ SetProcessDEPPolicy
+@ stdcall -version=0x501,0x600+ SetProcessDEPPolicy(long)
 @ stdcall SetProcessPriorityBoost(long long)
 @ stdcall SetProcessShutdownParameters(long long)
 @ stdcall SetProcessWorkingSetSize(long long long)

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -291,6 +291,7 @@ iphlpapi -
   modules/rostests/winetests/iphlpapi # Synced to WineStaging-1.9.11
 
 kernel32 -
+  dll/win32/kernel32/dep.c                       # Synced to Wine-11.0
   dll/win32/kernel32/wine/actctx.c               # Synced to wine-3.3
   dll/win32/kernel32/wine/comm.c                 # Synced to wine-3.3
   dll/win32/kernel32/wine/lzexpand.c             # Synced to WineStaging-3.3


### PR DESCRIPTION
## Purpose

Implements the Data Execution Prevention (DEP) functions that are available in Windows XP SP3 and from Windows Vista/Server 2008 onwards. This is one of two PRs needed to make Firefox 53.0.3 working on ReactOS built with `-DDLL_EXPORT_VERSION=0x600`, the other being #9258.

This pull request supersedes #4105 and was spun off from #9258 at the request of @whindsaks.

JIRA issue: [CORE-16503](https://jira.reactos.org/browse/CORE-16503)

## Proposed changes

- Implement GetProcessDEPPolicy, GetSystemDEPPolicy, and SetProcessDEPPolicy from Wine 11.0 in kernel32.dll. They require DLL_EXPORT_VERSION=0x501 or DLL_EXPORT_VERSION=0x600.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: