### PR TITLE
[USER32] Sync to Wine 11.11

### DIFF
--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -360,7 +360,7 @@ user32 -
   win32ss/user/user32/windows/cursoricon   # Forked from Wine-1.2-rc7
   win32ss/user/user32/windows/defwnd.c     # Forked
   win32ss/user/user32/windows/draw.c       # Forked at Wine-20020904 (uitools.c)
-  win32ss/user/user32/windows/mdi.c        # Synced to WineStaging-1.7.55
+  win32ss/user/user32/windows/mdi.c        # Synced to Wine-11.11
   win32ss/user/user32/windows/menu.c       # Forked
   win32ss/user/user32/windows/messagebox.c # Forked
   win32ss/user/user32/windows/rect.c       # Forked (uitools.c)

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -354,7 +354,7 @@ user32 -
   win32ss/user/user32/misc/ddeclient.c     # Synced to Wine-11.11 (dde_client.c)
   win32ss/user/user32/misc/ddeserver.c     # Synced to Wine-11.11 (dde_server.c)
   win32ss/user/user32/misc/exticon.c       # Synced to Wine-11.11
-  win32ss/user/user32/misc/resources.c     # Partially synced to WineStaging-1.7.55
+  win32ss/user/user32/misc/resources.c     # Partially synced to Wine-11.11
   win32ss/user/user32/misc/winhelp.c       # Last sync date unknown
 
   win32ss/user/user32/windows/cursoricon   # Forked from Wine-1.2-rc7

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -348,11 +348,11 @@ user32 -
   win32ss/user/user32/controls/scrollbar.c # Forked
   win32ss/user/user32/controls/static.c    # Synced to Wine-11.11
 
-  win32ss/user/user32/include/dde_private.h # Synced to WineStaging-1.7.55
+  win32ss/user/user32/include/dde_private.h # Synced to Wine-11.11
 
-  win32ss/user/user32/misc/dde.c           # Synced to WineStaging-1.7.55 (dde_misc.c)
-  win32ss/user/user32/misc/ddeclient.c     # Synced to WineStaging-1.7.55
-  win32ss/user/user32/misc/ddeserver.c     # Synced to WineStaging-1.7.55
+  win32ss/user/user32/misc/ddemisc.c       # Synced to Wine-11.11 (dde_misc.c)
+  win32ss/user/user32/misc/ddeclient.c     # Synced to Wine-11.11 (dde_client.c)
+  win32ss/user/user32/misc/ddeserver.c     # Synced to Wine-11.11 (dde_server.c)
   win32ss/user/user32/misc/exticon.c       # Synced to WineStaging-1.7.55
   win32ss/user/user32/misc/resources.c     # Partially synced to WineStaging-1.7.55
   win32ss/user/user32/misc/winhelp.c       # Last sync date unknown

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -344,7 +344,7 @@ user32 -
   win32ss/user/user32/controls/combo.c     # Synced to WineStaging-1.7.37
   win32ss/user/user32/controls/edit.c      # Synced to WineStaging-1.7.55
   win32ss/user/user32/controls/icontitle.c # Synced to WineStaging-1.7.55
-  win32ss/user/user32/controls/listbox.c   # Synced to WineStaging-1.7.55
+  win32ss/user/user32/controls/listbox.c   # Synced to Wine-11.11
   win32ss/user/user32/controls/scrollbar.c # Forked
   win32ss/user/user32/controls/static.c    # Synced to WineStaging-1.7.55
 

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -342,7 +342,7 @@ regedit
 user32 -
   win32ss/user/user32/controls/button.c    # Synced to Wine-11.11
   win32ss/user/user32/controls/combo.c     # Synced to Wine-11.11
-  win32ss/user/user32/controls/edit.c      # Synced to WineStaging-1.7.55
+  win32ss/user/user32/controls/edit.c      # Synced to Wine-11.11
   win32ss/user/user32/controls/icontitle.c # Synced to WineStaging-1.7.55
   win32ss/user/user32/controls/listbox.c   # Synced to Wine-11.11
   win32ss/user/user32/controls/scrollbar.c # Forked

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -346,7 +346,7 @@ user32 -
   win32ss/user/user32/controls/icontitle.c # Synced to WineStaging-1.7.55
   win32ss/user/user32/controls/listbox.c   # Synced to Wine-11.11
   win32ss/user/user32/controls/scrollbar.c # Forked
-  win32ss/user/user32/controls/static.c    # Synced to WineStaging-1.7.55
+  win32ss/user/user32/controls/static.c    # Synced to Wine-11.11
 
   win32ss/user/user32/include/dde_private.h # Synced to WineStaging-1.7.55
 

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -341,7 +341,7 @@ regedit
 
 user32 -
   win32ss/user/user32/controls/button.c    # Synced to Wine-11.11
-  win32ss/user/user32/controls/combo.c     # Synced to WineStaging-1.7.37
+  win32ss/user/user32/controls/combo.c     # Synced to Wine-11.11
   win32ss/user/user32/controls/edit.c      # Synced to WineStaging-1.7.55
   win32ss/user/user32/controls/icontitle.c # Synced to WineStaging-1.7.55
   win32ss/user/user32/controls/listbox.c   # Synced to Wine-11.11

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -343,7 +343,7 @@ user32 -
   win32ss/user/user32/controls/button.c    # Synced to Wine-11.11
   win32ss/user/user32/controls/combo.c     # Synced to Wine-11.11
   win32ss/user/user32/controls/edit.c      # Synced to Wine-11.11
-  win32ss/user/user32/controls/icontitle.c # Synced to WineStaging-1.7.55
+  win32ss/user/user32/controls/icontitle.c # Synced to Wine-11.11
   win32ss/user/user32/controls/listbox.c   # Synced to Wine-11.11
   win32ss/user/user32/controls/scrollbar.c # Forked
   win32ss/user/user32/controls/static.c    # Synced to Wine-11.11

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -353,7 +353,7 @@ user32 -
   win32ss/user/user32/misc/ddemisc.c       # Synced to Wine-11.11 (dde_misc.c)
   win32ss/user/user32/misc/ddeclient.c     # Synced to Wine-11.11 (dde_client.c)
   win32ss/user/user32/misc/ddeserver.c     # Synced to Wine-11.11 (dde_server.c)
-  win32ss/user/user32/misc/exticon.c       # Synced to WineStaging-1.7.55
+  win32ss/user/user32/misc/exticon.c       # Synced to Wine-11.11
   win32ss/user/user32/misc/resources.c     # Partially synced to WineStaging-1.7.55
   win32ss/user/user32/misc/winhelp.c       # Last sync date unknown
 

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -340,7 +340,7 @@ regedit
   base/applications/regedit/regproc.c   # Synced to Wine-7.17
 
 user32 -
-  win32ss/user/user32/controls/button.c    # Synced to WineStaging-1.7.37
+  win32ss/user/user32/controls/button.c    # Synced to Wine-11.11
   win32ss/user/user32/controls/combo.c     # Synced to WineStaging-1.7.37
   win32ss/user/user32/controls/edit.c      # Synced to WineStaging-1.7.55
   win32ss/user/user32/controls/icontitle.c # Synced to WineStaging-1.7.55

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -364,7 +364,7 @@ user32 -
   win32ss/user/user32/windows/menu.c       # Forked
   win32ss/user/user32/windows/messagebox.c # Forked
   win32ss/user/user32/windows/rect.c       # Forked (uitools.c)
-  win32ss/user/user32/windows/spy.c        # Synced to WineStaging-1.7.55
+  win32ss/user/user32/windows/spy.c        # Synced to Wine-11.11
   win32ss/user/user32/windows/text.c       # Forked (lstr.c)
   win32ss/user/user32/windows/winpos.c     # Forked
 

--- a/win32ss/include/ntusrtyp.h
+++ b/win32ss/include/ntusrtyp.h
@@ -102,6 +102,34 @@ typedef struct
     CURSORICONDIRENTRY  idEntries[1];
 } CURSORICONDIR;
 
+typedef struct _CURSORICONFILEDIRENTRY
+{
+    BYTE bWidth;
+    BYTE bHeight;
+    BYTE bColorCount;
+    BYTE bReserved;
+    union
+    {
+        WORD wPlanes; /* For icons */
+        WORD xHotspot; /* For cursors */
+    };
+    union
+    {
+        WORD wBitCount; /* For icons */
+        WORD yHotspot; /* For cursors */
+    };
+    DWORD dwDIBSize;
+    DWORD dwDIBOffset;
+} CURSORICONFILEDIRENTRY;
+
+typedef struct _CURSORICONFILEDIR
+{
+    WORD idReserved;
+    WORD idType;
+    WORD idCount;
+    CURSORICONFILEDIRENTRY idEntries[1];
+} CURSORICONFILEDIR;
+
 typedef struct
 {
     union

--- a/win32ss/user/user32/CMakeLists.txt
+++ b/win32ss/user/user32/CMakeLists.txt
@@ -86,6 +86,6 @@ target_link_libraries(user32 user32_vista_static user32_optional_vista user32_ws
 add_dependencies(user32 asm)
 
 add_delay_importlibs(user32 usp10 libpng)
-add_importlibs(user32 gdi32 advapi32 kernel32 ntdll)
+add_importlibs(user32 gdi32 advapi32 msvcrt kernel32 ntdll)
 add_pch(user32 include/user32.h SOURCE)
 add_cd_file(TARGET user32 DESTINATION reactos/system32 FOR all)

--- a/win32ss/user/user32/controls/button.c
+++ b/win32ss/user/user32/controls/button.c
@@ -18,15 +18,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  *
- * NOTES
- *
- * This code was audited for completeness against the documented features
- * of Comctl32.dll version 6.0 on Oct. 3, 2004, by Dimitrie O. Paun.
- * 
- * Unless otherwise noted, we believe this code to be complete, as per
- * the specification mentioned above.
- * If you discover missing features, or bugs, please note them below.
- * 
  * TODO
  *  Styles
  *  - BS_NOTIFY: is it complete?
@@ -34,45 +25,33 @@
  *
  *  Messages
  *  - WM_CHAR: Checks a (manual or automatic) check box on '+' or '=', clears it on '-' key.
- *  - WM_SETFOCUS: For (manual or automatic) radio buttons, send the parent window BN_CLICKED
  *  - WM_NCCREATE: Turns any BS_OWNERDRAW button into a BS_PUSHBUTTON button.
  *  - WM_SYSKEYUP
- *  - BCM_GETIDEALSIZE
- *  - BCM_GETIMAGELIST
- *  - BCM_GETTEXTMARGIN
- *  - BCM_SETIMAGELIST
- *  - BCM_SETTEXTMARGIN
- *  
+ *
  *  Notifications
- *  - BCN_HOTITEMCHANGE
  *  - BN_DISABLE
  *  - BN_PUSHED/BN_HILITE
  *  + BN_KILLFOCUS: is it OK?
  *  - BN_PAINT
  *  + BN_SETFOCUS: is it OK?
  *  - BN_UNPUSHED/BN_UNHILITE
- *  - NM_CUSTOMDRAW
- *
- *  Structures/Macros/Definitions
- *  - BUTTON_IMAGELIST
- *  - NMBCHOTITEM
- *  - Button_GetIdealSize
- *  - Button_GetImageList
- *  - Button_GetTextMargin
- *  - Button_SetImageList
- *  - Button_SetTextMargin
  */
 
 #include <user32.h>
+#include <wine-compat.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(button);
 
 /* GetWindowLong offsets for window extra information */
-#define STATE_GWL_OFFSET  0
-#define BUTTON_HFONT_GWL_OFFSET  (sizeof(LONG))
-#define HIMAGE_GWL_OFFSET (BUTTON_HFONT_GWL_OFFSET+sizeof(HFONT))
-#define BUTTON_UISTATE_GWL_OFFSET (HIMAGE_GWL_OFFSET+sizeof(HFONT))
-#define NB_EXTRA_BYTES    (BUTTON_UISTATE_GWL_OFFSET+sizeof(LONG_PTR))
+#define STATE_GWL_OFFSET   0
+#define HFONT_GWL_OFFSET   (sizeof(LONG))
+#define HICON_GWL_OFFSET   (HFONT_GWL_OFFSET+sizeof(HFONT))
+#ifdef __REACTOS__
+#define UISTATE_GWL_OFFSET (HICON_GWL_OFFSET+sizeof(HICON))
+#define NB_EXTRA_BYTES     (UISTATE_GWL_OFFSET+sizeof(LONG_PTR))
+#else
+#define NB_EXTRA_BYTES    (HICON_GWL_OFFSET+sizeof(HICON))
+#endif
 
 /* undocumented flags */
 #define BUTTON_NSTATES         0x0F
@@ -117,9 +96,9 @@ static const WORD maxCheckState[MAX_BTN_TYPE] =
     BST_UNCHECKED       /* BS_OWNERDRAW */
 };
 
-typedef void (*pfButtonPaint)( HWND hwnd, HDC hdc, UINT action );
+typedef void (*pfPaint)( HWND hwnd, HDC hdc, UINT action );
 
-static const pfButtonPaint btnPaintFunc[MAX_BTN_TYPE] =
+static const pfPaint btnPaintFunc[MAX_BTN_TYPE] =
 {
     PB_Paint,    /* BS_PUSHBUTTON */
     PB_Paint,    /* BS_DEFPUSHBUTTON */
@@ -135,6 +114,7 @@ static const pfButtonPaint btnPaintFunc[MAX_BTN_TYPE] =
     OB_Paint     /* BS_OWNERDRAW */
 };
 
+#ifdef __REACTOS__
 /*********************************************************************
  * button class descriptor
  */
@@ -143,50 +123,42 @@ const struct builtin_class_descr BUTTON_builtin_class =
 {
     buttonW,             /* name */
     CS_DBLCLKS | CS_VREDRAW | CS_HREDRAW | CS_PARENTDC, /* style  */
-#ifdef __REACTOS__
     ButtonWndProcA,      /* procA */
     ButtonWndProcW,      /* procW */
-#else
-    WINPROC_BUTTON,      /* proc */
-#endif
     NB_EXTRA_BYTES,      /* extra */
     IDC_ARROW,           /* cursor */
     0                    /* brush */
 };
-
+#endif
 
 static inline LONG get_button_state( HWND hwnd )
 {
-    return GetWindowLongW( hwnd, STATE_GWL_OFFSET );
+    return NtUserGetPrivateData( hwnd, STATE_GWL_OFFSET, sizeof(LONG) );
 }
 
-static inline void set_button_state( HWND hwnd, LONG state )
+static inline LONG set_button_state( HWND hwnd, LONG state )
 {
-    SetWindowLongW( hwnd, STATE_GWL_OFFSET, state );
+    return NtUserSetPrivateData( hwnd, STATE_GWL_OFFSET, sizeof(LONG), state );
 }
 
-#ifdef __REACTOS__
-
-static __inline void set_ui_state( HWND hwnd, LONG flags )
+static HFONT get_button_font( HWND hwnd )
 {
-    SetWindowLongPtrW( hwnd, BUTTON_UISTATE_GWL_OFFSET, flags );
+    return (HFONT)NtUserGetPrivateData( hwnd, HFONT_GWL_OFFSET, sizeof(HFONT) );
 }
 
-static __inline LONG get_ui_state( HWND hwnd )
+static HFONT set_button_font( HWND hwnd, HFONT font )
 {
-    return GetWindowLongPtrW( hwnd, BUTTON_UISTATE_GWL_OFFSET );
+    return (HFONT)NtUserSetPrivateData( hwnd, HFONT_GWL_OFFSET, sizeof(HFONT), (LONG_PTR)font );
 }
 
-#endif /* __REACTOS__ */
-
-static inline HFONT get_button_font( HWND hwnd )
+static HANDLE get_button_icon( HWND hwnd )
 {
-    return (HFONT)GetWindowLongPtrW( hwnd, BUTTON_HFONT_GWL_OFFSET );
+    return (HANDLE)NtUserGetPrivateData( hwnd, HICON_GWL_OFFSET, sizeof(HICON) );
 }
 
-static inline void set_button_font( HWND hwnd, HFONT font )
+static HANDLE set_button_icon( HWND hwnd, HANDLE icon )
 {
-    SetWindowLongPtrW( hwnd, BUTTON_HFONT_GWL_OFFSET, (LONG_PTR)font );
+    return (HANDLE)NtUserSetPrivateData( hwnd, HICON_GWL_OFFSET, sizeof(HICON), (LONG_PTR)icon );
 }
 
 static inline UINT get_button_type( LONG window_style )
@@ -199,22 +171,32 @@ static inline void paint_button( HWND hwnd, LONG style, UINT action )
 {
     if (btnPaintFunc[style] && IsWindowVisible(hwnd))
     {
-        HDC hdc = GetDC( hwnd );
+        HDC hdc = NtUserGetDC( hwnd );
         btnPaintFunc[style]( hwnd, hdc, action );
-        ReleaseDC( hwnd, hdc );
+        NtUserReleaseDC( hwnd, hdc );
     }
 }
 
 /* retrieve the button text; returned buffer must be freed by caller */
 static inline WCHAR *get_button_text( HWND hwnd )
 {
-    INT len = 512;
+    static const INT len = 512;
     WCHAR *buffer = HeapAlloc( GetProcessHeap(), 0, (len + 1) * sizeof(WCHAR) );
-    if (buffer) InternalGetWindowText( hwnd, buffer, len + 1 );
+    if (buffer) NtUserInternalGetWindowText( hwnd, buffer, len + 1 );
     return buffer;
 }
 
 #ifdef __REACTOS__
+static __inline void set_ui_state( HWND hwnd, LONG flags )
+{
+    SetWindowLongPtrW( hwnd, UISTATE_GWL_OFFSET, flags );
+}
+
+static __inline LONG get_ui_state( HWND hwnd )
+{
+    return GetWindowLongPtrW( hwnd, UISTATE_GWL_OFFSET );
+}
+
 /* Retrieve the UI state for the control */
 static BOOL button_update_uistate(HWND hwnd, BOOL unicode)
 {
@@ -235,44 +217,22 @@ static BOOL button_update_uistate(HWND hwnd, BOOL unicode)
 
     return FALSE;
 }
-#endif
+#endif /* __REACTOS__ */
 
 /***********************************************************************
  *           ButtonWndProc_common
  */
-LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
-                                  WPARAM wParam, LPARAM lParam, BOOL unicode )
+LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL unicode )
 {
     RECT rect;
     POINT pt;
-    LONG style = GetWindowLongPtrW( hWnd, GWL_STYLE );
+    LONG style = GetWindowLongW( hWnd, GWL_STYLE );
     UINT btn_type = get_button_type( style );
     LONG state;
     HANDLE oldHbitmap;
-#ifdef __REACTOS__
-    PWND pWnd;
 
-    pWnd = ValidateHwnd(hWnd);
-    if (pWnd)
-    {
-       if (!pWnd->fnid)
-       {
-          NtUserSetWindowFNID(hWnd, FNID_BUTTON);
-       }
-       else
-       {
-          if (pWnd->fnid != FNID_BUTTON)
-          {
-             ERR("Wrong window class for Button! fnId 0x%x\n",pWnd->fnid);
-             return 0;
-          }
-       }
-    }
-    else
-       return 0;
-#else
     if (!IsWindow( hWnd )) return 0;
-#endif
+    if (uMsg == WM_NCCREATE) NtUserSetWindowFNID( hWnd, MAKE_FNID(NTUSER_WNDPROC_BUTTON) );
 
     pt.x = (short)LOWORD(lParam);
     pt.y = (short)HIWORD(lParam);
@@ -300,15 +260,15 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
             return -1; /* abort */
 
         /* XP turns a BS_USERBUTTON into BS_PUSHBUTTON */
+#ifdef __REACTOS__
         if (btn_type == BS_USERBUTTON )
         {
             style = (style & ~BS_TYPEMASK) | BS_PUSHBUTTON;
-#ifdef __REACTOS__
             NtUserAlterWindowStyle(hWnd, GWL_STYLE, style );
-#else
-            WIN_SetStyle( hWnd, style, BS_TYPEMASK & ~style );
-#endif
         }
+#else
+        if (btn_type == BS_USERBUTTON ) NtUserAlterWindowStyle( hWnd, BS_TYPEMASK, BS_PUSHBUTTON );
+#endif
         set_button_state( hWnd, BST_UNCHECKED );
 #ifdef __REACTOS__
         button_update_uistate( hWnd, unicode );
@@ -347,14 +307,14 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
     case WM_PAINT:
     {
         PAINTSTRUCT ps;
-        HDC hdc = wParam ? (HDC)wParam : BeginPaint( hWnd, &ps );
+        HDC hdc = wParam ? (HDC)wParam : NtUserBeginPaint( hWnd, &ps );
         if (btnPaintFunc[btn_type])
         {
             int nOldMode = SetBkMode( hdc, OPAQUE );
             (btnPaintFunc[btn_type])( hWnd, hdc, ODA_DRAWENTIRE );
             SetBkMode(hdc, nOldMode); /*  reset painting mode */
         }
-        if ( !wParam ) EndPaint( hWnd, &ps );
+        if (!wParam) NtUserEndPaint( hWnd, &ps );
         break;
     }
 
@@ -363,7 +323,7 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
 	{
 	    SendMessageW( hWnd, BM_SETSTATE, TRUE, 0 );
             set_button_state( hWnd, get_button_state( hWnd ) | BUTTON_BTNPRESSED );
-            SetCapture( hWnd );
+            NtUserSetCapture( hWnd );
 	}
 	break;
 
@@ -378,9 +338,9 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
         }
         /* fall through */
     case WM_LBUTTONDOWN:
-        SetCapture( hWnd );
-        SetFocus( hWnd );
+        NtUserSetCapture( hWnd );
         set_button_state( hWnd, get_button_state( hWnd ) | BUTTON_BTNPRESSED );
+        NtUserSetFocus( hWnd );
         SendMessageW( hWnd, BM_SETSTATE, TRUE, 0 );
         break;
 
@@ -399,7 +359,7 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
         set_button_state( hWnd, state );
         if (!(state & BST_PUSHED))
         {
-            ReleaseCapture();
+            NtUserReleaseCapture();
             break;
         }
         SendMessageW( hWnd, BM_SETSTATE, FALSE, 0 );
@@ -420,17 +380,18 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
                                 (state & BST_INDETERMINATE) ? 0 : ((state & 3) + 1), 0 );
                 break;
             }
+
 #ifdef __REACTOS__
             TellParent = TRUE; // <---- Fix CORE-10194, Notify parent after capture is released.
 #else
-            ReleaseCapture();
+            NtUserReleaseCapture();
             BUTTON_NOTIFY_PARENT(hWnd, BN_CLICKED);
 #endif
         }
 #ifndef __REACTOS__
         else
         {
-            ReleaseCapture();
+            NtUserReleaseCapture();
         }
 #else
         ReleaseCapture();
@@ -462,25 +423,14 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
     case WM_SETTEXT:
     {
         /* Clear an old text here as Windows does */
-//
-// ReactOS Note :
-// wine Bug: http://bugs.winehq.org/show_bug.cgi?id=25790
-// Patch: http://source.winehq.org/patches/data/70889
-// By: Alexander LAW, Replicate Windows behavior of WM_SETTEXT handler regarding WM_CTLCOLOR*
-//
-#ifdef __REACTOS__
-        if (style & WS_VISIBLE)
-#else
         if (IsWindowVisible(hWnd))
-#endif
         {
-            HDC hdc = GetDC(hWnd);
+            HDC hdc = NtUserGetDC(hWnd);
             HBRUSH hbrush;
             RECT client, rc;
             HWND parent = GetParent(hWnd);
             UINT message = (btn_type == BS_PUSHBUTTON ||
                             btn_type == BS_DEFPUSHBUTTON ||
-                            btn_type == BS_PUSHLIKE ||
                             btn_type == BS_USERBUTTON ||
                             btn_type == BS_OWNERDRAW) ?
                             WM_CTLCOLORBTN : WM_CTLCOLORSTATIC;
@@ -506,13 +456,13 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
             if (rc.right > client.right) rc.right = client.right;
             if (rc.bottom > client.bottom) rc.bottom = client.bottom;
             FillRect(hdc, &rc, hbrush);
-            ReleaseDC(hWnd, hdc);
+            NtUserReleaseDC( hWnd, hdc );
         }
 
         if (unicode) DefWindowProcW( hWnd, WM_SETTEXT, wParam, lParam );
         else DefWindowProcA( hWnd, WM_SETTEXT, wParam, lParam );
         if (btn_type == BS_GROUPBOX) /* Yes, only for BS_GROUPBOX */
-            InvalidateRect( hWnd, NULL, TRUE );
+            NtUserInvalidateRect( hWnd, NULL, TRUE );
         else
             paint_button( hWnd, btn_type, ODA_DRAWENTIRE );
         return 1; /* success. FIXME: check text length */
@@ -520,7 +470,7 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
 
     case WM_SETFONT:
         set_button_font( hWnd, (HFONT)wParam );
-        if (lParam) InvalidateRect(hWnd, NULL, TRUE);
+        if (lParam) NtUserInvalidateRect(hWnd, NULL, TRUE);
         break;
 
     case WM_GETFONT:
@@ -532,13 +482,12 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
         paint_button( hWnd, btn_type, ODA_FOCUS );
         if (style & BS_NOTIFY)
             BUTTON_NOTIFY_PARENT(hWnd, BN_SETFOCUS);
-#ifdef __REACTOS__
+
         if (((btn_type == BS_RADIOBUTTON) || (btn_type == BS_AUTORADIOBUTTON)) &&
-            !(get_button_state(hWnd) & BST_CHECKED))
+            !(get_button_state(hWnd) & (BST_CHECKED | BUTTON_BTNPRESSED)))
         {
             BUTTON_NOTIFY_PARENT(hWnd, BN_CLICKED);
         }
-#endif
         break;
 
     case WM_KILLFOCUS:
@@ -548,29 +497,31 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
 	paint_button( hWnd, btn_type, ODA_FOCUS );
 
         if ((state & BUTTON_BTNPRESSED) && GetCapture() == hWnd)
-            ReleaseCapture();
+            NtUserReleaseCapture();
         if (style & BS_NOTIFY)
             BUTTON_NOTIFY_PARENT(hWnd, BN_KILLFOCUS);
 
-        InvalidateRect( hWnd, NULL, FALSE );
+        NtUserInvalidateRect( hWnd, NULL, FALSE );
         break;
 
     case WM_SYSCOLORCHANGE:
-        InvalidateRect( hWnd, NULL, FALSE );
+        NtUserInvalidateRect( hWnd, NULL, FALSE );
         break;
 
     case BM_SETSTYLE:
         btn_type = wParam & BS_TYPEMASK;
-        style = (style & ~BS_TYPEMASK) | btn_type;
 #ifdef __REACTOS__
+        style = (style & ~BS_TYPEMASK) | btn_type;
         NtUserAlterWindowStyle(hWnd, GWL_STYLE, style);
 #else
-        WIN_SetStyle( hWnd, style, BS_TYPEMASK & ~style );
+        NtUserAlterWindowStyle( hWnd, BS_TYPEMASK, btn_type );
 #endif
+
+        NtUserNotifyWinEvent( EVENT_OBJECT_STATECHANGE, hWnd, OBJID_CLIENT, 0 );
 
         /* Only redraw if lParam flag is set.*/
         if (lParam)
-            InvalidateRect( hWnd, NULL, TRUE );
+            NtUserInvalidateRect( hWnd, NULL, TRUE );
 
         break;
 
@@ -604,12 +555,12 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
         default:
             return 0;
         }
-        oldHbitmap = (HBITMAP)SetWindowLongPtrW( hWnd, HIMAGE_GWL_OFFSET, lParam );
-	InvalidateRect( hWnd, NULL, FALSE );
+        oldHbitmap = set_button_icon( hWnd, (HANDLE)lParam );
+	NtUserInvalidateRect( hWnd, NULL, FALSE );
 	return (LRESULT)oldHbitmap;
 
     case BM_GETIMAGE:
-        return GetWindowLongPtrW( hWnd, HIMAGE_GWL_OFFSET );
+        return (LRESULT)get_button_icon( hWnd );
 
     case BM_GETCHECK:
         return get_button_state( hWnd ) & 3;
@@ -624,14 +575,16 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
             else style &= ~WS_TABSTOP;
             NtUserAlterWindowStyle(hWnd, GWL_STYLE, style);
 #else
-            if (wParam) WIN_SetStyle( hWnd, WS_TABSTOP, 0 );
-            else WIN_SetStyle( hWnd, 0, WS_TABSTOP );
+            if (wParam) NtUserAlterWindowStyle( hWnd, WS_TABSTOP, WS_TABSTOP );
+            else NtUserAlterWindowStyle( hWnd, WS_TABSTOP, 0 );
 #endif
         }
         if ((state & 3) != wParam)
         {
             set_button_state( hWnd, (state & ~3) | wParam );
             paint_button( hWnd, btn_type, ODA_SELECT );
+
+            NtUserNotifyWinEvent( EVENT_OBJECT_STATECHANGE, hWnd, OBJID_CLIENT, 0 );
         }
         break;
 
@@ -646,6 +599,9 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
             set_button_state( hWnd, state & ~BST_PUSHED );
 
         paint_button( hWnd, btn_type, ODA_SELECT );
+
+        NtUserNotifyWinEvent( EVENT_OBJECT_STATECHANGE, hWnd, OBJID_CLIENT, 0 );
+
         break;
 
 #ifdef __REACTOS__
@@ -756,8 +712,8 @@ static UINT BUTTON_BStoDT( DWORD style, DWORD ex_style )
  */
 static UINT BUTTON_CalcLabelRect(HWND hwnd, HDC hdc, RECT *rc)
 {
-   LONG style = GetWindowLongPtrW( hwnd, GWL_STYLE );
-   LONG ex_style = GetWindowLongPtrW( hwnd, GWL_EXSTYLE );
+   LONG style = GetWindowLongW( hwnd, GWL_STYLE );
+   LONG ex_style = GetWindowLongW( hwnd, GWL_EXSTYLE );
    WCHAR *text;
    ICONINFO    iconInfo;
    BITMAP      bm;
@@ -795,7 +751,7 @@ static UINT BUTTON_CalcLabelRect(HWND hwnd, HDC hdc, RECT *rc)
       }
 
       case BS_ICON:
-         if (!GetIconInfo((HICON)GetWindowLongPtrW( hwnd, HIMAGE_GWL_OFFSET ), &iconInfo))
+         if (!GetIconInfo( get_button_icon( hwnd ), &iconInfo ))
             goto empty_rect;
 
          GetObjectW (iconInfo.hbmColor, sizeof(BITMAP), &bm);
@@ -808,7 +764,7 @@ static UINT BUTTON_CalcLabelRect(HWND hwnd, HDC hdc, RECT *rc)
          break;
 
       case BS_BITMAP:
-         if (!GetObjectW( (HANDLE)GetWindowLongPtrW( hwnd, HIMAGE_GWL_OFFSET ), sizeof(BITMAP), &bm))
+         if (!GetObjectW( get_button_icon( hwnd ), sizeof(BITMAP), &bm))
             goto empty_rect;
 
          r.right  = r.left + bm.bmWidth;
@@ -888,7 +844,7 @@ static void BUTTON_DrawLabel(HWND hwnd, HDC hdc, UINT dtFlags, const RECT *rc)
    HBRUSH hbr = 0;
    UINT flags = IsWindowEnabled(hwnd) ? DSS_NORMAL : DSS_DISABLED;
    LONG state = get_button_state( hwnd );
-   LONG style = GetWindowLongPtrW( hwnd, GWL_STYLE );
+   LONG style = GetWindowLongW( hwnd, GWL_STYLE );
    WCHAR *text = NULL;
 
    /* FIXME: To draw disabled label in Win31 look-and-feel, we probably
@@ -909,7 +865,7 @@ static void BUTTON_DrawLabel(HWND hwnd, HDC hdc, UINT dtFlags, const RECT *rc)
          lpOutputProc = BUTTON_DrawTextCallback;
          if (!(text = get_button_text( hwnd ))) return;
          lp = (LPARAM)text;
-         wp = (WPARAM)dtFlags;
+         wp = dtFlags;
 
 #ifdef __REACTOS__
          if (dtFlags & DT_HIDEPREFIX)
@@ -919,12 +875,12 @@ static void BUTTON_DrawLabel(HWND hwnd, HDC hdc, UINT dtFlags, const RECT *rc)
 
       case BS_ICON:
          flags |= DST_ICON;
-         lp = GetWindowLongPtrW( hwnd, HIMAGE_GWL_OFFSET );
+         lp = (LPARAM)get_button_icon( hwnd );
          break;
 
       case BS_BITMAP:
          flags |= DST_BITMAP;
-         lp = GetWindowLongPtrW( hwnd, HIMAGE_GWL_OFFSET );
+         lp = (LPARAM)get_button_icon( hwnd );
          break;
 
       default:
@@ -949,7 +905,7 @@ static void PB_Paint( HWND hwnd, HDC hDC, UINT action )
     COLORREF oldTxtColor;
     HFONT hFont;
     LONG state = get_button_state( hwnd );
-    LONG style = GetWindowLongPtrW( hwnd, GWL_STYLE );
+    LONG style = GetWindowLongW( hwnd, GWL_STYLE );
     BOOL pushedState = (state & BST_PUSHED);
     HWND parent;
     HRGN hrgn;
@@ -1026,8 +982,8 @@ draw_focus:
         if (!(get_ui_state(hwnd) & UISF_HIDEFOCUS))
         {
 #endif
-            InflateRect( &rc, -2, -2 );
-            DrawFocusRect( hDC, &rc );
+        InflateRect( &rc, -2, -2 );
+        DrawFocusRect( hDC, &rc );
 #ifdef __REACTOS__
         }
 #endif
@@ -1053,7 +1009,7 @@ static void CB_Paint( HWND hwnd, HDC hDC, UINT action )
     UINT dtFlags;
     HFONT hFont;
     LONG state = get_button_state( hwnd );
-    LONG style = GetWindowLongPtrW( hwnd, GWL_STYLE );
+    LONG style = GetWindowLongW( hwnd, GWL_STYLE );
     LONG ex_style = GetWindowLongW( hwnd, GWL_EXSTYLE );
     HWND parent;
     HRGN hrgn;
@@ -1067,8 +1023,13 @@ static void CB_Paint( HWND hwnd, HDC hDC, UINT action )
     GetClientRect(hwnd, &client);
     rbox = rtext = client;
 
+#ifdef __REACTOS__
     checkBoxWidth  = 12 * GetDeviceCaps( hDC, LOGPIXELSX ) / 96 + 1;
     checkBoxHeight = 12 * GetDeviceCaps( hDC, LOGPIXELSY ) / 96 + 1;
+#else
+    checkBoxWidth  = 12 * GetDpiForWindow( hwnd ) / 96 + 1;
+    checkBoxHeight = 12 * GetDpiForWindow( hwnd ) / 96 + 1;
+#endif
 
     if ((hFont = get_button_font( hwnd ))) SelectObject( hDC, hFont );
     GetCharWidthW( hDC, '0', '0', &text_offset );
@@ -1089,14 +1050,12 @@ static void CB_Paint( HWND hwnd, HDC hDC, UINT action )
 
     if (style & BS_LEFTTEXT || ex_style & WS_EX_RIGHT)
     {
-	/* magic +4 is what CTL3D expects */
-
-        rtext.right -= checkBoxWidth + text_offset;;
+        rtext.right -= checkBoxWidth + text_offset;
         rbox.left = rbox.right - checkBoxWidth;
     }
     else
     {
-        rtext.left += checkBoxWidth + text_offset;;
+        rtext.left += checkBoxWidth + text_offset;
         rbox.right = checkBoxWidth;
     }
 
@@ -1107,7 +1066,7 @@ static void CB_Paint( HWND hwnd, HDC hDC, UINT action )
     /* Draw label */
     client = rtext;
     dtFlags = BUTTON_CalcLabelRect(hwnd, hDC, &rtext);
-    
+
     /* Only adjust rbox when rtext is valid */
     if (dtFlags != (UINT)-1L)
     {
@@ -1132,15 +1091,15 @@ static void CB_Paint( HWND hwnd, HDC hDC, UINT action )
 
 	/* rbox must have the correct height */
 	delta = rbox.bottom - rbox.top - checkBoxHeight;
-	
-	if (style & BS_TOP) {
+
+	if ((style & BS_VCENTER) == BS_TOP) {
 	    if (delta > 0) {
 		rbox.bottom = rbox.top + checkBoxHeight;
-	    } else { 
+	    } else {
 		rbox.top -= -delta/2 + 1;
 		rbox.bottom = rbox.top + checkBoxHeight;
 	    }
-	} else if (style & BS_BOTTOM) {
+	} else if ((style & BS_VCENTER) == BS_BOTTOM) {
 	    if (delta > 0) {
 		rbox.top = rbox.bottom - checkBoxHeight;
 	    } else {
@@ -1175,10 +1134,10 @@ static void CB_Paint( HWND hwnd, HDC hDC, UINT action )
         if (!(get_ui_state(hwnd) & UISF_HIDEFOCUS))
         {
 #endif
-            rtext.left--;
-            rtext.right++;
-            IntersectRect(&rtext, &rtext, &client);
-            DrawFocusRect( hDC, &rtext );
+	rtext.left--;
+	rtext.right++;
+	IntersectRect(&rtext, &rtext, &client);
+	DrawFocusRect( hDC, &rtext );
 #ifdef __REACTOS__
         }
 #endif
@@ -1225,7 +1184,7 @@ static void GB_Paint( HWND hwnd, HDC hDC, UINT action )
     HFONT hFont;
     UINT dtFlags;
     TEXTMETRICW tm;
-    LONG style = GetWindowLongPtrW( hwnd, GWL_STYLE );
+    LONG style = GetWindowLongW( hwnd, GWL_STYLE );
     HWND parent;
     HRGN hrgn;
 
@@ -1252,7 +1211,7 @@ static void GB_Paint( HWND hwnd, HDC hDC, UINT action )
     InflateRect(&rc, -7, 1);
     dtFlags = BUTTON_CalcLabelRect(hwnd, hDC, &rc);
 
-    if (dtFlags != (UINT)-1L)
+    if (dtFlags != (UINT)-1)
     {
         /* Because buttons have CS_PARENTDC class style, there is a chance
          * that label will be drawn out of client rect.
@@ -1304,7 +1263,7 @@ static void UB_Paint( HWND hwnd, HDC hDC, UINT action )
     {
         if (!(get_ui_state(hwnd) & UISF_HIDEFOCUS))
 #endif
-            DrawFocusRect( hDC, &rc );
+        DrawFocusRect( hDC, &rc );
 #ifdef __REACTOS__
     }
 #endif
@@ -1336,7 +1295,7 @@ static void OB_Paint( HWND hwnd, HDC hDC, UINT action )
     DRAWITEMSTRUCT dis;
     LONG_PTR id = GetWindowLongPtrW( hwnd, GWLP_ID );
     HWND parent;
-    HFONT hFont, hPrevFont = 0;
+    HFONT hFont;
     HRGN hrgn;
 
     dis.CtlType    = ODT_BUTTON;
@@ -1351,7 +1310,7 @@ static void OB_Paint( HWND hwnd, HDC hDC, UINT action )
     dis.itemData   = 0;
     GetClientRect( hwnd, &dis.rcItem );
 
-    if ((hFont = get_button_font( hwnd ))) hPrevFont = SelectObject( hDC, hFont );
+    if ((hFont = get_button_font( hwnd ))) SelectObject( hDC, hFont );
     parent = GetParent(hwnd);
     if (!parent) parent = hwnd;
 #ifdef __REACTOS__
@@ -1363,7 +1322,6 @@ static void OB_Paint( HWND hwnd, HDC hDC, UINT action )
     hrgn = set_control_clipping( hDC, &dis.rcItem );
 
     SendMessageW( GetParent(hwnd), WM_DRAWITEM, id, (LPARAM)&dis );
-    if (hPrevFont) SelectObject(hDC, hPrevFont);
     SelectClipRgn( hDC, hrgn );
     if (hrgn) DeleteObject( hrgn );
 }

--- a/win32ss/user/user32/controls/combo.c
+++ b/win32ss/user/user32/controls/combo.c
@@ -22,6 +22,7 @@
  */
 
 #include <user32.h>
+#include <wine-compat.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(combo);
 
@@ -60,6 +61,7 @@ static UINT	CBitHeight, CBitWidth;
 #define COMBO_EDITBUTTONSPACE()  0
 #define EDIT_CONTROL_PADDING()   1
 
+#ifdef __REACTOS__
 /*********************************************************************
  * combo class descriptor
  */
@@ -68,17 +70,26 @@ const struct builtin_class_descr COMBO_builtin_class =
 {
     comboboxW,            /* name */
     CS_PARENTDC | CS_DBLCLKS | CS_HREDRAW | CS_VREDRAW, /* style  */
-#ifdef __REACTOS__
     ComboWndProcA,        /* procA */
     ComboWndProcW,        /* procW */
-#else
-    WINPROC_COMBO,        /* proc */
-#endif
     sizeof(HEADCOMBO *),  /* extra */
     IDC_ARROW,            /* cursor */
     0                     /* brush */
 };
+#endif
 
+static void CBCalcPlacement(HEADCOMBO *combo);
+static void CBResetPos(HEADCOMBO *combo, BOOL redraw);
+
+static HEADCOMBO *get_control_state( HWND hwnd )
+{
+    return (HEADCOMBO *)NtUserGetPrivateData( hwnd, 0, sizeof(HEADCOMBO *) );
+}
+
+static HEADCOMBO *set_control_state( HWND hwnd, HEADCOMBO *state )
+{
+    return (HEADCOMBO *)NtUserSetPrivateData( hwnd, 0, sizeof(HEADCOMBO *), (LONG_PTR)state );
+}
 
 /***********************************************************************
  *           COMBO_Init
@@ -136,10 +147,10 @@ static LRESULT COMBO_NCCreate(HWND hwnd, LONG style)
 {
     LPHEADCOMBO lphc;
 
-    if (COMBO_Init() && (lphc = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(HEADCOMBO))) )
+    if( COMBO_Init() && (lphc = calloc( 1, sizeof(HEADCOMBO) )) )
     {
         lphc->self = hwnd;
-        SetWindowLongPtrW( hwnd, 0, (LONG_PTR)lphc );
+        set_control_state( hwnd, lphc );
 
 #ifdef __REACTOS__
         COMBO_update_uistate(lphc);
@@ -177,13 +188,32 @@ static LRESULT COMBO_NCDestroy( LPHEADCOMBO lphc )
     {
         TRACE("[%p]: freeing storage\n", lphc->self);
 
-        if ( (CB_GETTYPE(lphc) != CBS_SIMPLE) && lphc->hWndLBox )
-            DestroyWindow( lphc->hWndLBox );
+       if( (CB_GETTYPE(lphc) != CBS_SIMPLE) && lphc->hWndLBox )
+           NtUserDestroyWindow( lphc->hWndLBox );
 
-        SetWindowLongPtrW( lphc->self, 0, 0 );
-        HeapFree( GetProcessHeap(), 0, lphc );
-    }
-    return 0;
+       set_control_state( lphc->self, NULL );
+       free( lphc );
+   }
+   return 0;
+}
+
+static INT combo_get_text_height(const HEADCOMBO *combo)
+{
+    HDC hdc = NtUserGetDC(combo->self);
+    HFONT prev_font = 0;
+    TEXTMETRICW tm;
+
+    if (combo->hFont)
+        prev_font = SelectObject(hdc, combo->hFont);
+
+    GetTextMetricsW(hdc, &tm);
+
+    if (prev_font)
+        SelectObject(hdc, prev_font);
+
+    NtUserReleaseDC( combo->self, hdc );
+
+    return tm.tmHeight + 4;
 }
 
 /***********************************************************************
@@ -198,37 +228,18 @@ static LRESULT COMBO_NCDestroy( LPHEADCOMBO lphc )
  * This height was determined through experimentation.
  * CBCalcPlacement will add 2*COMBO_YBORDERSIZE pixels for the border
  */
-static INT CBGetTextAreaHeight(
-  HWND        hwnd,
-  LPHEADCOMBO lphc)
+static INT CBGetTextAreaHeight(HEADCOMBO *lphc, BOOL clip_item_height)
 {
-  INT iTextItemHeight;
+  INT item_height, text_height;
 
-  if( lphc->editHeight ) /* explicitly set height */
+  if (clip_item_height && !CB_OWNERDRAWN(lphc))
   {
-    iTextItemHeight = lphc->editHeight;
+      text_height = combo_get_text_height(lphc);
+      if (lphc->item_height < text_height)
+          lphc->item_height = text_height;
   }
-  else
-  {
-    TEXTMETRICW tm;
-    HDC         hDC       = GetDC(hwnd);
-    HFONT       hPrevFont = 0;
-    INT         baseUnitY;
 
-    if (lphc->hFont)
-      hPrevFont = SelectObject( hDC, lphc->hFont );
-
-    GetTextMetricsW(hDC, &tm);
-
-    baseUnitY = tm.tmHeight;
-
-    if( hPrevFont )
-      SelectObject( hDC, hPrevFont );
-
-    ReleaseDC(hwnd, hDC);
-
-    iTextItemHeight = baseUnitY + 4;
-  }
+  item_height = lphc->item_height;
 
   /*
    * Check the ownerdraw case if we haven't asked the parent the size
@@ -239,13 +250,13 @@ static INT CBGetTextAreaHeight(
   {
     MEASUREITEMSTRUCT measureItem;
     RECT              clientRect;
-    INT               originalItemHeight = iTextItemHeight;
+    INT               originalItemHeight = item_height;
     UINT id = (UINT)GetWindowLongPtrW( lphc->self, GWLP_ID );
 
     /*
      * We use the client rect for the width of the item.
      */
-    GetClientRect(hwnd, &clientRect);
+    GetClientRect(lphc->self, &clientRect);
 
     lphc->wState &= ~CBF_MEASUREITEM;
 
@@ -256,10 +267,10 @@ static INT CBGetTextAreaHeight(
     measureItem.CtlID      = id;
     measureItem.itemID     = -1;
     measureItem.itemWidth  = clientRect.right;
-    measureItem.itemHeight = iTextItemHeight - 6; /* ownerdrawn cb is taller */
+    measureItem.itemHeight = item_height - 2; /* ownerdrawn cb is taller */
     measureItem.itemData   = 0;
     SendMessageW(lphc->owner, WM_MEASUREITEM, id, (LPARAM)&measureItem);
-    iTextItemHeight = 6 + measureItem.itemHeight;
+    item_height = 2 + measureItem.itemHeight;
 
     /*
      * Send a second one in the case of a fixed ownerdraw list to calculate the
@@ -280,10 +291,10 @@ static INT CBGetTextAreaHeight(
     /*
      * Keep the size for the next time
      */
-    lphc->editHeight = iTextItemHeight;
+    lphc->item_height = item_height;
   }
 
-  return iTextItemHeight;
+  return item_height;
 }
 
 /***********************************************************************
@@ -293,13 +304,12 @@ static INT CBGetTextAreaHeight(
  * a re-arranging of the contents of the combobox and the recalculation
  * of the size of the "real" control window.
  */
-static void CBForceDummyResize(
-  LPHEADCOMBO lphc)
+static void CBForceDummyResize(LPHEADCOMBO lphc)
 {
   RECT windowRect;
   int newComboHeight;
 
-  newComboHeight = CBGetTextAreaHeight(lphc->self,lphc) + 2*COMBO_YBORDERSIZE();
+  newComboHeight = CBGetTextAreaHeight(lphc, FALSE) + 2*COMBO_YBORDERSIZE();
 
   GetWindowRect(lphc->self, &windowRect);
 
@@ -311,12 +321,17 @@ static void CBForceDummyResize(
    * this will cancel-out in the processing of the WM_WINDOWPOSCHANGING
    * message.
    */
-  SetWindowPos( lphc->self,
-		NULL,
-		0, 0,
-		windowRect.right  - windowRect.left,
-		newComboHeight,
-		SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE );
+  lphc->wState |= CBF_NORESIZE;
+  NtUserSetWindowPos( lphc->self,
+                      NULL,
+                      0, 0,
+                      windowRect.right  - windowRect.left,
+                      newComboHeight,
+                      SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE );
+  lphc->wState &= ~CBF_NORESIZE;
+
+  CBCalcPlacement(lphc);
+  CBResetPos(lphc, FALSE);
 }
 
 /***********************************************************************
@@ -324,111 +339,70 @@ static void CBForceDummyResize(
  *
  * Set up component coordinates given valid lphc->RectCombo.
  */
-static void CBCalcPlacement(
-  HWND        hwnd,
-  LPHEADCOMBO lphc,
-  LPRECT      lprEdit,
-  LPRECT      lprButton,
-  LPRECT      lprLB)
+static void CBCalcPlacement(HEADCOMBO *combo)
 {
-  /*
-   * Again, start with the client rectangle.
-   */
-  GetClientRect(hwnd, lprEdit);
+    /* Start with the client rectangle. */
+    GetClientRect(combo->self, &combo->textRect);
 
-  /*
-   * Remove the borders
-   */
-  InflateRect(lprEdit, -COMBO_XBORDERSIZE(), -COMBO_YBORDERSIZE());
+    /* Remove the borders */
+    InflateRect(&combo->textRect, -COMBO_XBORDERSIZE(), -COMBO_YBORDERSIZE());
 
-  /*
-   * Chop off the bottom part to fit with the height of the text area.
-   */
-  lprEdit->bottom = lprEdit->top + CBGetTextAreaHeight(hwnd, lphc);
+    /* Chop off the bottom part to fit with the height of the text area. */
+    combo->textRect.bottom = combo->textRect.top + CBGetTextAreaHeight(combo, FALSE);
 
-  /*
-   * The button starts the same vertical position as the text area.
-   */
-  CopyRect(lprButton, lprEdit);
+    /* The button starts the same vertical position as the text area. */
+    combo->buttonRect = combo->textRect;
 
-  /*
-   * If the combobox is "simple" there is no button.
-   */
-  if( CB_GETTYPE(lphc) == CBS_SIMPLE )
-    lprButton->left = lprButton->right = lprButton->bottom = 0;
-  else
-  {
-    /*
-     * Let's assume the combobox button is the same width as the
-     * scrollbar button.
-     * size the button horizontally and cut-off the text area.
-     */
-    lprButton->left = lprButton->right - GetSystemMetrics(SM_CXVSCROLL);
-    lprEdit->right  = lprButton->left;
-  }
-
-  /*
-   * In the case of a dropdown, there is an additional spacing between the
-   * text area and the button.
-   */
-  if( CB_GETTYPE(lphc) == CBS_DROPDOWN )
-  {
-    lprEdit->right -= COMBO_EDITBUTTONSPACE();
-  }
-
-  /*
-   * If we have an edit control, we space it away from the borders slightly.
-   */
-  if (CB_GETTYPE(lphc) != CBS_DROPDOWNLIST)
-  {
-    InflateRect(lprEdit, -EDIT_CONTROL_PADDING(), -EDIT_CONTROL_PADDING());
-  }
-
-  /*
-   * Adjust the size of the listbox popup.
-   */
-  if( CB_GETTYPE(lphc) == CBS_SIMPLE )
-  {
-    /*
-     * Use the client rectangle to initialize the listbox rectangle
-     */
-    GetClientRect(hwnd, lprLB);
-
-    /*
-     * Then, chop-off the top part.
-     */
-    lprLB->top = lprEdit->bottom + COMBO_YBORDERSIZE();
-  }
-  else
-  {
-    /*
-     * Make sure the dropped width is as large as the combobox itself.
-     */
-    if (lphc->droppedWidth < (lprButton->right + COMBO_XBORDERSIZE()))
+    /* If the combobox is "simple" there is no button. */
+    if (CB_GETTYPE(combo) == CBS_SIMPLE)
+        combo->buttonRect.left = combo->buttonRect.right = combo->buttonRect.bottom = 0;
+    else
     {
-      lprLB->right  = lprLB->left + (lprButton->right + COMBO_XBORDERSIZE());
+        /*
+         * Let's assume the combobox button is the same width as the
+         * scrollbar button.
+         * size the button horizontally and cut-off the text area.
+         */
+        combo->buttonRect.left = combo->buttonRect.right - GetSystemMetrics(SM_CXVSCROLL);
+        combo->textRect.right = combo->buttonRect.left;
+    }
 
-      /*
-       * In the case of a dropdown, the popup listbox is offset to the right.
-       * so, we want to make sure it's flush with the right side of the
-       * combobox
-       */
-      if( CB_GETTYPE(lphc) == CBS_DROPDOWN )
-	lprLB->right -= COMBO_EDITBUTTONSPACE();
+    /* In the case of a dropdown, there is an additional spacing between the text area and the button. */
+    if (CB_GETTYPE(combo) == CBS_DROPDOWN)
+        combo->textRect.right -= COMBO_EDITBUTTONSPACE();
+
+    /* If we have an edit control, we space it away from the borders slightly. */
+    if (CB_GETTYPE(combo) != CBS_DROPDOWNLIST)
+        InflateRect(&combo->textRect, -EDIT_CONTROL_PADDING(), -EDIT_CONTROL_PADDING());
+
+    /* Adjust the size of the listbox popup. */
+    if (CB_GETTYPE(combo) == CBS_SIMPLE)
+    {
+        GetClientRect(combo->self, &combo->droppedRect);
+        combo->droppedRect.top = combo->textRect.bottom + COMBO_YBORDERSIZE();
     }
     else
-       lprLB->right = lprLB->left + lphc->droppedWidth;
-  }
+    {
+        /* Make sure the dropped width is as large as the combobox itself. */
+        if (combo->droppedWidth < (combo->buttonRect.right + COMBO_XBORDERSIZE()))
+        {
+            combo->droppedRect.right = combo->droppedRect.left + (combo->buttonRect.right + COMBO_XBORDERSIZE());
 
-  /* don't allow negative window width */
-  if (lprEdit->right < lprEdit->left)
-    lprEdit->right = lprEdit->left;
+            /* In the case of a dropdown, the popup listbox is offset to the right. We want to make sure it's flush
+               with the right side of the combobox. */
+            if (CB_GETTYPE(combo) == CBS_DROPDOWN)
+                combo->droppedRect.right -= COMBO_EDITBUTTONSPACE();
+        }
+        else
+            combo->droppedRect.right = combo->droppedRect.left + combo->droppedWidth;
+    }
 
-  TRACE("\ttext\t= (%s)\n", wine_dbgstr_rect(lprEdit));
+    /* Disallow negative window width */
+    if (combo->textRect.right < combo->textRect.left)
+        combo->textRect.right = combo->textRect.left;
 
-  TRACE("\tbutton\t= (%s)\n", wine_dbgstr_rect(lprButton));
-
-  TRACE("\tlbox\t= (%s)\n", wine_dbgstr_rect(lprLB));
+    TRACE("text %s, button %s, lbox %s.\n", wine_dbgstr_rect(&combo->textRect), wine_dbgstr_rect(&combo->buttonRect),
+            wine_dbgstr_rect(&combo->droppedRect));
 }
 
 /***********************************************************************
@@ -452,19 +426,14 @@ static void CBGetDroppedControlRect( LPHEADCOMBO lphc, LPRECT lpRect)
 static LRESULT COMBO_Create( HWND hwnd, LPHEADCOMBO lphc, HWND hwndParent, LONG style,
                              BOOL unicode )
 {
-  static const WCHAR clbName[] = {'C','o','m','b','o','L','B','o','x',0};
-  static const WCHAR editName[] = {'E','d','i','t',0};
-
   if( !CB_GETTYPE(lphc) ) lphc->dwStyle |= CBS_SIMPLE;
   if( CB_GETTYPE(lphc) != CBS_DROPDOWNLIST ) lphc->wState |= CBF_EDIT;
 
   lphc->owner = hwndParent;
 
-  /*
-   * The item height and dropped width are not set when the control
-   * is created.
-   */
-  lphc->droppedWidth = lphc->editHeight = 0;
+  lphc->droppedWidth = 0;
+
+  lphc->item_height = combo_get_text_height(lphc);
 
   /*
    * The first time we go through, we want to measure the ownerdraw item
@@ -488,7 +457,7 @@ static LRESULT COMBO_Create( HWND hwnd, LPHEADCOMBO lphc, HWND hwndParent, LONG 
        * recalculated.
        */
       GetClientRect( hwnd, &lphc->droppedRect );
-      CBCalcPlacement(hwnd, lphc, &lphc->textRect, &lphc->buttonRect, &lphc->droppedRect );
+      CBCalcPlacement(lphc);
 
       /*
        * Adjust the position of the popup listbox if it's necessary
@@ -541,7 +510,7 @@ static LRESULT COMBO_Create( HWND hwnd, LPHEADCOMBO lphc, HWND hwndParent, LONG 
       }
 
       if (unicode)
-          lphc->hWndLBox = CreateWindowExW(lbeExStyle, clbName, NULL, lbeStyle,
+          lphc->hWndLBox = CreateWindowExW(lbeExStyle, L"ComboLBox", NULL, lbeStyle,
                                            lphc->droppedRect.left,
                                            lphc->droppedRect.top,
                                            lphc->droppedRect.right - lphc->droppedRect.left,
@@ -576,7 +545,7 @@ static LRESULT COMBO_Create( HWND hwnd, LPHEADCOMBO lphc, HWND hwndParent, LONG 
               if (!IsWindowEnabled(hwnd)) lbeStyle |= WS_DISABLED;
 
               if (unicode)
-                  lphc->hWndEdit = CreateWindowExW(0, editName, NULL, lbeStyle,
+                  lphc->hWndEdit = CreateWindowExW(0, L"Edit", NULL, lbeStyle,
                                                    lphc->textRect.left, lphc->textRect.top,
                                                    lphc->textRect.right - lphc->textRect.left,
                                                    lphc->textRect.bottom - lphc->textRect.top,
@@ -599,7 +568,7 @@ static LRESULT COMBO_Create( HWND hwnd, LPHEADCOMBO lphc, HWND hwndParent, LONG 
 	    if( CB_GETTYPE(lphc) != CBS_SIMPLE )
 	    {
               /* Now do the trick with parent */
-	      SetParent(lphc->hWndLBox, HWND_DESKTOP);
+              NtUserSetParent( lphc->hWndLBox, HWND_DESKTOP );
               /*
                * If the combo is a dropdown, we must resize the control
 	       * to fit only the text area and button. To do this,
@@ -626,9 +595,12 @@ static LRESULT COMBO_Create( HWND hwnd, LPHEADCOMBO lphc, HWND hwndParent, LONG 
  *
  * Paint combo button (normal, pressed, and disabled states).
  */
-static void CBPaintButton( LPHEADCOMBO lphc, HDC hdc, RECT rectButton)
+static void CBPaintButton(HEADCOMBO *lphc, HDC hdc)
 {
     UINT buttonState = DFCS_SCROLLCOMBOBOX;
+
+    if (IsRectEmpty(&lphc->buttonRect))
+        return;
 
     if( lphc->wState & CBF_NOREDRAW )
       return;
@@ -640,7 +612,7 @@ static void CBPaintButton( LPHEADCOMBO lphc, HDC hdc, RECT rectButton)
     if (CB_DISABLED(lphc))
 	buttonState |= DFCS_INACTIVE;
 
-    DrawFrameControl(hdc, &rectButton, DFC_SCROLL, buttonState);
+    DrawFrameControl(hdc, &lphc->buttonRect, DFC_SCROLL, buttonState);
 }
 
 /***********************************************************************
@@ -652,47 +624,48 @@ static void CBPaintButton( LPHEADCOMBO lphc, HDC hdc, RECT rectButton)
  * It also returns the brush to use for the background.
  */
 static HBRUSH COMBO_PrepareColors(
-  LPHEADCOMBO lphc,
-  HDC         hDC)
+        LPHEADCOMBO lphc,
+        HDC         hDC)
 {
-  HBRUSH  hBkgBrush;
+    HBRUSH  hBkgBrush;
 
-  /*
-   * Get the background brush for this control.
-   */
-  if (CB_DISABLED(lphc))
-  {
+    /*
+     * Get the background brush for this control.
+     */
+    if (CB_DISABLED(lphc))
+    {
 #ifdef __REACTOS__
     hBkgBrush = GetControlColor(lphc->owner, lphc->self, hDC, WM_CTLCOLORSTATIC);
 #else
-    hBkgBrush = (HBRUSH)SendMessageW(lphc->owner, WM_CTLCOLORSTATIC,
-            (WPARAM)hDC, (LPARAM)lphc->self );
+        hBkgBrush = (HBRUSH)SendMessageW(lphc->owner, WM_CTLCOLORSTATIC,
+                (WPARAM)hDC, (LPARAM)lphc->self );
 #endif
-    /*
-     * We have to change the text color since WM_CTLCOLORSTATIC will
-     * set it to the "enabled" color. This is the same behavior as the
-     * edit control
-     */
-    SetTextColor(hDC, GetSysColor(COLOR_GRAYTEXT));
-  }
-  else
-  {
-      /* FIXME: In which cases WM_CTLCOLORLISTBOX should be sent? */
+
+        /*
+         * We have to change the text color since WM_CTLCOLORSTATIC will
+         * set it to the "enabled" color. This is the same behavior as the
+         * edit control
+         */
+        SetTextColor(hDC, GetSysColor(COLOR_GRAYTEXT));
+    }
+    else
+    {
+        /* FIXME: In which cases WM_CTLCOLORLISTBOX should be sent? */
 #ifdef __REACTOS__
       hBkgBrush = GetControlColor(lphc->owner, lphc->self, hDC, WM_CTLCOLOREDIT);
 #else
-      hBkgBrush = (HBRUSH)SendMessageW(lphc->owner, WM_CTLCOLOREDIT,
-              (WPARAM)hDC, (LPARAM)lphc->self );
+        hBkgBrush = (HBRUSH)SendMessageW(lphc->owner, WM_CTLCOLOREDIT,
+                (WPARAM)hDC, (LPARAM)lphc->self );
 #endif
-  }
+    }
 
-  /*
-   * Catch errors.
-   */
-  if( !hBkgBrush )
-    hBkgBrush = GetSysColorBrush(COLOR_WINDOW);
+    /*
+     * Catch errors.
+     */
+    if( !hBkgBrush )
+        hBkgBrush = GetSysColorBrush(COLOR_WINDOW);
 
-  return hBkgBrush;
+    return hBkgBrush;
 }
 
 /***********************************************************************
@@ -718,25 +691,24 @@ static void CBPaintText(
         size = SendMessageW(lphc->hWndLBox, LB_GETTEXTLEN, id, 0);
 	if (size == LB_ERR)
 	  FIXME("LB_ERR probably not handled yet\n");
-        if( (pText = HeapAlloc( GetProcessHeap(), 0, (size + 1) * sizeof(WCHAR))) )
+        if( (pText = malloc((size + 1) * sizeof(WCHAR))) )
 	{
             /* size from LB_GETTEXTLEN may be too large, from LB_GETTEXT is accurate */
-	    size=SendMessageW(lphc->hWndLBox, LB_GETTEXT, (WPARAM)id, (LPARAM)pText);
+           size=SendMessageW(lphc->hWndLBox, LB_GETTEXT, id, (LPARAM)pText);
 	    pText[size] = '\0';	/* just in case */
 	} else return;
    }
 
    if( lphc->wState & CBF_EDIT )
    {
-        static const WCHAR empty_stringW[] = { 0 };
-	if( CB_HASSTRINGS(lphc) ) SetWindowTextW( lphc->hWndEdit, pText ? pText : empty_stringW );
+	if( CB_HASSTRINGS(lphc) ) SetWindowTextW( lphc->hWndEdit, pText ? pText : L"" );
 	if( lphc->wState & CBF_FOCUSED )
-	    SendMessageW(lphc->hWndEdit, EM_SETSEL, 0, MAXLONG);
+           SendMessageW(lphc->hWndEdit, EM_SETSEL, 0, MAXLONG);
    }
    else if(!(lphc->wState & CBF_NOREDRAW) && IsWindowVisible( lphc->self ))
    {
      /* paint text field ourselves */
-     HDC hdc = hdc_paint ? hdc_paint : GetDC(lphc->self);
+     HDC hdc = hdc_paint ? hdc_paint : NtUserGetDC(lphc->self);
      UINT itemState = ODS_COMBOBOXEDIT;
      HFONT hPrevFont = (lphc->hFont) ? SelectObject(hdc, lphc->hFont) : 0;
      HBRUSH hPrevBrush, hBkgBrush;
@@ -785,8 +757,6 @@ static void CBPaintText(
      }
      else
      {
-       static const WCHAR empty_stringW[] = { 0 };
-
        if ( (lphc->wState & CBF_FOCUSED) &&
 	    !(lphc->wState & CBF_DROPPED) ) {
 
@@ -801,7 +771,7 @@ static void CBPaintText(
 		    rectEdit.top + 1,
 		    ETO_OPAQUE | ETO_CLIPPED,
 		    &rectEdit,
-		    pText ? pText : empty_stringW , size, NULL );
+		    pText ? pText : L"" , size, NULL );
 
 #ifdef __REACTOS__
        if(lphc->wState & CBF_FOCUSED &&
@@ -816,35 +786,32 @@ static void CBPaintText(
      if( hPrevFont )
        SelectObject(hdc, hPrevFont );
 
-     if( hPrevBrush )
+    if( hPrevBrush )
         SelectObject( hdc, hPrevBrush );
 
-     if( !hdc_paint )
-       ReleaseDC( lphc->self, hdc );
+     if (!hdc_paint)
+       NtUserReleaseDC( lphc->self, hdc );
    }
 #ifdef __REACTOS__
    if (pText)
 #endif
-	HeapFree( GetProcessHeap(), 0, pText );
+   free(pText);
 }
 
 /***********************************************************************
  *           CBPaintBorder
  */
-static void CBPaintBorder(
-  HWND            hwnd,
-  const HEADCOMBO *lphc,
-  HDC             hdc)
+static void CBPaintBorder(const HEADCOMBO *lphc, HDC hdc)
 {
   RECT clientRect;
 
   if (CB_GETTYPE(lphc) != CBS_SIMPLE)
   {
-    GetClientRect(hwnd, &clientRect);
+    GetClientRect(lphc->self, &clientRect);
   }
   else
   {
-    CopyRect(&clientRect, &lphc->textRect);
+    clientRect = lphc->textRect;
 
     InflateRect(&clientRect, EDIT_CONTROL_PADDING(), EDIT_CONTROL_PADDING());
     InflateRect(&clientRect, COMBO_XBORDERSIZE(), COMBO_YBORDERSIZE());
@@ -861,7 +828,7 @@ static LRESULT COMBO_Paint(LPHEADCOMBO lphc, HDC hParamDC)
   PAINTSTRUCT ps;
   HDC hDC;
 
-  hDC = (hParamDC) ? hParamDC : BeginPaint(lphc->self, &ps);
+  hDC = hParamDC ? hParamDC : NtUserBeginPaint(lphc->self, &ps );
 
   TRACE("hdc=%p\n", hDC);
 
@@ -881,10 +848,8 @@ static LRESULT COMBO_Paint(LPHEADCOMBO lphc, HDC hParamDC)
       /*
        * In non 3.1 look, there is a sunken border on the combobox
        */
-      CBPaintBorder(lphc->self, lphc, hDC);
-
-      if (!IsRectEmpty(&lphc->buttonRect))
-          CBPaintButton(lphc, hDC, lphc->buttonRect);
+      CBPaintBorder(lphc, hDC);
+      CBPaintButton(lphc, hDC);
 
       /* paint the edit control padding area */
       if (CB_GETTYPE(lphc) != CBS_DROPDOWNLIST)
@@ -903,8 +868,8 @@ static LRESULT COMBO_Paint(LPHEADCOMBO lphc, HDC hParamDC)
           SelectObject( hDC, hPrevBrush );
   }
 
-  if( !hParamDC )
-    EndPaint(lphc->self, &ps);
+  if (!hParamDC)
+    NtUserEndPaint( lphc->self, &ps );
 
   return 0;
 }
@@ -923,7 +888,7 @@ static INT CBUpdateLBox( LPHEADCOMBO lphc, BOOL bSelect )
    length = SendMessageW( lphc->hWndEdit, WM_GETTEXTLENGTH, 0, 0 );
 
    if (length > 0)
-       pText = HeapAlloc( GetProcessHeap(), 0, (length + 1) * sizeof(WCHAR));
+       pText = malloc((length + 1) * sizeof(WCHAR));
 
    TRACE("\t edit text length %i\n", length );
 
@@ -931,7 +896,7 @@ static INT CBUpdateLBox( LPHEADCOMBO lphc, BOOL bSelect )
    {
        GetWindowTextW( lphc->hWndEdit, pText, length + 1);
        idx = SendMessageW(lphc->hWndLBox, LB_FINDSTRING, (WPARAM)(-1), (LPARAM)pText);
-       HeapFree( GetProcessHeap(), 0, pText );
+       free(pText);
    }
 
    SendMessageW(lphc->hWndLBox, LB_SETCURSEL, (WPARAM)(bSelect ? idx : -1), 0);
@@ -952,7 +917,6 @@ static void CBUpdateEdit( LPHEADCOMBO lphc , INT index )
 {
    INT	length;
    LPWSTR pText = NULL;
-   static const WCHAR empty_stringW[] = { 0 };
 
    TRACE("\t %i\n", index );
 
@@ -961,7 +925,7 @@ static void CBUpdateEdit( LPHEADCOMBO lphc , INT index )
        length = SendMessageW(lphc->hWndLBox, LB_GETTEXTLEN, (WPARAM)index, 0);
        if( length != LB_ERR)
        {
-           if ((pText = HeapAlloc(GetProcessHeap(), 0, (length + 1) * sizeof(WCHAR))))
+           if ((pText = malloc((length + 1) * sizeof(WCHAR))))
                SendMessageW(lphc->hWndLBox, LB_GETTEXT, (WPARAM)index, (LPARAM)pText );
        }
    }
@@ -969,14 +933,14 @@ static void CBUpdateEdit( LPHEADCOMBO lphc , INT index )
    if( CB_HASSTRINGS(lphc) )
    {
       lphc->wState |= (CBF_NOEDITNOTIFY | CBF_NOLBSELECT);
-      SendMessageW(lphc->hWndEdit, WM_SETTEXT, 0, pText ? (LPARAM)pText : (LPARAM)empty_stringW);
+      SendMessageW(lphc->hWndEdit, WM_SETTEXT, 0, pText ? (LPARAM)pText : (LPARAM)L"");
       lphc->wState &= ~(CBF_NOEDITNOTIFY | CBF_NOLBSELECT);
    }
 
    if( lphc->wState & CBF_FOCUSED )
       SendMessageW(lphc->hWndEdit, EM_SETSEL, 0, (LPARAM)(-1));
 
-   HeapFree( GetProcessHeap(), 0, pText );
+   free(pText);
 }
 
 /***********************************************************************
@@ -989,7 +953,7 @@ static void CBDropDown( LPHEADCOMBO lphc )
     HMONITOR monitor;
     MONITORINFO mon_info;
    RECT rect,r;
-   int nItems = 0;
+   int nItems;
    int nDroppedHeight;
 
    TRACE("[%p]: drop down\n", lphc->self);
@@ -1066,16 +1030,16 @@ static void CBDropDown( LPHEADCOMBO lphc )
        r.bottom = min( r.top + nDroppedHeight, mon_info.rcWork.bottom );
    }
 
-   SetWindowPos( lphc->hWndLBox, HWND_TOPMOST, r.left, r.top, r.right - r.left, r.bottom - r.top,
-                 SWP_NOACTIVATE | SWP_SHOWWINDOW );
+   NtUserSetWindowPos( lphc->hWndLBox, HWND_TOPMOST, r.left, r.top, r.right - r.left, r.bottom - r.top,
+                       SWP_NOACTIVATE | SWP_SHOWWINDOW );
 
 
    if( !(lphc->wState & CBF_NOREDRAW) )
-     RedrawWindow( lphc->self, NULL, 0, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW );
+     NtUserRedrawWindow( lphc->self, NULL, 0, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW );
 
-   EnableWindow( lphc->hWndLBox, TRUE );
+   NtUserEnableWindow( lphc->hWndLBox, TRUE );
    if (GetCapture() != lphc->self)
-      SetCapture(lphc->hWndLBox);
+      NtUserSetCapture(lphc->hWndLBox);
 }
 
 /***********************************************************************
@@ -1100,11 +1064,11 @@ static void CBRollUp( LPHEADCOMBO lphc, BOOL ok, BOOL bButton )
 	   RECT	rect;
 
 	   lphc->wState &= ~CBF_DROPPED;
-	   ShowWindow( lphc->hWndLBox, SW_HIDE );
+	   NtUserShowWindow( lphc->hWndLBox, SW_HIDE );
 
            if(GetCapture() == lphc->hWndLBox)
            {
-               ReleaseCapture();
+               NtUserReleaseCapture();
            }
 
 	   if( CB_GETTYPE(lphc) == CBS_DROPDOWN )
@@ -1126,8 +1090,8 @@ static void CBRollUp( LPHEADCOMBO lphc, BOOL ok, BOOL bButton )
 	   }
 
 	   if( bButton && !(lphc->wState & CBF_NOREDRAW) )
-	       RedrawWindow( hWnd, &rect, 0, RDW_INVALIDATE |
-			       RDW_ERASE | RDW_UPDATENOW | RDW_NOCHILDREN );
+	       NtUserRedrawWindow( hWnd, &rect, 0, RDW_INVALIDATE |
+                                   RDW_ERASE | RDW_UPDATENOW | RDW_NOCHILDREN );
 	   CB_NOTIFY( lphc, CBN_CLOSEUP );
        }
    }
@@ -1154,9 +1118,9 @@ BOOL COMBO_FlipListbox( LPHEADCOMBO lphc, BOOL ok, BOOL bRedrawButton )
  *           CBRepaintButton
  */
 static void CBRepaintButton( LPHEADCOMBO lphc )
-   {
-  InvalidateRect(lphc->self, &lphc->buttonRect, TRUE);
-  UpdateWindow(lphc->self);
+{
+    NtUserInvalidateRect(lphc->self, &lphc->buttonRect, TRUE);
+    UpdateWindow(lphc->self);
 }
 
 /***********************************************************************
@@ -1174,7 +1138,7 @@ static void COMBO_SetFocus( LPHEADCOMBO lphc )
        /* lphc->wState |= CBF_FOCUSED;  */
 
        if( !(lphc->wState & CBF_EDIT) )
-	 InvalidateRect(lphc->self, &lphc->textRect, TRUE);
+           NtUserInvalidateRect(lphc->self, &lphc->textRect, TRUE);
 
        CB_NOTIFY( lphc, CBN_SETFOCUS );
        lphc->wState |= CBF_FOCUSED;
@@ -1200,7 +1164,7 @@ static void COMBO_KillFocus( LPHEADCOMBO lphc )
 
            /* redraw text */
 	   if( !(lphc->wState & CBF_EDIT) )
-	     InvalidateRect(lphc->self, &lphc->textRect, TRUE);
+               NtUserInvalidateRect(lphc->self, &lphc->textRect, TRUE);
 
            CB_NOTIFY( lphc, CBN_KILLFOCUS );
        }
@@ -1299,18 +1263,8 @@ static LRESULT COMBO_Command( LPHEADCOMBO lphc, WPARAM wParam, HWND hWnd )
 		if( HIWORD(wParam) == LBN_SELCHANGE)
 		{
 		   if( lphc->wState & CBF_EDIT )
-		   {
-		       INT index = SendMessageW(lphc->hWndLBox, LB_GETCURSEL, 0, 0);
 		       lphc->wState |= CBF_NOLBSELECT;
-		       CBUpdateEdit( lphc, index );
-		       /* select text in edit, as Windows does */
-               SendMessageW(lphc->hWndEdit, EM_SETSEL, 0, (LPARAM)(-1));
-		   }
-		   else
-                   {
-		       InvalidateRect(lphc->self, &lphc->textRect, TRUE);
-                       UpdateWindow(lphc->self);
-                   }
+		   CBPaintText( lphc, NULL );
 		}
                 break;
 
@@ -1397,7 +1351,7 @@ static LRESULT COMBO_GetTextW( LPHEADCOMBO lphc, INT count, LPWSTR buf )
         /* 'length' is without the terminating character */
         if (length >= count)
         {
-            LPWSTR lpBuffer = HeapAlloc(GetProcessHeap(), 0, (length + 1) * sizeof(WCHAR));
+            WCHAR *lpBuffer = malloc((length + 1) * sizeof(WCHAR));
             if (!lpBuffer) goto error;
             length = SendMessageW(lphc->hWndLBox, LB_GETTEXT, idx, (LPARAM)lpBuffer);
 
@@ -1407,7 +1361,7 @@ static LRESULT COMBO_GetTextW( LPHEADCOMBO lphc, INT count, LPWSTR buf )
                 lstrcpynW( buf, lpBuffer, count );
                 length = count;
             }
-            HeapFree( GetProcessHeap(), 0, lpBuffer );
+            free(lpBuffer);
         }
         else length = SendMessageW(lphc->hWndLBox, LB_GETTEXT, idx, (LPARAM)buf);
 
@@ -1447,7 +1401,7 @@ static LRESULT COMBO_GetTextA( LPHEADCOMBO lphc, INT count, LPSTR buf )
         /* 'length' is without the terminating character */
         if (length >= count)
         {
-            LPSTR lpBuffer = HeapAlloc(GetProcessHeap(), 0, (length + 1) );
+            char *lpBuffer = malloc(length + 1);
             if (!lpBuffer) goto error;
             length = SendMessageA(lphc->hWndLBox, LB_GETTEXT, idx, (LPARAM)lpBuffer);
 
@@ -1457,7 +1411,7 @@ static LRESULT COMBO_GetTextA( LPHEADCOMBO lphc, INT count, LPSTR buf )
                 lstrcpynA( buf, lpBuffer, count );
                 length = count;
             }
-            HeapFree( GetProcessHeap(), 0, lpBuffer );
+            free(lpBuffer);
         }
         else length = SendMessageA(lphc->hWndLBox, LB_GETTEXT, idx, (LPARAM)buf);
 
@@ -1477,50 +1431,44 @@ static LRESULT COMBO_GetTextA( LPHEADCOMBO lphc, INT count, LPSTR buf )
  * This function sets window positions according to the updated
  * component placement struct.
  */
-static void CBResetPos(
-  LPHEADCOMBO lphc,
-  const RECT  *rectEdit,
-  const RECT  *rectLB,
-  BOOL        bRedraw)
+static void CBResetPos(HEADCOMBO *combo, BOOL redraw)
 {
-   BOOL	bDrop = (CB_GETTYPE(lphc) != CBS_SIMPLE);
+    BOOL drop = CB_GETTYPE(combo) != CBS_SIMPLE;
 
-   /* NOTE: logs sometimes have WM_LBUTTONUP before a cascade of
-    * sizing messages */
+    /* NOTE: logs sometimes have WM_LBUTTONUP before a cascade of
+     * sizing messages */
+    if (combo->wState & CBF_EDIT)
+        NtUserSetWindowPos( combo->hWndEdit, 0, combo->textRect.left, combo->textRect.top,
+                            combo->textRect.right - combo->textRect.left,
+                            combo->textRect.bottom - combo->textRect.top,
+                            SWP_NOZORDER | SWP_NOACTIVATE | (drop ? SWP_NOREDRAW : 0) );
 
-   if( lphc->wState & CBF_EDIT )
-     SetWindowPos( lphc->hWndEdit, 0,
-		   rectEdit->left, rectEdit->top,
-		   rectEdit->right - rectEdit->left,
-		   rectEdit->bottom - rectEdit->top,
-                       SWP_NOZORDER | SWP_NOACTIVATE | ((bDrop) ? SWP_NOREDRAW : 0) );
+    NtUserSetWindowPos( combo->hWndLBox, 0, combo->droppedRect.left, combo->droppedRect.top,
+                        combo->droppedRect.right - combo->droppedRect.left,
+                        combo->droppedRect.bottom - combo->droppedRect.top,
+                        SWP_NOACTIVATE | SWP_NOZORDER | (drop ? SWP_NOREDRAW : 0) );
 
-   SetWindowPos( lphc->hWndLBox, 0,
-		 rectLB->left, rectLB->top,
-                 rectLB->right - rectLB->left,
-		 rectLB->bottom - rectLB->top,
-		   SWP_NOACTIVATE | SWP_NOZORDER | ((bDrop) ? SWP_NOREDRAW : 0) );
+    if (drop)
+    {
+        if (combo->wState & CBF_DROPPED)
+        {
+           combo->wState &= ~CBF_DROPPED;
+           NtUserShowWindow( combo->hWndLBox, SW_HIDE );
+        }
 
-   if( bDrop )
-   {
-       if( lphc->wState & CBF_DROPPED )
-       {
-           lphc->wState &= ~CBF_DROPPED;
-           ShowWindow( lphc->hWndLBox, SW_HIDE );
-       }
-
-       if( bRedraw && !(lphc->wState & CBF_NOREDRAW) )
-           RedrawWindow( lphc->self, NULL, 0,
-                           RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW );
-   }
+        if (redraw && !(combo->wState & CBF_NOREDRAW))
+            NtUserRedrawWindow( combo->self, NULL, 0, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW );
+    }
 }
-
 
 /***********************************************************************
  *           COMBO_Size
  */
-static void COMBO_Size( LPHEADCOMBO lphc )
+static void COMBO_Size( HEADCOMBO *lphc )
 {
+    if (!lphc->hWndLBox || (lphc->wState & CBF_NORESIZE))
+        return;
+
   /*
    * Those controls are always the same height. So we have to make sure
    * they are not resized to another value.
@@ -1533,7 +1481,7 @@ static void COMBO_Size( LPHEADCOMBO lphc )
     GetWindowRect(lphc->self, &rc);
     curComboHeight = rc.bottom - rc.top;
     curComboWidth = rc.right - rc.left;
-    newComboHeight = CBGetTextAreaHeight(lphc->self, lphc) + 2*COMBO_YBORDERSIZE();
+    newComboHeight = CBGetTextAreaHeight(lphc, TRUE) + 2*COMBO_YBORDERSIZE();
 
     /*
      * Resizing a combobox has another side effect, it resizes the dropped
@@ -1545,7 +1493,7 @@ static void COMBO_Size( LPHEADCOMBO lphc )
      */
     if( curComboHeight > newComboHeight )
     {
-      TRACE("oldComboHeight=%d, newComboHeight=%d, oldDropBottom=%d, oldDropTop=%d\n",
+      TRACE("oldComboHeight=%d, newComboHeight=%d, oldDropBottom=%ld, oldDropTop=%ld\n",
             curComboHeight, newComboHeight, lphc->droppedRect.bottom,
             lphc->droppedRect.top);
       lphc->droppedRect.bottom = lphc->droppedRect.top + curComboHeight - newComboHeight;
@@ -1553,18 +1501,18 @@ static void COMBO_Size( LPHEADCOMBO lphc )
     /*
      * Restore original height
      */
-    if( curComboHeight != newComboHeight )
-      SetWindowPos(lphc->self, 0, 0, 0, curComboWidth, newComboHeight,
-            SWP_NOZORDER|SWP_NOMOVE|SWP_NOACTIVATE|SWP_NOREDRAW);
+    if (curComboHeight != newComboHeight)
+    {
+        lphc->wState |= CBF_NORESIZE;
+        NtUserSetWindowPos( lphc->self, 0, 0, 0, curComboWidth, newComboHeight,
+                            SWP_NOZORDER | SWP_NOMOVE | SWP_NOACTIVATE | SWP_NOREDRAW );
+        lphc->wState &= ~CBF_NORESIZE;
+    }
   }
 
-  CBCalcPlacement(lphc->self,
-		  lphc,
-		  &lphc->textRect,
-		  &lphc->buttonRect,
-		  &lphc->droppedRect);
+  CBCalcPlacement(lphc);
 
-  CBResetPos( lphc, &lphc->textRect, &lphc->droppedRect, FALSE );
+  CBResetPos(lphc, FALSE);
 }
 
 
@@ -1573,10 +1521,9 @@ static void COMBO_Size( LPHEADCOMBO lphc )
  */
 static void COMBO_Font( LPHEADCOMBO lphc, HFONT hFont, BOOL bRedraw )
 {
-  /*
-   * Set the font
-   */
   lphc->hFont = hFont;
+  if (!CB_OWNERDRAWN(lphc))
+    lphc->item_height = combo_get_text_height(lphc);
 
   /*
    * Propagate to owned windows.
@@ -1590,13 +1537,9 @@ static void COMBO_Font( LPHEADCOMBO lphc, HFONT hFont, BOOL bRedraw )
    */
   if ( CB_GETTYPE(lphc) == CBS_SIMPLE)
   {
-    CBCalcPlacement(lphc->self,
-		    lphc,
-		    &lphc->textRect,
-		    &lphc->buttonRect,
-		    &lphc->droppedRect);
+    CBCalcPlacement(lphc);
 
-    CBResetPos( lphc, &lphc->textRect, &lphc->droppedRect, TRUE );
+    CBResetPos(lphc, TRUE);
   }
   else
   {
@@ -1616,20 +1559,16 @@ static LRESULT COMBO_SetItemHeight( LPHEADCOMBO lphc, INT index, INT height )
    {
        if( height < 32768 )
        {
-           lphc->editHeight = height + 2;  /* Is the 2 for 2*EDIT_CONTROL_PADDING? */
+           lphc->item_height = height + 2;  /* Is the 2 for 2*EDIT_CONTROL_PADDING? */
 
 	 /*
 	  * Redo the layout of the control.
 	  */
 	 if ( CB_GETTYPE(lphc) == CBS_SIMPLE)
 	 {
-	   CBCalcPlacement(lphc->self,
-			   lphc,
-			   &lphc->textRect,
-			   &lphc->buttonRect,
-			   &lphc->droppedRect);
+	   CBCalcPlacement(lphc);
 
-	   CBResetPos( lphc, &lphc->textRect, &lphc->droppedRect, TRUE );
+	   CBResetPos(lphc, TRUE);
 	 }
 	 else
 	 {
@@ -1657,7 +1596,7 @@ static LRESULT COMBO_SelectString( LPHEADCOMBO lphc, INT start, LPARAM pText, BO
        CBUpdateEdit( lphc, index );
      else
      {
-       InvalidateRect(lphc->self, &lphc->textRect, TRUE);
+       NtUserInvalidateRect(lphc->self, &lphc->textRect, TRUE);
      }
    }
    return (LRESULT)index;
@@ -1691,7 +1630,7 @@ static void COMBO_LButtonDown( LPHEADCOMBO lphc, LPARAM lParam )
            if( lphc->wState & CBF_CAPTURE )
            {
                lphc->wState &= ~CBF_CAPTURE;
-               ReleaseCapture();
+               NtUserReleaseCapture();
            }
        }
        else
@@ -1699,7 +1638,7 @@ static void COMBO_LButtonDown( LPHEADCOMBO lphc, LPARAM lParam )
 	   /* drop down the listbox and start tracking */
 
            lphc->wState |= CBF_CAPTURE;
-           SetCapture( hWnd );
+           NtUserSetCapture( hWnd );
            CBDropDown( lphc );
        }
        if( bButton ) CBRepaintButton( lphc );
@@ -1727,8 +1666,8 @@ static void COMBO_LButtonUp( LPHEADCOMBO lphc )
 	       lphc->wState &= ~CBF_NOLBSELECT;
 	   }
        }
-       ReleaseCapture();
-       SetCapture(lphc->hWndLBox);
+       NtUserReleaseCapture();
+       NtUserSetCapture(lphc->hWndLBox);
    }
 
    if( lphc->wState & CBF_BUTTONDOWN )
@@ -1770,7 +1709,7 @@ static void COMBO_MouseMove( LPHEADCOMBO lphc, WPARAM wParam, LPARAM lParam )
    if( PtInRect(&lbRect, pt) )
    {
        lphc->wState &= ~CBF_CAPTURE;
-       ReleaseCapture();
+       NtUserReleaseCapture();
        if( CB_GETTYPE(lphc) == CBS_DROPDOWN ) CBUpdateLBox( lphc, TRUE );
 
        /* hand over pointer tracking */
@@ -1796,6 +1735,7 @@ static LRESULT COMBO_GetComboBoxInfo(const HEADCOMBO *lphc, COMBOBOXINFO *pcbi)
     return TRUE;
 }
 
+#ifdef __REACTOS__
 static char *strdupA(LPCSTR str)
 {
     char *ret;
@@ -1805,19 +1745,23 @@ static char *strdupA(LPCSTR str)
 
     len = strlen(str);
     ret = HeapAlloc(GetProcessHeap(), 0, len + 1);
-#ifdef __REACTOS__
     if (ret != NULL)
-#endif
         memcpy(ret, str, len + 1);
     return ret;
 }
+
+#define strdup(String) strdupA(String)
+#endif
 
 /***********************************************************************
  *           ComboWndProc_common
  */
 LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam, BOOL unicode )
 {
-    LPHEADCOMBO lphc = (LPHEADCOMBO)GetWindowLongPtrW( hwnd, 0 );
+    LPHEADCOMBO lphc = get_control_state( hwnd );
+
+    TRACE("[%p]: msg %s wp %08Ix lp %08Ix\n", hwnd, SPY_GetMsgName(message, hwnd), wParam, lParam);
+
 #ifdef __REACTOS__
     PWND pWnd;
 
@@ -1837,16 +1781,17 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
             }
          }
     }
-#endif
-
-    TRACE("[%p]: msg %s wp %08lx lp %08lx\n", hwnd, SPY_GetMsgName(message, hwnd), wParam, lParam);
-
-#ifndef __REACTOS__
+    else
+    {
+        return 0;
+    }
+#else
     if (!IsWindow(hwnd)) return 0;
+    if (message == WM_NCCREATE || message == WM_CREATE) NtUserSetWindowFNID( hwnd, MAKE_FNID(NTUSER_WNDPROC_COMBO) );
 #endif
 
-    if (lphc || message == WM_NCCREATE)
-    switch(message)
+      if( lphc || message == WM_NCCREATE )
+      switch(message)
     {
     case WM_NCCREATE:
     {
@@ -1896,12 +1841,11 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
                 result |= DLGC_WANTMESSAGE;
         }
         return  result;
-    }
-    case WM_SIZE:
-        if (lphc->hWndLBox && !(lphc->wState & CBF_NORESIZE))
-            COMBO_Size( lphc );
-        return  TRUE;
-    case WM_SETFONT:
+	}
+	case WM_SIZE:
+	        COMBO_Size( lphc );
+		return  TRUE;
+	case WM_SETFONT:
         COMBO_Font( lphc, (HFONT)wParam, (BOOL)lParam );
         return TRUE;
     case WM_GETFONT:
@@ -1909,7 +1853,7 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
     case WM_SETFOCUS:
         if (lphc->wState & CBF_EDIT)
         {
-            SetFocus( lphc->hWndEdit );
+            NtUserSetFocus( lphc->hWndEdit );
             /* The first time focus is received, select all the text */
             if (!(lphc->wState & CBF_BEENFOCUSED))
             {
@@ -1970,11 +1914,11 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
         return COMBO_ItemOp(lphc, message, lParam);
     case WM_ENABLE:
         if (lphc->wState & CBF_EDIT)
-            EnableWindow( lphc->hWndEdit, (BOOL)wParam );
-        EnableWindow( lphc->hWndLBox, (BOOL)wParam );
+            NtUserEnableWindow( lphc->hWndEdit, (BOOL)wParam );
+        NtUserEnableWindow( lphc->hWndLBox, (BOOL)wParam );
 
         /* Force the control to repaint when the enabled state changes. */
-        InvalidateRect(lphc->self, NULL, TRUE);
+        NtUserInvalidateRect(lphc->self, NULL, TRUE);
         return  TRUE;
     case WM_SETREDRAW:
         if (wParam)
@@ -2034,8 +1978,8 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
                              SendMessageA(hwndTarget, message, wParam, lParam);
         }
     case WM_LBUTTONDOWN:
-        if ( !(lphc->wState & CBF_FOCUSED) ) SetFocus( lphc->self );
-        if ( lphc->wState & CBF_FOCUSED ) COMBO_LButtonDown( lphc, lParam );
+        if (!(lphc->wState & CBF_FOCUSED)) NtUserSetFocus( lphc->self );
+        if (lphc->wState & CBF_FOCUSED) COMBO_LButtonDown( lphc, lParam );
         return  TRUE;
     case WM_LBUTTONUP:
         COMBO_LButtonUp( lphc );
@@ -2052,26 +1996,27 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
 
         if (GET_WHEEL_DELTA_WPARAM(wParam) > 0) return SendMessageW(hwnd, WM_KEYDOWN, VK_UP, 0);
         if (GET_WHEEL_DELTA_WPARAM(wParam) < 0) return SendMessageW(hwnd, WM_KEYDOWN, VK_DOWN, 0);
-        return TRUE;
+                return TRUE;
 
-    case WM_CTLCOLOR:
-    case WM_CTLCOLORMSGBOX:
-    case WM_CTLCOLOREDIT:
-    case WM_CTLCOLORLISTBOX:
-    case WM_CTLCOLORBTN:
-    case WM_CTLCOLORDLG:
-    case WM_CTLCOLORSCROLLBAR:
-    case WM_CTLCOLORSTATIC:
+        case WM_CTLCOLOR:
+        case WM_CTLCOLORMSGBOX:
+        case WM_CTLCOLOREDIT:
+        case WM_CTLCOLORLISTBOX:
+        case WM_CTLCOLORBTN:
+        case WM_CTLCOLORDLG:
+        case WM_CTLCOLORSCROLLBAR:
+        case WM_CTLCOLORSTATIC:
 #ifdef __REACTOS__
         if (pWnd && !(pWnd->state2 & WNDS2_WIN40COMPAT)) break; // Must be Win 4.0 and above.
 #endif
-        if (lphc->owner)
-            return SendMessageW(lphc->owner, message, wParam, lParam);
-        break;
+            if (lphc->owner)
+                return SendMessageW(lphc->owner, message, wParam, lParam);
+            break;
 
-    /* Combo messages */
-    case CB_ADDSTRING:
-        if (unicode)
+	/* Combo messages */
+
+	case CB_ADDSTRING:
+		if( unicode )
         {
             if (lphc->dwStyle & CBS_LOWERCASE)
                 CharLowerW((LPWSTR)lParam);
@@ -2086,18 +2031,18 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
             LRESULT ret;
             if (lphc->dwStyle & CBS_LOWERCASE)
             {
-                string = strdupA((LPSTR)lParam);
+                string = strdup((char *)lParam);
                 CharLowerA(string);
             }
 
             else if (lphc->dwStyle & CBS_UPPERCASE)
             {
-                string = strdupA((LPSTR)lParam);
+                string = strdup((char *)lParam);
                 CharUpperA(string);
             }
 
             ret = SendMessageA(lphc->hWndLBox, LB_ADDSTRING, 0, string ? (LPARAM)string : lParam);
-            HeapFree(GetProcessHeap(), 0, string);
+            free(string);
             return ret;
         }
     case CB_INSERTSTRING:
@@ -2133,16 +2078,13 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
     case CB_GETITEMHEIGHT:
         if ((INT)wParam >= 0) /* listbox item */
             return SendMessageW(lphc->hWndLBox, LB_GETITEMHEIGHT, wParam, 0);
-        return  CBGetTextAreaHeight(hwnd, lphc);
+        return CBGetTextAreaHeight(lphc, FALSE);
     case CB_RESETCONTENT:
-        SendMessageW(lphc->hWndLBox, LB_RESETCONTENT, 0, 0);
-        if ((lphc->wState & CBF_EDIT) && CB_HASSTRINGS(lphc))
-        {
-            static const WCHAR empty_stringW[] = { 0 };
-            SendMessageW(lphc->hWndEdit, WM_SETTEXT, 0, (LPARAM)empty_stringW);
-        }
-        else
-            InvalidateRect(lphc->self, NULL, TRUE);
+		SendMessageW(lphc->hWndLBox, LB_RESETCONTENT, 0, 0);
+                if( (lphc->wState & CBF_EDIT) && CB_HASSTRINGS(lphc) )
+                    SendMessageW(lphc->hWndEdit, WM_SETTEXT, 0, (LPARAM)L"");
+                else
+                    NtUserInvalidateRect(lphc->self, NULL, TRUE);
         return  TRUE;
     case CB_INITSTORAGE:
         return SendMessageW(lphc->hWndLBox, LB_INITSTORAGE, wParam, lParam);
@@ -2166,7 +2108,7 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
             lphc->droppedWidth = 0;
 
         /* recalculate the combobox area */
-        CBCalcPlacement(hwnd, lphc, &lphc->textRect, &lphc->buttonRect, &lphc->droppedRect );
+        CBCalcPlacement(lphc);
 
         /* fall through */
     case CB_GETDROPPEDWIDTH:
@@ -2203,10 +2145,10 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
         if (lParam >= 0)
             SendMessageW(lphc->hWndLBox, LB_SETTOPINDEX, wParam, 0);
 
-        /* no LBN_SELCHANGE in this case, update manually */
-        CBPaintText(lphc, NULL);
-        lphc->wState &= ~CBF_SELCHANGE;
-        return lParam;
+		/* no LBN_SELCHANGE in this case, update manually */
+                CBPaintText( lphc, NULL );
+		lphc->wState &= ~CBF_SELCHANGE;
+	        return  lParam;
     case CB_GETLBTEXT:
         return unicode ? SendMessageW(lphc->hWndLBox, LB_GETTEXT, wParam, lParam) :
                          SendMessageA(lphc->hWndLBox, LB_GETTEXT, wParam, lParam);
@@ -2270,7 +2212,7 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
 
     default:
         if (message >= WM_USER)
-            WARN("unknown msg WM_USER+%04x wp=%04lx lp=%08lx\n", message - WM_USER, wParam, lParam );
+            WARN("unknown msg WM_USER+%04x wp=%04Ix lp=%08Ix\n", message - WM_USER, wParam, lParam );
         break;
     }
     return unicode ? DefWindowProcW(hwnd, message, wParam, lParam) :

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -20,22 +20,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  *
- * NOTES
- *
- * This code was audited for completeness against the documented features
- * of Comctl32.dll version 6.0 on Oct. 8, 2004, by Dimitrie O. Paun.
- * 
- * Unless otherwise noted, we believe this code to be complete, as per
- * the specification mentioned above.
- * If you discover missing features, or bugs, please note them below.
- *
  * TODO:
- *   - EDITBALLOONTIP structure
- *   - EM_GETCUEBANNER/Edit_GetCueBannerText
- *   - EM_HIDEBALLOONTIP/Edit_HideBalloonTip
- *   - EM_SETCUEBANNER/Edit_SetCueBannerText
- *   - EM_SHOWBALLOONTIP/Edit_ShowBalloonTip
- *   - EM_GETIMESTATUS, EM_SETIMESTATUS
  *   - EN_ALIGN_LTR_EC
  *   - EN_ALIGN_RTL_EC
  *   - ES_OEMCONVERT
@@ -45,6 +30,8 @@
 #include <user32.h>
 #define WIN32_LEAN_AND_MEAN
 #include <usp10.h>
+#include <wine-compat.h>
+
 #ifdef __REACTOS__
 #include <immdev.h>
 #define ImmGetCompositionStringW    IMM_FN(ImmGetCompositionStringW)
@@ -129,8 +116,6 @@ typedef struct
 	RECT format_rect;
 	INT text_width;			/* width of the widest line in pixels for multi line controls
 					   and just line width for single line controls	*/
-	INT region_posx;		/* Position of cursor relative to region: */
-	INT region_posy;		/* -1: to left, 0: within, 1: to right */
 	void *word_break_proc;		/* 32-bit word break proc: ANSI or Unicode */
 	INT line_count;			/* number of lines */
 	INT y_offset;			/* scroll offset in number of lines */
@@ -142,6 +127,7 @@ typedef struct
 					   should be sent to the first parent. */
 	HWND hwndListBox;		/* handle of ComboBox's listbox or NULL */
 	INT wheelDeltaRemainder;        /* scroll wheel delta left over after scrolling whole lines */
+	BYTE lead_byte;			/* DBCS lead byte store for WM_CHAR */
 	/*
 	 *	only for multi line controls
 	 */
@@ -156,10 +142,8 @@ typedef struct
 	/*
 	 * IME Data
 	 */
-#ifndef __REACTOS__ /* Rely on the composition window */
-	UINT composition_len;   /* length of composition, 0 == no composition */
-	int composition_start;  /* the character position for the composition */
-#endif
+	UINT ime_status;        /* IME status flag */
+
 	/*
 	 * Uniscribe Data
 	 */
@@ -171,13 +155,22 @@ typedef struct
 #define SWAP_UINT32(x,y) do { UINT temp = (UINT)(x); (x) = (UINT)(y); (y) = temp; } while(0)
 #define ORDER_UINT(x,y) do { if ((UINT)(y) < (UINT)(x)) SWAP_UINT32((x),(y)); } while(0)
 
-static const WCHAR empty_stringW[] = {0};
 static inline BOOL notify_parent(const EDITSTATE *es, INT code)
 {
     HWND hwnd = es->hwndSelf;
     TRACE("notification %d sent to %p.\n", code, es->hwndParent);
     SendMessageW(es->hwndParent, WM_COMMAND, MAKEWPARAM(GetWindowLongPtrW(es->hwndSelf, GWLP_ID), code), (LPARAM)es->hwndSelf);
     return IsWindow(hwnd);
+}
+
+static EDITSTATE *get_control_state( HWND hwnd )
+{
+    return (EDITSTATE *)NtUserGetPrivateData( hwnd, 0, sizeof(EDITSTATE *) );
+}
+
+static EDITSTATE *set_control_state( HWND hwnd, EDITSTATE *state )
+{
+    return (EDITSTATE *)NtUserSetPrivateData( hwnd, 0, sizeof(EDITSTATE *), (LONG_PTR)state );
 }
 
 static LRESULT EDIT_EM_PosFromChar(EDITSTATE *es, INT index, BOOL after_wrap);
@@ -189,7 +182,7 @@ static LRESULT EDIT_EM_PosFromChar(EDITSTATE *es, INT index, BOOL after_wrap);
  */
 static inline BOOL EDIT_EM_CanUndo(const EDITSTATE *es)
 {
-	return (es->undo_insert_count || strlenW(es->undo_text));
+	return (es->undo_insert_count || lstrlenW(es->undo_text));
 }
 
 
@@ -221,7 +214,7 @@ static inline void EDIT_EM_EmptyUndoBuffer(EDITSTATE *es)
  * applications with an expected version 0f 4.0 or higher.
  *
  */
-static DWORD get_app_version(void)
+DWORD get_app_version(void)
 {
     static DWORD version;
     if (!version)
@@ -266,7 +259,7 @@ static HBRUSH EDIT_NotifyCtlColor(EDITSTATE *es, HDC hdc)
 static inline UINT get_text_length(EDITSTATE *es)
 {
     if(es->text_length == (UINT)-1)
-        es->text_length = strlenW(es->text);
+        es->text_length = lstrlenW(es->text);
     return es->text_length;
 }
 
@@ -351,9 +344,10 @@ static INT EDIT_CallWordBreakProc(EDITSTATE *es, INT start, INT index, INT count
 	    {
 		EDITWORDBREAKPROCW wbpW = (EDITWORDBREAKPROCW)es->word_break_proc;
 
-		TRACE_(relay)("(UNICODE wordbrk=%p,str=%s,idx=%d,cnt=%d,act=%d)\n",
+		TRACE_(relay)("\1Call wordbreakW %p (str=%s,idx=%d,cnt=%d,act=%d)\n",
 			es->word_break_proc, debugstr_wn(es->text + start, count), index, count, action);
 		ret = wbpW(es->text + start, index, count, action);
+		TRACE_(relay)("\1Ret wordbreakW %p retval=%d\n", es->word_break_proc, ret );
 	    }
 	    else
 	    {
@@ -368,10 +362,11 @@ static INT EDIT_CallWordBreakProc(EDITSTATE *es, INT start, INT index, INT count
 		if (textA == NULL) return 0;
 #endif
 		WideCharToMultiByte(CP_ACP, 0, es->text + start, count, textA, countA, NULL, NULL);
-		TRACE_(relay)("(ANSI wordbrk=%p,str=%s,idx=%d,cnt=%d,act=%d)\n",
+		TRACE_(relay)("\1Call wordbreakA %p(str=%s,idx=%d,cnt=%d,act=%d)\n",
 			es->word_break_proc, debugstr_an(textA, countA), index, countA, action);
 		ret = wbpA(textA, index, countA, action);
 		HeapFree(GetProcessHeap(), 0, textA);
+		TRACE_(relay)("\1Ret wordbreakA %p retval=%d\n", es->word_break_proc, ret );
 	    }
         }
 	else
@@ -418,34 +413,46 @@ static SCRIPT_STRING_ANALYSIS EDIT_UpdateUniscribeData_linedef(EDITSTATE *es, HD
 		HRESULT hr;
 
 		if (!udc)
-			udc = GetDC(es->hwndSelf);
+			udc = NtUserGetDC(es->hwndSelf);
 		if (es->font)
 			old_font = SelectObject(udc, es->font);
 
 		tabdef.cTabStops = es->tabs_count;
-		tabdef.iScale = 0;
+		tabdef.iScale = GdiGetCharDimensions(udc, NULL, NULL);
 		tabdef.pTabStops = es->tabs;
 		tabdef.iTabOrigin = 0;
 
-		hr = ScriptStringAnalyse(udc, &es->text[index], line_def->net_length,
+		if (es->style & ES_PASSWORD)
+			hr = ScriptStringAnalyse(udc, &es->password_char, line_def->net_length,
 #ifdef __REACTOS__
-                                         /* ReactOS r57679 */
-                                         (3*line_def->net_length/2+16), -1,
+                                                  /* ReactOS r57679 */
+                                                  (3*line_def->net_length/2+16), -1,
 #else
-                                         (1.5*line_def->net_length+16), -1,
+                                                  (1.5*line_def->net_length+16), -1,
 #endif
-                                         SSA_LINK|SSA_FALLBACK|SSA_GLYPHS|SSA_TAB, -1,
-                                         NULL, NULL, NULL, &tabdef, NULL, &line_def->ssa);
+                                                  SSA_LINK|SSA_FALLBACK|SSA_GLYPHS|SSA_TAB|SSA_PASSWORD, -1,
+                                                  NULL, NULL, NULL, &tabdef, NULL, &line_def->ssa);
+		else
+			hr = ScriptStringAnalyse(udc, &es->text[index], line_def->net_length,
+#ifdef __REACTOS__
+                                                  /* ReactOS r57679 */
+                                                  (3*line_def->net_length/2+16), -1,
+#else
+                                                  (1.5*line_def->net_length+16), -1,
+#endif
+                                                  SSA_LINK|SSA_FALLBACK|SSA_GLYPHS|SSA_TAB, -1,
+                                                  NULL, NULL, NULL, &tabdef, NULL, &line_def->ssa);
+
 		if (FAILED(hr))
 		{
-			WARN("ScriptStringAnalyse failed (%x)\n",hr);
+			WARN("ScriptStringAnalyse failed (%lx)\n",hr);
 			line_def->ssa = NULL;
 		}
 
 		if (es->font)
 			SelectObject(udc, old_font);
 		if (udc != dc)
-			ReleaseDC(es->hwndSelf, udc);
+                    NtUserReleaseDC( es->hwndSelf, udc );
 	}
 
 	return line_def->ssa;
@@ -464,7 +471,7 @@ static SCRIPT_STRING_ANALYSIS EDIT_UpdateUniscribeData(EDITSTATE *es, HDC dc, IN
 			HDC udc = dc;
 
 			if (!udc)
-				udc = GetDC(es->hwndSelf);
+				udc = NtUserGetDC(es->hwndSelf);
 			if (es->font)
 				old_font = SelectObject(udc, es->font);
 
@@ -486,7 +493,7 @@ static SCRIPT_STRING_ANALYSIS EDIT_UpdateUniscribeData(EDITSTATE *es, HDC dc, IN
 			if (es->font)
 				SelectObject(udc, old_font);
 			if (udc != dc)
-				ReleaseDC(es->hwndSelf, udc);
+                            NtUserReleaseDC( es->hwndSelf, udc );
 		}
 		return es->ssa;
 	}
@@ -505,7 +512,7 @@ static SCRIPT_STRING_ANALYSIS EDIT_UpdateUniscribeData(EDITSTATE *es, HDC dc, IN
 
 static inline INT get_vertical_line_count(EDITSTATE *es)
 {
-	INT vlc = (es->format_rect.bottom - es->format_rect.top) / es->line_height;
+	INT vlc = es->line_height ? (es->format_rect.bottom - es->format_rect.top) / es->line_height : 0;
 	return max(1,vlc);
 }
 
@@ -580,7 +587,7 @@ static void EDIT_BuildLineDefs_ML(EDITSTATE *es, INT istart, INT iend, INT delta
 				   insert it into the link list */
 				LINEDEF *new_line = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(LINEDEF));
 #ifdef __REACTOS__
-				/* ReactOS r33509 */
+				/* ReactOS r33503 */
 				if (new_line == NULL)
 					break;
 #endif
@@ -621,7 +628,7 @@ static void EDIT_BuildLineDefs_ML(EDITSTATE *es, INT istart, INT iend, INT delta
 		/* Mark type of line termination */
 		if (!(*cp)) {
 			current_line->ending = END_0;
-			current_line->net_length = strlenW(current_position);
+			current_line->net_length = lstrlenW(current_position);
 		} else if ((cp > current_position) && (*(cp - 1) == '\r')) {
 			current_line->ending = END_SOFT;
 			current_line->net_length = cp - current_position - 1;
@@ -1146,15 +1153,11 @@ static LRESULT EDIT_EM_PosFromChar(EDITSTATE *es, INT index, BOOL after_wrap)
 		lw = line_def->width;
 		w = es->format_rect.right - es->format_rect.left;
 		if (line_def->ssa)
-		{
 			ScriptStringCPtoX(line_def->ssa, (index - 1) - li, TRUE, &x);
-			x -= es->x_offset;
-		}
-		else
 #ifdef __REACTOS__ /* CORE-15780 */
-			x = (lw > 0 ? es->x_offset : x - es->x_offset);
+		x = (lw > 0 ? es->x_offset : x - es->x_offset);
 #else
-			x = es->x_offset;
+		x -= es->x_offset;
 #endif
 
 		if (es->style & ES_RIGHT)
@@ -1381,7 +1384,6 @@ static void EDIT_UnlockBuffer(EDITSTATE *es, BOOL force)
 		ERR("es->text == 0 ... please report\n");
 		return;
 	}
-
 	if (force || (es->lock_count == 1)) {
 	    if (es->hloc32W) {
 		UINT countA = 0;
@@ -1505,7 +1507,7 @@ static void EDIT_UpdateTextRegion(EDITSTATE *es, HRGN hrgn, BOOL bErase)
         es->flags &= ~EF_UPDATE;
         if (!notify_parent(es, EN_UPDATE)) return;
     }
-    InvalidateRgn(es->hwndSelf, hrgn, bErase);
+    NtUserInvalidateRgn(es->hwndSelf, hrgn, bErase);
 }
 
 
@@ -1520,7 +1522,7 @@ static void EDIT_UpdateText(EDITSTATE *es, const RECT *rc, BOOL bErase)
         es->flags &= ~EF_UPDATE;
         if (!notify_parent(es, EN_UPDATE)) return;
     }
-    InvalidateRect(es->hwndSelf, rc, bErase);
+    NtUserInvalidateRect(es->hwndSelf, rc, bErase);
 }
 
 /*********************************************************************
@@ -1719,11 +1721,15 @@ static void EDIT_UpdateScrollInfo(EDITSTATE *es)
 	si.fMask	= SIF_PAGE | SIF_POS | SIF_RANGE | SIF_DISABLENOSCROLL;
 	si.nMin		= 0;
 	si.nMax		= es->line_count - 1;
-	si.nPage	= (es->format_rect.bottom - es->format_rect.top) / es->line_height;
+	si.nPage	= es->line_height ? (es->format_rect.bottom - es->format_rect.top) / es->line_height : 0;
 	si.nPos		= es->y_offset;
 	TRACE("SB_VERT, nMin=%d, nMax=%d, nPage=%d, nPos=%d\n",
 		si.nMin, si.nMax, si.nPage, si.nPos);
+#ifdef __REACTOS__
 	SetScrollInfo(es->hwndSelf, SB_VERT, &si, TRUE);
+#else
+	NtUserSetScrollInfo(es->hwndSelf, SB_VERT, &si, TRUE);
+#endif
     }
 
     if ((es->style & WS_HSCROLL) && !(es->flags & EF_HSCROLL_TRACK))
@@ -1737,7 +1743,11 @@ static void EDIT_UpdateScrollInfo(EDITSTATE *es)
 	si.nPos		= es->x_offset;
 	TRACE("SB_HORZ, nMin=%d, nMax=%d, nPage=%d, nPos=%d\n",
 		si.nMin, si.nMax, si.nPage, si.nPos);
+#ifdef __REACTOS__
 	SetScrollInfo(es->hwndSelf, SB_HORZ, &si, TRUE);
+#else
+	NtUserSetScrollInfo(es->hwndSelf, SB_HORZ, &si, TRUE);
+#endif
     }
 }
 
@@ -1755,8 +1765,12 @@ static BOOL EDIT_EM_LineScroll_internal(EDITSTATE *es, INT dx, INT dy)
 {
 	INT nyoff;
 	INT x_offset_in_pixels;
-	INT lines_per_page = (es->format_rect.bottom - es->format_rect.top) /
-			      es->line_height;
+	INT lines_per_page;
+
+	if (!es->line_height || !es->char_width)
+		return TRUE;
+
+	lines_per_page = (es->format_rect.bottom - es->format_rect.top) / es->line_height;
 
 	if (es->style & ES_MULTILINE)
 	{
@@ -1788,8 +1802,8 @@ static BOOL EDIT_EM_LineScroll_internal(EDITSTATE *es, INT dx, INT dy)
 
 		GetClientRect(es->hwndSelf, &rc1);
 		IntersectRect(&rc, &rc1, &es->format_rect);
-		ScrollWindowEx(es->hwndSelf, -dx, dy,
-				NULL, &rc, NULL, NULL, SW_INVALIDATE);
+                NtUserScrollWindowEx(es->hwndSelf, -dx, dy,
+                                     NULL, &rc, NULL, NULL, SW_INVALIDATE);
 		/* force scroll info update */
 		EDIT_UpdateScrollInfo(es);
 	}
@@ -1867,7 +1881,6 @@ static LRESULT EDIT_EM_Scroll(EDITSTATE *es, INT action)
 	return (LRESULT)FALSE;
 }
 
-
 #ifdef __REACTOS__
 static void EDIT_ImmSetCompositionWindow(EDITSTATE *es, POINT pt)
 {
@@ -1894,7 +1907,21 @@ static void EDIT_ImmSetCompositionWindow(EDITSTATE *es, POINT pt)
     ImmSetCompositionWindow(hIMC, &CompForm);
     ImmReleaseContext(es->hwndSelf, hIMC);
 }
+#else
+static void EDIT_UpdateImmCompositionWindow(EDITSTATE *es, UINT x, UINT y)
+{
+    COMPOSITIONFORM form =
+    {
+        .dwStyle = CFS_RECT,
+        .ptCurrentPos = {.x = x, .y = y},
+        .rcArea = es->format_rect,
+    };
+    HIMC himc = ImmGetContext(es->hwndSelf);
+    ImmSetCompositionWindow(himc, &form);
+    ImmReleaseContext(es->hwndSelf, himc);
+}
 #endif
+
 /*********************************************************************
  *
  *	EDIT_SetCaretPos
@@ -1903,7 +1930,11 @@ static void EDIT_ImmSetCompositionWindow(EDITSTATE *es, POINT pt)
 static void EDIT_SetCaretPos(EDITSTATE *es, INT pos,
 			     BOOL after_wrap)
 {
-	LRESULT res = EDIT_EM_PosFromChar(es, pos, after_wrap);
+	LRESULT res;
+
+	if (es->flags & EF_FOCUSED)
+	{
+		res = EDIT_EM_PosFromChar(es, pos, after_wrap);
 #ifdef __REACTOS__
     HKL hKL = GetKeyboardLayout(0);
     POINT pt = { (short)LOWORD(res), (short)HIWORD(res) };
@@ -1917,9 +1948,11 @@ static void EDIT_SetCaretPos(EDITSTATE *es, INT pos,
     if (ImmIsIME(hKL))
         EDIT_ImmSetCompositionWindow(es, pt);
 #else
-	TRACE("%d - %dx%d\n", pos, (short)LOWORD(res), (short)HIWORD(res));
-	SetCaretPos((short)LOWORD(res), (short)HIWORD(res));
+		TRACE("%d - %dx%d\n", pos, (short)LOWORD(res), (short)HIWORD(res));
+		NtUserSetCaretPos((short)LOWORD(res), (short)HIWORD(res));
+		EDIT_UpdateImmCompositionWindow(es, (short)LOWORD(res), (short)HIWORD(res));
 #endif
+	}
 }
 
 
@@ -1988,7 +2021,6 @@ static void EDIT_EM_ScrollCaret(EDITSTATE *es)
 		}
 	}
 
-    if(es->flags & EF_FOCUSED)
 	EDIT_SetCaretPos(es, es->selection_end, es->flags & EF_AFTER_WRAP);
 }
 
@@ -2260,9 +2292,6 @@ static INT EDIT_PaintText(EDITSTATE *es, HDC dc, INT x, INT y, INT line, INT col
 {
 	COLORREF BkColor;
 	COLORREF TextColor;
-	LOGFONTW underline_font;
-	HFONT hUnderline = 0;
-	HFONT old_font = 0;
 	INT ret;
 	INT li;
 	INT BkMode;
@@ -2274,24 +2303,9 @@ static INT EDIT_PaintText(EDITSTATE *es, HDC dc, INT x, INT y, INT line, INT col
 	BkColor = GetBkColor(dc);
 	TextColor = GetTextColor(dc);
 	if (rev) {
-#ifdef __REACTOS__
-            if (TRUE)
-#else
-	        if (es->composition_len == 0)
-#endif
-	        {
-			SetBkColor(dc, GetSysColor(COLOR_HIGHLIGHT));
-			SetTextColor(dc, GetSysColor(COLOR_HIGHLIGHTTEXT));
-			SetBkMode( dc, OPAQUE);
-	        }
-		else
-		{
-			HFONT current = GetCurrentObject(dc,OBJ_FONT);
-			GetObjectW(current,sizeof(LOGFONTW),&underline_font);
-			underline_font.lfUnderline = TRUE;
-	            	hUnderline = CreateFontIndirectW(&underline_font);
-			old_font = SelectObject(dc,hUnderline);
-	        }
+		SetBkColor(dc, GetSysColor(COLOR_HIGHLIGHT));
+		SetTextColor(dc, GetSysColor(COLOR_HIGHLIGHTTEXT));
+		SetBkMode(dc, OPAQUE);
 	}
 	li = EDIT_EM_LineIndex(es, line);
 	if (es->style & ES_MULTILINE) {
@@ -2303,23 +2317,9 @@ static INT EDIT_PaintText(EDITSTATE *es, HDC dc, INT x, INT y, INT line, INT col
 		ret = size.cx;
 	}
 	if (rev) {
-#ifdef __REACTOS__
-        if (TRUE)
-#else
-		if (es->composition_len == 0)
-#endif
-		{
-			SetBkColor(dc, BkColor);
-			SetTextColor(dc, TextColor);
-			SetBkMode( dc, BkMode);
-		}
-		else
-		{
-			if (old_font)
-				SelectObject(dc,old_font);
-			if (hUnderline)
-				DeleteObject(hUnderline);
-	        }
+		SetBkColor(dc, BkColor);
+		SetTextColor(dc, TextColor);
+		SetBkMode(dc, BkMode);
 	}
 	return ret;
 }
@@ -2440,19 +2440,29 @@ static void EDIT_AdjustFormatRect(EDITSTATE *es)
 	    EDIT_UpdateScrollInfo(es);
 	}
 	else
-	/* Windows doesn't care to fix text placement for SL controls */
-		es->format_rect.bottom = es->format_rect.top + es->line_height;
+        {
+            /* Windows doesn't care to fix text placement for SL controls */
+            es->format_rect.bottom = es->format_rect.top + es->line_height;
 
-	/* Always stay within the client area */
-	GetClientRect(es->hwndSelf, &ClientRect);
-	es->format_rect.bottom = min(es->format_rect.bottom, ClientRect.bottom);
+            /* Always stay within the client area */
+            GetClientRect(es->hwndSelf, &ClientRect);
+            es->format_rect.bottom = min(es->format_rect.bottom, ClientRect.bottom);
+        }
 
 	if ((es->style & ES_MULTILINE) && !(es->style & ES_AUTOHSCROLL))
 		EDIT_BuildLineDefs_ML(es, 0, get_text_length(es), 0, NULL);
-	
+
 	EDIT_SetCaretPos(es, es->selection_end, es->flags & EF_AFTER_WRAP);
 }
 
+static int EDIT_is_valid_format_rect(const EDITSTATE *es, const RECT *rc)
+{
+    if (IsRectEmpty(rc))
+        return 0;
+    if (es->text_width > (rc->right - rc->left) || (es->line_height * es->line_count) > (rc->bottom - rc->top))
+        return 0;
+    return 1;
+}
 
 /*********************************************************************
  *
@@ -2466,14 +2476,26 @@ static void EDIT_SetRectNP(EDITSTATE *es, const RECT *rc)
 {
 	LONG_PTR ExStyle;
 	INT bw, bh;
+        BOOL too_large = FALSE;
+        RECT edit_rect;
+
 	ExStyle = GetWindowLongPtrW(es->hwndSelf, GWL_EXSTYLE);
-	
-	CopyRect(&es->format_rect, rc);
-	
-	if (ExStyle & WS_EX_CLIENTEDGE) {
+
+        if (EDIT_is_valid_format_rect(es, rc))
+        {
+            CopyRect(&es->format_rect, rc);
+            GetClientRect(es->hwndSelf, &edit_rect);
+            too_large = (rc->bottom - rc->top) > (edit_rect.bottom - edit_rect.top);
+        }
+        else
+        {
+            GetClientRect(es->hwndSelf, &es->format_rect);
+        }
+
+        if (ExStyle & WS_EX_CLIENTEDGE && !too_large) {
 		es->format_rect.left++;
 		es->format_rect.right--;
-		
+
 		if (es->format_rect.bottom - es->format_rect.top
 		    >= es->line_height + 2)
 		{
@@ -2493,7 +2515,7 @@ static void EDIT_SetRectNP(EDITSTATE *es, const RECT *rc)
 		    es->format_rect.bottom -= bh;
 		}
 	}
-	
+
 	es->format_rect.left += es->left_margin;
 	es->format_rect.right -= es->right_margin;
 	EDIT_AdjustFormatRect(es);
@@ -2533,11 +2555,11 @@ static LRESULT EDIT_EM_CharFromPos(EDITSTATE *es, INT x, INT y)
  *	EM_FMTLINES
  *
  * Enable or disable soft breaks.
- * 
+ *
  * This means: insert or remove the soft linebreak character (\r\r\n).
  * Take care to check if the text still fits the buffer after insertion.
  * If not, notify with EN_ERRSPACE.
- * 
+ *
  */
 static BOOL EDIT_EM_FmtLines(EDITSTATE *es, BOOL add_eol)
 {
@@ -2596,7 +2618,7 @@ static HLOCAL EDIT_EM_GetHandle(EDITSTATE *es)
         /* The text buffer handle belongs to the app */
         es->hlocapp = hLocal;
 
-	TRACE("Returning %p, LocalSize() = %ld\n", hLocal, LocalSize(hLocal));
+	TRACE("Returning %p, LocalSize() = %Id\n", hLocal, LocalSize(hLocal));
 	return hLocal;
 }
 
@@ -2673,9 +2695,9 @@ static LRESULT EDIT_EM_GetSel(const EDITSTATE *es, PUINT start, PUINT end)
  *	FIXME: handle ES_NUMBER and ES_OEMCONVERT here
  *
  */
-static void EDIT_EM_ReplaceSel(EDITSTATE *es, BOOL can_undo, LPCWSTR lpsz_replace, BOOL send_update, BOOL honor_limit)
+static void EDIT_EM_ReplaceSel(EDITSTATE *es, BOOL can_undo, const WCHAR *lpsz_replace, UINT strl,
+                               BOOL send_update, BOOL honor_limit)
 {
-	UINT strl = strlenW(lpsz_replace);
 	UINT tl = get_text_length(es);
 	UINT utl;
 	UINT s;
@@ -2688,7 +2710,7 @@ static void EDIT_EM_ReplaceSel(EDITSTATE *es, BOOL can_undo, LPCWSTR lpsz_replac
 	UINT bufl;
 
 	TRACE("%s, can_undo %d, send_update %d\n",
-	    debugstr_w(lpsz_replace), can_undo, send_update);
+	    debugstr_wn(lpsz_replace, strl), can_undo, send_update);
 
 	s = es->selection_start;
 	e = es->selection_end;
@@ -2727,7 +2749,7 @@ static void EDIT_EM_ReplaceSel(EDITSTATE *es, BOOL can_undo, LPCWSTR lpsz_replac
 		memcpy(buf, es->text + s, bufl * sizeof(WCHAR));
 		buf[bufl] = 0; /* ensure 0 termination */
 		/* now delete */
-		strcpyW(es->text + s, es->text + e);
+		lstrcpyW(es->text + s, es->text + e);
                 text_buffer_changed(es);
 	}
 	if (strl) {
@@ -2755,12 +2777,12 @@ static void EDIT_EM_ReplaceSel(EDITSTATE *es, BOOL can_undo, LPCWSTR lpsz_replac
 		/* if text is too long undo all changes */
 		if (honor_limit && !(es->style & ES_AUTOVSCROLL) && (es->line_count > vlc)) {
 			if (strl)
-				strcpyW(es->text + e, es->text + e + strl);
+				lstrcpyW(es->text + e, es->text + e + strl);
 			if (e != s)
 				for (i = 0 , p = es->text ; i < e - s ; i++)
 					p[i + s] = buf[i];
                         text_buffer_changed(es);
-			EDIT_BuildLineDefs_ML(es, s, e, 
+			EDIT_BuildLineDefs_ML(es, s, e,
 				abs(es->selection_end - es->selection_start) - strl, hrgn);
 			strl = 0;
 			e = s;
@@ -2775,7 +2797,7 @@ static void EDIT_EM_ReplaceSel(EDITSTATE *es, BOOL can_undo, LPCWSTR lpsz_replac
 		/* remove chars that don't fit */
 		if (honor_limit && !(es->style & ES_AUTOHSCROLL) && (es->text_width > fw)) {
 			while ((es->text_width > fw) && s + strl >= s) {
-				strcpyW(es->text + s + strl - 1, es->text + s + strl);
+				lstrcpyW(es->text + s + strl - 1, es->text + s + strl);
 				strl--;
 				es->text_length = -1;
 				EDIT_InvalidateUniscribeData(es);
@@ -2785,10 +2807,10 @@ static void EDIT_EM_ReplaceSel(EDITSTATE *es, BOOL can_undo, LPCWSTR lpsz_replac
 			if (!notify_parent(es, EN_MAXTEXT)) return;
 		}
 	}
-	
+
 	if (e != s) {
 		if (can_undo) {
-			utl = strlenW(es->undo_text);
+			utl = lstrlenW(es->undo_text);
 			if (!es->undo_insert_count && (*es->undo_text && (s == es->undo_position))) {
 				/* undo-buffer is extended to the right */
 				EDIT_MakeUndoFit(es, utl + e - s);
@@ -2836,7 +2858,7 @@ static void EDIT_EM_ReplaceSel(EDITSTATE *es, BOOL can_undo, LPCWSTR lpsz_replac
 	}
 
 	HeapFree(GetProcessHeap(), 0, buf);
- 
+
 	s += strl;
 
 	/* If text has been deleted and we're right or center aligned then scroll rightward */
@@ -2972,6 +2994,40 @@ static void EDIT_EM_SetLimitText(EDITSTATE *es, UINT limit)
     es->buffer_limit = limit;
 }
 
+static BOOL is_cjk_charset(HDC dc)
+{
+    switch (GdiGetCodePage(dc)) {
+    case 932: case 936: case 949: case 950: case 1361:
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
+static BOOL is_cjk_font(HDC dc)
+{
+    const DWORD FS_DBCS_MASK = FS_JISJAPAN|FS_CHINESESIMP|FS_WANSUNG|FS_CHINESETRAD|FS_JOHAB;
+    FONTSIGNATURE fs;
+    return (GetTextCharsetInfo(dc, &fs, 0) != DEFAULT_CHARSET &&
+            (fs.fsCsb[0] & FS_DBCS_MASK));
+}
+
+static int get_cjk_fontinfo_margin(int width, int side_bearing)
+{
+    int margin;
+    if (side_bearing < 0)
+        margin = min(-side_bearing, width/2);
+    else
+        margin = 0;
+    return margin;
+}
+
+struct char_width_info {
+    INT min_lsb, min_rsb, unknown;
+};
+
+/* Undocumented gdi32 export */
+extern BOOL WINAPI GetCharWidthInfo(HDC, struct char_width_info *);
 
 /*********************************************************************
  *
@@ -2981,26 +3037,10 @@ static void EDIT_EM_SetLimitText(EDITSTATE *es, UINT limit)
  * action wParam despite what the docs say. EC_USEFONTINFO calculates the
  * margin according to the textmetrics of the current font.
  *
- * When EC_USEFONTINFO is used in the non_cjk case the margins only
- * change if the edit control is equal to or larger than a certain
- * size.  Though there is an exception for the empty client rect case
- * with small font sizes.
+ * When EC_USEFONTINFO is used, the margins only change if the edit control is
+ * equal to or larger than a certain size. The empty client rect is treated as
+ * 80 pixels width.
  */
-static BOOL is_cjk(UINT charset)
-{
-    switch(charset)
-    {
-    case SHIFTJIS_CHARSET:
-    case HANGUL_CHARSET:
-    case GB2312_CHARSET:
-    case CHINESEBIG5_CHARSET:
-        return TRUE;
-    }
-    /* HANGUL_CHARSET is strange, though treated as CJK by Win 8, it is
-     * not by other versions including Win 10. */
-    return FALSE;
-}
-
 static void EDIT_EM_SetMargins(EDITSTATE *es, INT action,
 			       WORD left, WORD right, BOOL repaint)
 {
@@ -3010,31 +3050,36 @@ static void EDIT_EM_SetMargins(EDITSTATE *es, INT action,
 
         /* Set the default margins depending on the font */
         if (es->font && (left == EC_USEFONTINFO || right == EC_USEFONTINFO)) {
-            HDC dc = GetDC(es->hwndSelf);
+            HDC dc = NtUserGetDC(es->hwndSelf);
             HFONT old_font = SelectObject(dc, es->font);
-            LONG width = GdiGetCharDimensions(dc, &tm, NULL);
+            LONG width = GdiGetCharDimensions(dc, &tm, NULL), rc_width;
             RECT rc;
 
             /* The default margins are only non zero for TrueType or Vector fonts */
             if (tm.tmPitchAndFamily & ( TMPF_VECTOR | TMPF_TRUETYPE )) {
-                if (!is_cjk(tm.tmCharSet)) {
-                    default_left_margin = width / 2;
-                    default_right_margin = width / 2;
+                struct char_width_info width_info;
 
-                    GetClientRect(es->hwndSelf, &rc);
-                    if (rc.right - rc.left < (width / 2 + width) * 2 &&
-                        (width >= 28 || !IsRectEmpty(&rc)) ) {
-                        default_left_margin = es->left_margin;
-                        default_right_margin = es->right_margin;
-                    }
-                } else {
-                    /* FIXME: figure out the CJK values. They are not affected by the client rect. */
+                if ((is_cjk_charset(dc) || is_cjk_font(dc)) &&
+                    GetCharWidthInfo(dc, &width_info))
+                {
+                    default_left_margin = get_cjk_fontinfo_margin(width, width_info.min_lsb);
+                    default_right_margin = get_cjk_fontinfo_margin(width, width_info.min_rsb);
+                }
+                else
+                {
                     default_left_margin = width / 2;
                     default_right_margin = width / 2;
                 }
+
+                GetClientRect(es->hwndSelf, &rc);
+                rc_width = !IsRectEmpty(&rc) ? rc.right - rc.left : 80;
+                if (rc_width < default_left_margin + default_right_margin + width * 2) {
+                    default_left_margin = es->left_margin;
+                    default_right_margin = es->right_margin;
+                }
             }
             SelectObject(dc, old_font);
-            ReleaseDC(es->hwndSelf, dc);
+            NtUserReleaseDC( es->hwndSelf, dc );
         }
 
 	if (action & EC_LEFTMARGIN) {
@@ -3054,12 +3099,12 @@ static void EDIT_EM_SetMargins(EDITSTATE *es, INT action,
 			es->right_margin = default_right_margin;
 		es->format_rect.right -= es->right_margin;
 	}
-	
+
 	if (action & (EC_LEFTMARGIN | EC_RIGHTMARGIN)) {
 		EDIT_AdjustFormatRect(es);
 		if (repaint) EDIT_UpdateText(es, NULL, TRUE);
 	}
-	
+
 	TRACE("left=%d, right=%d\n", es->left_margin, es->right_margin);
 }
 
@@ -3069,15 +3114,12 @@ static void EDIT_EM_SetMargins(EDITSTATE *es, INT action,
  *	EM_SETPASSWORDCHAR
  *
  */
-static void EDIT_EM_SetPasswordChar(EDITSTATE *es, WCHAR c)
+static BOOL EDIT_EM_SetPasswordChar(EDITSTATE *es, WCHAR c)
 {
 	LONG style;
 
-	if (es->style & ES_MULTILINE)
-		return;
-
 	if (es->password_char == c)
-		return;
+		return TRUE;
 
         style = GetWindowLongW( es->hwndSelf, GWL_STYLE );
 	es->password_char = c;
@@ -3090,6 +3132,7 @@ static void EDIT_EM_SetPasswordChar(EDITSTATE *es, WCHAR c)
 	}
 	EDIT_InvalidateUniscribeData(es);
 	EDIT_UpdateText(es, NULL, TRUE);
+	return TRUE;
 }
 
 
@@ -3157,23 +3200,23 @@ static BOOL EDIT_EM_Undo(EDITSTATE *es)
 	if( es->style & ES_READONLY )
             return !(es->style & ES_MULTILINE);
 
-	ulength = strlenW(es->undo_text);
+	ulength = lstrlenW(es->undo_text);
 
 	utext = HeapAlloc(GetProcessHeap(), 0, (ulength + 1) * sizeof(WCHAR));
 #ifdef __REACTOS__
 	/* ReactOS r33503 */
-	if (utext == NULL) 
+	if (utext == NULL)
 		return FALSE;
 #endif
 
-	strcpyW(utext, es->undo_text);
+	lstrcpyW(utext, es->undo_text);
 
 	TRACE("before UNDO:insertion length = %d, deletion buffer = %s\n",
 		     es->undo_insert_count, debugstr_w(utext));
 
 	EDIT_EM_SetSel(es, es->undo_position, es->undo_position + es->undo_insert_count, FALSE);
 	EDIT_EM_EmptyUndoBuffer(es);
-	EDIT_EM_ReplaceSel(es, TRUE, utext, TRUE, TRUE);
+	EDIT_EM_ReplaceSel(es, TRUE, utext, ulength, TRUE, TRUE);
 	EDIT_EM_SetSel(es, es->undo_position, es->undo_position + es->undo_insert_count, FALSE);
         /* send the notification after the selection start and end are set */
         if (!notify_parent(es, EN_CHANGE)) return TRUE;
@@ -3207,7 +3250,8 @@ static inline BOOL EDIT_IsInsideDialog(EDITSTATE *es)
 static void EDIT_WM_Paste(EDITSTATE *es)
 {
 	HGLOBAL hsrc;
-	LPWSTR src;
+	LPWSTR src, ptr;
+	int len;
 
 	/* Protect read-only edit control from modification */
 	if(es->style & ES_READONLY)
@@ -3216,14 +3260,21 @@ static void EDIT_WM_Paste(EDITSTATE *es)
 	OpenClipboard(es->hwndSelf);
 	if ((hsrc = GetClipboardData(CF_UNICODETEXT))) {
 		src = GlobalLock(hsrc);
-		EDIT_EM_ReplaceSel(es, TRUE, src, TRUE, TRUE);
+                len = lstrlenW(src);
+		/* Protect single-line edit against pasting new line character */
+		if (!(es->style & ES_MULTILINE) && ((ptr = wcschr(src, '\n')))) {
+			len = ptr - src;
+			if (len && src[len - 1] == '\r')
+				--len;
+		}
+                EDIT_EM_ReplaceSel(es, TRUE, src, len, TRUE, TRUE);
 		GlobalUnlock(hsrc);
 	}
         else if (es->style & ES_PASSWORD) {
             /* clear selected text in password edit box even with empty clipboard */
-            EDIT_EM_ReplaceSel(es, TRUE, empty_stringW, TRUE, TRUE);
+            EDIT_EM_ReplaceSel(es, TRUE, NULL, 0, TRUE, TRUE);
         }
-	CloseClipboard();
+	NtUserCloseClipboard();
 }
 
 
@@ -3250,9 +3301,9 @@ static void EDIT_WM_Copy(EDITSTATE *es)
 	TRACE("%s\n", debugstr_w(dst));
 	GlobalUnlock(hdst);
 	OpenClipboard(es->hwndSelf);
-	EmptyClipboard();
+	NtUserEmptyClipboard();
 	SetClipboardData(CF_UNICODETEXT, hdst);
-	CloseClipboard();
+	NtUserCloseClipboard();
 }
 
 
@@ -3267,7 +3318,7 @@ static inline void EDIT_WM_Clear(EDITSTATE *es)
 	if(es->style & ES_READONLY)
 	    return;
 
-	EDIT_EM_ReplaceSel(es, TRUE, empty_stringW, TRUE, TRUE);
+	EDIT_EM_ReplaceSel(es, TRUE, NULL, 0, TRUE, TRUE);
 }
 
 
@@ -3292,12 +3343,11 @@ static LRESULT EDIT_WM_Char(EDITSTATE *es, WCHAR c)
 {
         BOOL control;
 
-#ifdef __REACTOS__
-	if (es->bCaptureState)
-		return 0;
-#endif
 
-	control = GetKeyState(VK_CONTROL) & 0x8000;
+	if (es->bCaptureState)
+		return 1;
+
+	control = NtUserGetKeyState(VK_CONTROL) & 0x8000;
 
 	switch (c) {
 	case '\r':
@@ -3314,18 +3364,16 @@ static LRESULT EDIT_WM_Char(EDITSTATE *es, WCHAR c)
 				EDIT_MoveHome(es, FALSE, FALSE);
 				EDIT_MoveDown_ML(es, FALSE);
 			} else {
-				static const WCHAR cr_lfW[] = {'\r','\n',0};
-				EDIT_EM_ReplaceSel(es, TRUE, cr_lfW, TRUE, TRUE);
+				EDIT_EM_ReplaceSel(es, TRUE, L"\r\n", 2, TRUE, TRUE);
 			}
 		}
 		break;
 	case '\t':
 		if ((es->style & ES_MULTILINE) && !(es->style & ES_READONLY))
 		{
-			static const WCHAR tabW[] = {'\t',0};
                         if (EDIT_IsInsideDialog(es))
                             break;
-			EDIT_EM_ReplaceSel(es, TRUE, tabW, TRUE, TRUE);
+			EDIT_EM_ReplaceSel(es, TRUE, L"\t", 1, TRUE, TRUE);
 		}
 		break;
 	case VK_BACK:
@@ -3361,13 +3409,9 @@ static LRESULT EDIT_WM_Char(EDITSTATE *es, WCHAR c)
 		/*If Edit control style is ES_NUMBER allow users to key in only numeric values*/
 		if( (es->style & ES_NUMBER) && !( c >= '0' && c <= '9') )
 			break;
-			
-		if (!(es->style & ES_READONLY) && (c >= ' ') && (c != 127)) {
-			WCHAR str[2];
- 			str[0] = c;
- 			str[1] = '\0';
- 			EDIT_EM_ReplaceSel(es, TRUE, str, TRUE, TRUE);
- 		}
+
+		if (!(es->style & ES_READONLY) && (c >= ' ') && (c != 127))
+ 			EDIT_EM_ReplaceSel(es, TRUE, &c, 1, TRUE, TRUE);
 		break;
 	}
     return 1;
@@ -3429,40 +3473,56 @@ static void EDIT_WM_ContextMenu(EDITSTATE *es, INT x, INT y)
 	HMENU popup = GetSubMenu(menu, 0);
 	UINT start = es->selection_start;
 	UINT end = es->selection_end;
+        BOOL enabled;
 	UINT cmd;
 
 	ORDER_UINT(start, end);
 
-	/* undo */
-	EnableMenuItem(popup, 0, MF_BYPOSITION | (EDIT_EM_CanUndo(es) && !(es->style & ES_READONLY) ? MF_ENABLED : MF_GRAYED));
-	/* cut */
-	EnableMenuItem(popup, 2, MF_BYPOSITION | ((end - start) && !(es->style & ES_PASSWORD) && !(es->style & ES_READONLY) ? MF_ENABLED : MF_GRAYED));
-	/* copy */
-	EnableMenuItem(popup, 3, MF_BYPOSITION | ((end - start) && !(es->style & ES_PASSWORD) ? MF_ENABLED : MF_GRAYED));
-	/* paste */
-	EnableMenuItem(popup, 4, MF_BYPOSITION | (IsClipboardFormatAvailable(CF_UNICODETEXT) && !(es->style & ES_READONLY) ? MF_ENABLED : MF_GRAYED));
-	/* delete */
-	EnableMenuItem(popup, 5, MF_BYPOSITION | ((end - start) && !(es->style & ES_READONLY) ? MF_ENABLED : MF_GRAYED));
-	/* select all */
-	EnableMenuItem(popup, 7, MF_BYPOSITION | (start || (end != get_text_length(es)) ? MF_ENABLED : MF_GRAYED));
+        /* undo */
+        enabled = EDIT_EM_CanUndo(es) && !(es->style & ES_READONLY);
+        NtUserEnableMenuItem( popup, 0, MF_BYPOSITION | (enabled ? MF_ENABLED : MF_GRAYED) );
+        /* cut */
+        enabled = (end - start) && !(es->style & ES_PASSWORD) && !(es->style & ES_READONLY);
+        NtUserEnableMenuItem( popup, 2, MF_BYPOSITION | (enabled ? MF_ENABLED : MF_GRAYED) );
+        /* copy */
+        enabled = (end - start) && !(es->style & ES_PASSWORD);
+        NtUserEnableMenuItem( popup, 3, MF_BYPOSITION | (enabled ? MF_ENABLED : MF_GRAYED) );
+        /* paste */
+        enabled = NtUserIsClipboardFormatAvailable(CF_UNICODETEXT) && !(es->style & ES_READONLY);
+        NtUserEnableMenuItem( popup, 4, MF_BYPOSITION | (enabled ? MF_ENABLED : MF_GRAYED) );
+        /* delete */
+        enabled = (end - start) && !(es->style & ES_READONLY);
+        NtUserEnableMenuItem( popup, 5, MF_BYPOSITION | (enabled ? MF_ENABLED : MF_GRAYED) );
+        /* select all */
+        enabled = start || end != get_text_length(es);
+        NtUserEnableMenuItem( popup, 7, MF_BYPOSITION | (enabled ? MF_ENABLED : MF_GRAYED) );
 
         if (x == -1 && y == -1) /* passed via VK_APPS press/release */
         {
+#ifdef __REACTOS__ /* Should be dropped */
             RECT rc;
-            /* Windows places the menu at the edit's center in this case */
-#ifdef __REACTOS__
-            /* ReactOS r55202 */
+
+            /* ReactOS r29811 */
             GetClientRect(es->hwndSelf, &rc);
             MapWindowPoints(es->hwndSelf, 0, (POINT *)&rc, 2);
-#else
-            WIN_GetRectangles( es->hwndSelf, COORDS_SCREEN, NULL, &rc );
-#endif
             x = rc.left + (rc.right - rc.left) / 2;
             y = rc.top + (rc.bottom - rc.top) / 2;
+#else
+            POINT pt;
+            RECT rc;
+
+            /* Windows places the menu at the edit's center in this case */
+            GetClientRect( es->hwndSelf, &rc );
+            pt.x = rc.right / 2;
+            pt.y = rc.bottom / 2;
+            ClientToScreen( es->hwndSelf, &pt );
+            x = pt.x;
+            y = pt.y;
+#endif
         }
 
 	if (!(es->flags & EF_FOCUSED))
-            SetFocus(es->hwndSelf);
+            NtUserSetFocus(es->hwndSelf);
 
 	cmd = TrackPopupMenu(popup, TPM_LEFTALIGN | TPM_RIGHTBUTTON | TPM_RETURNCMD | TPM_NONOTIFY,
 			     x, y, 0, es->hwndSelf, NULL);
@@ -3470,7 +3530,7 @@ static void EDIT_WM_ContextMenu(EDITSTATE *es, INT x, INT y)
 	if (cmd)
 	    EDIT_ContextMenuCommand(es, cmd);
 
-	DestroyMenu(menu);
+        NtUserDestroyMenu(menu);
 }
 
 
@@ -3486,7 +3546,7 @@ static INT EDIT_WM_GetText(const EDITSTATE *es, INT count, LPWSTR dst, BOOL unic
     if(unicode)
     {
 	lstrcpynW(dst, es->text, count);
-	return strlenW(dst);
+	return lstrlenW(dst);
     }
     else
     {
@@ -3569,11 +3629,14 @@ static LRESULT EDIT_WM_KeyDown(EDITSTATE *es, INT key)
 	BOOL shift;
 	BOOL control;
 
-	if (GetKeyState(VK_MENU) & 0x8000)
+	if (es->bCaptureState)
+		return 1;
+
+	if (NtUserGetKeyState(VK_MENU) & 0x8000)
 		return 0;
 
-	shift = GetKeyState(VK_SHIFT) & 0x8000;
-	control = GetKeyState(VK_CONTROL) & 0x8000;
+	shift = NtUserGetKeyState(VK_SHIFT) & 0x8000;
+	control = NtUserGetKeyState(VK_CONTROL) & 0x8000;
 
 	switch (key) {
 	case VK_F4:
@@ -3629,22 +3692,17 @@ static LRESULT EDIT_WM_KeyDown(EDITSTATE *es, INT key)
 				else
 					EDIT_WM_Clear(es);
 			} else {
-				if (shift) {
+				EDIT_EM_SetSel(es, ~0u, 0, FALSE);
+				if (shift)
 					/* delete character left of caret */
-					EDIT_EM_SetSel(es, (UINT)-1, 0, FALSE);
 					EDIT_MoveBackward(es, TRUE);
-					EDIT_WM_Clear(es);
-				} else if (control) {
+				else if (control)
 					/* delete to end of line */
-					EDIT_EM_SetSel(es, (UINT)-1, 0, FALSE);
 					EDIT_MoveEnd(es, TRUE, FALSE);
-					EDIT_WM_Clear(es);
-				} else {
+				else
 					/* delete character right of caret */
-					EDIT_EM_SetSel(es, (UINT)-1, 0, FALSE);
 					EDIT_MoveForward(es, TRUE);
-					EDIT_WM_Clear(es);
-				}
+				EDIT_WM_Clear(es);
 			}
 		}
 		break;
@@ -3727,12 +3785,12 @@ static LRESULT EDIT_WM_KillFocus(EDITSTATE *es)
 	}
 #else
         es->flags &= ~EF_FOCUSED;
-        DestroyCaret();
-        if(!(es->style & ES_NOHIDESEL))
-                EDIT_InvalidateText(es, es->selection_start, es->selection_end);
-        if (!notify_parent(es, EN_KILLFOCUS)) return 0;
-        /* throw away left over scroll when we lose focus */
-        es->wheelDeltaRemainder = 0;
+        NtUserDestroyCaret();
+	if(!(es->style & ES_NOHIDESEL))
+		EDIT_InvalidateText(es, es->selection_start, es->selection_end);
+	if (!notify_parent(es, EN_KILLFOCUS)) return 0;
+	/* throw away left over scroll when we lose focus */
+	es->wheelDeltaRemainder = 0;
 #endif
         return 0;
 }
@@ -3754,7 +3812,7 @@ static LRESULT EDIT_WM_LButtonDblClk(EDITSTATE *es)
 	INT ll;
 
 	es->bCaptureState = TRUE;
-	SetCapture(es->hwndSelf);
+	NtUserSetCapture(es->hwndSelf);
 
 	l = EDIT_EM_LineFromChar(es, e);
 	li = EDIT_EM_LineIndex(es, l);
@@ -3763,8 +3821,6 @@ static LRESULT EDIT_WM_LButtonDblClk(EDITSTATE *es)
 	e = li + EDIT_CallWordBreakProc(es, li, e - li, ll, WB_RIGHT);
 	EDIT_EM_SetSel(es, s, e, FALSE);
 	EDIT_EM_ScrollCaret(es);
-	es->region_posx = es->region_posy = 0;
-	SetTimer(es->hwndSelf, 0, 100, NULL);
 	return 0;
 }
 
@@ -3780,16 +3836,13 @@ static LRESULT EDIT_WM_LButtonDown(EDITSTATE *es, DWORD keys, INT x, INT y)
 	BOOL after_wrap;
 
 	es->bCaptureState = TRUE;
-	SetCapture(es->hwndSelf);
+	NtUserSetCapture(es->hwndSelf);
 	EDIT_ConfinePoint(es, &x, &y);
 	e = EDIT_CharFromPos(es, x, y, &after_wrap);
 	EDIT_EM_SetSel(es, (keys & MK_SHIFT) ? es->selection_start : e, e, after_wrap);
 	EDIT_EM_ScrollCaret(es);
-	es->region_posx = es->region_posy = 0;
-	SetTimer(es->hwndSelf, 0, 100, NULL);
-
 	if (!(es->flags & EF_FOCUSED))
-            SetFocus(es->hwndSelf);
+            NtUserSetFocus(es->hwndSelf);
 
 	return 0;
 }
@@ -3803,8 +3856,7 @@ static LRESULT EDIT_WM_LButtonDown(EDITSTATE *es, DWORD keys, INT x, INT y)
 static LRESULT EDIT_WM_LButtonUp(EDITSTATE *es)
 {
 	if (es->bCaptureState) {
-		KillTimer(es->hwndSelf, 0);
-		if (GetCapture() == es->hwndSelf) ReleaseCapture();
+		if (GetCapture() == es->hwndSelf) NtUserReleaseCapture();
 	}
 	es->bCaptureState = FALSE;
 	return 0;
@@ -3832,7 +3884,6 @@ static LRESULT EDIT_WM_MouseMove(EDITSTATE *es, INT x, INT y)
 {
 	INT e;
 	BOOL after_wrap;
-	INT prex, prey;
 
         /* If the mouse has been captured by process other than the edit control itself,
          * the windows edit controls will not select the strings with mouse move.
@@ -3840,17 +3891,10 @@ static LRESULT EDIT_WM_MouseMove(EDITSTATE *es, INT x, INT y)
         if (!es->bCaptureState || GetCapture() != es->hwndSelf)
 		return 0;
 
-	/*
-	 *	FIXME: gotta do some scrolling if outside client
-	 *		area.  Maybe reset the timer ?
-	 */
-	prex = x; prey = y;
-	EDIT_ConfinePoint(es, &x, &y);
-	es->region_posx = (prex < x) ? -1 : ((prex > x) ? 1 : 0);
-	es->region_posy = (prey < y) ? -1 : ((prey > y) ? 1 : 0);
 	e = EDIT_CharFromPos(es, x, y, &after_wrap);
 	EDIT_EM_SetSel(es, es->selection_start, e, after_wrap);
 	EDIT_SetCaretPos(es,es->selection_end,es->flags & EF_AFTER_WRAP);
+	EDIT_EM_ScrollCaret(es);
 	return 0;
 }
 
@@ -3876,7 +3920,7 @@ static void EDIT_WM_Paint(EDITSTATE *es, HDC hdc)
 	BOOL rev = es->bEnableState &&
 				((es->flags & EF_FOCUSED) ||
 					(es->style & ES_NOHIDESEL));
-        dc = hdc ? hdc : BeginPaint(es->hwndSelf, &ps);
+        dc = hdc ? hdc : NtUserBeginPaint( es->hwndSelf, &ps );
 
 	/* The dc we use for calculating may not be the one we paint into.
 	   This is the safest action. */
@@ -3888,7 +3932,7 @@ static void EDIT_WM_Paint(EDITSTATE *es, HDC hdc)
 
 	/* paint the border and the background */
 	IntersectClipRect(dc, rcClient.left, rcClient.top, rcClient.right, rcClient.bottom);
-	
+
 	if(es->style & WS_BORDER) {
 		bw = GetSystemMetrics(SM_CXBORDER);
 		bh = GetSystemMetrics(SM_CYBORDER);
@@ -3897,7 +3941,7 @@ static void EDIT_WM_Paint(EDITSTATE *es, HDC hdc)
 			if(es->style & WS_HSCROLL) rc.bottom+=bh;
 			if(es->style & WS_VSCROLL) rc.right+=bw;
 		}
-		
+
 		/* Draw the frame. Same code as in nonclient.c */
 		old_brush = SelectObject(dc, GetSysColorBrush(COLOR_WINDOWFRAME));
 		PatBlt(dc, rc.left, rc.top, rc.right - rc.left, bh, PATCOPY);
@@ -3905,12 +3949,12 @@ static void EDIT_WM_Paint(EDITSTATE *es, HDC hdc)
 		PatBlt(dc, rc.left, rc.bottom - 1, rc.right - rc.left, -bw, PATCOPY);
 		PatBlt(dc, rc.right - 1, rc.top, -bw, rc.bottom - rc.top, PATCOPY);
 		SelectObject(dc, old_brush);
-		
+
 		/* Keep the border clean */
 		IntersectClipRect(dc, rc.left+bw, rc.top+bh,
 		    max(rc.right-bw, rc.left+bw), max(rc.bottom-bh, rc.top+bh));
 	}
-	
+
 	GetClipBox(dc, &rc);
 	FillRect(dc, &rc, brush);
 
@@ -3946,7 +3990,7 @@ static void EDIT_WM_Paint(EDITSTATE *es, HDC hdc)
 		SelectObject(dc, old_font);
 
         if (!hdc)
-            EndPaint(es->hwndSelf, &ps);
+            NtUserEndPaint( es->hwndSelf, &ps );
 }
 
 
@@ -3965,23 +4009,63 @@ static void EDIT_WM_SetFocus(EDITSTATE *es)
         /* single line edit updates itself */
         if (IsWindowVisible(es->hwndSelf) && !(es->style & ES_MULTILINE))
         {
-            HDC hdc = GetDC(es->hwndSelf);
+            HDC hdc = NtUserGetDC(es->hwndSelf);
             EDIT_WM_Paint(es, hdc);
-            ReleaseDC(es->hwndSelf, hdc);
+            NtUserReleaseDC( es->hwndSelf, hdc );
         }
 
 #ifdef __REACTOS__
     SystemParametersInfo(SPI_GETCARETWIDTH, 0, &es->dwCaretWidth, 0);
     CreateCaret(es->hwndSelf, NULL, es->dwCaretWidth, es->line_height);
 #else
-	CreateCaret(es->hwndSelf, 0, 1, es->line_height);
+        NtUserCreateCaret( es->hwndSelf, 0, 1, es->line_height );
 #endif
 	EDIT_SetCaretPos(es, es->selection_end,
 			 es->flags & EF_AFTER_WRAP);
-	ShowCaret(es->hwndSelf);
+        NtUserShowCaret( es->hwndSelf );
 	notify_parent(es, EN_SETFOCUS);
 }
 
+static DWORD get_font_margins(HDC hdc, const TEXTMETRICW *tm, BOOL unicode)
+{
+	ABC abc[256];
+	SHORT left, right;
+	UINT i;
+
+	if (!(tm->tmPitchAndFamily & (TMPF_VECTOR | TMPF_TRUETYPE)))
+		return MAKELONG(EC_USEFONTINFO, EC_USEFONTINFO);
+
+	if (unicode) {
+		if (!is_cjk_charset(hdc) && !is_cjk_font(hdc))
+			return MAKELONG(EC_USEFONTINFO, EC_USEFONTINFO);
+		if (!GetCharABCWidthsW(hdc, 0, 255, abc))
+			return 0;
+	}
+	else if (is_cjk_charset(hdc)) {
+		if (!GetCharABCWidthsA(hdc, 0, 255, abc))
+			return 0;
+	}
+	else
+		return MAKELONG(EC_USEFONTINFO, EC_USEFONTINFO);
+
+	left = right = 0;
+	for (i = 0; i < ARRAY_SIZE(abc); i++) {
+		if (-abc[i].abcA > right) right = -abc[i].abcA;
+		if (-abc[i].abcC > left ) left  = -abc[i].abcC;
+	}
+	return MAKELONG(left, right);
+}
+
+#ifndef __REACTOS__
+static void EDIT_UpdateImmCompositionFont(EDITSTATE *es)
+{
+    LOGFONTW composition_font;
+    HIMC himc = ImmGetContext(es->hwndSelf);
+    GetObjectW(es->font, sizeof(LOGFONTW), &composition_font);
+    ImmSetCompositionFontW(himc, &composition_font);
+    ImmReleaseContext(es->hwndSelf, himc);
+}
+#endif
 
 /*********************************************************************
  *
@@ -3998,24 +4082,27 @@ static void EDIT_WM_SetFont(EDITSTATE *es, HFONT font, BOOL redraw)
 	HDC dc;
 	HFONT old_font = 0;
 	RECT clientRect;
+	DWORD margins;
 
 	es->font = font;
 	EDIT_InvalidateUniscribeData(es);
-	dc = GetDC(es->hwndSelf);
+	dc = NtUserGetDC(es->hwndSelf);
 	if (font)
 		old_font = SelectObject(dc, font);
 	GetTextMetricsW(dc, &tm);
 	es->line_height = tm.tmHeight;
 	es->char_width = tm.tmAveCharWidth;
+	margins = get_font_margins(dc, &tm, es->is_unicode);
 	if (font)
 		SelectObject(dc, old_font);
-	ReleaseDC(es->hwndSelf, dc);
-	
+	NtUserReleaseDC( es->hwndSelf, dc );
+
 	/* Reset the format rect and the margins */
 	GetClientRect(es->hwndSelf, &clientRect);
 	EDIT_SetRectNP(es, &clientRect);
-	EDIT_EM_SetMargins(es, EC_LEFTMARGIN | EC_RIGHTMARGIN,
-			   EC_USEFONTINFO, EC_USEFONTINFO, FALSE);
+	if (margins)
+		EDIT_EM_SetMargins(es, EC_LEFTMARGIN | EC_RIGHTMARGIN,
+				   LOWORD(margins), HIWORD(margins), FALSE);
 
 	if (es->style & ES_MULTILINE)
 		EDIT_BuildLineDefs_ML(es, 0, get_text_length(es), 0, NULL);
@@ -4029,12 +4116,13 @@ static void EDIT_WM_SetFont(EDITSTATE *es, HFONT font, BOOL redraw)
 #ifdef __REACTOS__
 		CreateCaret(es->hwndSelf, NULL, es->dwCaretWidth, es->line_height);
 #else
-		CreateCaret(es->hwndSelf, 0, 1, es->line_height);
+		NtUserCreateCaret( es->hwndSelf, 0, 1, es->line_height );
 #endif
 		EDIT_SetCaretPos(es, es->selection_end,
 				 es->flags & EF_AFTER_WRAP);
-		ShowCaret(es->hwndSelf);
+		NtUserShowCaret( es->hwndSelf );
 	}
+
 #ifdef __REACTOS__
     if (ImmIsIME(GetKeyboardLayout(0)))
     {
@@ -4046,6 +4134,8 @@ static void EDIT_WM_SetFont(EDITSTATE *es, HFONT font, BOOL redraw)
         ImmSetCompositionFontW(hIMC, &lf);
         ImmReleaseContext(es->hwndSelf, hIMC);
     }
+#else
+	EDIT_UpdateImmCompositionFont(es);
 #endif
 }
 
@@ -4081,17 +4171,17 @@ static void EDIT_WM_SetText(EDITSTATE *es, LPCWSTR text, BOOL unicode)
 	    "selection.\n");
 
     EDIT_EM_SetSel(es, 0, (UINT)-1, FALSE);
-    if (text) 
+    if (text)
     {
 	TRACE("%s\n", debugstr_w(text));
-	EDIT_EM_ReplaceSel(es, FALSE, text, FALSE, FALSE);
+	EDIT_EM_ReplaceSel(es, FALSE, text, lstrlenW(text), FALSE, FALSE);
 	if(!unicode)
 	    HeapFree(GetProcessHeap(), 0, textW);
-    } 
-    else 
+    }
+    else
     {
 	TRACE("<NULL>\n");
-	EDIT_EM_ReplaceSel(es, FALSE, empty_stringW, FALSE, FALSE);
+	EDIT_EM_ReplaceSel(es, FALSE, NULL, 0, FALSE, FALSE);
     }
     es->x_offset = 0;
     es->flags &= ~EF_MODIFIED;
@@ -4107,7 +4197,7 @@ static void EDIT_WM_SetText(EDITSTATE *es, LPCWSTR text, BOOL unicode)
         if (!notify_parent(es, EN_CHANGE)) return;
     }
     EDIT_EM_ScrollCaret(es);
-    EDIT_UpdateScrollInfo(es);    
+    EDIT_UpdateScrollInfo(es);
     EDIT_InvalidateUniscribeData(es);
 }
 
@@ -4184,7 +4274,7 @@ static LRESULT  EDIT_WM_StyleChanged ( EDITSTATE *es, WPARAM which, const STYLES
         } else if (GWL_EXSTYLE == which) {
                 ; /* FIXME - what is needed here */
         } else {
-                WARN ("Invalid style change %ld\n",which);
+                WARN ("Invalid style change %Id\n",which);
         }
 
         return 0;
@@ -4206,25 +4296,6 @@ static LRESULT EDIT_WM_SysKeyDown(EDITSTATE *es, INT key, DWORD key_data)
 			return 0;
 	}
 	return DefWindowProcW(es->hwndSelf, WM_SYSKEYDOWN, key, key_data);
-}
-
-
-/*********************************************************************
- *
- *	WM_TIMER
- *
- */
-static void EDIT_WM_Timer(EDITSTATE *es)
-{
-	if (es->region_posx < 0) {
-		EDIT_MoveBackward(es, TRUE);
-	} else if (es->region_posx > 0) {
-		EDIT_MoveForward(es, TRUE);
-	}
-/*
- *	FIXME: gotta do some vertical scrolling here, like
- *		EDIT_EM_LineScroll(hwnd, 0, 1);
- */
 }
 
 /*********************************************************************
@@ -4333,7 +4404,7 @@ static LRESULT EDIT_WM_HScroll(EDITSTATE *es, INT action, INT pos)
 		    INT fw = es->format_rect.right - es->format_rect.left;
 		    ret = es->text_width ? es->x_offset * 100 / (es->text_width - fw) : 0;
 		}
-		TRACE("EM_GETTHUMB: returning %ld\n", ret);
+		TRACE("EM_GETTHUMB: returning %Id\n", ret);
 		return ret;
 	}
 	case EM_LINESCROLL:
@@ -4456,7 +4527,7 @@ static LRESULT EDIT_WM_VScroll(EDITSTATE *es, INT action, INT pos)
 		    INT vlc = get_vertical_line_count(es);
 		    ret = es->line_count ? es->y_offset * 100 / (es->line_count - vlc) : 0;
 		}
-		TRACE("EM_GETTHUMB: returning %ld\n", ret);
+		TRACE("EM_GETTHUMB: returning %Id\n", ret);
 		return ret;
 	}
 	case EM_LINESCROLL:
@@ -4492,81 +4563,9 @@ static LRESULT EDIT_EM_GetThumb(EDITSTATE *es)
 
 
 /********************************************************************
- * 
+ *
  * The Following code is to handle inline editing from IMEs
  */
-
-static void EDIT_GetCompositionStr(HIMC hIMC, LPARAM CompFlag, EDITSTATE *es)
-{
-    LONG buflen;
-    LPWSTR lpCompStr;
-    LPSTR lpCompStrAttr = NULL;
-    DWORD dwBufLenAttr;
-
-    buflen = ImmGetCompositionStringW(hIMC, GCS_COMPSTR, NULL, 0);
-
-    if (buflen < 0)
-    {
-        return;
-    }
-
-    lpCompStr = HeapAlloc(GetProcessHeap(),0,buflen + sizeof(WCHAR));
-    if (!lpCompStr)
-    {
-        ERR("Unable to allocate IME CompositionString\n");
-        return;
-    }
-
-    if (buflen)
-        ImmGetCompositionStringW(hIMC, GCS_COMPSTR, lpCompStr, buflen);
-    lpCompStr[buflen/sizeof(WCHAR)] = 0;
-
-    if (CompFlag & GCS_COMPATTR)
-    {
-        /* 
-         * We do not use the attributes yet. it would tell us what characters
-         * are in transition and which are converted or decided upon
-         */
-        dwBufLenAttr = ImmGetCompositionStringW(hIMC, GCS_COMPATTR, NULL, 0);
-        if (dwBufLenAttr)
-        {
-            dwBufLenAttr ++;
-            lpCompStrAttr = HeapAlloc(GetProcessHeap(),0,dwBufLenAttr+1);
-            if (!lpCompStrAttr)
-            {
-                ERR("Unable to allocate IME Attribute String\n");
-                HeapFree(GetProcessHeap(),0,lpCompStr);
-                return;
-            }
-            ImmGetCompositionStringW(hIMC,GCS_COMPATTR, lpCompStrAttr, 
-                    dwBufLenAttr);
-            lpCompStrAttr[dwBufLenAttr] = 0;
-        }
-    }
-
-#ifndef __REACTOS__ /* We don't use internal composition string. Rely on the composition window */
-    /* check for change in composition start */
-    if (es->selection_end < es->composition_start)
-        es->composition_start = es->selection_end;
-    
-    /* replace existing selection string */
-    es->selection_start = es->composition_start;
-
-    if (es->composition_len > 0)
-        es->selection_end = es->composition_start + es->composition_len;
-    else
-        es->selection_end = es->selection_start;
-
-    EDIT_EM_ReplaceSel(es, FALSE, lpCompStr, TRUE, TRUE);
-    es->composition_len = abs(es->composition_start - es->selection_end);
-
-    es->selection_start = es->composition_start;
-    es->selection_end = es->selection_start + es->composition_len;
-#endif
-
-    HeapFree(GetProcessHeap(),0,lpCompStrAttr);
-    HeapFree(GetProcessHeap(),0,lpCompStr);
-}
 
 static void EDIT_GetResultStr(HIMC hIMC, EDITSTATE *es)
 {
@@ -4579,7 +4578,7 @@ static void EDIT_GetResultStr(HIMC hIMC, EDITSTATE *es)
         return;
     }
 
-    lpResultStr = HeapAlloc(GetProcessHeap(),0, buflen+sizeof(WCHAR));
+    lpResultStr = HeapAlloc(GetProcessHeap(),0, buflen);
     if (!lpResultStr)
     {
         ERR("Unable to alloc buffer for IME string\n");
@@ -4587,60 +4586,21 @@ static void EDIT_GetResultStr(HIMC hIMC, EDITSTATE *es)
     }
 
     ImmGetCompositionStringW(hIMC, GCS_RESULTSTR, lpResultStr, buflen);
-    lpResultStr[buflen/sizeof(WCHAR)] = 0;
-
-#ifndef __REACTOS__
-    /* check for change in composition start */
-    if (es->selection_end < es->composition_start)
-        es->composition_start = es->selection_end;
-
-    es->selection_start = es->composition_start;
-    es->selection_end = es->composition_start + es->composition_len;
-    EDIT_EM_ReplaceSel(es, TRUE, lpResultStr, TRUE, TRUE);
-    es->composition_start = es->selection_end;
-    es->composition_len = 0;
-#endif
-
+    EDIT_EM_ReplaceSel(es, TRUE, lpResultStr, buflen / sizeof(WCHAR), TRUE, TRUE);
     HeapFree(GetProcessHeap(),0,lpResultStr);
 }
 
 static void EDIT_ImeComposition(HWND hwnd, LPARAM CompFlag, EDITSTATE *es)
 {
     HIMC hIMC;
-    int cursor;
-
-#ifdef __REACTOS__
-    if (es->selection_start != es->selection_end)
-        EDIT_EM_ReplaceSel(es, TRUE, empty_stringW, TRUE, TRUE);
-#else
-    if (es->composition_len == 0 && es->selection_start != es->selection_end)
-    {
-        EDIT_EM_ReplaceSel(es, TRUE, empty_stringW, TRUE, TRUE);
-        es->composition_start = es->selection_end;
-    }
-#endif
 
     hIMC = ImmGetContext(hwnd);
     if (!hIMC)
         return;
 
     if (CompFlag & GCS_RESULTSTR)
-    {
         EDIT_GetResultStr(hIMC, es);
-        cursor = 0;
-    }
-    else
-    {
-        if (CompFlag & GCS_COMPSTR)
-            EDIT_GetCompositionStr(hIMC, CompFlag, es);
-#ifdef __REACTOS__
-        cursor = 0;
-#else
-        cursor = ImmGetCompositionStringW(hIMC, GCS_CURSORPOS, 0, 0);
-#endif
-    }
     ImmReleaseContext(hwnd, hIMC);
-    EDIT_SetCaretPos(es, es->selection_start + cursor, es->flags & EF_AFTER_WRAP);
 }
 
 
@@ -4655,12 +4615,12 @@ static LRESULT EDIT_WM_NCCreate(HWND hwnd, LPCREATESTRUCTW lpcs, BOOL unicode)
 	EDITSTATE *es;
 	UINT alloc_size;
 
-	TRACE("Creating %s edit control, style = %08x\n",
+	TRACE("Creating %s edit control, style = %08lx\n",
 		unicode ? "Unicode" : "ANSI", lpcs->style);
 
 	if (!(es = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*es))))
 		return FALSE;
-        SetWindowLongPtrW( hwnd, 0, (LONG_PTR)es );
+        set_control_state( hwnd, es );
 
        /*
         *      Note: since the EDITSTATE has not been fully initialized yet,
@@ -4749,7 +4709,7 @@ static LRESULT EDIT_WM_NCCreate(HWND hwnd, LPCREATESTRUCTW lpcs, BOOL unicode)
 	return TRUE;
 
 cleanup:
-	SetWindowLongPtrW(es->hwndSelf, 0, 0);
+	set_control_state( es->hwndSelf, NULL );
 	EDIT_InvalidateUniscribeData(es);
 	HeapFree(GetProcessHeap(), 0, es->first_line_def);
 	HeapFree(GetProcessHeap(), 0, es->undo_text);
@@ -4785,7 +4745,7 @@ static LRESULT EDIT_WM_Create(EDITSTATE *es, LPCWSTR name)
         EDIT_SetRectNP(es, &clientRect);
 
        if (name && *name) {
-	   EDIT_EM_ReplaceSel(es, FALSE, name, FALSE, FALSE);
+	   EDIT_EM_ReplaceSel(es, FALSE, name, lstrlenW(name), FALSE, FALSE);
 	   /* if we insert text to the editline, the text scrolls out
             * of the window, as the caret is placed after the insert
             * pos normally; thus we reset es->selection... to 0 and
@@ -4835,7 +4795,7 @@ static LRESULT EDIT_WM_NCDestroy(EDITSTATE *es)
 		pc = pp;
 	}
 
-	SetWindowLongPtrW( es->hwndSelf, 0, 0 );
+	set_control_state( es->hwndSelf, NULL );
 	HeapFree(GetProcessHeap(), 0, es->undo_text);
 	HeapFree(GetProcessHeap(), 0, es);
 
@@ -4860,31 +4820,15 @@ static inline LRESULT DefWindowProcT(HWND hwnd, UINT msg, WPARAM wParam, LPARAM 
  */
 LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, BOOL unicode )
 {
-	EDITSTATE *es = (EDITSTATE *)GetWindowLongPtrW( hwnd, 0 );
+	EDITSTATE *es = get_control_state( hwnd );
 	LRESULT result = 0;
-#ifdef __REACTOS__
-    /* ReactOS r50219 */
-    PWND pWnd;
-
-    pWnd = ValidateHwnd(hwnd);
-    if (pWnd)
-    {
-        if (!pWnd->fnid)
-        {
-            NtUserSetWindowFNID(hwnd, FNID_EDIT);
-        }
-        else
-        {
-            if (pWnd->fnid != FNID_EDIT)
-            {
-                ERR("Wrong window class for Edit! fnId 0x%x\n",pWnd->fnid);
-                return 0;
-            }
-        }
-    }
+#ifndef __REACTOS__ /* WM_IME_SETCONTEXT */
+	POINT pt;
 #endif
 
-        TRACE("hwnd=%p msg=%x (%s) wparam=%lx lparam=%lx\n", hwnd, msg, SPY_GetMsgName(msg, hwnd), wParam, lParam);
+        TRACE("hwnd=%p msg=%x (%s) wparam=%Ix lparam=%Ix\n", hwnd, msg, SPY_GetMsgName(msg, hwnd), wParam, lParam);
+
+	if (msg == WM_NCCREATE) NtUserSetWindowFNID( hwnd, MAKE_FNID(NTUSER_WNDPROC_EDIT) );
 
 	if (!es && msg != WM_NCCREATE)
 		return DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
@@ -4990,7 +4934,7 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
                     MultiByteToWideChar(CP_ACP, 0, textA, -1, textW, countW);
 		}
 
-		EDIT_EM_ReplaceSel(es, (BOOL)wParam, textW, TRUE, TRUE);
+		EDIT_EM_ReplaceSel(es, (BOOL)wParam, textW, lstrlenW(textW), TRUE, TRUE);
 		result = 1;
 
 		if(!unicode)
@@ -5039,7 +4983,7 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 		    MultiByteToWideChar(CP_ACP, 0, &charA, 1, &charW, 1);
 		}
 
-		EDIT_EM_SetPasswordChar(es, charW);
+		result = EDIT_EM_SetPasswordChar(es, charW);
 		break;
 	}
 
@@ -5066,7 +5010,7 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 		}
 
 		if (old_style ^ es->style)
-		    InvalidateRect(es->hwndSelf, NULL, TRUE);
+		    NtUserInvalidateRect(es->hwndSelf, NULL, TRUE);
 
 		result = 1;
 		break;
@@ -5074,6 +5018,7 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 
 	case EM_SETWORDBREAKPROC:
 		EDIT_EM_SetWordBreakProc(es, (void *)lParam);
+		result = 1;
 		break;
 
 	case EM_GETWORDBREAKPROC:
@@ -5115,6 +5060,17 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 		result = EDIT_EM_CharFromPos(es, (short)LOWORD(lParam), (short)HIWORD(lParam));
 		break;
 
+        case EM_SETIMESTATUS:
+            if (wParam == EMSIS_COMPOSITIONSTRING)
+                es->ime_status = lParam & 0xFFFF;
+
+            result = 1;
+            break;
+
+        case EM_GETIMESTATUS:
+            result = wParam == EMSIS_COMPOSITIONSTRING ? es->ime_status : 1;
+            break;
+
         /* End of the EM_ messages which were in numerical order; what order
          * are these in?  vaguely alphabetical?
          */
@@ -5155,26 +5111,6 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
                 }
 		break;
 
-        case WM_IME_CHAR:
-#ifdef __REACTOS__
-	        /* Rely on DefWindowProc */
-            result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
-            break;
-#else
-            if (!unicode)
-            {
-                WCHAR charW;
-                CHAR  strng[2];
-
-                strng[0] = wParam >> 8;
-                strng[1] = wParam & 0xff;
-                if (strng[0]) MultiByteToWideChar(CP_ACP, 0, strng, 2, &charW, 1);
-                else MultiByteToWideChar(CP_ACP, 0, &strng[1], 1, &charW, 1);
-		result = EDIT_WM_Char(es, charW);
-		break;
-            }
-            /* fall through */
-#endif
 	case WM_CHAR:
 	{
 		WCHAR charW;
@@ -5183,8 +5119,24 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 		    charW = wParam;
 		else
 		{
-		    CHAR charA = wParam;
-		    MultiByteToWideChar(CP_ACP, 0, &charA, 1, &charW, 1);
+		    BYTE low = wParam;
+		    DWORD cp = get_input_codepage();
+		    if (es->lead_byte)
+		    {
+			char ch[2];
+			ch[0] = es->lead_byte;
+			ch[1] = low;
+			MultiByteToWideChar(cp, 0, ch, 2, &charW, 1);
+		    }
+		    else if (IsDBCSLeadByteEx(cp, low))
+		    {
+			es->lead_byte = low;
+			result = 1;
+			break;
+		    }
+		    else
+			MultiByteToWideChar(cp, 0, (char *)&low, 1, &charW, 1);
+		    es->lead_byte = 0;
 		}
 
                 if (es->hwndListBox)
@@ -5350,10 +5302,6 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 		result = EDIT_WM_SysKeyDown(es, (INT)wParam, (DWORD)lParam);
 		break;
 
-	case WM_TIMER:
-		EDIT_WM_Timer(es);
-		break;
-
 	case WM_VSCROLL:
 #ifdef __REACTOS__
     {
@@ -5370,13 +5318,17 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
     }
 #else
 		result = EDIT_WM_VScroll(es, LOWORD(wParam), (short)HIWORD(wParam));
-#endif
 		break;
+#endif
+
+        case WM_CAPTURECHANGED:
+            es->bCaptureState = FALSE;
+            break;
 
         case WM_MOUSEWHEEL:
                 {
                     int wheelDelta;
-                    UINT pulScrollLines = 3;
+                    INT pulScrollLines = 3;
                     SystemParametersInfoW(SPI_GETWHEELSCROLLLINES,0, &pulScrollLines, 0);
 
                     if (wParam & (MK_SHIFT | MK_CONTROL)) {
@@ -5393,9 +5345,9 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
                     if (es->wheelDeltaRemainder && pulScrollLines)
                     {
                         int cLineScroll;
-                        pulScrollLines = (int) min((UINT) es->line_count, pulScrollLines);
-                        cLineScroll = pulScrollLines * (float)es->wheelDeltaRemainder / WHEEL_DELTA;
-                        es->wheelDeltaRemainder -= WHEEL_DELTA * cLineScroll / (int)pulScrollLines;
+                        pulScrollLines = min(es->line_count, pulScrollLines);
+                        cLineScroll = pulScrollLines * es->wheelDeltaRemainder / WHEEL_DELTA;
+                        es->wheelDeltaRemainder -= WHEEL_DELTA * cLineScroll / pulScrollLines;
                         result = EDIT_EM_LineScroll(es, 0, -cLineScroll);
                     }
                 }
@@ -5428,11 +5380,15 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 
             result = DefWindowProcT(hwnd, WM_IME_SETCONTEXT, wParam, lParam, unicode);
         }
+#else
+		NtUserGetCaretPos(&pt);
+		EDIT_UpdateImmCompositionWindow(es, pt.x, pt.y);
+		EDIT_UpdateImmCompositionFont(es);
 #endif
 		break;
 
-	case WM_IME_STARTCOMPOSITION:
 #ifdef __REACTOS__
+	case WM_IME_STARTCOMPOSITION:
         {
             HKL hKL = GetKeyboardLayout(0);
 
@@ -5442,34 +5398,14 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 
             result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
         }
-#else
-		es->composition_start = es->selection_end;
-		es->composition_len = 0;
-#endif
 		break;
+#endif
 
 	case WM_IME_COMPOSITION:
-                EDIT_ImeComposition(hwnd, lParam, es);
-#ifdef __REACTOS__
-        result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
-#endif
-		break;
-
-	case WM_IME_ENDCOMPOSITION:
-#ifdef __REACTOS__
-        result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
-#else
-                if (es->composition_len > 0)
-                {
-                        EDIT_EM_ReplaceSel(es, TRUE, empty_stringW, TRUE, TRUE);
-                        es->selection_end = es->selection_start;
-                        es->composition_len= 0;
-                }
-#endif
-		break;
-
-	case WM_IME_COMPOSITIONFULL:
-		break;
+		EDIT_EM_ReplaceSel(es, TRUE, NULL, 0, TRUE, TRUE);
+		if ((lParam & GCS_RESULTSTR) && (es->ime_status & EIMES_GETCOMPSTRATONCE))
+			EDIT_ImeComposition(hwnd, lParam, es);
+		return DefWindowProcW(hwnd, msg, wParam, lParam);
 
 	case WM_IME_SELECT:
 #ifdef __REACTOS__
@@ -5517,7 +5453,7 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 #endif
             EDIT_UnlockBuffer(es, FALSE);
 
-        TRACE("hwnd=%p msg=%x (%s) -- 0x%08lx\n", hwnd, msg, SPY_GetMsgName(msg, hwnd), result);
+        TRACE("hwnd=%p msg=%x (%s) -- 0x%08Ix\n", hwnd, msg, SPY_GetMsgName(msg, hwnd), result);
 
 	return result;
 }
@@ -5542,8 +5478,6 @@ LRESULT WINAPI EditWndProcW(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     return EditWndProc_common(hWnd, uMsg, wParam, lParam, TRUE);
 }
 
-#endif /* __REACTOS__ */
-
 /*********************************************************************
  * edit class descriptor
  */
@@ -5552,12 +5486,8 @@ const struct builtin_class_descr EDIT_builtin_class =
 {
     editW,                /* name */
     CS_DBLCLKS | CS_PARENTDC,   /* style */
-#ifdef __REACTOS__
     EditWndProcA,         /* procA */
     EditWndProcW,         /* procW */
-#else
-    WINPROC_EDIT,         /* proc */
-#endif
 #ifndef _WIN64
     sizeof(EDITSTATE *) + sizeof(WORD), /* extra */
 #else
@@ -5566,3 +5496,4 @@ const struct builtin_class_descr EDIT_builtin_class =
     IDC_IBEAM,            /* cursor */
     0                     /* brush */
 };
+#endif

--- a/win32ss/user/user32/controls/icontitle.c
+++ b/win32ss/user/user32/controls/icontitle.c
@@ -19,50 +19,25 @@
  */
 
 #include <user32.h>
+#include <wine-compat.h>
 
 static BOOL bMultiLineTitle;
 static HFONT hIconTitleFont;
 
+#ifdef __REACTOS__
 /*********************************************************************
  * icon title class descriptor
  */
 const struct builtin_class_descr ICONTITLE_builtin_class =
 {
-    WC_ICONTITLE,     /* name */
-    0,                /* style */
-    NULL,             /* procA (winproc is Unicode only) */
-    IconTitleWndProc, /* procW */
-    0,                /* extra */
-    IDC_ARROW,        /* cursor */
-    0                 /* brush */
+    WC_ICONTITLE,       /* name */
+    0,                  /* style */
+    IconTitleWndProcW,  /* procA */
+    IconTitleWndProcW,  /* procW */
+    0,                  /* extra */
+    IDC_ARROW,          /* cursor */
+    0                   /* brush */
 };
-
-
-
-#ifndef __REACTOS__
-/***********************************************************************
- *           ICONTITLE_Create
- */
-HWND ICONTITLE_Create( HWND owner )
-{
-    HWND hWnd;
-    HINSTANCE instance = (HINSTANCE)GetWindowLongPtrA( owner, GWLP_HINSTANCE );
-    LONG style = WS_CLIPSIBLINGS;
-
-    if (!IsWindowEnabled(owner)) style |= WS_DISABLED;
-    if( GetWindowLongPtrA( owner, GWL_STYLE ) & WS_CHILD )
-	hWnd = CreateWindowExA( 0, (LPCSTR)ICONTITLE_CLASS_ATOM, NULL,
-                                style | WS_CHILD, 0, 0, 1, 1,
-                                GetParent(owner), 0, instance, NULL );
-    else
-	hWnd = CreateWindowExA( 0, (LPCSTR)ICONTITLE_CLASS_ATOM, NULL,
-                                style, 0, 0, 1, 1,
-                                owner, 0, instance, NULL );
-    WIN_SetOwner( hWnd, owner );  /* MDI depends on this */
-    SetWindowLongPtrW( hWnd, GWL_STYLE,
-                       GetWindowLongPtrW( hWnd, GWL_STYLE ) & ~(WS_CAPTION | WS_BORDER) );
-    return hWnd;
-}
 #endif
 
 /***********************************************************************
@@ -70,7 +45,6 @@ HWND ICONTITLE_Create( HWND owner )
  */
 static BOOL ICONTITLE_SetTitlePos( HWND hwnd, HWND owner )
 {
-    static const WCHAR emptyTitleText[] = {'<','.','.','.','>',0};
     WCHAR str[80];
     HDC hDC;
     HFONT hPrevFont;
@@ -78,18 +52,18 @@ static BOOL ICONTITLE_SetTitlePos( HWND hwnd, HWND owner )
     INT cx, cy;
     POINT pt;
 
-    int length = GetWindowTextW( owner, str, sizeof(str)/sizeof(WCHAR) );
+    int length = GetWindowTextW( owner, str, ARRAY_SIZE( str ));
 
     while (length && str[length - 1] == ' ') /* remove trailing spaces */
         str[--length] = 0;
 
     if( !length )
     {
-        strcpyW( str, emptyTitleText );
-        length = strlenW( str );
+        lstrcpyW( str, L"<...>" );
+        length = lstrlenW( str );
     }
 
-    if (!(hDC = GetDC( hwnd ))) return FALSE;
+    if (!(hDC = NtUserGetDC( hwnd ))) return FALSE;
 
     hPrevFont = SelectObject( hDC, hIconTitleFont );
 
@@ -101,7 +75,7 @@ static BOOL ICONTITLE_SetTitlePos( HWND hwnd, HWND owner )
                (( bMultiLineTitle ) ? 0 : DT_SINGLELINE) );
 
     SelectObject( hDC, hPrevFont );
-    ReleaseDC( hwnd, hDC );
+    NtUserReleaseDC( hwnd, hDC );
 
     cx = rect.right - rect.left +  4 * GetSystemMetrics(SM_CXBORDER);
     cy = rect.bottom - rect.top;
@@ -112,7 +86,7 @@ static BOOL ICONTITLE_SetTitlePos( HWND hwnd, HWND owner )
     /* point is relative to owner, make it relative to parent */
     MapWindowPoints( owner, GetParent(hwnd), &pt, 1 );
 
-    SetWindowPos( hwnd, owner, pt.x, pt.y, cx, cy, SWP_NOACTIVATE );
+    NtUserSetWindowPos( hwnd, owner, pt.x, pt.y, cx, cy, SWP_NOACTIVATE );
     return TRUE;
 }
 
@@ -166,7 +140,7 @@ static BOOL ICONTITLE_Paint( HWND hwnd, HWND owner, HDC hDC, BOOL bActive )
     {
 	WCHAR buffer[80];
 
-        INT length = GetWindowTextW( owner, buffer, sizeof(buffer)/sizeof(buffer[0]) );
+        INT length = GetWindowTextW( owner, buffer, ARRAY_SIZE( buffer ));
         SetTextColor( hDC, textColor );
         SetBkMode( hDC, TRANSPARENT );
 
@@ -179,10 +153,10 @@ static BOOL ICONTITLE_Paint( HWND hwnd, HWND owner, HDC hDC, BOOL bActive )
 }
 
 /***********************************************************************
- *           IconTitleWndProc
+ *           IconTitleWndProc_common
  */
-LRESULT WINAPI IconTitleWndProc( HWND hWnd, UINT msg,
-                                 WPARAM wParam, LPARAM lParam )
+static LRESULT WINAPI IconTitleWndProc_common( HWND hWnd, UINT msg,
+                                               WPARAM wParam, LPARAM lParam )
 {
     HWND owner = GetWindow( hWnd, GW_OWNER );
 
@@ -205,7 +179,7 @@ LRESULT WINAPI IconTitleWndProc( HWND hWnd, UINT msg,
 	case WM_NCLBUTTONDBLCLK:
 	     return SendMessageW( owner, msg, wParam, lParam );
 	case WM_ACTIVATE:
-	     if( wParam ) SetActiveWindow( owner );
+	     if (wParam) NtUserSetActiveWindow( owner );
              return 0;
 	case WM_CLOSE:
 	     return 0;
@@ -218,8 +192,50 @@ LRESULT WINAPI IconTitleWndProc( HWND hWnd, UINT msg,
             else
                 lParam = (owner == GetActiveWindow());
             if( ICONTITLE_Paint( hWnd, owner, (HDC)wParam, (BOOL)lParam ) )
-                ValidateRect( hWnd, NULL );
+                NtUserValidateRect( hWnd, NULL );
             return 1;
+    }
+    return 0;
+}
+
+/***********************************************************************
+ *           IconTitleWndProcA
+ */
+LRESULT WINAPI IconTitleWndProcA( HWND hWnd, UINT msg,
+                                  WPARAM wParam, LPARAM lParam )
+{
+    switch (msg)
+    {
+    case WM_CREATE:
+    case WM_NCHITTEST:
+    case WM_NCMOUSEMOVE:
+    case WM_NCLBUTTONDBLCLK:
+    case WM_ACTIVATE:
+    case WM_CLOSE:
+    case WM_SHOWWINDOW:
+    case WM_ERASEBKGND:
+        return IconTitleWndProc_common( hWnd, msg, wParam, lParam );
+    }
+    return DefWindowProcA( hWnd, msg, wParam, lParam );
+}
+
+/***********************************************************************
+ *           IconTitleWndProcW
+ */
+LRESULT WINAPI IconTitleWndProcW( HWND hWnd, UINT msg,
+                                  WPARAM wParam, LPARAM lParam )
+{
+    switch (msg)
+    {
+    case WM_CREATE:
+    case WM_NCHITTEST:
+    case WM_NCMOUSEMOVE:
+    case WM_NCLBUTTONDBLCLK:
+    case WM_ACTIVATE:
+    case WM_CLOSE:
+    case WM_SHOWWINDOW:
+    case WM_ERASEBKGND:
+        return IconTitleWndProc_common( hWnd, msg, wParam, lParam );
     }
     return DefWindowProcW( hWnd, msg, wParam, lParam );
 }

--- a/win32ss/user/user32/controls/listbox.c
+++ b/win32ss/user/user32/controls/listbox.c
@@ -21,7 +21,7 @@
  *
  * This code was audited for completeness against the documented features
  * of Comctl32.dll version 6.0 on Oct. 9, 2004, by Dimitrie O. Paun.
- * 
+ *
  * Unless otherwise noted, we believe this code to be complete, as per
  * the specification mentioned above.
  * If you discover missing features, or bugs, please note them below.
@@ -31,10 +31,11 @@
  */
 
 #include <user32.h>
+#include <wine-compat.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(listbox);
 
-/* Items array granularity */
+/* Items array granularity (must be power of 2) */
 #define LB_ARRAY_GRANULARITY 16
 
 /* Scrolling timeout in ms */
@@ -63,8 +64,13 @@ typedef struct
     UINT        style;          /* Window style */
     INT         width;          /* Window width */
     INT         height;         /* Window height */
-    LB_ITEMDATA  *items;        /* Array of items */
+    union
+    {
+        LB_ITEMDATA *items;     /* Array of items */
+        BYTE *nodata_items;     /* For multi-selection LBS_NODATA */
+    } u;
     INT         nb_items;       /* Number of items */
+    UINT        items_size;     /* Total number of allocated items in the array */
     INT         top_item;       /* Top visible item */
     INT         selected_item;  /* Selected item */
     INT         focus_item;     /* Item that has the focus */
@@ -80,11 +86,13 @@ typedef struct
     INT         wheel_remain;   /* Left over scroll amount */
     BOOL        caret_on;       /* Is caret on? */
     BOOL        captured;       /* Is mouse captured? */
-    BOOL	in_focus;
+    BOOL        in_focus;
     HFONT       font;           /* Current font */
-    LCID          locale;       /* Current locale for string comparisons */
-    LPHEADCOMBO   lphc;		/* ComboLBox */
-    LONG        UIState;        // REACTOS
+    LCID        locale;         /* Current locale for string comparisons */
+    HEADCOMBO  *lphc;           /* ComboLBox */
+#ifdef __REACTOS__
+    LONG        UIState;        /* UISF_ACTIVE, UISF_HIDEACCEL, UISF_HIDEFOCUS */
+#endif
 } LB_DESCR;
 
 
@@ -119,6 +127,7 @@ static TIMER_DIRECTION LISTBOX_Timer = LB_TIMER_NONE;
 
 static LRESULT LISTBOX_GetItemRect( const LB_DESCR *descr, INT index, RECT *rect );
 
+#ifdef __REACTOS__
 /*********************************************************************
  * listbox class descriptor
  */
@@ -149,6 +158,134 @@ const struct builtin_class_descr COMBOLBOX_builtin_class =
     IDC_ARROW,            /* cursor */
     0                     /* brush */
 };
+#endif
+
+static LB_DESCR *get_control_state( HWND hwnd )
+{
+    return (LB_DESCR *)NtUserGetPrivateData( hwnd, 0, sizeof(LB_DESCR *) );
+}
+
+static LB_DESCR *set_control_state( HWND hwnd, LB_DESCR *state )
+{
+    return (LB_DESCR *)NtUserSetPrivateData( hwnd, 0, sizeof(LB_DESCR *), (LONG_PTR)state );
+}
+
+/*
+   For listboxes without LBS_NODATA, an array of LB_ITEMDATA is allocated
+   to store the states of each item into descr->u.items.
+
+   For single-selection LBS_NODATA listboxes, no storage is allocated,
+   and thus descr->u.nodata_items will always be NULL.
+
+   For multi-selection LBS_NODATA listboxes, one byte per item is stored
+   for the item's selection state into descr->u.nodata_items.
+*/
+static size_t get_sizeof_item( const LB_DESCR *descr )
+{
+    return (descr->style & LBS_NODATA) ? sizeof(BYTE) : sizeof(LB_ITEMDATA);
+}
+
+static BOOL resize_storage(LB_DESCR *descr, UINT items_size)
+{
+    LB_ITEMDATA *items;
+
+    if (items_size > descr->items_size ||
+        items_size + LB_ARRAY_GRANULARITY * 2 < descr->items_size)
+    {
+        items_size = (items_size + LB_ARRAY_GRANULARITY - 1) & ~(LB_ARRAY_GRANULARITY - 1);
+        if ((descr->style & (LBS_NODATA | LBS_MULTIPLESEL | LBS_EXTENDEDSEL)) != LBS_NODATA)
+        {
+            items = realloc(descr->u.items, items_size * get_sizeof_item(descr));
+            if (!items)
+            {
+                SEND_NOTIFICATION(descr, LBN_ERRSPACE);
+                return FALSE;
+            }
+            descr->u.items = items;
+        }
+        descr->items_size = items_size;
+    }
+
+    if ((descr->style & LBS_NODATA) && descr->u.nodata_items && items_size > descr->nb_items)
+    {
+        memset(descr->u.nodata_items + descr->nb_items, 0,
+               (items_size - descr->nb_items) * get_sizeof_item(descr));
+    }
+    return TRUE;
+}
+
+static ULONG_PTR get_item_data( const LB_DESCR *descr, UINT index )
+{
+    return (descr->style & LBS_NODATA) ? 0 : descr->u.items[index].data;
+}
+
+static void set_item_data( LB_DESCR *descr, UINT index, ULONG_PTR data )
+{
+    if (!(descr->style & LBS_NODATA)) descr->u.items[index].data = data;
+}
+
+static WCHAR *get_item_string( const LB_DESCR *descr, UINT index )
+{
+    return HAS_STRINGS(descr) ? descr->u.items[index].str : NULL;
+}
+
+static void set_item_string( const LB_DESCR *descr, UINT index, WCHAR *string )
+{
+    if (!(descr->style & LBS_NODATA)) descr->u.items[index].str = string;
+}
+
+static UINT get_item_height( const LB_DESCR *descr, UINT index )
+{
+    return (descr->style & LBS_NODATA) ? 0 : descr->u.items[index].height;
+}
+
+static void set_item_height( LB_DESCR *descr, UINT index, UINT height )
+{
+    if (!(descr->style & LBS_NODATA)) descr->u.items[index].height = height;
+}
+
+static BOOL is_item_selected( const LB_DESCR *descr, UINT index )
+{
+    if (!(descr->style & (LBS_MULTIPLESEL | LBS_EXTENDEDSEL)))
+        return index == descr->selected_item;
+    if (descr->style & LBS_NODATA)
+        return descr->u.nodata_items[index];
+    else
+        return descr->u.items[index].selected;
+}
+
+static void set_item_selected_state(LB_DESCR *descr, UINT index, BOOL state)
+{
+    if (descr->style & (LBS_MULTIPLESEL | LBS_EXTENDEDSEL))
+    {
+        if (descr->style & LBS_NODATA)
+            descr->u.nodata_items[index] = state;
+        else
+            descr->u.items[index].selected = state;
+    }
+}
+
+static void insert_item_data(LB_DESCR *descr, UINT index)
+{
+    size_t size = get_sizeof_item(descr);
+    BYTE *p = descr->u.nodata_items + index * size;
+
+    if (!descr->u.items) return;
+
+    if (index < descr->nb_items)
+        memmove(p + size, p, (descr->nb_items - index) * size);
+}
+
+static void remove_item_data(LB_DESCR *descr, UINT index)
+{
+    size_t size = get_sizeof_item(descr);
+    BYTE *p = descr->u.nodata_items + index * size;
+
+    if (!descr->u.items) return;
+
+    if (index < descr->nb_items)
+        memmove(p, p + size, (descr->nb_items - index) * size);
+}
 
 
 /***********************************************************************
@@ -162,7 +299,7 @@ static INT LISTBOX_GetCurrentPageSize( const LB_DESCR *descr )
     if (!(descr->style & LBS_OWNERDRAWVARIABLE)) return descr->page_size;
     for (i = descr->top_item, height = 0; i < descr->nb_items; i++)
     {
-        if ((height += descr->items[i].height) > descr->height) break;
+        if ((height += get_item_height(descr, i)) > descr->height) break;
     }
     if (i == descr->top_item) return 1;
     else return i - descr->top_item;
@@ -182,7 +319,7 @@ static INT LISTBOX_GetMaxTopIndex( const LB_DESCR *descr )
     {
         page = descr->height;
         for (max = descr->nb_items - 1; max >= 0; max--)
-            if ((page -= descr->items[max].height) < 0) break;
+            if ((page -= get_item_height(descr, max)) < 0) break;
         if (max < descr->nb_items - 1) max++;
     }
     else if (descr->style & LBS_MULTICOLUMN)
@@ -211,7 +348,7 @@ static void LISTBOX_UpdateScroll( LB_DESCR *descr )
     SCROLLINFO info;
 
     /* Check the listbox scroll bar flags individually before we call
-       SetScrollInfo otherwise when the listbox style is WS_HSCROLL and
+       NtUserSetScrollInfo otherwise when the listbox style is WS_HSCROLL and
        no WS_VSCROLL, we end up with an uninitialized, visible horizontal
        scroll bar when we do not need one.
     if (!(descr->style & WS_VSCROLL)) return;
@@ -239,11 +376,19 @@ static void LISTBOX_UpdateScroll( LB_DESCR *descr )
         if (descr->style & LBS_DISABLENOSCROLL)
             info.fMask |= SIF_DISABLENOSCROLL;
         if (descr->style & WS_HSCROLL)
+#ifdef __REACTOS__
             SetScrollInfo( descr->self, SB_HORZ, &info, TRUE );
+#else
+            NtUserSetScrollInfo( descr->self, SB_HORZ, &info, TRUE );
+#endif
         info.nMax = 0;
         info.fMask = SIF_RANGE;
         if (descr->style & WS_VSCROLL)
+#ifdef __REACTOS__
             SetScrollInfo( descr->self, SB_VERT, &info, TRUE );
+#else
+            NtUserSetScrollInfo( descr->self, SB_VERT, &info, TRUE );
+#endif
     }
     else
     {
@@ -255,7 +400,11 @@ static void LISTBOX_UpdateScroll( LB_DESCR *descr )
         if (descr->style & LBS_DISABLENOSCROLL)
             info.fMask |= SIF_DISABLENOSCROLL;
         if (descr->style & WS_VSCROLL)
+#ifdef __REACTOS__
             SetScrollInfo( descr->self, SB_VERT, &info, TRUE );
+#else
+            NtUserSetScrollInfo( descr->self, SB_VERT, &info, TRUE );
+#endif
 
         if ((descr->style & WS_HSCROLL) && descr->horz_extent)
         {
@@ -264,7 +413,11 @@ static void LISTBOX_UpdateScroll( LB_DESCR *descr )
             info.fMask = SIF_POS | SIF_PAGE;
             if (descr->style & LBS_DISABLENOSCROLL)
                 info.fMask |= SIF_DISABLENOSCROLL;
+#ifdef __REACTOS__
             SetScrollInfo( descr->self, SB_HORZ, &info, TRUE );
+#else
+            NtUserSetScrollInfo( descr->self, SB_HORZ, &info, TRUE );
+#endif
         }
         else
         {
@@ -273,11 +426,15 @@ static void LISTBOX_UpdateScroll( LB_DESCR *descr )
                 info.nMin  = 0;
                 info.nMax  = 0;
                 info.fMask = SIF_RANGE | SIF_DISABLENOSCROLL;
+#ifdef __REACTOS__
                 SetScrollInfo( descr->self, SB_HORZ, &info, TRUE );
+#else
+                NtUserSetScrollInfo( descr->self, SB_HORZ, &info, TRUE );
+#endif
             }
             else
             {
-                ShowScrollBar( descr->self, SB_HORZ, FALSE );
+                NtUserShowScrollBar( descr->self, SB_HORZ, FALSE );
             }
         }
     }
@@ -301,38 +458,31 @@ static LRESULT LISTBOX_SetTopItem( LB_DESCR *descr, INT index, BOOL scroll )
     if (descr->top_item == index) return LB_OKAY;
     if (scroll)
     {
-        INT diff;
+        INT dx = 0, dy = 0;
         if (descr->style & LBS_MULTICOLUMN)
-            diff = (descr->top_item - index) / descr->page_size * descr->column_width;
+            dx = (descr->top_item - index) / descr->page_size * descr->column_width;
         else if (descr->style & LBS_OWNERDRAWVARIABLE)
         {
             INT i;
-            diff = 0;
             if (index > descr->top_item)
             {
                 for (i = index - 1; i >= descr->top_item; i--)
-                    diff -= descr->items[i].height;
+                    dy -= get_item_height(descr, i);
             }
             else
             {
                 for (i = index; i < descr->top_item; i++)
-                    diff += descr->items[i].height;
+                    dy += get_item_height(descr, i);
             }
         }
         else
-            diff = (descr->top_item - index) * descr->item_height;
+            dy = (descr->top_item - index) * descr->item_height;
 
-#ifdef __REACTOS__
-        if (descr->style & LBS_MULTICOLUMN)
-            ScrollWindowEx(descr->self, diff, 0, NULL, NULL, 0, NULL,
-                           SW_INVALIDATE | SW_ERASE | SW_SCROLLCHILDREN);
-        else
-#endif
-        ScrollWindowEx( descr->self, 0, diff, NULL, NULL, 0, NULL,
-                        SW_INVALIDATE | SW_ERASE | SW_SCROLLCHILDREN );
+        NtUserScrollWindowEx( descr->self, dx, dy, NULL, NULL, 0, NULL,
+                              SW_INVALIDATE | SW_ERASE | SW_SCROLLCHILDREN );
     }
     else
-        InvalidateRect( descr->self, NULL, TRUE );
+        NtUserInvalidateRect( descr->self, NULL, TRUE );
     descr->top_item = index;
     LISTBOX_UpdateScroll( descr );
     return LB_OKAY;
@@ -354,7 +504,7 @@ static void LISTBOX_UpdatePage( LB_DESCR *descr )
     if (page_size == descr->page_size) return;
     descr->page_size = page_size;
     if (descr->style & LBS_MULTICOLUMN)
-        InvalidateRect( descr->self, NULL, TRUE );
+        NtUserInvalidateRect( descr->self, NULL, TRUE );
     LISTBOX_SetTopItem( descr, descr->top_item, FALSE );
 }
 
@@ -377,21 +527,34 @@ static void LISTBOX_UpdateSize( LB_DESCR *descr )
     descr->height = rect.bottom - rect.top;
     if (!(descr->style & LBS_NOINTEGRALHEIGHT) && !(descr->style & LBS_OWNERDRAWVARIABLE))
     {
+        int height = descr->height;
         INT remaining;
         RECT rect;
 
+        /* The whole point of integral height is to ensure that partial items
+         * aren't displayed. Native seems to fail to take the horizontal
+         * scrollbar into account (while successfully taking into account e.g.
+         * WS_EX_CLIENTEDGE), so it ends up obscuring partial items anyway.
+         *
+         * It's not clear if native is trying to work from
+         * the window rect as opposed to the client rect [and badly
+         * reimplementing AdjustWindowRect()] or poorly working around the case
+         * where the horizontal scrollbar is repeatedly toggled (which could
+         * unnecessarily shrink the scrollbar every time it happens). */
+        if (GetWindowLongW( descr->self, GWL_STYLE ) & WS_HSCROLL)
+            height += GetSystemMetrics( SM_CYHSCROLL );
+
         GetWindowRect( descr->self, &rect );
         if(descr->item_height != 0)
-            remaining = descr->height % descr->item_height;
+            remaining = height % descr->item_height;
         else
             remaining = 0;
-        if ((descr->height > descr->item_height) && remaining)
+        if ((height > descr->item_height) && remaining)
         {
-            TRACE("[%p]: changing height %d -> %d\n",
-                  descr->self, descr->height, descr->height - remaining );
-            SetWindowPos( descr->self, 0, 0, 0, rect.right - rect.left,
-                          rect.bottom - rect.top - remaining,
-                          SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE );
+            TRACE( "[%p]: changing height %d -> %d\n", descr->self, height, height - remaining );
+            NtUserSetWindowPos( descr->self, 0, 0, 0, rect.right - rect.left,
+                                rect.bottom - rect.top - remaining,
+                                SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE );
             return;
         }
     }
@@ -402,7 +565,7 @@ static void LISTBOX_UpdateSize( LB_DESCR *descr )
     /* Invalidate the focused item so it will be repainted correctly */
     if (LISTBOX_GetItemRect( descr, descr->focus_item, &rect ) == 1)
     {
-        InvalidateRect( descr->self, &rect, FALSE );
+        NtUserInvalidateRect( descr->self, &rect, FALSE );
     }
 }
 
@@ -418,7 +581,7 @@ static LRESULT LISTBOX_GetItemRect( const LB_DESCR *descr, INT index, RECT *rect
     /* Index <= 0 is legal even on empty listboxes */
     if (index && (index >= descr->nb_items))
     {
-        memset(rect, 0, sizeof(*rect));
+        SetRectEmpty(rect);
         SetLastError(ERROR_INVALID_INDEX);
         return LB_ERR;
     }
@@ -441,14 +604,14 @@ static LRESULT LISTBOX_GetItemRect( const LB_DESCR *descr, INT index, RECT *rect
             if (index < descr->top_item)
             {
                 for (i = descr->top_item-1; i >= index; i--)
-                    rect->top -= descr->items[i].height;
+                    rect->top -= get_item_height(descr, i);
             }
             else
             {
                 for (i = descr->top_item; i < index; i++)
-                    rect->top += descr->items[i].height;
+                    rect->top += get_item_height(descr, i);
             }
-            rect->bottom = rect->top + descr->items[index].height;
+            rect->bottom = rect->top + get_item_height(descr, index);
 
         }
     }
@@ -483,7 +646,7 @@ static INT LISTBOX_GetItemFromPoint( const LB_DESCR *descr, INT x, INT y )
         {
             while (index < descr->nb_items)
             {
-                if ((pos += descr->items[index].height) > y) break;
+                if ((pos += get_item_height(descr, index)) > y) break;
                 index++;
             }
         }
@@ -492,7 +655,7 @@ static INT LISTBOX_GetItemFromPoint( const LB_DESCR *descr, INT x, INT y )
             while (index > 0)
             {
                 index--;
-                if ((pos -= descr->items[index].height) <= y) break;
+                if ((pos -= get_item_height(descr, index)) <= y) break;
             }
         }
     }
@@ -518,11 +681,24 @@ static INT LISTBOX_GetItemFromPoint( const LB_DESCR *descr, INT x, INT y )
  *
  * Paint an item.
  */
-static void LISTBOX_PaintItem( LB_DESCR *descr, HDC hdc, const RECT *rect, 
+static void LISTBOX_PaintItem( LB_DESCR *descr, HDC hdc, const RECT *rect,
 			       INT index, UINT action, BOOL ignoreFocus )
 {
-    LB_ITEMDATA *item = NULL;
-    if (index < descr->nb_items) item = &descr->items[index];
+    BOOL selected = FALSE, focused;
+    WCHAR *item_str = NULL;
+
+    if (index < descr->nb_items)
+    {
+        item_str = get_item_string(descr, index);
+        selected = !(descr->style & LBS_NOSEL) && is_item_selected(descr, index);
+    }
+
+#ifdef __REACTOS__
+    focused = !ignoreFocus && descr->focus_item == index && descr->caret_on && descr->in_focus
+              && !(descr->UIState & UISF_HIDEFOCUS);
+#else
+    focused = !ignoreFocus && descr->focus_item == index && descr->caret_on && descr->in_focus;
+#endif
 
     if (IS_OWNERDRAW(descr))
     {
@@ -530,7 +706,7 @@ static void LISTBOX_PaintItem( LB_DESCR *descr, HDC hdc, const RECT *rect,
         RECT r;
         HRGN hrgn;
 
-	if (!item)
+	if (index >= descr->nb_items)
 	{
 	    if (action == ODA_FOCUS)
             { // REACTOS
@@ -556,15 +732,15 @@ static void LISTBOX_PaintItem( LB_DESCR *descr, HDC hdc, const RECT *rect,
         dis.hDC          = hdc;
         dis.itemID       = index;
         dis.itemState    = 0;
-        if (item->selected) dis.itemState |= ODS_SELECTED;
-        if (!ignoreFocus && (descr->focus_item == index) &&
-            (descr->caret_on) &&
-            (descr->in_focus)) dis.itemState |= ODS_FOCUS;
+        if (selected)
+            dis.itemState |= ODS_SELECTED;
+        if (focused)
+            dis.itemState |= ODS_FOCUS;
         if (!IsWindowEnabled(descr->self)) dis.itemState |= ODS_DISABLED;
-        dis.itemData     = item->data;
+        dis.itemData     = get_item_data(descr, index);
         dis.rcItem       = *rect;
         TRACE("[%p]: drawitem %d (%s) action=%02x state=%02x rect=%s\n",
-              descr->self, index, debugstr_w(item->str), action,
+              descr->self, index, debugstr_w(item_str), action,
               dis.itemState, wine_dbgstr_rect(rect) );
         SendMessageW(descr->owner, WM_DRAWITEM, dis.CtlID, (LPARAM)&dis);
         SelectClipRgn( hdc, hrgn );
@@ -580,43 +756,43 @@ static void LISTBOX_PaintItem( LB_DESCR *descr, HDC hdc, const RECT *rect,
                 DrawFocusRect( hdc, rect );
             return;
         }
-        if (item && item->selected)
+        if (selected)
         {
             oldBk = SetBkColor( hdc, GetSysColor( COLOR_HIGHLIGHT ) );
             oldText = SetTextColor( hdc, GetSysColor(COLOR_HIGHLIGHTTEXT));
         }
 #ifdef __REACTOS__
         else
-        {   
+        {
             HBRUSH br = GetCurrentObject(hdc, OBJ_BRUSH);
             FillRect(hdc, rect, br);
         }
 #endif
 
         TRACE("[%p]: painting %d (%s) action=%02x rect=%s\n",
-              descr->self, index, item ? debugstr_w(item->str) : "", action,
+              descr->self, index, debugstr_w(item_str), action,
               wine_dbgstr_rect(rect) );
-        if (!item)
+        if (!item_str)
             ExtTextOutW( hdc, rect->left + 1, rect->top,
                            ETO_OPAQUE | ETO_CLIPPED, rect, NULL, 0, NULL );
         else if (!(descr->style & LBS_USETABSTOPS))
 #ifdef __REACTOS__
         {
             RECT rc = *rect;
-            if (!item->selected)
+            if (!selected)
             {
                 SIZE sz;
-                GetTextExtentPoint32(hdc, item->str, strlenW(item->str), &sz);
+                GetTextExtentPoint32(hdc, item_str, strlenW(item_str), &sz);
                 rc.right = min(sz.cx, rc.right);
             }
             ExtTextOutW( hdc, rect->left + 1, rect->top,
-                         ETO_OPAQUE | ETO_CLIPPED, &rc, item->str,
-                         strlenW(item->str), NULL);
+                         ETO_OPAQUE | ETO_CLIPPED, &rc, item_str,
+                         strlenW(item_str), NULL);
         }
 #else
             ExtTextOutW( hdc, rect->left + 1, rect->top,
-                         ETO_OPAQUE | ETO_CLIPPED, rect, item->str,
-                         strlenW(item->str), NULL );
+                         ETO_OPAQUE | ETO_CLIPPED, rect, item_str,
+                         lstrlenW(item_str), NULL );
 #endif
         else
 	{
@@ -624,18 +800,16 @@ static void LISTBOX_PaintItem( LB_DESCR *descr, HDC hdc, const RECT *rect,
             ExtTextOutW( hdc, rect->left + 1, rect->top,
                          ETO_OPAQUE | ETO_CLIPPED, rect, NULL, 0, NULL );
             TabbedTextOutW( hdc, rect->left + 1 , rect->top,
-                            item->str, strlenW(item->str),
+                            item_str, lstrlenW(item_str),
                             descr->nb_tabs, descr->tabs, 0);
 	}
-        if (item && item->selected)
+        if (selected)
         {
             SetBkColor( hdc, oldBk );
             SetTextColor( hdc, oldText );
         }
-        if (!ignoreFocus && (descr->focus_item == index) &&
-            (descr->caret_on) &&
-            (descr->in_focus) &&
-            !(descr->UIState & UISF_HIDEFOCUS)) DrawFocusRect( hdc, rect );
+        if (focused)
+            DrawFocusRect( hdc, rect );
     }
 }
 
@@ -653,7 +827,7 @@ static void LISTBOX_SetRedraw( LB_DESCR *descr, BOOL on )
         descr->style &= ~LBS_NOREDRAW;
         if (descr->style & LBS_DISPLAYCHANGED)
         {     /* page was changed while setredraw false, refresh automatically */
-            InvalidateRect(descr->self, NULL, TRUE);
+            NtUserInvalidateRect(descr->self, NULL, TRUE);
             if ((descr->top_item + descr->page_size) > descr->nb_items)
             {      /* reset top of page if less than number of items/page */
                 descr->top_item = descr->nb_items - descr->page_size;
@@ -687,7 +861,7 @@ static void LISTBOX_RepaintItem( LB_DESCR *descr, INT index, UINT action )
         return;
     }
     if (LISTBOX_GetItemRect( descr, index, &rect ) != 1) return;
-    if (!(hdc = GetDCEx( descr->self, 0, DCX_CACHE ))) return;
+    if (!(hdc = NtUserGetDCEx( descr->self, 0, DCX_CACHE ))) return;
     if (descr->font) oldFont = SelectObject( hdc, descr->font );
 #ifdef __REACTOS__
     hbrush = GetControlColor( descr->owner, descr->self, hdc, WM_CTLCOLORLISTBOX);
@@ -702,7 +876,7 @@ static void LISTBOX_RepaintItem( LB_DESCR *descr, INT index, UINT action )
     LISTBOX_PaintItem( descr, hdc, &rect, index, action, TRUE );
     if (oldFont) SelectObject( hdc, oldFont );
     if (oldBrush) SelectObject( hdc, oldBrush );
-    ReleaseDC( descr->self, hdc );
+    NtUserReleaseDC( descr->self, hdc );
 }
 
 
@@ -722,14 +896,14 @@ static void LISTBOX_DrawFocusRect( LB_DESCR *descr, BOOL on )
     if (!descr->caret_on || !descr->in_focus) return;
 
     if (LISTBOX_GetItemRect( descr, descr->focus_item, &rect ) != 1) return;
-    if (!(hdc = GetDCEx( descr->self, 0, DCX_CACHE ))) return;
+    if (!(hdc = NtUserGetDCEx( descr->self, 0, DCX_CACHE ))) return;
     if (descr->font) oldFont = SelectObject( hdc, descr->font );
     if (!IsWindowEnabled(descr->self))
         SetTextColor( hdc, GetSysColor( COLOR_GRAYTEXT ) );
     SetWindowOrgEx( hdc, descr->horz_pos, 0, NULL );
     LISTBOX_PaintItem( descr, hdc, &rect, descr->focus_item, ODA_FOCUS, !on );
     if (oldFont) SelectObject( hdc, oldFont );
-    ReleaseDC( descr->self, hdc );
+    NtUserReleaseDC( descr->self, hdc );
 }
 
 
@@ -738,27 +912,11 @@ static void LISTBOX_DrawFocusRect( LB_DESCR *descr, BOOL on )
  */
 static LRESULT LISTBOX_InitStorage( LB_DESCR *descr, INT nb_items )
 {
-    LB_ITEMDATA *item;
+    UINT new_size = descr->nb_items + nb_items;
 
-    nb_items += LB_ARRAY_GRANULARITY - 1;
-    nb_items -= (nb_items % LB_ARRAY_GRANULARITY);
-    if (descr->items) {
-        nb_items += HeapSize( GetProcessHeap(), 0, descr->items ) / sizeof(*item);
-	item = HeapReAlloc( GetProcessHeap(), 0, descr->items,
-                              nb_items * sizeof(LB_ITEMDATA));
-    }
-    else {
-	item = HeapAlloc( GetProcessHeap(), 0,
-                              nb_items * sizeof(LB_ITEMDATA));
-    }
-
-    if (!item)
-    {
-        SEND_NOTIFICATION( descr, LBN_ERRSPACE );
+    if (new_size > descr->items_size && !resize_storage(descr, new_size))
         return LB_ERRSPACE;
-    }
-    descr->items = item;
-    return LB_OKAY;
+    return descr->items_size;
 }
 
 
@@ -806,30 +964,32 @@ static LRESULT LISTBOX_GetText( LB_DESCR *descr, INT index, LPWSTR buffer, BOOL 
         SetLastError(ERROR_INVALID_INDEX);
         return LB_ERR;
     }
+
     if (HAS_STRINGS(descr))
     {
+        WCHAR *str = get_item_string(descr, index);
+
         if (!buffer)
         {
-            len = strlenW(descr->items[index].str);
+            len = lstrlenW(str);
             if( unicode )
                 return len;
-            return WideCharToMultiByte( CP_ACP, 0, descr->items[index].str, len,
-                                        NULL, 0, NULL, NULL );
+            return WideCharToMultiByte( CP_ACP, 0, str, len, NULL, 0, NULL, NULL );
         }
 
-	TRACE("index %d (0x%04x) %s\n", index, index, debugstr_w(descr->items[index].str));
+        TRACE("index %d (0x%04x) %s\n", index, index, debugstr_w(str));
 
         _SEH2_TRY  /* hide a Delphi bug that passes a read-only buffer */
         {
             if(unicode)
             {
-                strcpyW( buffer, descr->items[index].str );
-                len = strlenW(buffer);
+                lstrcpyW(buffer, str);
+                len = lstrlenW(buffer);
             }
             else
             {
-                len = WideCharToMultiByte(CP_ACP, 0, descr->items[index].str, -1,
-                                          (LPSTR)buffer, 0x7FFFFFFF, NULL, NULL) - 1;
+                len = WideCharToMultiByte(CP_ACP, 0, str, -1, (LPSTR)buffer,
+                                          0x7FFFFFFF, NULL, NULL) - 1;
             }
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
@@ -839,17 +999,18 @@ static LRESULT LISTBOX_GetText( LB_DESCR *descr, INT index, LPWSTR buffer, BOOL 
             len = LB_ERR;
         }
         _SEH2_END
-    } else {
+    } else
+    {
         if (buffer)
-            *((LPDWORD)buffer)=*(LPDWORD)(&descr->items[index].data);
-        len = sizeof(DWORD);
+            *((ULONG_PTR *)buffer) = get_item_data(descr, index);
+        len = sizeof(ULONG_PTR);
     }
     return len;
 }
 
-static inline INT LISTBOX_lstrcmpiW( LCID lcid, LPCWSTR str1, LPCWSTR str2 )
+static inline INT LISTBOX_lstrcmpiW( LCID lcid, LPCWSTR str1, LPCWSTR str2, int len )
 {
-    INT ret = CompareStringW( lcid, NORM_IGNORECASE, str1, -1, str2, -1 );
+    INT ret = CompareStringW( lcid, NORM_IGNORECASE, str1, len, str2, len );
     if (ret == CSTR_LESS_THAN)
         return -1;
     if (ret == CSTR_EQUAL)
@@ -869,14 +1030,15 @@ static INT LISTBOX_FindStringPos( LB_DESCR *descr, LPCWSTR str, BOOL exact )
 {
     INT index, min, max, res;
 
-    if (!(descr->style & LBS_SORT)) return -1;  /* Add it at the end */
+    if (!descr->nb_items || !(descr->style & LBS_SORT)) return -1;  /* Add it at the end */
+
     min = 0;
-    max = descr->nb_items;
-    while (min != max)
+    max = descr->nb_items - 1;
+    while (min <= max)
     {
         index = (min + max) / 2;
         if (HAS_STRINGS(descr))
-            res = LISTBOX_lstrcmpiW( descr->locale, str, descr->items[index].str);
+            res = LISTBOX_lstrcmpiW( descr->locale, get_item_string(descr, index), str, -1 );
         else
         {
             COMPAREITEMSTRUCT cis;
@@ -887,18 +1049,18 @@ static INT LISTBOX_FindStringPos( LB_DESCR *descr, LPCWSTR str, BOOL exact )
             cis.hwndItem   = descr->self;
             /* note that some application (MetaStock) expects the second item
              * to be in the listbox */
-            cis.itemID1    = -1;
-            cis.itemData1  = (ULONG_PTR)str;
-            cis.itemID2    = index;
-            cis.itemData2  = descr->items[index].data;
+            cis.itemID1    = index;
+            cis.itemData1  = get_item_data(descr, index);
+            cis.itemID2    = -1;
+            cis.itemData2  = (ULONG_PTR)str;
             cis.dwLocaleId = descr->locale;
             res = SendMessageW( descr->owner, WM_COMPAREITEM, id, (LPARAM)&cis );
         }
         if (!res) return index;
-        if (res < 0) max = index;
+        if (res > 0) max = index - 1;
         else min = index + 1;
     }
-    return exact ? -1 : max;
+    return exact ? -1 : min;
 }
 
 
@@ -919,7 +1081,7 @@ static INT LISTBOX_FindFileStrPos( LB_DESCR *descr, LPCWSTR str )
     while (min != max)
     {
         INT index = (min + max) / 2;
-        LPCWSTR p = descr->items[index].str;
+        LPCWSTR p = get_item_string(descr, index);
         if (*p == '[')  /* drive or directory */
         {
             if (*str != '[') res = -1;
@@ -931,13 +1093,13 @@ static INT LISTBOX_FindFileStrPos( LB_DESCR *descr, LPCWSTR str )
             else  /* directory */
             {
                 if (str[1] == '-') res = 1;
-                else res = LISTBOX_lstrcmpiW( descr->locale, str, p );
+                else res = LISTBOX_lstrcmpiW( descr->locale, str, p, -1 );
             }
         }
         else  /* filename */
         {
             if (*str == '[') res = 1;
-            else res = LISTBOX_lstrcmpiW( descr->locale, str, p );
+            else res = LISTBOX_lstrcmpiW( descr->locale, str, p, -1 );
         }
         if (!res) return index;
         if (res < 0) max = index;
@@ -954,44 +1116,46 @@ static INT LISTBOX_FindFileStrPos( LB_DESCR *descr, LPCWSTR str )
  */
 static INT LISTBOX_FindString( LB_DESCR *descr, INT start, LPCWSTR str, BOOL exact )
 {
-    INT i;
-    LB_ITEMDATA *item;
+    INT i, index;
 
-    if (start >= descr->nb_items) start = -1;
-    item = descr->items + start + 1;
+    if (descr->style & LBS_NODATA)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return LB_ERR;
+    }
+
+    start++;
+    if (start >= descr->nb_items) start = 0;
     if (HAS_STRINGS(descr))
     {
         if (!str || ! str[0] ) return LB_ERR;
         if (exact)
         {
-            for (i = start + 1; i < descr->nb_items; i++, item++)
-                if (!LISTBOX_lstrcmpiW( descr->locale, str, item->str )) return i;
-            for (i = 0, item = descr->items; i <= start; i++, item++)
-                if (!LISTBOX_lstrcmpiW( descr->locale, str, item->str )) return i;
+            for (i = 0, index = start; i < descr->nb_items; i++, index++)
+            {
+                if (index == descr->nb_items) index = 0;
+                if (!LISTBOX_lstrcmpiW(descr->locale, str, get_item_string(descr, index), -1))
+                    return index;
+            }
         }
         else
         {
- /* Special case for drives and directories: ignore prefix */
-#define CHECK_DRIVE(item) \
-    if ((item)->str[0] == '[') \
-    { \
-        if (!strncmpiW( str, (item)->str+1, len )) return i; \
-        if (((item)->str[1] == '-') && !strncmpiW(str, (item)->str+2, len)) \
-        return i; \
-    }
+            /* Special case for drives and directories: ignore prefix */
+            INT len = lstrlenW(str);
+            WCHAR *item_str;
 
-            INT len = strlenW(str);
-            for (i = start + 1; i < descr->nb_items; i++, item++)
+            for (i = 0, index = start; i < descr->nb_items; i++, index++)
             {
-               if (!strncmpiW( str, item->str, len )) return i;
-               CHECK_DRIVE(item);
+                if (index == descr->nb_items) index = 0;
+                item_str = get_item_string(descr, index);
+
+                if (!LISTBOX_lstrcmpiW(descr->locale, str, item_str, len)) return index;
+                if (item_str[0] == '[')
+                {
+                    if (!LISTBOX_lstrcmpiW(descr->locale, str, item_str + 1, len)) return index;
+                    if (item_str[1] == '-' && !LISTBOX_lstrcmpiW(descr->locale, str, item_str + 2, len)) return index;
+                }
             }
-            for (i = 0, item = descr->items; i <= start; i++, item++)
-            {
-               if (!strncmpiW( str, item->str, len )) return i;
-               CHECK_DRIVE(item);
-            }
-#undef CHECK_DRIVE
         }
     }
     else
@@ -1001,10 +1165,11 @@ static INT LISTBOX_FindString( LB_DESCR *descr, INT start, LPCWSTR str, BOOL exa
             return LISTBOX_FindStringPos( descr, str, TRUE );
 
         /* Otherwise use a linear search */
-        for (i = start + 1; i < descr->nb_items; i++, item++)
-            if (item->data == (ULONG_PTR)str) return i;
-        for (i = 0, item = descr->items; i <= start; i++, item++)
-            if (item->data == (ULONG_PTR)str) return i;
+        for (i = 0, index = start; i < descr->nb_items; i++, index++)
+        {
+            if (index == descr->nb_items) index = 0;
+            if (get_item_data(descr, index) == (ULONG_PTR)str) return index;
+        }
     }
     return LB_ERR;
 }
@@ -1016,13 +1181,12 @@ static INT LISTBOX_FindString( LB_DESCR *descr, INT start, LPCWSTR str, BOOL exa
 static LRESULT LISTBOX_GetSelCount( const LB_DESCR *descr )
 {
     INT i, count;
-    const LB_ITEMDATA *item = descr->items;
 
     if (!(descr->style & LBS_MULTIPLESEL) ||
         (descr->style & LBS_NOSEL))
       return LB_ERR;
-    for (i = count = 0; i < descr->nb_items; i++, item++)
-        if (item->selected) count++;
+    for (i = count = 0; i < descr->nb_items; i++)
+        if (is_item_selected(descr, i)) count++;
     return count;
 }
 
@@ -1033,11 +1197,10 @@ static LRESULT LISTBOX_GetSelCount( const LB_DESCR *descr )
 static LRESULT LISTBOX_GetSelItems( const LB_DESCR *descr, INT max, LPINT array )
 {
     INT i, count;
-    const LB_ITEMDATA *item = descr->items;
 
     if (!(descr->style & LBS_MULTIPLESEL)) return LB_ERR;
-    for (i = count = 0; (i < descr->nb_items) && (count < max); i++, item++)
-        if (item->selected) array[count++] = i;
+    for (i = count = 0; (i < descr->nb_items) && (count < max); i++)
+        if (is_item_selected(descr, i)) array[count++] = i;
     return count;
 }
 
@@ -1069,7 +1232,7 @@ static LRESULT LISTBOX_Paint( LB_DESCR *descr, HDC hdc )
     hbrush = GetControlColor( descr->owner, descr->self, hdc, WM_CTLCOLORLISTBOX);
 #else
     hbrush = (HBRUSH)SendMessageW( descr->owner, WM_CTLCOLORLISTBOX,
-			   	   (WPARAM)hdc, (LPARAM)descr->self );
+				   (WPARAM)hdc, (LPARAM)descr->self );
 #endif
     if (hbrush) oldBrush = SelectObject( hdc, hbrush );
     if (!IsWindowEnabled(descr->self)) SetTextColor( hdc, GetSysColor( COLOR_GRAYTEXT ) );
@@ -1093,7 +1256,7 @@ static LRESULT LISTBOX_Paint( LB_DESCR *descr, HDC hdc )
         if (!(descr->style & LBS_OWNERDRAWVARIABLE))
             rect.bottom = rect.top + descr->item_height;
         else
-            rect.bottom = rect.top + descr->items[i].height;
+            rect.bottom = rect.top + get_item_height(descr, i);
 
         /* keep the focus rect, to paint the focus item after */
         if (i == descr->focus_item)
@@ -1122,6 +1285,7 @@ static LRESULT LISTBOX_Paint( LB_DESCR *descr, HDC hdc )
             rect.right += descr->column_width;
             rect.top = 0;
             col_pos = descr->page_size - 1;
+            if (rect.left >= descr->width) break;
         }
         else
         {
@@ -1188,14 +1352,14 @@ static void LISTBOX_InvalidateItems( LB_DESCR *descr, INT index )
             return;
         }
         rect.bottom = descr->height;
-        InvalidateRect( descr->self, &rect, TRUE );
+        NtUserInvalidateRect( descr->self, &rect, TRUE );
         if (descr->style & LBS_MULTICOLUMN)
         {
             /* Repaint the other columns */
             rect.left  = rect.right;
             rect.right = descr->width;
             rect.top   = 0;
-            InvalidateRect( descr->self, &rect, TRUE );
+            NtUserInvalidateRect( descr->self, &rect, TRUE );
         }
     }
 }
@@ -1205,7 +1369,7 @@ static void LISTBOX_InvalidateItemRect( LB_DESCR *descr, INT index )
     RECT rect;
 
     if (LISTBOX_GetItemRect( descr, index, &rect ) == 1)
-        InvalidateRect( descr->self, &rect, TRUE );
+        NtUserInvalidateRect( descr->self, &rect, TRUE );
 }
 
 /***********************************************************************
@@ -1220,7 +1384,7 @@ static LRESULT LISTBOX_GetItemHeight( const LB_DESCR *descr, INT index )
             SetLastError(ERROR_INVALID_INDEX);
             return LB_ERR;
         }
-        return descr->items[index].height;
+        return get_item_height(descr, index);
     }
     else return descr->item_height;
 }
@@ -1244,7 +1408,7 @@ static LRESULT LISTBOX_SetItemHeight( LB_DESCR *descr, INT index, INT height, BO
             return LB_ERR;
         }
         TRACE("[%p]: item %d height = %d\n", descr->self, index, height );
-        descr->items[index].height = height;
+        set_item_height(descr, index, height);
         LISTBOX_UpdateScroll( descr );
 	if (repaint)
 	    LISTBOX_InvalidateItems( descr, index );
@@ -1256,7 +1420,7 @@ static LRESULT LISTBOX_SetItemHeight( LB_DESCR *descr, INT index, INT height, BO
         LISTBOX_UpdatePage( descr );
         LISTBOX_UpdateScroll( descr );
 	if (repaint)
-	    InvalidateRect( descr->self, 0, TRUE );
+	    NtUserInvalidateRect( descr->self, 0, TRUE );
     }
     return LB_OKAY;
 }
@@ -1281,12 +1445,12 @@ static void LISTBOX_SetHorizontalPos( LB_DESCR *descr, INT pos )
         RECT rect;
         /* Invalidate the focused item so it will be repainted correctly */
         if (LISTBOX_GetItemRect( descr, descr->focus_item, &rect ) == 1)
-            InvalidateRect( descr->self, &rect, TRUE );
-        ScrollWindowEx( descr->self, diff, 0, NULL, NULL, 0, NULL,
-                          SW_INVALIDATE | SW_ERASE | SW_SCROLLCHILDREN );
+            NtUserInvalidateRect( descr->self, &rect, TRUE );
+        NtUserScrollWindowEx( descr->self, diff, 0, NULL, NULL, 0, NULL,
+                              SW_INVALIDATE | SW_ERASE | SW_SCROLLCHILDREN );
     }
     else
-        InvalidateRect( descr->self, NULL, TRUE );
+        NtUserInvalidateRect( descr->self, NULL, TRUE );
 }
 
 
@@ -1308,7 +1472,11 @@ static LRESULT LISTBOX_SetHorizontalExtent( LB_DESCR *descr, INT extent )
         info.fMask = SIF_RANGE;
         if (descr->style & LBS_DISABLENOSCROLL)
             info.fMask |= SIF_DISABLENOSCROLL;
-        SetScrollInfo( descr->self, SB_HORZ, &info, TRUE );
+#ifdef __REACTOS__
+        SetScrollInfo(descr->self, SB_HORZ, &info, TRUE);
+#else
+        NtUserSetScrollInfo( descr->self, SB_HORZ, &info, TRUE );
+#endif
     }
     if (descr->horz_pos > extent - descr->width)
         LISTBOX_SetHorizontalPos( descr, extent - descr->width );
@@ -1319,12 +1487,19 @@ static LRESULT LISTBOX_SetHorizontalExtent( LB_DESCR *descr, INT extent )
 /***********************************************************************
  *           LISTBOX_SetColumnWidth
  */
-static LRESULT LISTBOX_SetColumnWidth( LB_DESCR *descr, INT width)
+static LRESULT LISTBOX_SetColumnWidth( LB_DESCR *descr, INT column_width)
 {
-    if (width == descr->column_width) return LB_OKAY;
-    TRACE("[%p]: new column width = %d\n", descr->self, width );
-    descr->column_width = width;
-    LISTBOX_UpdatePage( descr );
+    RECT rect;
+
+    TRACE("[%p]: new column width = %d\n", descr->self, column_width);
+
+    GetClientRect(descr->self, &rect);
+    descr->width = rect.right - rect.left;
+    descr->height = rect.bottom - rect.top;
+    descr->column_width = column_width;
+
+    LISTBOX_UpdatePage(descr);
+    LISTBOX_UpdateScroll(descr);
     return LB_OKAY;
 }
 
@@ -1343,7 +1518,7 @@ static INT LISTBOX_SetFont( LB_DESCR *descr, HFONT font )
 
     descr->font = font;
 
-    if (!(hdc = GetDCEx( descr->self, 0, DCX_CACHE )))
+    if (!(hdc = NtUserGetDCEx( descr->self, 0, DCX_CACHE )))
     {
         ERR("unable to get DC.\n" );
         return 16;
@@ -1351,7 +1526,7 @@ static INT LISTBOX_SetFont( LB_DESCR *descr, HFONT font )
     if (font) oldFont = SelectObject( hdc, font );
     GetTextExtentPointA( hdc, alphabet, 52, &sz);
     if (oldFont) SelectObject( hdc, oldFont );
-    ReleaseDC( descr->self, hdc );
+    NtUserReleaseDC( descr->self, hdc );
 
     descr->avg_char_width = (sz.cx / 26 + 1) / 2;
     if (!IS_OWNERDRAW(descr))
@@ -1383,9 +1558,9 @@ static void LISTBOX_MakeItemVisible( LB_DESCR *descr, INT index, BOOL fully )
     }
     else if (descr->style & LBS_OWNERDRAWVARIABLE)
     {
-        INT height = fully ? descr->items[index].height : 1;
+        INT height = fully ? get_item_height(descr, index) : 1;
         for (top = index; top > descr->top_item; top--)
-            if ((height += descr->items[top-1].height) > descr->height) break;
+            if ((height += get_item_height(descr, top - 1)) > descr->height) break;
     }
     else
     {
@@ -1406,19 +1581,23 @@ static void LISTBOX_MakeItemVisible( LB_DESCR *descr, INT index, BOOL fully )
  */
 static LRESULT LISTBOX_SetCaretIndex( LB_DESCR *descr, INT index, BOOL fully_visible )
 {
-    INT oldfocus = descr->focus_item;
+    BOOL focus_changed = descr->focus_item != index;
 
-    TRACE("old focus %d, index %d\n", oldfocus, index);
+    TRACE("old focus %d, index %d\n", descr->focus_item, index);
 
     if (descr->style & LBS_NOSEL) return LB_ERR;
     if ((index < 0) || (index >= descr->nb_items)) return LB_ERR;
-    if (index == oldfocus) return LB_OKAY;
 
-    LISTBOX_DrawFocusRect( descr, FALSE );
-    descr->focus_item = index;
+    if (focus_changed)
+    {
+        LISTBOX_DrawFocusRect( descr, FALSE );
+        descr->focus_item = index;
+    }
 
     LISTBOX_MakeItemVisible( descr, index, fully_visible );
-    LISTBOX_DrawFocusRect( descr, TRUE );
+
+    if (focus_changed)
+        LISTBOX_DrawFocusRect( descr, TRUE );
 
     return LB_OKAY;
 }
@@ -1449,8 +1628,8 @@ static LRESULT LISTBOX_SelectItemRange( LB_DESCR *descr, INT first,
     {
         for (i = first; i <= last; i++)
         {
-            if (descr->items[i].selected) continue;
-            descr->items[i].selected = TRUE;
+            if (is_item_selected(descr, i)) continue;
+            set_item_selected_state(descr, i, TRUE);
             LISTBOX_InvalidateItemRect(descr, i);
         }
     }
@@ -1458,8 +1637,8 @@ static LRESULT LISTBOX_SelectItemRange( LB_DESCR *descr, INT first,
     {
         for (i = first; i <= last; i++)
         {
-            if (!descr->items[i].selected) continue;
-            descr->items[i].selected = FALSE;
+            if (!is_item_selected(descr, i)) continue;
+            set_item_selected_state(descr, i, FALSE);
             LISTBOX_InvalidateItemRect(descr, i);
         }
     }
@@ -1492,10 +1671,10 @@ static LRESULT LISTBOX_SetSelection( LB_DESCR *descr, INT index,
     {
         INT oldsel = descr->selected_item;
         if (index == oldsel) return LB_OKAY;
-        if (oldsel != -1) descr->items[oldsel].selected = FALSE;
-        if (index != -1) descr->items[index].selected = TRUE;
-        if (oldsel != -1) LISTBOX_RepaintItem( descr, oldsel, ODA_SELECT );
+        if (oldsel != -1) set_item_selected_state(descr, oldsel, FALSE);
+        if (index != -1) set_item_selected_state(descr, index, TRUE);
         descr->selected_item = index;
+        if (oldsel != -1) LISTBOX_RepaintItem( descr, oldsel, ODA_SELECT );
         if (index != -1) LISTBOX_RepaintItem( descr, index, ODA_SELECT );
         if (send_notify && descr->nb_items) SEND_NOTIFICATION( descr,
                                (index != -1) ? LBN_SELCHANGE : LBN_SELCANCEL );
@@ -1562,43 +1741,18 @@ static void LISTBOX_MoveCaret( LB_DESCR *descr, INT index, BOOL fully_visible )
 static LRESULT LISTBOX_InsertItem( LB_DESCR *descr, INT index,
                                    LPWSTR str, ULONG_PTR data )
 {
-    LB_ITEMDATA *item;
-    INT max_items;
     INT oldfocus = descr->focus_item;
 
     if (index == -1) index = descr->nb_items;
     else if ((index < 0) || (index > descr->nb_items)) return LB_ERR;
-    if (!descr->items) max_items = 0;
-    else max_items = HeapSize( GetProcessHeap(), 0, descr->items ) / sizeof(*item);
-    if (descr->nb_items == max_items)
-    {
-        /* We need to grow the array */
-        max_items += LB_ARRAY_GRANULARITY;
-	if (descr->items)
-    	    item = HeapReAlloc( GetProcessHeap(), 0, descr->items,
-                                  max_items * sizeof(LB_ITEMDATA) );
-	else
-	    item = HeapAlloc( GetProcessHeap(), 0,
-                                  max_items * sizeof(LB_ITEMDATA) );
-        if (!item)
-        {
-            SEND_NOTIFICATION( descr, LBN_ERRSPACE );
-            return LB_ERRSPACE;
-        }
-        descr->items = item;
-    }
+    if (!resize_storage(descr, descr->nb_items + 1)) return LB_ERR;
 
-    /* Insert the item structure */
-
-    item = &descr->items[index];
-    if (index < descr->nb_items)
-        RtlMoveMemory( item + 1, item,
-                       (descr->nb_items - index) * sizeof(LB_ITEMDATA) );
-    item->str      = str;
-    item->data     = data;
-    item->height   = 0;
-    item->selected = FALSE;
+    insert_item_data(descr, index);
     descr->nb_items++;
+    set_item_string(descr, index, str);
+    set_item_data(descr, index, HAS_STRINGS(descr) ? 0 : data);
+    set_item_height(descr, index, 0);
+    set_item_selected_state(descr, index, FALSE);
 
     /* Get item height */
 
@@ -1610,13 +1764,15 @@ static LRESULT LISTBOX_InsertItem( LB_DESCR *descr, INT index,
         mis.CtlType    = ODT_LISTBOX;
         mis.CtlID      = id;
         mis.itemID     = index;
-        mis.itemData   = descr->items[index].data;
+        mis.itemData   = str ? (ULONG_PTR)str : data;
         mis.itemHeight = descr->item_height;
         SendMessageW( descr->owner, WM_MEASUREITEM, id, (LPARAM)&mis );
-        item->height = mis.itemHeight ? mis.itemHeight : 1;
+        set_item_height(descr, index, mis.itemHeight ? mis.itemHeight : 1);
         TRACE("[%p]: measure item %d (%s) = %d\n",
-              descr->self, index, str ? debugstr_w(str) : "", item->height );
+              descr->self, index, str ? debugstr_w(str) : "", get_item_height(descr, index));
     }
+
+    NtUserNotifyWinEvent( EVENT_OBJECT_CREATE, descr->self, OBJID_CLIENT, index + 1 );
 
     /* Repaint the items */
 
@@ -1651,24 +1807,21 @@ static LRESULT LISTBOX_InsertItem( LB_DESCR *descr, INT index,
 static LRESULT LISTBOX_InsertString( LB_DESCR *descr, INT index, LPCWSTR str )
 {
     LPWSTR new_str = NULL;
-    ULONG_PTR data = 0;
     LRESULT ret;
 
     if (HAS_STRINGS(descr))
     {
-        static const WCHAR empty_stringW[] = { 0 };
-        if (!str) str = empty_stringW;
-        if (!(new_str = HeapAlloc( GetProcessHeap(), 0, (strlenW(str) + 1) * sizeof(WCHAR) )))
+        if (!str) str = L"";
+        if (!(new_str = HeapAlloc( GetProcessHeap(), 0, (lstrlenW(str) + 1) * sizeof(WCHAR) )))
         {
             SEND_NOTIFICATION( descr, LBN_ERRSPACE );
             return LB_ERRSPACE;
         }
-        strcpyW(new_str, str);
+        lstrcpyW(new_str, str);
     }
-    else data = (ULONG_PTR)str;
 
     if (index == -1) index = descr->nb_items;
-    if ((ret = LISTBOX_InsertItem( descr, index, new_str, data )) != 0)
+    if ((ret = LISTBOX_InsertItem( descr, index, new_str, (ULONG_PTR)str )) != 0)
     {
         HeapFree( GetProcessHeap(), 0, new_str );
         return ret;
@@ -1687,19 +1840,12 @@ static LRESULT LISTBOX_InsertString( LB_DESCR *descr, INT index, LPCWSTR str )
  */
 static void LISTBOX_DeleteItem( LB_DESCR *descr, INT index )
 {
-    /* save the item data before it gets freed by LB_RESETCONTENT */
-    ULONG_PTR item_data = descr->items[index].data;
-    LPWSTR item_str = descr->items[index].str;
-
-    if (!descr->nb_items)
-        SendMessageW( descr->self, LB_RESETCONTENT, 0, 0 );
-
     /* Note: Win 3.1 only sends DELETEITEM on owner-draw items,
      *       while Win95 sends it for all items with user data.
      *       It's probably better to send it too often than not
      *       often enough, so this is what we do here.
      */
-    if (IS_OWNERDRAW(descr) || item_data)
+    if (IS_OWNERDRAW(descr) || get_item_data(descr, index))
     {
         DELETEITEMSTRUCT dis;
         UINT id = (UINT)GetWindowLongPtrW( descr->self, GWLP_ID );
@@ -1708,11 +1854,10 @@ static void LISTBOX_DeleteItem( LB_DESCR *descr, INT index )
         dis.CtlID    = id;
         dis.itemID   = index;
         dis.hwndItem = descr->self;
-        dis.itemData = item_data;
+        dis.itemData = get_item_data(descr, index);
         SendMessageW( descr->owner, WM_DELETEITEM, id, (LPARAM)&dis );
     }
-    if (HAS_STRINGS(descr))
-        HeapFree( GetProcessHeap(), 0, item_str );
+    HeapFree( GetProcessHeap(), 0, get_item_string(descr, index) );
 }
 
 
@@ -1723,37 +1868,24 @@ static void LISTBOX_DeleteItem( LB_DESCR *descr, INT index )
  */
 static LRESULT LISTBOX_RemoveItem( LB_DESCR *descr, INT index )
 {
-    LB_ITEMDATA *item;
-    INT max_items;
-
     if ((index < 0) || (index >= descr->nb_items)) return LB_ERR;
 
     /* We need to invalidate the original rect instead of the updated one. */
     LISTBOX_InvalidateItems( descr, index );
 
+    NtUserNotifyWinEvent( EVENT_OBJECT_DESTROY, descr->self, OBJID_CLIENT, index + 1 );
+
+    if (descr->nb_items == 1)
+    {
+        SendMessageW(descr->self, LB_RESETCONTENT, 0, 0);
+        return LB_OKAY;
+    }
     descr->nb_items--;
     LISTBOX_DeleteItem( descr, index );
+    remove_item_data(descr, index);
 
-    if (!descr->nb_items) return LB_OKAY;
-
-    /* Remove the item */
-
-    item = &descr->items[index];
-    if (index < descr->nb_items)
-        RtlMoveMemory( item, item + 1,
-                       (descr->nb_items - index) * sizeof(LB_ITEMDATA) );
     if (descr->anchor_item == descr->nb_items) descr->anchor_item--;
-
-    /* Shrink the item array if possible */
-
-    max_items = HeapSize( GetProcessHeap(), 0, descr->items ) / sizeof(LB_ITEMDATA);
-    if (descr->nb_items < max_items - 2*LB_ARRAY_GRANULARITY)
-    {
-        max_items -= LB_ARRAY_GRANULARITY;
-        item = HeapReAlloc( GetProcessHeap(), 0, descr->items,
-                            max_items * sizeof(LB_ITEMDATA) );
-        if (item) descr->items = item;
-    }
+    resize_storage(descr, descr->nb_items);
     /* Repaint the items */
 
     LISTBOX_UpdateScroll( descr );
@@ -1791,45 +1923,60 @@ static void LISTBOX_ResetContent( LB_DESCR *descr )
 {
     INT i;
 
-    for(i = descr->nb_items - 1; i>=0; i--) LISTBOX_DeleteItem( descr, i);
-    HeapFree( GetProcessHeap(), 0, descr->items );
+    if (!(descr->style & LBS_NODATA))
+        for (i = descr->nb_items - 1; i >= 0; i--) LISTBOX_DeleteItem(descr, i);
+    free( descr->u.items );
     descr->nb_items      = 0;
     descr->top_item      = 0;
     descr->selected_item = -1;
     descr->focus_item    = 0;
     descr->anchor_item   = -1;
-    descr->items         = NULL;
+    descr->items_size    = 0;
+    descr->u.items       = NULL;
 }
 
 
 /***********************************************************************
  *           LISTBOX_SetCount
  */
-static LRESULT LISTBOX_SetCount( LB_DESCR *descr, INT count )
+static LRESULT LISTBOX_SetCount( LB_DESCR *descr, UINT count )
 {
-    LRESULT ret;
+    UINT orig_num = descr->nb_items;
 
-    if (HAS_STRINGS(descr))
+    if (!(descr->style & LBS_NODATA))
     {
         SetLastError(ERROR_SETCOUNT_ON_BAD_LB);
         return LB_ERR;
     }
 
-    /* FIXME: this is far from optimal... */
-    if (count > descr->nb_items)
-    {
-        while (count > descr->nb_items)
-            if ((ret = LISTBOX_InsertString( descr, -1, 0 )) < 0)
-                return ret;
-    }
-    else if (count < descr->nb_items)
-    {
-        while (count < descr->nb_items)
-            if ((ret = LISTBOX_RemoveItem( descr, (descr->nb_items - 1) )) < 0)
-                return ret;
-    }
+    if (!resize_storage(descr, count))
+        return LB_ERRSPACE;
+    descr->nb_items = count;
+    if (descr->style & LBS_NOREDRAW)
+        descr->style |= LBS_DISPLAYCHANGED;
 
-    InvalidateRect( descr->self, NULL, TRUE );
+    if (count)
+    {
+        LISTBOX_UpdateScroll(descr);
+        if (count < orig_num)
+        {
+            descr->anchor_item = min(descr->anchor_item, count - 1);
+            if (descr->selected_item >= count)
+                descr->selected_item = -1;
+
+            /* If we removed the scrollbar, reset the top of the list */
+            if (count <= descr->page_size && orig_num > descr->page_size)
+                LISTBOX_SetTopItem(descr, 0, TRUE);
+
+            descr->focus_item = min(descr->focus_item, count - 1);
+        }
+
+        /* If it was empty before growing, set focus to the first item */
+        else if (orig_num == 0) LISTBOX_SetCaretIndex(descr, 0, FALSE);
+    }
+    else SendMessageW(descr->self, LB_RESETCONTENT, 0, 0);
+
+    NtUserInvalidateRect( descr->self, NULL, TRUE );
     return LB_OKAY;
 }
 
@@ -1861,16 +2008,14 @@ static LRESULT LISTBOX_Directory( LB_DESCR *descr, UINT attrib,
                 WCHAR buffer[270];
                 if (entry.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
                 {
-                    static const WCHAR bracketW[]  = { ']',0 };
-                    static const WCHAR dotW[] = { '.',0 };
                     if (!(attrib & DDL_DIRECTORY) ||
-                        !strcmpW( entry.cFileName, dotW )) continue;
+                        !wcscmp( entry.cFileName, L"." )) continue;
                     buffer[0] = '[';
                     if (!long_names && entry.cAlternateFileName[0])
-                        strcpyW( buffer + 1, entry.cAlternateFileName );
+                        lstrcpyW( buffer + 1, entry.cAlternateFileName );
                     else
-                        strcpyW( buffer + 1, entry.cFileName );
-                    strcatW(buffer, bracketW);
+                        lstrcpyW( buffer + 1, entry.cFileName );
+                    lstrcatW(buffer, L"]");
                 }
                 else  /* not a directory */
                 {
@@ -1882,9 +2027,9 @@ static LRESULT LISTBOX_Directory( LB_DESCR *descr, UINT attrib,
                         continue;
 #undef ATTRIBS
                     if (!long_names && entry.cAlternateFileName[0])
-                        strcpyW( buffer, entry.cAlternateFileName );
+                        lstrcpyW( buffer, entry.cAlternateFileName );
                     else
-                        strcpyW( buffer, entry.cFileName );
+                        lstrcpyW( buffer, entry.cFileName );
                 }
                 if (!long_names) CharLowerW( buffer );
                 pos = LISTBOX_FindFileStrPos( descr, buffer );
@@ -1902,8 +2047,8 @@ static LRESULT LISTBOX_Directory( LB_DESCR *descr, UINT attrib,
         /* scan drives */
         if (attrib & DDL_DRIVES)
         {
-            WCHAR buffer[] = {'[','-','a','-',']',0};
-            WCHAR root[] = {'A',':','\\',0};
+            WCHAR buffer[] = L"[-a-]";
+            WCHAR root[] = L"A:\\";
             int drive;
             for (drive = 0; drive < 26; drive++, buffer[2]++, root[0]++)
             {
@@ -2056,7 +2201,7 @@ static LRESULT LISTBOX_HandleHScroll( LB_DESCR *descr, WORD scrollReq, WORD pos 
 
 static LRESULT LISTBOX_HandleMouseWheel(LB_DESCR *descr, SHORT delta )
 {
-    UINT pulScrollLines = 3;
+    INT pulScrollLines = 3;
 
     SystemParametersInfoW(SPI_GETWHEELSCROLLLINES,0, &pulScrollLines, 0);
 
@@ -2070,13 +2215,24 @@ static LRESULT LISTBOX_HandleMouseWheel(LB_DESCR *descr, SHORT delta )
     if (descr->wheel_remain && pulScrollLines)
     {
         int cLineScroll;
-        pulScrollLines = min((UINT) descr->page_size, pulScrollLines);
-        cLineScroll = pulScrollLines * (float)descr->wheel_remain / WHEEL_DELTA;
-        descr->wheel_remain -= WHEEL_DELTA * cLineScroll / (int)pulScrollLines;
+        if (descr->style & LBS_MULTICOLUMN)
+        {
+            pulScrollLines = min(descr->width / descr->column_width, pulScrollLines);
+            pulScrollLines = max(1, pulScrollLines);
+            cLineScroll = pulScrollLines * descr->wheel_remain / WHEEL_DELTA;
+            descr->wheel_remain -= WHEEL_DELTA * cLineScroll / pulScrollLines;
+            cLineScroll *= descr->page_size;
+        }
+        else
+        {
+            pulScrollLines = min(descr->page_size, pulScrollLines);
+            cLineScroll = pulScrollLines * descr->wheel_remain / WHEEL_DELTA;
+            descr->wheel_remain -= WHEEL_DELTA * cLineScroll / pulScrollLines;
 #ifdef __REACTOS__
         if (cLineScroll < 0)
             cLineScroll -= descr->page_size;
 #endif
+        }
         LISTBOX_SetTopItem( descr, descr->top_item - cLineScroll, TRUE );
     }
     return 0;
@@ -2096,8 +2252,8 @@ static LRESULT LISTBOX_HandleLButtonDown( LB_DESCR *descr, DWORD keys, INT x, IN
 
     if (!descr->in_focus)
     {
-        if( !descr->lphc ) SetFocus( descr->self );
-        else SetFocus( (descr->lphc->hWndEdit) ? descr->lphc->hWndEdit : descr->lphc->self );
+        if( !descr->lphc ) NtUserSetFocus( descr->self );
+        else NtUserSetFocus( (descr->lphc->hWndEdit) ? descr->lphc->hWndEdit : descr->lphc->self );
     }
 
     if (index == -1) return 0;
@@ -2110,7 +2266,7 @@ static LRESULT LISTBOX_HandleLButtonDown( LB_DESCR *descr, DWORD keys, INT x, IN
     }
 
     descr->captured = TRUE;
-    SetCapture( descr->self );
+    NtUserSetCapture( descr->self );
 
     if (descr->style & (LBS_EXTENDEDSEL | LBS_MULTIPLESEL))
     {
@@ -2125,7 +2281,7 @@ static LRESULT LISTBOX_HandleLButtonDown( LB_DESCR *descr, DWORD keys, INT x, IN
         {
             LISTBOX_SetCaretIndex( descr, index, FALSE );
             LISTBOX_SetSelection( descr, index,
-                                  !descr->items[index].selected,
+                                  !is_item_selected(descr, index),
                                   (descr->style & LBS_NOTIFY) != 0);
         }
         else
@@ -2135,13 +2291,13 @@ static LRESULT LISTBOX_HandleLButtonDown( LB_DESCR *descr, DWORD keys, INT x, IN
             if (descr->style & LBS_EXTENDEDSEL)
             {
                 LISTBOX_SetSelection( descr, index,
-                               descr->items[index].selected,
+                               is_item_selected(descr, index),
                               (descr->style & LBS_NOTIFY) != 0 );
             }
             else
             {
                 LISTBOX_SetSelection( descr, index,
-                               !descr->items[index].selected,
+                               !is_item_selected(descr, index),
                               (descr->style & LBS_NOTIFY) != 0 );
             }
         }
@@ -2152,6 +2308,8 @@ static LRESULT LISTBOX_HandleLButtonDown( LB_DESCR *descr, DWORD keys, INT x, IN
         LISTBOX_MoveCaret( descr, index, FALSE );
         LISTBOX_SetSelection( descr, index,
                               TRUE, (descr->style & LBS_NOTIFY) != 0 );
+        NtUserNotifyWinEvent( EVENT_OBJECT_FOCUS, descr->self, OBJID_CLIENT, index + 1 );
+        NtUserNotifyWinEvent( EVENT_OBJECT_SELECTION, descr->self, OBJID_CLIENT, index + 1 );
     }
 
     if (!descr->lphc)
@@ -2219,7 +2377,7 @@ static LRESULT LISTBOX_HandleLButtonDownCombo( LB_DESCR *descr, UINT msg, DWORD 
         /* Check the Non-Client Area */
         screenMousePos = mousePos;
         hWndOldCapture = GetCapture();
-        ReleaseCapture();
+        NtUserReleaseCapture();
         GetWindowRect(descr->self, &screenRect);
         ClientToScreen(descr->self, &screenMousePos);
 
@@ -2259,7 +2417,7 @@ static LRESULT LISTBOX_HandleLButtonDownCombo( LB_DESCR *descr, UINT msg, DWORD 
             /* Resume the Capture after scrolling is complete
              */
             if(hWndOldCapture != 0)
-                SetCapture(hWndOldCapture);
+                NtUserSetCapture(hWndOldCapture);
         }
     }
     return 0;
@@ -2271,12 +2429,12 @@ static LRESULT LISTBOX_HandleLButtonDownCombo( LB_DESCR *descr, UINT msg, DWORD 
 static LRESULT LISTBOX_HandleLButtonUp( LB_DESCR *descr )
 {
     if (LISTBOX_Timer != LB_TIMER_NONE)
-        KillSystemTimer( descr->self, LB_TIMER_ID );
+        NtUserKillSystemTimer( descr->self, LB_TIMER_ID );
     LISTBOX_Timer = LB_TIMER_NONE;
     if (descr->captured)
     {
         descr->captured = FALSE;
-        if (GetCapture() == descr->self) ReleaseCapture();
+        if (GetCapture() == descr->self) NtUserReleaseCapture();
         if ((descr->style & LBS_NOTIFY) && descr->nb_items)
             SEND_NOTIFICATION( descr, LBN_SELCHANGE );
     }
@@ -2328,7 +2486,7 @@ static LRESULT LISTBOX_HandleSystemTimer( LB_DESCR *descr )
 {
     if (!LISTBOX_HandleTimer( descr, descr->focus_item, LISTBOX_Timer ))
     {
-        KillSystemTimer( descr->self, LB_TIMER_ID );
+        NtUserKillSystemTimer( descr->self, LB_TIMER_ID );
         LISTBOX_Timer = LB_TIMER_NONE;
     }
     return 0;
@@ -2378,9 +2536,9 @@ static void LISTBOX_HandleMouseMove( LB_DESCR *descr,
     /* Start/stop the system timer */
 
     if (dir != LB_TIMER_NONE)
-        SetSystemTimer( descr->self, LB_TIMER_ID, LB_SCROLL_TIMEOUT, NULL);
+        NtUserSetSystemTimer( descr->self, LB_TIMER_ID, LB_SCROLL_TIMEOUT );
     else if (LISTBOX_Timer != LB_TIMER_NONE)
-        KillSystemTimer( descr->self, LB_TIMER_ID );
+        NtUserKillSystemTimer( descr->self, LB_TIMER_ID );
     LISTBOX_Timer = dir;
 }
 
@@ -2421,8 +2579,7 @@ static LRESULT LISTBOX_HandleKeyDown( LB_DESCR *descr, DWORD key )
         if (descr->style & LBS_MULTICOLUMN)
         {
             bForceSelection = FALSE;
-            if (descr->focus_item + descr->page_size < descr->nb_items)
-                caret = descr->focus_item + descr->page_size;
+            caret = min(descr->focus_item + descr->page_size, descr->nb_items - 1);
             break;
         }
         /* fall through */
@@ -2462,7 +2619,7 @@ static LRESULT LISTBOX_HandleKeyDown( LB_DESCR *descr, DWORD key )
         else if (descr->style & LBS_MULTIPLESEL)
         {
             LISTBOX_SetSelection( descr, descr->focus_item,
-                                  !descr->items[descr->focus_item].selected,
+                                  !is_item_selected(descr, descr->focus_item),
                                   (descr->style & LBS_NOTIFY) != 0 );
         }
         break;
@@ -2474,7 +2631,7 @@ static LRESULT LISTBOX_HandleKeyDown( LB_DESCR *descr, DWORD key )
     if (caret >= 0)
     {
         if (((descr->style & LBS_EXTENDEDSEL) &&
-            !(GetKeyState( VK_SHIFT ) & 0x8000)) ||
+            !(NtUserGetKeyState( VK_SHIFT ) & 0x8000)) ||
             !IS_MULTISELECT(descr))
             descr->anchor_item = caret;
         LISTBOX_MoveCaret( descr, caret, TRUE );
@@ -2515,7 +2672,7 @@ static LRESULT LISTBOX_HandleChar( LB_DESCR *descr, WCHAR charW )
                                 (LPARAM)descr->self );
         if (caret == -2) return 0;
     }
-    if (caret == -1)
+    if (caret == -1 && !(descr->style & LBS_NODATA))
         caret = LISTBOX_FindString( descr, descr->focus_item, str, FALSE);
     if (caret != -1)
     {
@@ -2557,7 +2714,8 @@ static BOOL LISTBOX_Create( HWND hwnd, LPHEADCOMBO lphc )
     descr->style         = GetWindowLongPtrW( descr->self, GWL_STYLE );
     descr->width         = rect.right - rect.left;
     descr->height        = rect.bottom - rect.top;
-    descr->items         = NULL;
+    descr->u.items       = NULL;
+    descr->items_size    = 0;
     descr->nb_items      = 0;
     descr->top_item      = 0;
     descr->selected_item = -1;
@@ -2585,7 +2743,7 @@ static BOOL LISTBOX_Create( HWND hwnd, LPHEADCOMBO lphc )
         descr->owner = lphc->self;
     }
 
-    SetWindowLongPtrW( descr->self, 0, (LONG_PTR)descr );
+    set_control_state( descr->self, descr );
 
     LISTBOX_update_uistate(descr); // ReactOS
 
@@ -2602,10 +2760,14 @@ static BOOL LISTBOX_Create( HWND hwnd, LPHEADCOMBO lphc )
         (!(descr->style & LBS_OWNERDRAWFIXED) || descr->style & (LBS_HASSTRINGS|LBS_SORT) ) )
        descr->style &= ~LBS_NODATA;
     ////
+    if ((descr->style & (LBS_OWNERDRAWFIXED | LBS_HASSTRINGS | LBS_SORT)) != LBS_OWNERDRAWFIXED)
+        descr->style &= ~LBS_NODATA;
     descr->item_height = LISTBOX_SetFont( descr, 0 );
 
     if (descr->style & LBS_OWNERDRAWFIXED)
     {
+        descr->style &= ~LBS_OWNERDRAWVARIABLE;
+
 	if( descr->lphc && (descr->lphc->dwStyle & CBS_DROPDOWN))
 	{
 	    /* WinWord gets VERY unhappy if we send WM_MEASUREITEM from here */
@@ -2636,7 +2798,7 @@ static BOOL LISTBOX_Create( HWND hwnd, LPHEADCOMBO lphc )
 static BOOL LISTBOX_Destroy( LB_DESCR *descr )
 {
     LISTBOX_ResetContent( descr );
-    SetWindowLongPtrW( descr->self, 0, 0 );
+    set_control_state( descr->self, NULL );
     HeapFree( GetProcessHeap(), 0, descr );
     return TRUE;
 }
@@ -2648,29 +2810,10 @@ static BOOL LISTBOX_Destroy( LB_DESCR *descr )
 LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
                                    WPARAM wParam, LPARAM lParam, BOOL unicode )
 {
-    LB_DESCR *descr = (LB_DESCR *)GetWindowLongPtrW( hwnd, 0 );
-    LPHEADCOMBO lphc = 0;
+    LB_DESCR *descr = get_control_state( hwnd );
+    HEADCOMBO *lphc = NULL;
     LRESULT ret;
-#ifdef __REACTOS__
-    PWND pWnd;
-
-    pWnd = ValidateHwnd(hwnd);
-    if (pWnd)
-    {
-       if (!pWnd->fnid)
-       {
-          NtUserSetWindowFNID(hwnd, FNID_LISTBOX); // Could be FNID_COMBOLBOX by class.
-       }
-       else
-       {
-          if (pWnd->fnid != FNID_LISTBOX)
-          {
-             ERR("Wrong window class for listbox! fnId 0x%x\n",pWnd->fnid);
-             return 0;
-          }
-       }
-    }    
-#endif    
+    if (msg == WM_CREATE || msg == WM_NCCREATE) NtUserSetWindowFNID( hwnd, MAKE_FNID(NTUSER_WNDPROC_LISTBOX) );
 
     if (!descr)
     {
@@ -2681,7 +2824,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
 	    CREATESTRUCTW *lpcs = (CREATESTRUCTW *)lParam;
             if (lpcs->style & LBS_COMBOBOX) lphc = lpcs->lpCreateParams;
             if (!LISTBOX_Create( hwnd, lphc )) return -1;
-            TRACE("creating hwnd %p descr %p\n", hwnd, (void *)GetWindowLongPtrW( hwnd, 0 ) );
+            TRACE("creating hwnd %p descr %p\n", hwnd, get_control_state( hwnd ) );
             return 0;
         }
         /* Ignore all other messages before we get a WM_CREATE */
@@ -2690,7 +2833,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
     }
     if (descr->style & LBS_COMBOBOX) lphc = descr->lphc;
 
-    TRACE("[%p]: msg %s wp %08lx lp %08lx\n",
+    TRACE("[%p]: msg %s wp %08Ix lp %08Ix\n",
           descr->self, SPY_GetMsgName(msg, descr->self), wParam, lParam );
 
     switch(msg)
@@ -2698,7 +2841,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
     case LB_RESETCONTENT:
         LISTBOX_ResetContent( descr );
         LISTBOX_UpdateScroll( descr );
-        InvalidateRect( descr->self, NULL, TRUE );
+        NtUserInvalidateRect( descr->self, NULL, TRUE );
         return 0;
 
     case LB_ADDSTRING:
@@ -2805,7 +2948,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
             SetLastError(ERROR_INVALID_INDEX);
             return LB_ERR;
         }
-        return descr->items[wParam].data;
+        return get_item_data(descr, wParam);
 
     case LB_SETITEMDATA:
         if (((INT)wParam < 0) || ((INT)wParam >= descr->nb_items))
@@ -2813,7 +2956,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
             SetLastError(ERROR_INVALID_INDEX);
             return LB_ERR;
         }
-        descr->items[wParam].data = lParam;
+        set_item_data(descr, wParam, lParam);
         /* undocumented: returns TRUE, not LB_OKAY (0) */
         return TRUE;
 
@@ -2829,10 +2972,10 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
             SetLastError(ERROR_INVALID_INDEX);
             return LB_ERR;
         }
-        if (!HAS_STRINGS(descr)) return sizeof(DWORD);
-        if (unicode) return strlenW( descr->items[wParam].str );
-        return WideCharToMultiByte( CP_ACP, 0, descr->items[wParam].str,
-                                    strlenW(descr->items[wParam].str), NULL, 0, NULL, NULL );
+        if (!HAS_STRINGS(descr)) return sizeof(ULONG_PTR);
+        if (unicode) return lstrlenW(get_item_string(descr, wParam));
+        return WideCharToMultiByte( CP_ACP, 0, get_item_string(descr, wParam),
+                                    lstrlenW(get_item_string(descr, wParam)), NULL, 0, NULL, NULL );
 
     case LB_GETCURSEL:
         if (descr->nb_items == 0)
@@ -2971,26 +3114,38 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
         if(!unicode && HAS_STRINGS(descr))
             HeapFree(GetProcessHeap(), 0, textW);
         if (index != LB_ERR)
-	{
+        {
             LISTBOX_MoveCaret( descr, index, TRUE );
             LISTBOX_SetSelection( descr, index, TRUE, FALSE );
-	}
+        }
         return index;
     }
 
     case LB_GETSEL:
         if (((INT)wParam < 0) || ((INT)wParam >= descr->nb_items))
             return LB_ERR;
-        return descr->items[wParam].selected;
+        return is_item_selected(descr, wParam);
 
     case LB_SETSEL:
-        return LISTBOX_SetSelection( descr, lParam, wParam, FALSE );
+        ret = LISTBOX_SetSelection( descr, lParam, wParam, FALSE );
+        if (ret != LB_ERR && wParam)
+        {
+            descr->anchor_item = lParam;
+            if (lParam != -1)
+                LISTBOX_SetCaretIndex( descr, lParam, TRUE );
+        }
+        return ret;
 
     case LB_SETCURSEL:
         if (IS_MULTISELECT(descr)) return LB_ERR;
         LISTBOX_SetCaretIndex( descr, wParam, TRUE );
         ret = LISTBOX_SetSelection( descr, wParam, TRUE, FALSE );
-	if (ret != LB_ERR) ret = descr->selected_item;
+        if (ret != LB_ERR)
+        {
+            ret = descr->selected_item;
+            NtUserNotifyWinEvent( EVENT_OBJECT_FOCUS, descr->self, OBJID_CLIENT, ret + 1 );
+            NtUserNotifyWinEvent( EVENT_OBJECT_SELECTION, descr->self, OBJID_CLIENT, ret + 1 );
+        }
 	return ret;
 
     case LB_GETSELCOUNT:
@@ -3095,7 +3250,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
         return LISTBOX_Destroy( descr );
 
     case WM_ENABLE:
-        InvalidateRect( descr->self, NULL, TRUE );
+        NtUserInvalidateRect( descr->self, NULL, TRUE );
         return 0;
 
     case WM_SETREDRAW:
@@ -3109,9 +3264,9 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
     case WM_PAINT:
         {
             PAINTSTRUCT ps;
-            HDC hdc = ( wParam ) ? ((HDC)wParam) :  BeginPaint( descr->self, &ps );
+            HDC hdc = ( wParam ) ? ((HDC)wParam) :  NtUserBeginPaint( descr->self, &ps );
             ret = LISTBOX_Paint( descr, hdc );
-            if( !wParam ) EndPaint( descr->self, &ps );
+            if (!wParam) NtUserEndPaint( descr->self, &ps );
         }
         return ret;
     case WM_SIZE:
@@ -3121,7 +3276,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
         return (LRESULT)descr->font;
     case WM_SETFONT:
         LISTBOX_SetFont( descr, (HFONT)wParam );
-        if (lParam) InvalidateRect( descr->self, 0, TRUE );
+        if (lParam) NtUserInvalidateRect( descr->self, 0, TRUE );
         return 0;
     case WM_SETFOCUS:
         descr->in_focus = TRUE;
@@ -3129,6 +3284,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
         if (descr->focus_item != -1)
             LISTBOX_DrawFocusRect( descr, TRUE );
         SEND_NOTIFICATION( descr, LBN_SETFOCUS );
+        NtUserNotifyWinEvent( EVENT_OBJECT_FOCUS, descr->self, OBJID_CLIENT, descr->focus_item + 1 );
         return 0;
     case WM_KILLFOCUS:
         LISTBOX_HandleLButtonUp( descr ); /* Release capture if we have it */
@@ -3159,7 +3315,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
             return LISTBOX_HandleLButtonDownCombo(descr, msg, wParam,
                                                   (INT16)LOWORD(lParam),
                                                   (INT16)HIWORD(lParam) );
-        if (descr->style & LBS_NOTIFY)
+        if ((descr->style & LBS_NOTIFY) && descr->nb_items)
             SEND_NOTIFICATION( descr, LBN_DBLCLK );
         return 0;
     case WM_MOUSEMOVE:
@@ -3182,7 +3338,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
             LISTBOX_HandleMouseMove( descr, mousePos.x, mousePos.y);
 
             descr->captured = captured;
-        } 
+        }
         else if (GetCapture() == descr->self)
         {
             LISTBOX_HandleMouseMove( descr, (INT16)LOWORD(lParam),
@@ -3280,7 +3436,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
     case WM_NCACTIVATE:
         if (lphc) return 0;
 	break;
-// ReactOS
+#ifdef __REACTOS__
     case WM_UPDATEUISTATE:
         if (unicode)
             DefWindowProcW(descr->self, msg, wParam, lParam);
@@ -3294,10 +3450,10 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
                LISTBOX_DrawFocusRect( descr, descr->in_focus );
         }
         break;
-//
+#endif
     default:
         if ((msg >= WM_USER) && (msg < 0xc000))
-            WARN("[%p]: unknown msg %04x wp %08lx lp %08lx\n",
+            WARN("[%p]: unknown msg %04x wp %08Ix lp %08Ix\n",
                  hwnd, msg, wParam, lParam );
     }
 
@@ -3305,6 +3461,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
                      DefWindowProcA( hwnd, msg, wParam, lParam );
 }
 
+#ifdef __REACTOS__
 /***********************************************************************
  *           ListBoxWndProcA
  */
@@ -3320,3 +3477,4 @@ LRESULT WINAPI ListBoxWndProcW( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 {
     return ListBoxWndProc_common( hwnd, msg, wParam, lParam, TRUE );
 }
+#endif

--- a/win32ss/user/user32/controls/regcontrol.c
+++ b/win32ss/user/user32/controls/regcontrol.c
@@ -147,8 +147,8 @@ BOOL WINAPI RegisterClientPFN(VOID)
 
   pfnClientA.pfnScrollBarWndProc      = ScrollBarWndProcA;
   pfnClientW.pfnScrollBarWndProc      = ScrollBarWndProcW;
-  pfnClientA.pfnTitleWndProc          = IconTitleWndProc;
-  pfnClientW.pfnTitleWndProc          = IconTitleWndProc;
+  pfnClientA.pfnTitleWndProc          = IconTitleWndProcA;
+  pfnClientW.pfnTitleWndProc          = IconTitleWndProcW;
   pfnClientA.pfnMenuWndProc           = PopupMenuWndProcA;
   pfnClientW.pfnMenuWndProc           = PopupMenuWndProcW;
   pfnClientA.pfnDesktopWndProc        = DesktopWndProcA;
@@ -208,6 +208,6 @@ BOOL WINAPI RegisterClientPFN(VOID)
                                             &pfnClientW,
                                             &pfnClientWorker,
                                             User32Instance);
-  
+
   return NT_SUCCESS(Status) ? TRUE : FALSE;
 }

--- a/win32ss/user/user32/controls/static.c
+++ b/win32ss/user/user32/controls/static.c
@@ -29,26 +29,29 @@
  */
 
 #include <user32.h>
+#include <wine-compat.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(static);
 
-static void STATIC_PaintOwnerDrawfn( HWND hwnd, HDC hdc, DWORD style );
-static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, DWORD style );
-static void STATIC_PaintRectfn( HWND hwnd, HDC hdc, DWORD style );
-static void STATIC_PaintIconfn( HWND hwnd, HDC hdc, DWORD style );
-static void STATIC_PaintBitmapfn( HWND hwnd, HDC hdc, DWORD style );
-static void STATIC_PaintEnhMetafn( HWND hwnd, HDC hdc, DWORD style );
-static void STATIC_PaintEtchedfn( HWND hwnd, HDC hdc, DWORD style );
+static void STATIC_PaintOwnerDrawfn( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style );
+static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style );
+static void STATIC_PaintRectfn( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style );
+static void STATIC_PaintIconfn( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style );
+static void STATIC_PaintBitmapfn( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style );
+static void STATIC_PaintEnhMetafn( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style );
+static void STATIC_PaintEtchedfn( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style );
 
 static COLORREF color_3dshadow, color_3ddkshadow, color_3dhighlight;
 
 /* offsets for GetWindowLong for static private information */
 #define HFONT_GWL_OFFSET    0
 #define HICON_GWL_OFFSET    (sizeof(HFONT))
+#ifdef __REACTOS__
 #define UISTATE_GWL_OFFSET (HICON_GWL_OFFSET+sizeof(HICON)) // ReactOS: keep in sync with STATIC_UISTATE_GWL_OFFSET
 #define STATIC_EXTRA_BYTES  (UISTATE_GWL_OFFSET + sizeof(LONG))
+#endif
 
-typedef void (*pfPaint)( HWND hwnd, HDC hdc, DWORD style );
+typedef void (*pfPaint)( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style );
 
 static const pfPaint staticPaintFunc[SS_TYPEMASK+1] =
 {
@@ -68,12 +71,13 @@ static const pfPaint staticPaintFunc[SS_TYPEMASK+1] =
     STATIC_PaintOwnerDrawfn, /* SS_OWNERDRAW */
     STATIC_PaintBitmapfn,    /* SS_BITMAP */
     STATIC_PaintEnhMetafn,   /* SS_ENHMETAFILE */
-    STATIC_PaintEtchedfn,    /* SS_ETCHEDHORZ */
-    STATIC_PaintEtchedfn,    /* SS_ETCHEDVERT */
+    NULL,                    /* SS_ETCHEDHORZ */
+    NULL,                    /* SS_ETCHEDVERT */
     STATIC_PaintEtchedfn,    /* SS_ETCHEDFRAME */
 };
 
 
+#ifdef __REACTOS__
 /*********************************************************************
  * static class descriptor
  */
@@ -88,6 +92,27 @@ const struct builtin_class_descr STATIC_builtin_class =
     IDC_ARROW,           /* cursor */
     0                    /* brush */
 };
+#endif
+
+static HFONT get_control_font( HWND hwnd )
+{
+    return (HFONT)NtUserGetPrivateData( hwnd, HFONT_GWL_OFFSET, sizeof(HFONT) );
+}
+
+static HFONT set_control_font( HWND hwnd, HFONT font )
+{
+    return (HFONT)NtUserSetPrivateData( hwnd, HFONT_GWL_OFFSET, sizeof(font), (LONG_PTR)font );
+}
+
+static HANDLE get_control_icon( HWND hwnd )
+{
+    return (HFONT)NtUserGetPrivateData( hwnd, HICON_GWL_OFFSET, sizeof(HICON) );
+}
+
+static HANDLE set_control_icon( HWND hwnd, HANDLE icon )
+{
+    return (HANDLE)NtUserSetPrivateData( hwnd, HICON_GWL_OFFSET, sizeof(icon), (LONG_PTR)icon );
+}
 
 /***********************************************************************
  *           STATIC_SetIcon
@@ -99,13 +124,12 @@ static HICON STATIC_SetIcon( HWND hwnd, HICON hicon, DWORD style )
     HICON prevIcon;
     SIZE size;
 
-    if ((style & SS_TYPEMASK) != SS_ICON) return 0;
     if (hicon && !get_icon_size( hicon, &size ))
     {
         WARN("hicon != 0, but invalid\n");
         return 0;
     }
-    prevIcon = (HICON)SetWindowLongPtrW( hwnd, HICON_GWL_OFFSET, (LONG_PTR)hicon );
+    prevIcon = set_control_icon( hwnd, hicon );
     if (hicon && !(style & SS_CENTERIMAGE) && !(style & SS_REALSIZECONTROL))
     {
         /* Windows currently doesn't implement SS_RIGHTJUST */
@@ -119,7 +143,7 @@ static HICON STATIC_SetIcon( HWND hwnd, HICON hicon, DWORD style )
         }
         else */
         {
-            SetWindowPos( hwnd, 0, 0, 0, size.cx, size.cy, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER );
+            NtUserSetWindowPos( hwnd, 0, 0, 0, size.cx, size.cy, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER );
         }
     }
     return prevIcon;
@@ -134,12 +158,11 @@ static HBITMAP STATIC_SetBitmap( HWND hwnd, HBITMAP hBitmap, DWORD style )
 {
     HBITMAP hOldBitmap;
 
-    if ((style & SS_TYPEMASK) != SS_BITMAP) return 0;
     if (hBitmap && GetObjectType(hBitmap) != OBJ_BITMAP) {
         WARN("hBitmap != 0, but it's not a bitmap\n");
         return 0;
     }
-    hOldBitmap = (HBITMAP)SetWindowLongPtrW( hwnd, HICON_GWL_OFFSET, (LONG_PTR)hBitmap );
+    hOldBitmap = set_control_icon( hwnd, hBitmap );
     if (hBitmap && !(style & SS_CENTERIMAGE) && !(style & SS_REALSIZECONTROL))
     {
         BITMAP bm;
@@ -155,8 +178,8 @@ static HBITMAP STATIC_SetBitmap( HWND hwnd, HBITMAP hBitmap, DWORD style )
         }
         else */
         {
-            SetWindowPos( hwnd, 0, 0, 0, bm.bmWidth, bm.bmHeight,
-                          SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER );
+            NtUserSetWindowPos( hwnd, 0, 0, 0, bm.bmWidth, bm.bmHeight,
+                                SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER );
         }
 
     }
@@ -170,12 +193,11 @@ static HBITMAP STATIC_SetBitmap( HWND hwnd, HBITMAP hBitmap, DWORD style )
  */
 static HENHMETAFILE STATIC_SetEnhMetaFile( HWND hwnd, HENHMETAFILE hEnhMetaFile, DWORD style )
 {
-    if ((style & SS_TYPEMASK) != SS_ENHMETAFILE) return 0;
     if (hEnhMetaFile && GetObjectType(hEnhMetaFile) != OBJ_ENHMETAFILE) {
         WARN("hEnhMetaFile != 0, but it's not an enhanced metafile\n");
         return 0;
     }
-    return (HENHMETAFILE)SetWindowLongPtrW( hwnd, HICON_GWL_OFFSET, (LONG_PTR)hEnhMetaFile );
+    return set_control_icon( hwnd, hEnhMetaFile );
 }
 
 /***********************************************************************
@@ -201,7 +223,7 @@ static HANDLE STATIC_GetImage( HWND hwnd, WPARAM wParam, DWORD style )
         default:
             return NULL;
     }
-    return (HANDLE)GetWindowLongPtrW( hwnd, HICON_GWL_OFFSET );
+    return get_control_icon( hwnd );
 }
 
 /***********************************************************************
@@ -228,6 +250,26 @@ static HICON STATIC_LoadIconA( HINSTANCE hInstance, LPCSTR name, DWORD style )
        probably because most IDs for standard cursors conflict
        with the IDs for standard icons anyway */
     return hicon;
+}
+/***********************************************************************
+ *           STATIC_SendWmCtlColorStatic
+ *
+ * Sends WM_CTLCOLORSTATIC message and returns brush to be used for painting.
+ */
+static HBRUSH STATIC_SendWmCtlColorStatic(HWND hwnd, HDC hdc)
+{
+#ifdef __REACTOS__
+    return GetControlBrush( hwnd, hdc, WM_CTLCOLORSTATIC);
+#else
+    HBRUSH hBrush;
+    HWND parent = GetParent(hwnd);
+
+    if (!parent) parent = hwnd;
+    hBrush = (HBRUSH) SendMessageW( parent, WM_CTLCOLORSTATIC, (WPARAM)hdc, (LPARAM)hwnd );
+    if (!hBrush) /* did the app forget to call DefWindowProc ? */
+        hBrush = (HBRUSH)DefWindowProcW( parent, WM_CTLCOLORSTATIC, (WPARAM)hdc, (LPARAM)hwnd);
+    return hBrush;
+#endif
 }
 
 /***********************************************************************
@@ -263,44 +305,24 @@ static HICON STATIC_LoadIconW( HINSTANCE hInstance, LPCWSTR name, DWORD style )
  */
 static VOID STATIC_TryPaintFcn(HWND hwnd, LONG full_style)
 {
-    LONG style = full_style & SS_TYPEMASK;
-    RECT rc;
-
-    GetClientRect( hwnd, &rc );
-    if (!IsRectEmpty(&rc) && IsWindowVisible(hwnd) && staticPaintFunc[style])
+    if (IsWindowVisible(hwnd))
     {
-	HDC hdc;
+        RECT rc;
+        HDC hdc;
         HRGN hrgn;
+        HBRUSH hbrush;
+        LONG style = full_style & SS_TYPEMASK;
 
-	hdc = GetDC( hwnd );
+        GetClientRect( hwnd, &rc );
+        hdc = NtUserGetDC( hwnd );
         hrgn = set_control_clipping( hdc, &rc );
-	(staticPaintFunc[style])( hwnd, hdc, full_style );
+        hbrush = STATIC_SendWmCtlColorStatic( hwnd, hdc );
+        if (staticPaintFunc[style])
+            (staticPaintFunc[style])( hwnd, hdc, hbrush, full_style );
         SelectClipRgn( hdc, hrgn );
         if (hrgn) DeleteObject( hrgn );
-	ReleaseDC( hwnd, hdc );
+        NtUserReleaseDC( hwnd, hdc );
     }
-}
-
-static HBRUSH STATIC_SendWmCtlColorStatic(HWND hwnd, HDC hdc)
-{
-#ifdef __REACTOS__
-    return GetControlBrush( hwnd, hdc, WM_CTLCOLORSTATIC);
-#else
-    HBRUSH hBrush;
-    HWND parent = GetParent(hwnd);
-
-    if (!parent) parent = hwnd;
-    hBrush = (HBRUSH) SendMessageW( parent,
-                    WM_CTLCOLORSTATIC, (WPARAM)hdc, (LPARAM)hwnd );
-    if (!hBrush) /* did the app forget to call DefWindowProc ? */
-    {
-        /* FIXME: DefWindowProc should return different colors if a
-                  manifest is present */
-        hBrush = (HBRUSH)DefWindowProcW( parent, WM_CTLCOLORSTATIC,
-                                        (WPARAM)hdc, (LPARAM)hwnd);
-    }
-    return hBrush;
-#endif
 }
 
 static VOID STATIC_InitColours(void)
@@ -339,28 +361,9 @@ LRESULT WINAPI StaticWndProc_common( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
     LRESULT lResult = 0;
     LONG full_style = GetWindowLongW( hwnd, GWL_STYLE );
     LONG style = full_style & SS_TYPEMASK;
-#ifdef __REACTOS__
-    PWND pWnd;
-
-    pWnd = ValidateHwnd(hwnd);
-    if (pWnd)
-    {
-       if (!pWnd->fnid)
-       {
-          NtUserSetWindowFNID(hwnd, FNID_STATIC);
-       }
-       else
-       {
-          if (pWnd->fnid != FNID_STATIC)
-          {
-             ERR("Wrong window class for Static! fnId 0x%x\n",pWnd->fnid);
-             return 0;
-          }
-       }
-    }
-#endif
 
     if (!IsWindow( hwnd )) return 0;
+    NtUserSetWindowFNID( hwnd, MAKE_FNID(NTUSER_WNDPROC_STATIC) );
 
     switch (uMsg)
     {
@@ -401,16 +404,18 @@ LRESULT WINAPI StaticWndProc_common( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
         {
             PAINTSTRUCT ps;
             RECT rect;
-            HDC hdc = wParam ? (HDC)wParam : BeginPaint(hwnd, &ps);
+            HDC hdc = wParam ? (HDC)wParam : NtUserBeginPaint( hwnd, &ps );
+            HRGN hrgn;
+            HBRUSH hbrush;
+
             GetClientRect( hwnd, &rect );
+            hrgn = set_control_clipping( hdc, &rect );
+            hbrush = STATIC_SendWmCtlColorStatic( hwnd, hdc );
             if (staticPaintFunc[style])
-            {
-                HRGN hrgn = set_control_clipping( hdc, &rect );
-                (staticPaintFunc[style])( hwnd, hdc, full_style );
-                SelectClipRgn( hdc, hrgn );
-                if (hrgn) DeleteObject( hrgn );
-            }
-            if (!wParam) EndPaint(hwnd, &ps);
+                (staticPaintFunc[style])( hwnd, hdc, hbrush, full_style );
+            SelectClipRgn( hdc, hrgn );
+            if (hrgn) DeleteObject( hrgn );
+            if (!wParam) NtUserEndPaint( hwnd, &ps );
         }
         break;
 
@@ -437,29 +442,68 @@ LRESULT WINAPI StaticWndProc_common( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
         {
             CREATESTRUCTW *cs = (CREATESTRUCTW *)lParam;
 
-            if (full_style & SS_SUNKEN)
+            if (full_style & SS_SUNKEN || style == SS_ETCHEDHORZ || style == SS_ETCHEDVERT)
                 SetWindowLongW( hwnd, GWL_EXSTYLE,
                                 GetWindowLongW( hwnd, GWL_EXSTYLE ) | WS_EX_STATICEDGE );
+
+            if (style == SS_ETCHEDHORZ || style == SS_ETCHEDVERT)
+            {
+                RECT rc;
+                GetClientRect(hwnd, &rc);
+                if (style == SS_ETCHEDHORZ)
+                    rc.bottom = rc.top;
+                else
+                    rc.right = rc.left;
+                AdjustWindowRectEx(&rc, full_style, FALSE, GetWindowLongW(hwnd, GWL_EXSTYLE));
+                NtUserSetWindowPos( hwnd, NULL, 0, 0, rc.right - rc.left, rc.bottom - rc.top,
+                                    SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER );
+            }
 
             switch (style) {
             case SS_ICON:
                 {
+                    const WCHAR *name = cs->lpszName;
                     HICON hIcon;
-                    if (unicode || IS_INTRESOURCE(cs->lpszName))
-                       hIcon = STATIC_LoadIconW(cs->hInstance, cs->lpszName, full_style);
+
+                    if (!unicode)
+                    {
+                        const char *nameA = (const char *)name;
+                        if (nameA && nameA[0] == '\xff')
+                            name = MAKEINTRESOURCEW(MAKEWORD(nameA[1], nameA[2]));
+                    }
+                    else if (name && name[0] == 0xffff)
+                    {
+                        name = MAKEINTRESOURCEW(name[1]);
+                    }
+
+                    if (unicode || IS_INTRESOURCE(name))
+                       hIcon = STATIC_LoadIconW(cs->hInstance, name, full_style);
                     else
-                       hIcon = STATIC_LoadIconA(cs->hInstance, (LPCSTR)cs->lpszName, full_style);
+                       hIcon = STATIC_LoadIconA(cs->hInstance, (const char *)name, full_style);
                     STATIC_SetIcon(hwnd, hIcon, full_style);
                 }
                 break;
             case SS_BITMAP:
                 if ((ULONG_PTR)cs->hInstance >> 16)
                 {
+                    const WCHAR *name = cs->lpszName;
                     HBITMAP hBitmap;
-                    if (unicode || IS_INTRESOURCE(cs->lpszName))
-                        hBitmap = LoadBitmapW(cs->hInstance, cs->lpszName);
+
+                    if (!unicode)
+                    {
+                        const char *nameA = (const char *)name;
+                        if (nameA && nameA[0] == '\xff')
+                            name = MAKEINTRESOURCEW(MAKEWORD(nameA[1], nameA[2]));
+                    }
+                    else if (name && name[0] == 0xffff)
+                    {
+                        name = MAKEINTRESOURCEW(name[1]);
+                    }
+
+                    if (unicode || IS_INTRESOURCE(name))
+                        hBitmap = LoadBitmapW(cs->hInstance, name);
                     else
-                        hBitmap = LoadBitmapA(cs->hInstance, (LPCSTR)cs->lpszName);
+                        hBitmap = LoadBitmapA(cs->hInstance, (const char *)name);
                     STATIC_SetBitmap(hwnd, hBitmap, full_style);
                 }
                 break;
@@ -484,14 +528,15 @@ LRESULT WINAPI StaticWndProc_common( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
     case WM_SETFONT:
         if (hasTextStyle( full_style ))
         {
-            SetWindowLongPtrW( hwnd, HFONT_GWL_OFFSET, wParam );
+            set_control_font( hwnd, (HFONT)wParam );
             if (LOWORD(lParam))
-                RedrawWindow( hwnd, NULL, 0, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN );
+                NtUserRedrawWindow( hwnd, NULL, 0, RDW_INVALIDATE | RDW_ERASE |
+                                    RDW_UPDATENOW | RDW_ALLCHILDREN );
         }
         break;
 
     case WM_GETFONT:
-        return GetWindowLongPtrW( hwnd, HFONT_GWL_OFFSET );
+        return (LRESULT)get_control_font( hwnd );
 
     case WM_NCHITTEST:
         if (full_style & SS_NOTIFY)
@@ -526,25 +571,29 @@ LRESULT WINAPI StaticWndProc_common( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
         switch(wParam) {
 	case IMAGE_BITMAP:
 	    if (style != SS_BITMAP) return 0; // ReactOS r43158
+            if (style != SS_BITMAP) return 0;
 	    lResult = (LRESULT)STATIC_SetBitmap( hwnd, (HBITMAP)lParam, full_style );
 	    break;
 	case IMAGE_ENHMETAFILE:
 	    if (style != SS_ENHMETAFILE) return 0; // ReactOS r43158
+            if (style != SS_ENHMETAFILE) return 0;
 	    lResult = (LRESULT)STATIC_SetEnhMetaFile( hwnd, (HENHMETAFILE)lParam, full_style );
 	    break;
 	case IMAGE_ICON:
 	case IMAGE_CURSOR:
 	    if (style != SS_ICON) return 0; // ReactOS r43158
+            if (style != SS_ICON) return 0;
 	    lResult = (LRESULT)STATIC_SetIcon( hwnd, (HICON)lParam, full_style );
 	    break;
 	default:
-	    FIXME("STM_SETIMAGE: Unhandled type %lx\n", wParam);
+	    FIXME("STM_SETIMAGE: Unhandled type %Ix\n", wParam);
 	    break;
 	}
         STATIC_TryPaintFcn( hwnd, full_style );
 	break;
 
     case STM_SETICON:
+        if (style != SS_ICON) return 0;
         lResult = (LRESULT)STATIC_SetIcon( hwnd, (HICON)wParam, full_style );
         STATIC_TryPaintFcn( hwnd, full_style );
         break;
@@ -588,7 +637,7 @@ LRESULT WINAPI StaticWndProcW( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
     return StaticWndProc_common(hWnd, uMsg, wParam, lParam, TRUE);
 }
 
-static void STATIC_PaintOwnerDrawfn( HWND hwnd, HDC hdc, DWORD style )
+static void STATIC_PaintOwnerDrawfn( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style )
 {
   DRAWITEMSTRUCT dis;
   HFONT font, oldFont = NULL;
@@ -604,9 +653,8 @@ static void STATIC_PaintOwnerDrawfn( HWND hwnd, HDC hdc, DWORD style )
   dis.itemData   = 0;
   GetClientRect( hwnd, &dis.rcItem );
 
-  font = (HFONT)GetWindowLongPtrW( hwnd, HFONT_GWL_OFFSET );
+  font = get_control_font( hwnd );
   if (font) oldFont = SelectObject( hdc, font );
-  /* hBrush = */ STATIC_SendWmCtlColorStatic(hwnd, hdc);
   SendMessageW( GetParent(hwnd), WM_DRAWITEM, id, (LPARAM)&dis );
   if (font) SelectObject( hdc, oldFont );
 }
@@ -620,10 +668,9 @@ static BOOL CALLBACK STATIC_DrawTextCallback(HDC hdc, LPARAM lp, WPARAM wp, int 
     return TRUE;
 }
 
-static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, DWORD style )
+static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style )
 {
     RECT rc;
-    HBRUSH hBrush;
     HFONT hFont, hOldFont = NULL;
     UINT format;
     INT len, buf_size;
@@ -662,8 +709,10 @@ static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, DWORD style )
 
     if (style & SS_NOPREFIX)
         format |= DT_NOPREFIX;
+#ifdef __REACTOS__
     else if (GetWindowLongW(hwnd, UISTATE_GWL_OFFSET) & UISF_HIDEACCEL) // ReactOS r30727
         format |= DT_HIDEPREFIX;
+#endif
 
     if ((style & SS_TYPEMASK) != SS_SIMPLE)
     {
@@ -679,16 +728,12 @@ static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, DWORD style )
             format |= DT_SINGLELINE | DT_WORD_ELLIPSIS;
     }
 
-    if ((hFont = (HFONT)GetWindowLongPtrW( hwnd, HFONT_GWL_OFFSET )))
+    if ((hFont = get_control_font( hwnd )))
         hOldFont = SelectObject( hdc, hFont );
-
-    /* SS_SIMPLE controls: WM_CTLCOLORSTATIC is sent, but the returned
-                           brush is not used */
-    hBrush = STATIC_SendWmCtlColorStatic(hwnd, hdc);
 
     if ((style & SS_TYPEMASK) != SS_SIMPLE)
     {
-        FillRect( hdc, &rc, hBrush );
+        FillRect( hdc, &rc, hbrush );
         if (!IsWindowEnabled(hwnd)) SetTextColor(hdc, GetSysColor(COLOR_GRAYTEXT));
     }
 
@@ -696,7 +741,7 @@ static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, DWORD style )
     if (!(text = HeapAlloc( GetProcessHeap(), 0, buf_size * sizeof(WCHAR) )))
         goto no_TextOut;
 
-    while ((len = InternalGetWindowText( hwnd, text, buf_size )) == buf_size - 1)
+    while ((len = NtUserInternalGetWindowText( hwnd, text, buf_size )) == buf_size - 1)
     {
         buf_size *= 2;
         if (!(text = HeapReAlloc( GetProcessHeap(), 0, text, buf_size * sizeof(WCHAR) )))
@@ -713,17 +758,24 @@ static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, DWORD style )
         ExtTextOutW( hdc, rc.left, rc.top, ETO_CLIPPED | ETO_OPAQUE,
                      &rc, text, len, NULL );
     }
+#ifdef __REACTOS__
     else
     {
         UINT flags = DST_COMPLEX;
         if (style & WS_DISABLED)
             flags |= DSS_DISABLED;
-        DrawStateW(hdc, hBrush, STATIC_DrawTextCallback,
+        DrawStateW(hdc, hbrush, STATIC_DrawTextCallback,
                    (LPARAM)text, (WPARAM)format,
                    rc.left, rc.top,
                    rc.right - rc.left, rc.bottom - rc.top,
                    flags);
     }
+#else
+    else
+    {
+        DrawTextW( hdc, text, -1, &rc, format );
+    }
+#endif
 
 no_TextOut:
     HeapFree( GetProcessHeap(), 0, text );
@@ -732,60 +784,54 @@ no_TextOut:
         SelectObject( hdc, hOldFont );
 }
 
-static void STATIC_PaintRectfn( HWND hwnd, HDC hdc, DWORD style )
+static void STATIC_PaintRectfn( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style )
 {
     RECT rc;
-    HBRUSH hBrush;
 
     GetClientRect( hwnd, &rc);
 
     /* FIXME: send WM_CTLCOLORSTATIC */
-#ifdef __REACTOS__
-    hBrush = STATIC_SendWmCtlColorStatic(hwnd, hdc); // Always sent....
-#endif
     switch (style & SS_TYPEMASK)
     {
     case SS_BLACKRECT:
-	hBrush = CreateSolidBrush(color_3ddkshadow);
-        FillRect( hdc, &rc, hBrush );
+	hbrush = CreateSolidBrush(color_3ddkshadow);
+        FillRect( hdc, &rc, hbrush );
 	break;
     case SS_GRAYRECT:
-	hBrush = CreateSolidBrush(color_3dshadow);
-        FillRect( hdc, &rc, hBrush );
+	hbrush = CreateSolidBrush(color_3dshadow);
+        FillRect( hdc, &rc, hbrush );
 	break;
     case SS_WHITERECT:
-	hBrush = CreateSolidBrush(color_3dhighlight);
-        FillRect( hdc, &rc, hBrush );
+	hbrush = CreateSolidBrush(color_3dhighlight);
+        FillRect( hdc, &rc, hbrush );
 	break;
     case SS_BLACKFRAME:
-	hBrush = CreateSolidBrush(color_3ddkshadow);
-        FrameRect( hdc, &rc, hBrush );
+	hbrush = CreateSolidBrush(color_3ddkshadow);
+        FrameRect( hdc, &rc, hbrush );
 	break;
     case SS_GRAYFRAME:
-	hBrush = CreateSolidBrush(color_3dshadow);
-        FrameRect( hdc, &rc, hBrush );
+	hbrush = CreateSolidBrush(color_3dshadow);
+        FrameRect( hdc, &rc, hbrush );
 	break;
     case SS_WHITEFRAME:
-	hBrush = CreateSolidBrush(color_3dhighlight);
-        FrameRect( hdc, &rc, hBrush );
+	hbrush = CreateSolidBrush(color_3dhighlight);
+        FrameRect( hdc, &rc, hbrush );
 	break;
     default:
         return;
     }
-    DeleteObject( hBrush );
+    DeleteObject( hbrush );
 }
 
 
-static void STATIC_PaintIconfn( HWND hwnd, HDC hdc, DWORD style )
+static void STATIC_PaintIconfn( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style )
 {
     RECT rc, iconRect;
-    HBRUSH hbrush;
     HICON hIcon;
     SIZE size;
 
     GetClientRect( hwnd, &rc );
-    hbrush = STATIC_SendWmCtlColorStatic(hwnd, hdc);
-    hIcon = (HICON)GetWindowLongPtrW( hwnd, HICON_GWL_OFFSET );
+    hIcon = get_control_icon( hwnd );
     if (!hIcon || !get_icon_size( hIcon, &size ))
     {
         FillRect(hdc, &rc, hbrush);
@@ -802,20 +848,17 @@ static void STATIC_PaintIconfn( HWND hwnd, HDC hdc, DWORD style )
         else
             iconRect = rc;
         FillRect( hdc, &rc, hbrush );
-        DrawIconEx( hdc, iconRect.left, iconRect.top, hIcon, iconRect.right - iconRect.left,
-                    iconRect.bottom - iconRect.top, 0, NULL, DI_NORMAL );
+        NtUserDrawIconEx( hdc, iconRect.left, iconRect.top, hIcon, iconRect.right - iconRect.left,
+                          iconRect.bottom - iconRect.top, 0, NULL, DI_NORMAL );
     }
 }
 
-static void STATIC_PaintBitmapfn(HWND hwnd, HDC hdc, DWORD style )
+static void STATIC_PaintBitmapfn(HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style )
 {
     HDC hMemDC;
     HBITMAP hBitmap, oldbitmap;
 
-    /* message is still sent, even if the returned brush is not used */
-    STATIC_SendWmCtlColorStatic(hwnd, hdc);
-
-    if ((hBitmap = (HBITMAP)GetWindowLongPtrW( hwnd, HICON_GWL_OFFSET ))
+    if ((hBitmap = get_control_icon( hwnd ))
          && (GetObjectType(hBitmap) == OBJ_BITMAP)
          && (hMemDC = CreateCompatibleDC( hdc )))
     {
@@ -828,9 +871,9 @@ static void STATIC_PaintBitmapfn(HWND hwnd, HDC hdc, DWORD style )
         GetClientRect(hwnd, &rcClient);
         if (style & SS_CENTERIMAGE)
         {
-            HBRUSH hbrush = CreateSolidBrush(GetPixel(hMemDC, 0, 0));
+            hbrush = CreateSolidBrush(GetPixel(hMemDC, 0, 0));
 
-            FillRect( hdc, &rcClient, hbrush );
+            FillRect(hdc, &rcClient, hbrush);
 
             rcClient.left = (rcClient.right - rcClient.left)/2 - bm.bmWidth/2;
             rcClient.top = (rcClient.bottom - rcClient.top)/2 - bm.bmHeight/2;
@@ -848,16 +891,14 @@ static void STATIC_PaintBitmapfn(HWND hwnd, HDC hdc, DWORD style )
 }
 
 
-static void STATIC_PaintEnhMetafn(HWND hwnd, HDC hdc, DWORD style )
+static void STATIC_PaintEnhMetafn(HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style )
 {
     HENHMETAFILE hEnhMetaFile;
     RECT rc;
-    HBRUSH hbrush;
 
     GetClientRect(hwnd, &rc);
-    hbrush = STATIC_SendWmCtlColorStatic(hwnd, hdc);
     FillRect(hdc, &rc, hbrush);
-    if ((hEnhMetaFile = (HENHMETAFILE)GetWindowLongPtrW( hwnd, HICON_GWL_OFFSET )))
+    if ((hEnhMetaFile = get_control_icon( hwnd )))
     {
         /* The control's current font is not selected into the
            device context! */
@@ -867,22 +908,10 @@ static void STATIC_PaintEnhMetafn(HWND hwnd, HDC hdc, DWORD style )
 }
 
 
-static void STATIC_PaintEtchedfn( HWND hwnd, HDC hdc, DWORD style )
+static void STATIC_PaintEtchedfn( HWND hwnd, HDC hdc, HBRUSH hbrush, DWORD style )
 {
     RECT rc;
 
-    /* FIXME: sometimes (not always) sends WM_CTLCOLORSTATIC */
     GetClientRect( hwnd, &rc );
-    switch (style & SS_TYPEMASK)
-    {
-	case SS_ETCHEDHORZ:
-	    DrawEdge(hdc,&rc,EDGE_ETCHED,BF_TOP|BF_BOTTOM);
-	    break;
-	case SS_ETCHEDVERT:
-	    DrawEdge(hdc,&rc,EDGE_ETCHED,BF_LEFT|BF_RIGHT);
-	    break;
-	case SS_ETCHEDFRAME:
-	    DrawEdge (hdc, &rc, EDGE_ETCHED, BF_RECT);
-	    break;
-    }
+    DrawEdge (hdc, &rc, EDGE_ETCHED, BF_RECT);
 }

--- a/win32ss/user/user32/include/controls.h
+++ b/win32ss/user/user32/include/controls.h
@@ -74,7 +74,7 @@ typedef struct
    INT            droppedIndex;
    INT            fixedOwnerDrawHeight;
    INT            droppedWidth;   /* last two are not used unless set */
-   INT            editHeight;     /* explicitly */
+   INT            item_height;
    LONG           UIState;
 } HEADCOMBO,*LPHEADCOMBO;
 

--- a/win32ss/user/user32/include/controls.h
+++ b/win32ss/user/user32/include/controls.h
@@ -94,7 +94,8 @@ LRESULT WINAPI DesktopWndProcA( HWND hwnd, UINT message, WPARAM wParam, LPARAM l
 LRESULT WINAPI DesktopWndProcW( HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam );
 LRESULT WINAPI User32DefWindowProc(HWND,UINT,WPARAM,LPARAM,BOOL);
 BOOL WINAPI RegisterClientPFN(VOID);
-LRESULT WINAPI IconTitleWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam );
+LRESULT WINAPI IconTitleWndProcA( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam );
+LRESULT WINAPI IconTitleWndProcW( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam );
 LRESULT WINAPI ButtonWndProcA( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam );
 LRESULT WINAPI ButtonWndProcW( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam );
 LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL unicode);

--- a/win32ss/user/user32/include/dde_private.h
+++ b/win32ss/user/user32/include/dde_private.h
@@ -25,6 +25,9 @@
 #ifndef __WINE_DDEML_PRIVATE_H
 #define __WINE_DDEML_PRIVATE_H
 
+#include "dde.h"
+#include "ddeml.h"
+
 /* defined in atom.c file.
  */
 #define MAX_ATOM_LEN              255
@@ -69,7 +72,7 @@
  * are available (most notably the REGISTER/UNREGISTER and CONNECT_CONFIRM messages
  * to the callback function). To be correct in every situation, all the basic
  * exchanges are made using the 'pure' DDE protocol. A (future !) enhancement would
- * be to provide a new protocol in the case were both partners are handled by DDEML.
+ * be to provide a new protocol in the case where both partners are handled by DDEML.
  *
  * The StringHandles are in fact stored as local atoms. So an HSZ and a (local) atom
  * can be used interchangeably. However, in order to keep track of the allocated HSZ,
@@ -187,51 +190,51 @@ typedef enum {
 
 extern	HDDEDATA 	WDML_InvokeCallback(WDML_INSTANCE* pInst, UINT uType, UINT uFmt, HCONV hConv,
 					    HSZ hsz1, HSZ hsz2, HDDEDATA hdata,
-					    ULONG_PTR dwData1, ULONG_PTR dwData2) DECLSPEC_HIDDEN;
-extern	WDML_SERVER*	WDML_AddServer(WDML_INSTANCE* pInstance, HSZ hszService, HSZ hszTopic) DECLSPEC_HIDDEN;
-extern	void		WDML_RemoveServer(WDML_INSTANCE* pInstance, HSZ hszService, HSZ hszTopic) DECLSPEC_HIDDEN;
-extern	WDML_SERVER*	WDML_FindServer(WDML_INSTANCE* pInstance, HSZ hszService, HSZ hszTopic) DECLSPEC_HIDDEN;
+					    ULONG_PTR dwData1, ULONG_PTR dwData2);
+extern	WDML_SERVER*	WDML_AddServer(WDML_INSTANCE* pInstance, HSZ hszService, HSZ hszTopic);
+extern	void		WDML_RemoveServer(WDML_INSTANCE* pInstance, HSZ hszService, HSZ hszTopic);
+extern	WDML_SERVER*	WDML_FindServer(WDML_INSTANCE* pInstance, HSZ hszService, HSZ hszTopic);
 /* transaction handler on the server side */
-extern WDML_QUEUE_STATE WDML_ServerHandle(WDML_CONV* pConv, WDML_XACT* pXAct) DECLSPEC_HIDDEN;
+extern WDML_QUEUE_STATE WDML_ServerHandle(WDML_CONV* pConv, WDML_XACT* pXAct);
 /* transaction handler on the client side */
-HDDEDATA WDML_ClientHandle(WDML_CONV *pConv, WDML_XACT *pXAct, DWORD dwTimeout, LPDWORD pdwResult) DECLSPEC_HIDDEN;
+HDDEDATA WDML_ClientHandle(WDML_CONV *pConv, WDML_XACT *pXAct, DWORD dwTimeout, LPDWORD pdwResult);
 /* called both in DdeClientTransaction and server side. */
 extern	WDML_CONV* 	WDML_AddConv(WDML_INSTANCE* pInstance, WDML_SIDE side,
-				     HSZ hszService, HSZ hszTopic, HWND hwndClient, HWND hwndServer) DECLSPEC_HIDDEN;
-extern	void		WDML_RemoveConv(WDML_CONV* pConv, WDML_SIDE side) DECLSPEC_HIDDEN;
-extern	WDML_CONV*	WDML_GetConv(HCONV hConv, BOOL checkConnected) DECLSPEC_HIDDEN;
-extern	WDML_CONV*	WDML_GetConvFromWnd(HWND hWnd) DECLSPEC_HIDDEN;
+				     HSZ hszService, HSZ hszTopic, HWND hwndClient, HWND hwndServer);
+extern	void		WDML_RemoveConv(WDML_CONV* pConv, WDML_SIDE side);
+extern	WDML_CONV*	WDML_GetConv(HCONV hConv, BOOL checkConnected);
+extern	WDML_CONV*	WDML_GetConvFromWnd(HWND hWnd);
 extern	WDML_CONV*	WDML_FindConv(WDML_INSTANCE* pInstance, WDML_SIDE side,
-				      HSZ hszService, HSZ hszTopic) DECLSPEC_HIDDEN;
+				      HSZ hszService, HSZ hszTopic);
 extern  BOOL		WDML_PostAck(WDML_CONV* pConv, WDML_SIDE side, WORD appRetCode,
-				     BOOL fBusy, BOOL fAck, UINT_PTR pmt, LPARAM lParam, UINT oldMsg) DECLSPEC_HIDDEN;
+				     BOOL fBusy, BOOL fAck, UINT_PTR pmt, LPARAM lParam, UINT oldMsg);
 extern	void		WDML_AddLink(WDML_INSTANCE* pInstance, HCONV hConv, WDML_SIDE side,
-				     UINT wType, HSZ hszItem, UINT wFmt) DECLSPEC_HIDDEN;
+				     UINT wType, HSZ hszItem, UINT wFmt);
 extern	WDML_LINK*	WDML_FindLink(WDML_INSTANCE* pInstance, HCONV hConv, WDML_SIDE side,
-				      HSZ hszItem, BOOL use_fmt, UINT uFmt) DECLSPEC_HIDDEN;
+				      HSZ hszItem, BOOL use_fmt, UINT uFmt);
 extern	void 		WDML_RemoveLink(WDML_INSTANCE* pInstance, HCONV hConv, WDML_SIDE side,
-					HSZ hszItem, UINT wFmt) DECLSPEC_HIDDEN;
+					HSZ hszItem, UINT wFmt);
 /* string internals */
-extern	BOOL		WDML_DecHSZ(WDML_INSTANCE* pInstance, HSZ hsz) DECLSPEC_HIDDEN;
-extern	BOOL		WDML_IncHSZ(WDML_INSTANCE* pInstance, HSZ hsz) DECLSPEC_HIDDEN;
-extern	ATOM		WDML_MakeAtomFromHsz(HSZ hsz) DECLSPEC_HIDDEN;
-extern	HSZ		WDML_MakeHszFromAtom(const WDML_INSTANCE* pInstance, ATOM atom) DECLSPEC_HIDDEN;
+extern	BOOL		WDML_DecHSZ(WDML_INSTANCE* pInstance, HSZ hsz);
+extern	BOOL		WDML_IncHSZ(WDML_INSTANCE* pInstance, HSZ hsz);
+extern	ATOM		WDML_MakeAtomFromHsz(HSZ hsz);
+extern	HSZ		WDML_MakeHszFromAtom(const WDML_INSTANCE* pInstance, ATOM atom);
 /* client calls these */
-extern	WDML_XACT*	WDML_AllocTransaction(WDML_INSTANCE* pInstance, UINT ddeMsg, UINT wFmt, HSZ hszItem) DECLSPEC_HIDDEN;
-extern	void		WDML_QueueTransaction(WDML_CONV* pConv, WDML_XACT* pXAct) DECLSPEC_HIDDEN;
-extern	BOOL		WDML_UnQueueTransaction(WDML_CONV* pConv, WDML_XACT*  pXAct) DECLSPEC_HIDDEN;
-extern	void		WDML_FreeTransaction(WDML_INSTANCE* pInstance, WDML_XACT* pXAct, BOOL doFreePmt) DECLSPEC_HIDDEN;
+extern	WDML_XACT*	WDML_AllocTransaction(WDML_INSTANCE* pInstance, UINT ddeMsg, UINT wFmt, HSZ hszItem);
+extern	void		WDML_QueueTransaction(WDML_CONV* pConv, WDML_XACT* pXAct);
+extern	BOOL		WDML_UnQueueTransaction(WDML_CONV* pConv, WDML_XACT*  pXAct);
+extern	void		WDML_FreeTransaction(WDML_INSTANCE* pInstance, WDML_XACT* pXAct, BOOL doFreePmt);
 extern	HGLOBAL		WDML_DataHandle2Global(HDDEDATA hDdeData, BOOL fResponse, BOOL fRelease,
-					       BOOL fDeferUpd, BOOL dAckReq) DECLSPEC_HIDDEN;
-extern	HDDEDATA	WDML_Global2DataHandle(WDML_CONV* pConv, HGLOBAL hMem, WINE_DDEHEAD* da) DECLSPEC_HIDDEN;
-extern  BOOL            WDML_IsAppOwned(HDDEDATA hDdeData) DECLSPEC_HIDDEN;
-extern	WDML_INSTANCE*	WDML_GetInstance(DWORD InstId) DECLSPEC_HIDDEN;
-extern	WDML_INSTANCE*	WDML_GetInstanceFromWnd(HWND hWnd) DECLSPEC_HIDDEN;
+					       BOOL fDeferUpd, BOOL dAckReq);
+extern	HDDEDATA	WDML_Global2DataHandle(WDML_CONV* pConv, HGLOBAL hMem, WINE_DDEHEAD* da);
+extern  BOOL            WDML_IsAppOwned(HDDEDATA hDdeData);
+extern	WDML_INSTANCE*	WDML_GetInstance(DWORD InstId);
+extern	WDML_INSTANCE*	WDML_GetInstanceFromWnd(HWND hWnd);
 /* broadcasting to DDE windows */
 extern	void		WDML_BroadcastDDEWindows(LPCWSTR clsName, UINT uMsg,
-						 WPARAM wParam, LPARAM lParam) DECLSPEC_HIDDEN;
-extern	void		WDML_NotifyThreadExit(DWORD tid) DECLSPEC_HIDDEN;
-extern	void 		WDML_NotifyThreadDetach(void) DECLSPEC_HIDDEN;
+						 WPARAM wParam, LPARAM lParam);
+extern	void		WDML_NotifyThreadExit(DWORD tid);
+extern	void 		WDML_NotifyThreadDetach(void);
 
 
 static __inline void WDML_ExtractAck(WORD status, DDEACK* da)
@@ -239,11 +242,11 @@ static __inline void WDML_ExtractAck(WORD status, DDEACK* da)
     *da = *((DDEACK*)&status);
 }
 
-extern const WCHAR WDML_szEventClass[] DECLSPEC_HIDDEN; /* class of window for events (aka instance) */
-extern const char WDML_szServerConvClassA[] DECLSPEC_HIDDEN; /* ANSI class of window for server side conv */
-extern const WCHAR WDML_szServerConvClassW[] DECLSPEC_HIDDEN; /* unicode class of window for server side conv */
-extern const char WDML_szClientConvClassA[] DECLSPEC_HIDDEN; /* ANSI class of window for client side conv */
-extern const WCHAR WDML_szClientConvClassW[] DECLSPEC_HIDDEN; /* unicode class of window for client side conv */
+extern const WCHAR WDML_szEventClass[]; /* class of window for events (aka instance) */
+extern const char WDML_szServerConvClassA[]; /* ANSI class of window for server side conv */
+extern const WCHAR WDML_szServerConvClassW[]; /* unicode class of window for server side conv */
+extern const char WDML_szClientConvClassA[]; /* ANSI class of window for client side conv */
+extern const WCHAR WDML_szClientConvClassW[]; /* unicode class of window for client side conv */
 
 #define WM_WDML_REGISTER	(WM_USER + 0x200)
 #define WM_WDML_UNREGISTER	(WM_USER + 0x201)

--- a/win32ss/user/user32/include/wine-compat.h
+++ b/win32ss/user/user32/include/wine-compat.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+#endif
+
+/* Unimplemented */
+
+#define GetDpiForWindow(HWND) 96
+
+#define get_input_codepage() CP_ACP
+
+#define NtUserGetPrivateData(HWND, OFFSET, SIZE) GetWindowLongPtrW((HWND), (OFFSET))
+#define NtUserSetPrivateData(HWND, OFFSET, SIZE, VALUE) SetWindowLongPtrW((HWND), (OFFSET), (VALUE))
+
+#define NtUserGetWindowSysSubMenu(HWND) GetSubMenu(GetMenu((HWND)), 0)
+
+#define NtUserGetMDIClientInfo(HWND) (MDICLIENTINFO *)GetWindowLongPtr((HWND), GWLP_MDIWND)
+#define NtUserSetMDIClientInfo(HWND, INFO) SetWindowLongPtr((HWND), GWLP_MDIWND, (LONG_PTR)(INFO))
+
+/* NtUser functions map */
+
+#define NtUserReleaseDC(HWND, HDC) NtUserxReleaseDC((HDC))
+#define NtUserReleaseCapture() NtUserxReleaseCapture()
+#define NtUserKillSystemTimer(HWND, ID) NtUserxKillSystemTimer((HWND), (ID))
+#define NtUserEnableWindow(HWND, ENABLE) NtUserxEnableWindow((HWND), (ENABLE))
+#define NtUserDrawMenuBar(HWND) NtUserxDrawMenuBar((HWND))
+#define NtUserArrangeIconicWindows(HWND) NtUserxArrangeIconicWindows((HWND))
+/* WINE calls NtUserSetSystemTimer with 3 parameters instead of 4 */
+#define NtUserSetSystemTimer(HWND, ID, TIMEOUT) NtUserSetSystemTimer((HWND), (ID), (TIMEOUT), NULL)
+/* WINE calls NtUserDrawIconEx with 9 arguments instead of 11 */
+#define NtUserDrawIconEx(P1, P2, P3, P4, P5, P6, P7, P8, P9) DrawIconEx((P1), (P2), (P3), (P4), (P5), (P6), (P7), (P8), (P9))
+/* WINE calls NtUserSetMenu with 2 parameters instead of 2 */
+#define NtUserSetMenu(P1, P2) SetMenu((P1), (P2))
+
+/* standard C */
+
+#define malloc(size) HeapAlloc(GetProcessHeap(), 0, (size))
+#define calloc(count, size) HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (count) * (size))
+#define realloc(ptr, size) ptr ? HeapReAlloc(GetProcessHeap(), 0, (ptr), (size)) : HeapAlloc(GetProcessHeap(), 0, (size))
+#define free(ptr) HeapFree(GetProcessHeap(), 0, (ptr))
+
+/* MAKE_FNID */
+
+#define NTUSER_WNDPROC_SCROLLBAR    FNID_SCROLLBAR
+#define NTUSER_WNDPROC_MENU         FNID_MENU
+#define NTUSER_WNDPROC_DESKTOP      FNID_DESKTOP
+#define NTUSER_WNDPROC_ICONTITLE    FNID_ICONTITLE
+#define NTUSER_WNDPROC_BUTTON       FNID_BUTTON
+#define NTUSER_WNDPROC_COMBO        FNID_COMBOBOX
+#define NTUSER_WNDPROC_COMBOLBOX    FNID_COMBOLBOX
+#define NTUSER_WNDPROC_DIALOG       FNID_DIALOG
+#define NTUSER_WNDPROC_EDIT         FNID_EDIT
+#define NTUSER_WNDPROC_LISTBOX      FNID_LISTBOX
+#define NTUSER_WNDPROC_MDICLIENT    FNID_MDICLIENT
+#define NTUSER_WNDPROC_STATIC       FNID_STATIC
+#define NTUSER_WNDPROC_IME          FNID_IME
+#define NTUSER_WNDPROC_GHOST        FNID_GHOST
+
+#define MAKE_FNID(index) (index)

--- a/win32ss/user/user32/misc/ddeclient.c
+++ b/win32ss/user/user32/misc/ddeclient.c
@@ -28,8 +28,13 @@
 WINE_DEFAULT_DEBUG_CHANNEL(ddeml);
 
 static LRESULT CALLBACK WDML_ClientProc(HWND, UINT, WPARAM, LPARAM);	/* only for one client, not conv list */
+#ifdef __REACTOS__
 const char WDML_szClientConvClassA[] = "DDEMLAnsiClient";
 const WCHAR WDML_szClientConvClassW[] = L"DDEMLUnicodeClient";
+#else
+const char WDML_szClientConvClassA[] = "WineDdeClientA";
+const WCHAR WDML_szClientConvClassW[] = L"WineDdeClientW";
+#endif
 
 /******************************************************************************
  * DdeConnectList [USER32.@]  Establishes conversation with DDE servers
@@ -48,7 +53,7 @@ const WCHAR WDML_szClientConvClassW[] = L"DDEMLUnicodeClient";
 HCONVLIST WINAPI DdeConnectList(DWORD idInst, HSZ hszService, HSZ hszTopic,
 				HCONVLIST hConvList, PCONVCONTEXT pCC)
 {
-    FIXME("(%d,%p,%p,%p,%p): stub\n", idInst, hszService, hszTopic, hConvList, pCC);
+    FIXME("(%ld,%p,%p,%p,%p): stub\n", idInst, hszService, hszTopic, hConvList, pCC);
     return (HCONVLIST)1;
 }
 
@@ -89,7 +94,7 @@ HCONV WINAPI DdeConnect(DWORD idInst, HSZ hszService, HSZ hszTopic,
     WDML_CONV*		pConv;
     ATOM		aSrv = 0, aTpc = 0;
 
-    TRACE("(0x%x,%p,%p,%p)\n", idInst, hszService, hszTopic, pCC);
+    TRACE("(0x%lx,%p,%p,%p)\n", idInst, hszService, hszTopic, pCC);
 
     pInstance = WDML_GetInstance(idInst);
     if (!pInstance)
@@ -509,7 +514,7 @@ static WDML_QUEUE_STATE WDML_HandleRequestReply(WDML_CONV* pConv, MSG* msg, WDML
 
     case WM_DDE_DATA:
         UnpackDDElParam(WM_DDE_DATA, msg->lParam, &uiLo, &uiHi);
-	TRACE("Got the result (%08lx)\n", uiLo);
+	TRACE("Got the result (%08Ix)\n", uiLo);
 
 	hsz = WDML_MakeHszFromAtom(pConv->instance, uiHi);
 
@@ -1010,7 +1015,7 @@ static HDDEDATA WDML_SyncWaitTransactionReply(HCONV hConv, DWORD dwTimeout, cons
     DWORD	err;
     WDML_CONV*	pConv;
 
-    TRACE("Starting wait for a timeout of %d ms\n", dwTimeout);
+    TRACE("Starting wait for a timeout of %ld ms\n", dwTimeout);
 
     start = GetTickCount();
     while ((elapsed = GetTickCount() - start) < dwTimeout)
@@ -1093,7 +1098,7 @@ HDDEDATA WDML_ClientHandle(WDML_CONV *pConv, WDML_XACT *pXAct, DWORD dwTimeout, 
 
     if (!PostMessageW(pConv->hwndServer, pXAct->ddeMsg, (WPARAM)pConv->hwndClient, pXAct->lParam))
     {
-        WARN("Failed posting message %x to %p (error=0x%x)\n",
+        WARN("Failed posting message %x to %p (error=0x%lx)\n",
               pXAct->ddeMsg, pConv->hwndServer, GetLastError());
         pConv->wStatus &= ~ST_CONNECTED;
         pConv->instance->lastError = DMLERR_POSTMSG_FAILED;
@@ -1126,7 +1131,7 @@ HDDEDATA WINAPI DdeClientTransaction(LPBYTE pData, DWORD cbData, HCONV hConv, HS
     WDML_XACT*		pXAct;
     HDDEDATA		hDdeData;
 
-    TRACE("(%p,%d,%p,%p,%x,%x,%d,%p)\n",
+    TRACE("(%p,%ld,%p,%p,%x,%x,%ld,%p)\n",
 	  pData, cbData, hConv, hszItem, wFmt, wType, dwTimeout, pdwResult);
 
     if (hConv == 0)
@@ -1200,7 +1205,7 @@ HDDEDATA WINAPI DdeClientTransaction(LPBYTE pData, DWORD cbData, HCONV hConv, HS
 
     WDML_QueueTransaction(pConv, pXAct);
 
-    TRACE("pConv->wStatus %04x\n", pConv->wStatus);
+    TRACE("pConv->wStatus %04lx\n", pConv->wStatus);
 
     if (pConv->wStatus & ST_BLOCKED)
     {
@@ -1282,7 +1287,7 @@ static LRESULT CALLBACK WDML_ClientProc(HWND hwnd, UINT iMsg, WPARAM wParam, LPA
     WDML_CONV*	pConv = NULL;
     HSZ		hszSrv, hszTpc;
 
-    TRACE("%p %04x %08lx %08lx\n", hwnd, iMsg, wParam , lParam);
+    TRACE("%p %04x %08Ix %08Ix\n", hwnd, iMsg, wParam, lParam);
 
     if (iMsg == WM_DDE_ACK &&
 	/* in the initial WM_INITIATE sendmessage */

--- a/win32ss/user/user32/misc/ddemisc.c
+++ b/win32ss/user/user32/misc/ddemisc.c
@@ -35,7 +35,11 @@ WINE_DEFAULT_DEBUG_CHANNEL(ddeml);
 
 static WDML_INSTANCE*	WDML_InstanceList = NULL;
 static LONG		WDML_MaxInstanceID = 0;  /* OK for present, have to worry about wrap-around later */
+#ifdef __REACTOS__
 const WCHAR		WDML_szEventClass[] = L"DDEMLEvent";
+#else
+const WCHAR		WDML_szEventClass[] = L"WineDdeEventClass";
+#endif
 
 /* protection for instance list */
 static CRITICAL_SECTION WDML_CritSect;
@@ -193,7 +197,7 @@ LPARAM WINAPI ReuseDDElParam(LPARAM lParam, UINT msgIn, UINT msgOut,
             }
             params[0] = uiLo;
             params[1] = uiHi;
-            TRACE("Reusing pack %08lx %08lx\n", uiLo, uiHi);
+            TRACE("Reusing pack %08Ix %08Ix\n", uiLo, uiHi);
             GlobalUnlock( (HGLOBAL)lParam );
             return lParam;
 
@@ -503,7 +507,7 @@ DWORD WINAPI DdeQueryStringA(DWORD idInst, HSZ hsz, LPSTR psz, DWORD cchMax, INT
     DWORD		ret = 0;
     WDML_INSTANCE*	pInstance;
 
-    TRACE("(%d, %p, %p, %d, %d)\n", idInst, hsz, psz, cchMax, iCodePage);
+    TRACE("(%ld, %p, %p, %ld, %d)\n", idInst, hsz, psz, cchMax, iCodePage);
 
     /*  First check instance
      */
@@ -514,7 +518,7 @@ DWORD WINAPI DdeQueryStringA(DWORD idInst, HSZ hsz, LPSTR psz, DWORD cchMax, INT
 	ret = WDML_QueryString(pInstance, hsz, psz, cchMax, iCodePage);
     }
 
-    TRACE("returning %d (%s)\n", ret, debugstr_a(psz));
+    TRACE("returning %ld (%s)\n", ret, debugstr_a(psz));
     return ret;
 }
 
@@ -527,7 +531,7 @@ DWORD WINAPI DdeQueryStringW(DWORD idInst, HSZ hsz, LPWSTR psz, DWORD cchMax, IN
     DWORD		ret = 0;
     WDML_INSTANCE*	pInstance;
 
-    TRACE("(%d, %p, %p, %d, %d)\n", idInst, hsz, psz, cchMax, iCodePage);
+    TRACE("(%ld, %p, %p, %ld, %d)\n", idInst, hsz, psz, cchMax, iCodePage);
 
     /*  First check instance
      */
@@ -538,7 +542,7 @@ DWORD WINAPI DdeQueryStringW(DWORD idInst, HSZ hsz, LPWSTR psz, DWORD cchMax, IN
 	ret = WDML_QueryString(pInstance, hsz, psz, cchMax, iCodePage);
     }
 
-    TRACE("returning %d (%s)\n", ret, debugstr_w(psz));
+    TRACE("returning %ld (%s)\n", ret, debugstr_w(psz));
     return ret;
 }
 
@@ -579,7 +583,7 @@ HSZ WINAPI DdeCreateStringHandleA(DWORD idInst, LPCSTR psz, INT codepage)
     HSZ			hsz = 0;
     WDML_INSTANCE*	pInstance;
 
-    TRACE("(%d,%s,%d)\n", idInst, debugstr_a(psz), codepage);
+    TRACE("(%ld,%s,%d)\n", idInst, debugstr_a(psz), codepage);
 
     pInstance = WDML_GetInstance(idInst);
     if (pInstance == NULL)
@@ -633,7 +637,7 @@ BOOL WINAPI DdeFreeStringHandle(DWORD idInst, HSZ hsz)
     WDML_INSTANCE*	pInstance;
     BOOL		ret = FALSE;
 
-    TRACE("(%d,%p):\n", idInst, hsz);
+    TRACE("(%ld,%p):\n", idInst, hsz);
 
     /*  First check instance
      */
@@ -656,7 +660,7 @@ BOOL WINAPI DdeKeepStringHandle(DWORD idInst, HSZ hsz)
     WDML_INSTANCE*	pInstance;
     BOOL		ret = FALSE;
 
-    TRACE("(%d,%p):\n", idInst, hsz);
+    TRACE("(%ld,%p):\n", idInst, hsz);
 
     /*  First check instance
      */
@@ -748,7 +752,7 @@ static void WDML_IncrementInstanceId(WDML_INSTANCE* pInstance)
     DWORD	id = InterlockedIncrement(&WDML_MaxInstanceID);
 
     pInstance->instanceID = id;
-    TRACE("New instance id %d allocated\n", id);
+    TRACE("New instance id %ld allocated\n", id);
 }
 
 /******************************************************************
@@ -832,7 +836,7 @@ static UINT WDML_Initialize(LPDWORD pidInst, PFNCALLBACK pfnCallback,
     UINT			ret;
     WNDCLASSEXW			wndclass;
 
-    TRACE("(%p,%p,0x%x,%d,0x%x)\n",
+    TRACE("(%p,%p,0x%lx,%ld,0x%x)\n",
 	  pidInst, pfnCallback, afCmd, ulRes, bUnicode);
 
     if (ulRes)
@@ -887,7 +891,7 @@ static UINT WDML_Initialize(LPDWORD pidInst, PFNCALLBACK pfnCallback,
     if (*pidInst == 0)
     {
 	/*  Initialisation of new Instance Identifier */
-	TRACE("new instance, callback %p flags %X\n",pfnCallback,afCmd);
+	TRACE("new instance, callback %p flags %lX\n", pfnCallback, afCmd);
 
 	EnterCriticalSection(&WDML_CritSect);
 
@@ -990,7 +994,7 @@ static UINT WDML_Initialize(LPDWORD pidInst, PFNCALLBACK pfnCallback,
     else
     {
 	/* Reinitialisation situation   --- FIX  */
-	TRACE("reinitialisation of (%p,%p,0x%x,%d): stub\n", pidInst, pfnCallback, afCmd, ulRes);
+	TRACE("reinitialisation of (%p,%p,0x%lx,%ld): stub\n", pidInst, pfnCallback, afCmd, ulRes);
 
 	EnterCriticalSection(&WDML_CritSect);
 
@@ -1117,7 +1121,7 @@ BOOL WINAPI DdeUninitialize(DWORD idInst)
     WDML_CONV*			pConv;
     WDML_CONV*			pConvNext;
 
-    TRACE("(%d)\n", idInst);
+    TRACE("(%ld)\n", idInst);
 
     /*  First check instance
      */
@@ -1149,7 +1153,7 @@ BOOL WINAPI DdeUninitialize(DWORD idInst)
      */
     WDML_FreeAllHSZ(pInstance);
 
-    DestroyWindow(pInstance->hwndEvent);
+    NtUserDestroyWindow( pInstance->hwndEvent );
 
     /* OK now delete the instance handle itself */
 
@@ -1212,7 +1216,7 @@ HDDEDATA 	WDML_InvokeCallback(WDML_INSTANCE* pInstance, UINT uType, UINT uFmt, H
     if (pInstance == NULL)
 	return NULL;
 
-    TRACE("invoking CB[%p] (%x %x %p %p %p %p %lx %lx)\n",
+    TRACE("invoking CB[%p] (%x %x %p %p %p %p %Ix %Ix)\n",
 	  pInstance->callback, uType, uFmt,
 	  hConv, hsz1, hsz2, hdata, dwData1, dwData2);
     ret = pInstance->callback(uType, uFmt, hConv, hsz1, hsz2, hdata, dwData1, dwData2);
@@ -1249,7 +1253,7 @@ WDML_INSTANCE*	WDML_GetInstance(DWORD instId)
     LeaveCriticalSection(&WDML_CritSect);
 
     if (!pInstance)
-        WARN("Instance entry missing for id %04x\n", instId);
+        WARN("Instance entry missing for id %04lx\n", instId);
     return pInstance;
 }
 
@@ -1299,7 +1303,7 @@ HDDEDATA WINAPI DdeCreateDataHandle(DWORD idInst, LPBYTE pSrc, DWORD cb, DWORD c
         psz[1] = 0;
     }
 
-    TRACE("(%d,%p,cb %d, cbOff %d,%p <%s>,fmt %04x,%x)\n",
+    TRACE("(%ld,%p,cb %ld, cbOff %ld,%p <%s>,fmt %04x,%x)\n",
 	  idInst, pSrc, cb, cbOff, hszItem, debugstr_w(psz), wFmt, afCmd);
 
     if (afCmd != 0 && afCmd != HDATA_APPOWNED)
@@ -1325,7 +1329,8 @@ HDDEDATA WINAPI DdeCreateDataHandle(DWORD idInst, LPBYTE pSrc, DWORD cb, DWORD c
     pByte = (LPBYTE)(pDdh + 1);
     if (pSrc)
     {
-	memcpy(pByte, pSrc + cbOff, cb);
+        if (cbOff) memset(pByte, 0, cbOff);
+        memcpy(pByte + cbOff, pSrc, cb);
     }
     GlobalUnlock(hMem);
 
@@ -1342,7 +1347,7 @@ HDDEDATA WINAPI DdeAddData(HDDEDATA hData, LPBYTE pSrc, DWORD cb, DWORD cbOff)
     DWORD	old_sz, new_sz;
     LPBYTE	pDst;
 
-    TRACE("(%p,%p,cb %d, cbOff %d)\n", hData, pSrc, cb, cbOff);
+    TRACE("(%p,%p,cb %ld, cbOff %ld)\n", hData, pSrc, cb, cbOff);
 
     pDst = DdeAccessData(hData, &old_sz);
     if (!pDst) return 0;
@@ -1381,7 +1386,7 @@ DWORD WINAPI DdeGetData(HDDEDATA hData, LPBYTE pDst, DWORD cbMax, DWORD cbOff)
     DWORD   dwSize, dwRet;
     LPBYTE  pByte;
 
-    TRACE("(%p,%p,%d,%d)\n", hData, pDst, cbMax, cbOff);
+    TRACE("(%p,%p,%ld,%ld)\n", hData, pDst, cbMax, cbOff);
 
     pByte = DdeAccessData(hData, &dwSize);
 
@@ -1437,7 +1442,7 @@ LPBYTE WINAPI DdeAccessData(HDDEDATA hData, LPDWORD pcbDataSize)
     {
 	*pcbDataSize = GlobalSize(hMem) - sizeof(DDE_DATAHANDLE_HEAD);
     }
-    TRACE("=> %p (%lu) fmt %04x\n", pDdh + 1, GlobalSize(hMem) - sizeof(DDE_DATAHANDLE_HEAD), pDdh->cfFormat);
+    TRACE("=> %p (%Iu) fmt %04x\n", pDdh + 1, GlobalSize(hMem) - sizeof(DDE_DATAHANDLE_HEAD), pDdh->cfFormat);
     return (LPBYTE)(pDdh + 1);
 }
 
@@ -1544,7 +1549,7 @@ HDDEDATA        WDML_Global2DataHandle(WDML_CONV* pConv, HGLOBAL hMem, WINE_DDEH
                     }
                     else
                     {
-                        ERR("Wrong count: %u / %d\n", size, count);
+                        ERR("Wrong count: %lu / %d\n", size, count);
                     }
                 } else ERR("No bitmap header\n");
                 break;
@@ -1637,7 +1642,6 @@ HGLOBAL WDML_DataHandle2Global(HDDEDATA hDdeData, BOOL fResponse, BOOL fRelease,
  */
 WDML_SERVER*	WDML_AddServer(WDML_INSTANCE* pInstance, HSZ hszService, HSZ hszTopic)
 {
-    static const WCHAR fmtW[] = {'%','s','(','0','x','%','*','x',')',0};
     WDML_SERVER* 	pServer;
     WCHAR		buf1[256];
     WCHAR		buf2[256];
@@ -1649,7 +1653,11 @@ WDML_SERVER*	WDML_AddServer(WDML_INSTANCE* pInstance, HSZ hszService, HSZ hszTop
     WDML_IncHSZ(pInstance, hszService);
 
     DdeQueryStringW(pInstance->instanceID, hszService, buf1, 256, CP_WINUNICODE);
-    snprintfW(buf2, 256, fmtW, buf1, 2*sizeof(ULONG_PTR), GetCurrentProcessId());
+#ifdef __REACTOS__
+    swprintf(buf2, 256, L"%s(0x%*x)", buf1, (int)(2*sizeof(ULONG_PTR)), GetCurrentProcessId());
+#else
+    swprintf(buf2, 256, L"%s(0x%*x)", buf1, 2*sizeof(ULONG_PTR), GetCurrentProcessId());
+#endif
     pServer->hszServiceSpec = DdeCreateStringHandleW(pInstance->instanceID, buf2, CP_WINUNICODE);
 
     pServer->atomService = WDML_MakeAtomFromHsz(pServer->hszService);
@@ -1703,7 +1711,7 @@ void WDML_RemoveServer(WDML_INSTANCE* pInstance, HSZ hszService, HSZ hszTopic)
 		pPrev->next = pServer->next;
 	    }
 
-	    DestroyWindow(pServer->hwndServer);
+	    NtUserDestroyWindow(pServer->hwndServer);
 	    WDML_DecHSZ(pInstance, pServer->hszServiceSpec);
 	    WDML_DecHSZ(pInstance, pServer->hszService);
 
@@ -2035,7 +2043,7 @@ WDML_CONV*	WDML_AddConv(WDML_INSTANCE* pInstance, WDML_SIDE side,
     pConv->next = pInstance->convs[side];
     pInstance->convs[side] = pConv;
 
-    TRACE("pConv->wStatus %04x pInstance(%p)\n", pConv->wStatus, pInstance);
+    TRACE("pConv->wStatus %04lx pInstance(%p)\n", pConv->wStatus, pInstance);
 
     return pConv;
 }
@@ -2097,7 +2105,7 @@ void WDML_RemoveConv(WDML_CONV* pRef, WDML_SIDE side)
     hWnd = (side == WDML_CLIENT_SIDE) ? pRef->hwndClient : pRef->hwndServer;
     SetWindowLongPtrW(hWnd, GWL_WDML_CONVERSATION, 0);
 
-    DestroyWindow((side == WDML_CLIENT_SIDE) ? pRef->hwndClient : pRef->hwndServer);
+    NtUserDestroyWindow((side == WDML_CLIENT_SIDE) ? pRef->hwndClient : pRef->hwndServer);
 
     WDML_DecHSZ(pRef->instance, pRef->hszService);
     WDML_DecHSZ(pRef->instance, pRef->hszTopic);
@@ -2114,7 +2122,8 @@ void WDML_RemoveConv(WDML_CONV* pRef, WDML_SIDE side)
 	    {
 		pPrev->next = pCurrent->next;
 	    }
-	    pCurrent->magic = 0;
+            /* Ensure compiler doesn't optimize out the assignment with 0. */
+	    SecureZeroMemory(&pCurrent->magic, sizeof(pCurrent->magic));
 	    HeapFree(GetProcessHeap(), 0, pCurrent);
 	    break;
 	}
@@ -2129,7 +2138,7 @@ static BOOL WDML_EnableCallback(WDML_CONV *pConv, UINT wCmd)
     if (wCmd == EC_DISABLE)
     {
         pConv->wStatus |= ST_BLOCKED;
-        TRACE("EC_DISABLE: conv %p status flags %04x\n", pConv, pConv->wStatus);
+        TRACE("EC_DISABLE: conv %p status flags %04lx\n", pConv, pConv->wStatus);
         return TRUE;
     }
 
@@ -2145,7 +2154,7 @@ static BOOL WDML_EnableCallback(WDML_CONV *pConv, UINT wCmd)
     if (wCmd == EC_ENABLEALL)
     {
         pConv->wStatus &= ~ST_BLOCKED;
-        TRACE("EC_ENABLEALL: conv %p status flags %04x\n", pConv, pConv->wStatus);
+        TRACE("EC_ENABLEALL: conv %p status flags %04lx\n", pConv, pConv->wStatus);
     }
 
     while (pConv->transactions)
@@ -2180,7 +2189,7 @@ BOOL WINAPI DdeEnableCallback(DWORD idInst, HCONV hConv, UINT wCmd)
     BOOL ret = FALSE;
     WDML_CONV *pConv;
 
-    TRACE("(%d, %p, %04x)\n", idInst, hConv, wCmd);
+    TRACE("(%ld, %p, %04x)\n", idInst, hConv, wCmd);
 
     if (hConv)
     {
@@ -2202,12 +2211,12 @@ BOOL WINAPI DdeEnableCallback(DWORD idInst, HCONV hConv, UINT wCmd)
         if (wCmd == EC_DISABLE)
         {
             pInstance->wStatus |= ST_BLOCKED;
-            TRACE("EC_DISABLE: inst %p status flags %04x\n", pInstance, pInstance->wStatus);
+            TRACE("EC_DISABLE: inst %p status flags %04lx\n", pInstance, pInstance->wStatus);
         }
         else if (wCmd == EC_ENABLEALL)
         {
             pInstance->wStatus &= ~ST_BLOCKED;
-            TRACE("EC_ENABLEALL: inst %p status flags %04x\n", pInstance, pInstance->wStatus);
+            TRACE("EC_ENABLEALL: inst %p status flags %04lx\n", pInstance, pInstance->wStatus);
         }
 
         ret = TRUE;
@@ -2429,7 +2438,7 @@ UINT WINAPI DdeQueryConvInfo(HCONV hConv, DWORD id, PCONVINFO lpConvInfo)
     CONVINFO	ci;
     WDML_CONV*	pConv;
 
-    TRACE("(%p,%x,%p)\n", hConv, id, lpConvInfo);
+    TRACE("(%p,%lx,%p)\n", hConv, id, lpConvInfo);
 
     if (!hConv)
     {

--- a/win32ss/user/user32/misc/ddeserver.c
+++ b/win32ss/user/user32/misc/ddeserver.c
@@ -27,9 +27,14 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(ddeml);
 
+#ifdef __REACTOS__
 static const WCHAR szServerNameClass[] = L"DDEMLMom";
 const char WDML_szServerConvClassA[] = "DDEMLAnsiServer";
 const WCHAR WDML_szServerConvClassW[] = L"DDEMLUnicodeServer";
+#else
+const char WDML_szServerConvClassA[] = "WineDdeServerConvA";
+const WCHAR WDML_szServerConvClassW[] = L"WineDdeServerConvW";
+#endif
 
 static LRESULT CALLBACK WDML_ServerNameProc(HWND, UINT, WPARAM, LPARAM);
 static LRESULT CALLBACK WDML_ServerConvProc(HWND, UINT, WPARAM, LPARAM);
@@ -56,7 +61,7 @@ BOOL WINAPI DdePostAdvise(DWORD idInst, HSZ hszTopic, HSZ hszItem)
     ATOM		atom;
     UINT		count;
 
-    TRACE("(%d,%p,%p)\n", idInst, hszTopic, hszItem);
+    TRACE("(%ld,%p,%p)\n", idInst, hszTopic, hszItem);
 
     pInstance = WDML_GetInstance(idInst);
 
@@ -158,7 +163,7 @@ HDDEDATA WINAPI DdeNameService(DWORD idInst, HSZ hsz1, HSZ hsz2, UINT afCmd)
     HWND 		hwndServer;
     WNDCLASSEXW  	wndclass;
 
-    TRACE("(%d,%p,%p,%x)\n", idInst, hsz1, hsz2, afCmd);
+    TRACE("(%ld,%p,%p,%x)\n", idInst, hsz1, hsz2, afCmd);
 
     /*  First check instance
      */
@@ -218,18 +223,23 @@ HDDEDATA WINAPI DdeNameService(DWORD idInst, HSZ hsz1, HSZ hsz2, UINT afCmd)
 	wndclass.hCursor       = 0;
 	wndclass.hbrBackground = 0;
 	wndclass.lpszMenuName  = NULL;
-	wndclass.lpszClassName = szServerNameClass;
+#ifdef __REACTOS__
+    wndclass.lpszClassName = szServerNameClass;
+#else
+	wndclass.lpszClassName = L"WineDdeServerName";
+#endif
 	wndclass.hIconSm       = 0;
 
 	RegisterClassExW(&wndclass);
 
-	hwndServer = CreateWindowW(szServerNameClass, NULL,
-				   WS_POPUP, 0, 0, 0, 0,
-				   0, 0, 0, 0);
-
+#ifdef __REACTOS__
+	hwndServer = CreateWindowW(szServerNameClass, NULL, WS_POPUP, 0, 0, 0, 0, 0, 0, 0, 0);
+#else
+	hwndServer = CreateWindowW(L"WineDdeServerName", NULL, WS_POPUP, 0, 0, 0, 0, 0, 0, 0, 0);
+#endif
 	SetWindowLongPtrW(hwndServer, GWL_WDML_INSTANCE, (ULONG_PTR)pInstance);
 	SetWindowLongPtrW(hwndServer, GWL_WDML_SERVER, (ULONG_PTR)pServer);
-	TRACE("Created nameServer=%p for instance=%08x\n", hwndServer, idInst);
+	TRACE("Created nameServer=%p for instance=%08lx\n", hwndServer, idInst);
 
 	pServer->hwndServer = hwndServer;
 	break;
@@ -330,7 +340,7 @@ static WDML_CONV* WDML_CreateServerConv(WDML_INSTANCE* pInstance, HWND hwndClien
                                       hwndServerName, 0, 0, 0);
     }
 
-    TRACE("Created convServer=%p (nameServer=%p) for instance=%08x unicode=%d\n",
+    TRACE("Created convServer=%p (nameServer=%p) for instance=%08lx unicode=%d\n",
 	  hwndServerConv, hwndServerName, pInstance->instanceID, pInstance->unicode);
 
     pConv = WDML_AddConv(pInstance, WDML_SERVER_SIDE, hszApp, hszTopic,
@@ -352,7 +362,7 @@ static WDML_CONV* WDML_CreateServerConv(WDML_INSTANCE* pInstance, HWND hwndClien
     }
     else
     {
-	DestroyWindow(hwndServerConv);
+	NtUserDestroyWindow(hwndServerConv);
     }
     return pConv;
 }
@@ -383,7 +393,7 @@ static LRESULT CALLBACK WDML_ServerNameProc(HWND hwndServer, UINT iMsg, WPARAM w
 
 	pInstance = WDML_GetInstanceFromWnd(hwndServer);
 	if (!pInstance) return 0;
-	TRACE("idInst=%d, threadID=0x%x\n", pInstance->instanceID, GetCurrentThreadId());
+	TRACE("idInst=%ld, threadID=0x%lx\n", pInstance->instanceID, GetCurrentThreadId());
 
 	/* don't free DDEParams, since this is a broadcast */
 	UnpackDDElParam(WM_DDE_INITIATE, lParam, &uiLo, &uiHi);
@@ -774,7 +784,7 @@ static HDDEDATA map_A_to_W( DWORD instance, void *ptr, DWORD size )
     return ret;
 }
 
-/* convert data to ASCII, unless it looks like it's not in Unicode format */
+/* convert data to ANSI, unless it looks like it's not in Unicode format */
 static HDDEDATA map_W_to_A( DWORD instance, void *ptr, DWORD size )
 {
     HDDEDATA ret;
@@ -784,7 +794,7 @@ static HDDEDATA map_W_to_A( DWORD instance, void *ptr, DWORD size )
     if (data_looks_unicode( ptr, size ))
     {
         size /= sizeof(WCHAR);
-        if ((end = memchrW( ptr, 0, size ))) size = end + 1 - (const WCHAR *)ptr;
+        if ((end = wmemchr( ptr, 0, size ))) size = end + 1 - (const WCHAR *)ptr;
         len = WideCharToMultiByte( CP_ACP, 0, ptr, size, NULL, 0, NULL, NULL );
         ret = DdeCreateDataHandle( instance, NULL, len, 0, 0, CF_TEXT, 0);
         WideCharToMultiByte( CP_ACP, 0, ptr, size, (char *)DdeAccessData(ret, NULL), len, NULL, NULL );
@@ -813,7 +823,7 @@ static	WDML_QUEUE_STATE WDML_ServerHandleExecute(WDML_CONV* pConv, WDML_XACT* pX
 	{
             if (pConv->instance->unicode)  /* Unicode server, try to map A->W */
                 hDdeData = map_A_to_W( pConv->instance->instanceID, ptr, size );
-            else if (!IsWindowUnicode( pConv->hwndClient )) /* ASCII server and client, try to map W->A */
+            else if (!IsWindowUnicode( pConv->hwndClient )) /* ANSI server and client, try to map W->A */
                 hDdeData = map_W_to_A( pConv->instance->instanceID, ptr, size );
             else
                 hDdeData = DdeCreateDataHandle(pConv->instance->instanceID, ptr, size, 0, 0, CF_TEXT, 0);
@@ -1019,7 +1029,7 @@ static LRESULT CALLBACK WDML_ServerConvProc(HWND hwndServer, UINT iMsg, WPARAM w
     WDML_CONV*		pConv;
     WDML_XACT*		pXAct = NULL;
 
-    TRACE("%p %04x %08lx %08lx\n", hwndServer, iMsg, wParam, lParam);
+    TRACE("%p %04x %08Ix %08Ix\n", hwndServer, iMsg, wParam, lParam);
 
     if (iMsg == WM_DESTROY)
     {

--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -32,7 +32,11 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(icon);
 
+#ifdef __REACTOS__
 #include <pshpack1.h>
+#else
+#pragma pack(push,1)
+#endif
 
 typedef struct
 {
@@ -91,10 +95,14 @@ typedef struct taganiheader
 #define NE_RSCTYPE_ICON        0x8003
 #define NE_RSCTYPE_GROUP_ICON  0x800e
 
+#ifdef __REACTOS__
 #include <poppack.h>
+#else
+#pragma pack(pop)
+#endif
 
 #if 0
-static void dumpIcoDirEnty ( LPicoICONDIRENTRY entry )
+static void dumpIcoDirEntry ( LPicoICONDIRENTRY entry )
 {
 	TRACE("width = 0x%08x height = 0x%08x\n", entry->bWidth, entry->bHeight);
 	TRACE("colors = 0x%08x planes = 0x%08x\n", entry->bColorCount, entry->wPlanes);
@@ -107,7 +115,7 @@ static void dumpIcoDir ( LPicoICONDIR entry )
 }
 #endif
 
-#ifndef WINE
+#ifdef __REACTOS__
 DWORD get_best_icon_file_offset(const LPBYTE dir,
                                 DWORD dwFileSize,
                                 int cxDesired,
@@ -233,13 +241,13 @@ static BYTE * ICO_LoadIcon( LPBYTE peimage, LPicoICONDIRENTRY lpiIDE, ULONG *uSi
  */
 static BYTE * ICO_GetIconDirectory( LPBYTE peimage, LPicoICONDIR* lplpiID, ULONG *uSize )
 {
-	CURSORICONDIR	* lpcid;	/* icon resource in resource-dir format */
+	CURSORICONFILEDIR *lpcid;	/* icon resource in resource-dir format */
 	CURSORICONDIR	* lpID;		/* icon resource in resource format */
 	int		i;
 
 	TRACE("%p %p\n", peimage, lplpiID);
 
-	lpcid = (CURSORICONDIR*)peimage;
+	lpcid = (CURSORICONFILEDIR*)peimage;
 
 	if( lpcid->idReserved || (lpcid->idType != 1) || (!lpcid->idCount) )
 	  return 0;
@@ -292,7 +300,7 @@ static UINT ICO_ExtractIconExW(
      * The other is from User32 using PrivateExtractIcons.
      * Based on W2K3SP2 testing, the count of icons returned
      * is zero (0) for PNG ones using ExtractIconEx and
-     * one (1) for PNG icons using PrivateExtractIcons. 
+     * one (1) for PNG icons using PrivateExtractIcons.
      * We can handle the difference using the fIconEx flag.*/
     BOOL fIconEx)
 #else
@@ -389,7 +397,7 @@ static UINT ICO_ExtractIconExW(
             goto end;
 
         /* Look though the reported size less search string length */
-        anihMax = uSize - strlen("anih"); 
+        anihMax = uSize - strlen("anih");
         /* Search for 'anih' indicating animation header */
         for (anihOffset = 0; anihOffset < anihMax; anihOffset++)
         {
@@ -439,7 +447,7 @@ static UINT ICO_ExtractIconExW(
 	  LPicoICONDIR	lpiID = NULL;
 	  ULONG		uSize = 0;
 
-          TRACE("-- OS2/icon Signature (0x%08x)\n", sig);
+          TRACE("-- OS2/icon Signature (0x%08lx)\n", sig);
 
 	  if (pData == (BYTE*)-1)
 	  {
@@ -447,7 +455,7 @@ static UINT ICO_ExtractIconExW(
 	    if (pCIDir)
 	    {
 	      iconDirCount = 1; iconCount = lpiID->idCount;
-              TRACE("-- icon found %p 0x%08x 0x%08x 0x%08x\n", pCIDir, uSize, iconDirCount, iconCount);
+              TRACE("-- icon found %p 0x%08lx 0x%08x 0x%08x\n", pCIDir, uSize, iconDirCount, iconCount);
 	    }
 	  }
 	  else while (pTInfo->type_id && !(pIconStorage && pIconDir))

--- a/win32ss/user/user32/misc/resources.c
+++ b/win32ss/user/user32/misc/resources.c
@@ -16,9 +16,9 @@ static HINSTANCE hSetupApi = NULL;
 
 /**********************************************************************
  *	LoadStringW		(USER32.@)
- *	Synced with Wine Staging 1.7.55
+ *	Synced with Wine 11.11
  */
-INT WINAPI LoadStringW( HINSTANCE instance, UINT resource_id,
+INT WINAPI DECLSPEC_HOTPATCH LoadStringW( HINSTANCE instance, UINT resource_id,
                             LPWSTR buffer, INT buflen )
 {
     HGLOBAL hmem;
@@ -33,12 +33,13 @@ INT WINAPI LoadStringW( HINSTANCE instance, UINT resource_id,
     if(buffer == NULL)
         return 0;
 
-    /* Use loword (incremented by 1) as resourceid */
-    hrsrc = FindResourceW( instance, MAKEINTRESOURCEW((LOWORD(resource_id) >> 4) + 1),
-                           (LPWSTR)RT_STRING );
-    if (!hrsrc) return 0;
-    hmem = LoadResource( instance, hrsrc );
-    if (!hmem) return 0;
+    if (!(hrsrc = FindResourceW( instance, MAKEINTRESOURCEW((LOWORD(resource_id) >> 4) + 1), (LPWSTR)RT_STRING )) ||
+        !(hmem = LoadResource( instance, hrsrc )))
+    {
+        TRACE( "Failed to load string.\n" );
+        if (buflen > 0) buffer[0] = 0;
+        return 0;
+    }
 
     p = LockResource(hmem);
     string_num = resource_id & 0x000f;
@@ -56,25 +57,18 @@ INT WINAPI LoadStringW( HINSTANCE instance, UINT resource_id,
     }
 
     i = min(buflen - 1, *p);
-    if (i > 0) {
-	memcpy(buffer, p + 1, i * sizeof (WCHAR));
-        buffer[i] = 0;
-    } else {
-	if (buflen > 1) {
-            buffer[0] = 0;
-	    return 0;
-	}
-    }
+    memcpy(buffer, p + 1, i * sizeof(WCHAR));
+    buffer[i] = 0;
 
-    TRACE("%s loaded !\n", debugstr_w(buffer));
+    TRACE("returning %s\n", debugstr_w(buffer));
     return i;
 }
 
 /**********************************************************************
  *	LoadStringA	(USER32.@)
- *	Synced with Wine Staging 1.7.55
+ *	Synced with Wine 11.11
  */
-INT WINAPI LoadStringA( HINSTANCE instance, UINT resource_id, LPSTR buffer, INT buflen )
+INT WINAPI DECLSPEC_HOTPATCH LoadStringA( HINSTANCE instance, UINT resource_id, LPSTR buffer, INT buflen )
 {
     HGLOBAL hmem;
     HRSRC hrsrc;
@@ -95,8 +89,7 @@ INT WINAPI LoadStringA( HINSTANCE instance, UINT resource_id, LPSTR buffer, INT 
 
         while (id--) p += *p + 1;
 
-        if (buflen != 1)
-            RtlUnicodeToMultiByteN( buffer, buflen - 1, &retval, (PWSTR)(p + 1), *p * sizeof(WCHAR) );
+        RtlUnicodeToMultiByteN( buffer, buflen - 1, &retval, p + 1, *p * sizeof(WCHAR) );
     }
     buffer[retval] = 0;
     TRACE("returning %s\n", debugstr_a(buffer));

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -14,36 +14,6 @@ WINE_DEFAULT_DEBUG_CHANNEL(cursor);
 WINE_DECLARE_DEBUG_CHANNEL(icon);
 //WINE_DECLARE_DEBUG_CHANNEL(resource);
 
-#include <pshpack1.h>
-typedef struct _CURSORICONFILEDIRENTRY
-{
-    BYTE bWidth;
-    BYTE bHeight;
-    BYTE bColorCount;
-    BYTE bReserved;
-    union
-    {
-        WORD wPlanes; /* For icons */
-        WORD xHotspot; /* For cursors */
-    };
-    union
-    {
-        WORD wBitCount; /* For icons */
-        WORD yHotspot; /* For cursors */
-    };
-    DWORD dwDIBSize;
-    DWORD dwDIBOffset;
-} CURSORICONFILEDIRENTRY;
-
-typedef struct _CURSORICONFILEDIR
-{
-    WORD idReserved;
-    WORD idType;
-    WORD idCount;
-    CURSORICONFILEDIRENTRY idEntries[1];
-} CURSORICONFILEDIR;
-#include <poppack.h>
-
 #define PNG_CHECK_SIG_SIZE 8 /* Check signature size */
 
 /* libpng helpers */

--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -82,12 +82,13 @@
  */
 
 #include <user32.h>
+#include <wine-compat.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(mdi);
 
 #define MDI_MAXTITLELENGTH      0xa1
 
-#define WM_MDICALCCHILDSCROLL   0x003F  /* this is exactly what Windows uses */
+#define WM_MDICALCCHILDSCROLL   0x003f /* this is exactly what Windows uses */
 
 /* "More Windows..." definitions */
 #define MDI_MOREWINDOWSLIMIT    9       /* after this number of windows, a "More Windows..."
@@ -175,10 +176,6 @@ HWND* WIN_ListChildren (HWND hWndparent)
   return pHwnd;
 }
 
-#ifdef __REACTOS__
-void WINAPI ScrollChildren(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-void WINAPI CalcChildScroll(HWND hwnd, INT scroll);
-#endif
 
 /* -------- Miscellaneous service functions ----------
  *
@@ -206,7 +203,7 @@ static void MDI_PostUpdate(HWND hwnd, MDICLIENTINFO* ci, WORD recalc)
     ci->sbRecalc = recalc;
 }
 
-
+#ifdef __REACTOS__
 /*********************************************************************
  * MDIClient class descriptor
  */
@@ -220,37 +217,18 @@ const struct builtin_class_descr MDICLIENT_builtin_class =
     IDC_ARROW,              /* cursor */
     (HBRUSH)(COLOR_APPWORKSPACE+1)    /* brush */
 };
-
+#endif
 
 static MDICLIENTINFO *get_client_info( HWND client )
 {
-#ifdef __REACTOS__
-    return (MDICLIENTINFO *)GetWindowLongPtr(client, GWLP_MDIWND);
-#else
-    MDICLIENTINFO *ret = NULL;
-    WND *win = WIN_GetPtr( client );
-    if (win)
-    {
-        if (win == WND_OTHER_PROCESS || win == WND_DESKTOP)
-        {
-            if (IsWindow(client)) WARN( "client %p belongs to other process\n", client );
-            return NULL;
-        }
-        if (win->flags & WIN_ISMDICLIENT)
-            ret = (MDICLIENTINFO *)win->wExtra;
-        else
-            WARN( "%p is not an MDI client\n", client );
-        WIN_ReleasePtr( win );
-    }
-    return ret;
-#endif
+    return NtUserGetMDIClientInfo( client );
 }
 
 static BOOL is_close_enabled(HWND hwnd, HMENU hSysMenu)
 {
     if (GetClassLongPtrW(hwnd, GCL_STYLE) & CS_NOCLOSE) return FALSE;
 
-    if (!hSysMenu) hSysMenu = GetSystemMenu(hwnd, FALSE);
+    if (!hSysMenu) hSysMenu = NtUserGetSystemMenu( hwnd, FALSE );
     if (hSysMenu)
     {
         UINT state = GetMenuState(hSysMenu, SC_CLOSE, MF_BYCOMMAND);
@@ -380,17 +358,17 @@ static LRESULT MDISetMenu( HWND hwnd, HMENU hmenuFrame,
 
             ci->hWindowMenu = hmenuWindow;
 
-            /* Add items to the new Window menu */
             ci->nActiveChildren = nActiveChildren_old;
-            MDI_RefreshMenu(ci);
         }
         else
             ci->hWindowMenu = hmenuWindow;
+
+        MDI_RefreshMenu(ci);
     }
 
     if (hmenuFrame)
     {
-        SetMenu(hwndFrame, hmenuFrame);
+        NtUserSetMenu(hwndFrame, hmenuFrame);
         if( hmenuFrame != ci->hFrameMenu )
         {
             HMENU oldFrameMenu = ci->hFrameMenu;
@@ -450,7 +428,7 @@ static LRESULT MDI_RefreshMenu(MDICLIENTINFO *ci)
                     if (mii.wID == ci->idFirstChild)
                     {
                         TRACE("removing %u items including separator\n", count - i);
-                        while (RemoveMenu(ci->hWindowMenu, i, MF_BYPOSITION))
+                        while (NtUserRemoveMenu( ci->hWindowMenu, i, MF_BYPOSITION ))
                             /* nothing */;
 
                         break;
@@ -469,7 +447,7 @@ static LRESULT MDI_RefreshMenu(MDICLIENTINFO *ci)
 
             if (visible == MDI_MOREWINDOWSLIMIT)
             {
-                LoadStringW(User32Instance, IDS_MDI_MOREWINDOWS, buf, sizeof(buf)/sizeof(WCHAR));
+                LoadStringW(User32Instance, IDS_MDI_MOREWINDOWS, buf, ARRAY_SIZE(buf));
                 AppendMenuW(ci->hWindowMenu, MF_STRING, id, buf);
                 break;
             }
@@ -485,12 +463,16 @@ static LRESULT MDI_RefreshMenu(MDICLIENTINFO *ci)
             buf[0] = '&';
             buf[1] = '0' + visible;
             buf[2] = ' ';
-            InternalGetWindowText(ci->child[i], buf + 3, sizeof(buf)/sizeof(WCHAR) - 3);
+            NtUserInternalGetWindowText(ci->child[i], buf + 3, ARRAY_SIZE(buf) - 3);
             TRACE("Adding %p, id %u %s\n", ci->child[i], id, debugstr_w(buf));
             AppendMenuW(ci->hWindowMenu, MF_STRING, id, buf);
 
             if (ci->child[i] == ci->hwndActiveChild)
+#ifdef __REACTOS__
                 CheckMenuItem(ci->hWindowMenu, id, MF_CHECKED);
+#else
+                NtUserCheckMenuItem(ci->hWindowMenu, id, MF_CHECKED);
+#endif
         }
         else
             TRACE("MDI child %p is not visible, skipping\n", ci->child[i]);
@@ -543,20 +525,21 @@ static void MDI_SwitchActiveChild( MDICLIENTINFO *ci, HWND hwndTo, BOOL activate
     {
         BOOL was_zoomed = IsZoomed(hwndPrev);
 
-        if (was_zoomed)
+        if (was_zoomed && (GetWindowLongW( hwndTo, GWL_STYLE ) & WS_MAXIMIZEBOX))
         {
             /* restore old MDI child */
             SendMessageW( hwndPrev, WM_SETREDRAW, FALSE, 0 );
-            ShowWindow( hwndPrev, SW_RESTORE );
+            NtUserShowWindow( hwndPrev, SW_RESTORE );
             SendMessageW( hwndPrev, WM_SETREDRAW, TRUE, 0 );
 
             /* activate new MDI child */
-            SetWindowPos( hwndTo, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE );
+            NtUserSetWindowPos( hwndTo, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE );
             /* maximize new MDI child */
-            ShowWindow( hwndTo, SW_MAXIMIZE );
+            NtUserShowWindow( hwndTo, SW_MAXIMIZE );
         }
         /* activate new MDI child */
-        SetWindowPos( hwndTo, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | (activate ? 0 : SWP_NOACTIVATE) );
+        NtUserSetWindowPos( hwndTo, HWND_TOP, 0, 0, 0, 0,
+                            SWP_NOMOVE | SWP_NOSIZE | (activate ? 0 : SWP_NOACTIVATE) );
     }
 }
 
@@ -578,7 +561,7 @@ static LRESULT MDIDestroyChild( HWND client, MDICLIENTINFO *ci,
             MDI_SwitchActiveChild(ci, next, TRUE);
         else
         {
-            ShowWindow(child, SW_HIDE);
+            NtUserShowWindow( child, SW_HIDE );
             if (child == ci->hwndChildMaximized)
             {
                 HWND frame = GetParent(client);
@@ -622,7 +605,7 @@ static LRESULT MDIDestroyChild( HWND client, MDICLIENTINFO *ci,
     {
         SendMessageW(client, WM_MDIREFRESHMENU, 0, 0);
         MDI_PostUpdate(GetParent(child), ci, SB_BOTH+1);
-        DestroyWindow(child);
+        NtUserDestroyWindow(child);
     }
 
     TRACE("child destroyed - %p\n", child);
@@ -672,7 +655,7 @@ static LONG MDI_ChildActivate( HWND client, HWND child )
          * SetFocus won't work. It appears that Windows sends WM_SETFOCUS
          * manually in this case.
          */
-        if (SetFocus(client) == client)
+        if (NtUserSetFocus(client) == client)
             SendMessageW( client, WM_SETFOCUS, (WPARAM)client, 0 );
     }
 
@@ -764,13 +747,12 @@ static LONG MDICascade( HWND client, MDICLIENTINFO *ci )
             style = GetWindowLongW(win_array[i], GWL_STYLE);
 
             if (!(style & WS_SIZEBOX)) posOptions |= SWP_NOSIZE;
-            SetWindowPos( win_array[i], 0, pos[0].x, pos[0].y, pos[1].x, pos[1].y,
-                           posOptions);
+            NtUserSetWindowPos( win_array[i], 0, pos[0].x, pos[0].y, pos[1].x, pos[1].y, posOptions );
         }
     }
     HeapFree( GetProcessHeap(), 0, win_array );
 
-    if (has_icons) ArrangeIconicWindows( client );
+    if (has_icons) NtUserArrangeIconicWindows( client );
     return 0;
 }
 
@@ -850,7 +832,7 @@ static void MDITile( HWND client, MDICLIENTINFO *ci, WPARAM wParam )
                 LONG style = GetWindowLongW(win_array[i], GWL_STYLE);
                 if (!(style & WS_SIZEBOX)) posOptions |= SWP_NOSIZE;
 
-                SetWindowPos(*pWnd, 0, x, y, xsize, ysize, posOptions);
+                NtUserSetWindowPos( *pWnd, 0, x, y, xsize, ysize, posOptions );
                 y += ysize;
                 pWnd++;
             }
@@ -858,7 +840,7 @@ static void MDITile( HWND client, MDICLIENTINFO *ci, WPARAM wParam )
         }
     }
     HeapFree( GetProcessHeap(), 0, win_array );
-    if (has_icons) ArrangeIconicWindows( client );
+    if (has_icons) NtUserArrangeIconicWindows( client );
 }
 
 /* ----------------------- Frame window ---------------------------- */
@@ -890,7 +872,7 @@ static BOOL MDI_AugmentFrameMenu( HWND frame, HWND hChild )
     }
 //// End
     /* create a copy of sysmenu popup and insert it into frame menu bar */
-    if (!(hSysPopup = GetSystemMenu(hChild, FALSE)))
+    if (!(hSysPopup = NtUserGetSystemMenu( hChild, FALSE )))
     {
         TRACE("child %p doesn't have a system menu\n", hChild);
         return FALSE;
@@ -914,12 +896,12 @@ static BOOL MDI_AugmentFrameMenu( HWND frame, HWND hChild )
         hIcon = (HICON)GetClassLongPtrW(hChild, GCLP_HICON);
     if (!hIcon)
         hIcon = LoadImageW(0, (LPWSTR)IDI_WINLOGO, IMAGE_ICON, GetSystemMetrics(SM_CXSMICON),
-                           GetSystemMetrics(SM_CYSMICON), LR_DEFAULTCOLOR);
+                           GetSystemMetrics(SM_CYSMICON), LR_DEFAULTCOLOR | LR_SHARED);
     if (hIcon)
     {
       HDC hMemDC;
       HBITMAP hBitmap, hOldBitmap;
-      HDC hdc = GetDC(hChild);
+      HDC hdc = NtUserGetDC(hChild);
 
       if (hdc)
       {
@@ -930,10 +912,10 @@ static BOOL MDI_AugmentFrameMenu( HWND frame, HWND hChild )
         hBitmap = CreateCompatibleBitmap(hdc, cx, cy);
         hOldBitmap = SelectObject(hMemDC, hBitmap);
         SetMapMode(hMemDC, MM_TEXT);
-        DrawIconEx(hMemDC, 0, 0, hIcon, cx, cy, 0, GetSysColorBrush(COLOR_MENU), DI_NORMAL);
+        NtUserDrawIconEx(hMemDC, 0, 0, hIcon, cx, cy, 0, GetSysColorBrush(COLOR_MENU), DI_NORMAL);
         SelectObject (hMemDC, hOldBitmap);
         DeleteDC(hMemDC);
-        ReleaseDC(hChild, hdc);
+        NtUserReleaseDC( hChild, hdc );
         hSysMenuBitmap = hBitmap;
       }
     }
@@ -942,17 +924,17 @@ static BOOL MDI_AugmentFrameMenu( HWND frame, HWND hChild )
                      (UINT_PTR)hSysPopup, (LPSTR)hSysMenuBitmap))
     {
         TRACE("not inserted\n");
-	DestroyMenu(hSysPopup);
+        NtUserDestroyMenu( hSysPopup );
         return FALSE;
     }
 
-    EnableMenuItem(hSysPopup, SC_SIZE, MF_BYCOMMAND | MF_GRAYED);
-    EnableMenuItem(hSysPopup, SC_MOVE, MF_BYCOMMAND | MF_GRAYED);
-    EnableMenuItem(hSysPopup, SC_MAXIMIZE, MF_BYCOMMAND | MF_GRAYED);
-    SetMenuDefaultItem(hSysPopup, SC_CLOSE, FALSE);
+    NtUserEnableMenuItem(hSysPopup, SC_SIZE, MF_BYCOMMAND | MF_GRAYED);
+    NtUserEnableMenuItem(hSysPopup, SC_MOVE, MF_BYCOMMAND | MF_GRAYED);
+    NtUserEnableMenuItem(hSysPopup, SC_MAXIMIZE, MF_BYCOMMAND | MF_GRAYED);
+    NtUserSetMenuDefaultItem(hSysPopup, SC_CLOSE, FALSE);
 
     /* redraw menu */
-    DrawMenuBar(frame);
+    NtUserDrawMenuBar(frame);
 
     return TRUE;
 }
@@ -993,7 +975,7 @@ static BOOL MDI_RestoreFrameMenu( HWND frame, HWND hChild, HBITMAP hBmpClose )
 		     TRUE,
 		     &menuInfo);
 
-    RemoveMenu(menu,0,MF_BYPOSITION);
+    NtUserRemoveMenu( menu, 0, MF_BYPOSITION );
 
     if ( (menuInfo.fType & MFT_BITMAP) &&
 	 (menuInfo.dwTypeData != 0) &&
@@ -1006,13 +988,13 @@ static BOOL MDI_RestoreFrameMenu( HWND frame, HWND hChild, HBITMAP hBmpClose )
          DeleteObject(menuInfo.hbmpItem);
 
     /* close */
-    DeleteMenu(menu, SC_CLOSE, MF_BYCOMMAND);
+    NtUserDeleteMenu( menu, SC_CLOSE, MF_BYCOMMAND );
     /* restore */
-    DeleteMenu(menu, SC_RESTORE, MF_BYCOMMAND);
+    NtUserDeleteMenu( menu, SC_RESTORE, MF_BYCOMMAND );
     /* minimize */
-    DeleteMenu(menu, SC_MINIMIZE, MF_BYCOMMAND);
+    NtUserDeleteMenu( menu, SC_MINIMIZE, MF_BYCOMMAND );
 
-    DrawMenuBar(frame);
+    NtUserDrawMenuBar(frame);
 
     return TRUE;
 }
@@ -1036,7 +1018,7 @@ static void MDI_UpdateFrameText( HWND frame, HWND hClient, BOOL repaint, LPCWSTR
 
     if (!lpTitle && !ci->frameTitle)  /* first time around, get title from the frame window */
     {
-        GetWindowTextW( frame, lpBuffer, sizeof(lpBuffer)/sizeof(WCHAR) );
+        GetWindowTextW( frame, lpBuffer, ARRAY_SIZE( lpBuffer ));
         lpTitle = lpBuffer;
     }
 
@@ -1044,8 +1026,8 @@ static void MDI_UpdateFrameText( HWND frame, HWND hClient, BOOL repaint, LPCWSTR
     if (lpTitle)
     {
 	HeapFree( GetProcessHeap(), 0, ci->frameTitle );
-	if ((ci->frameTitle = HeapAlloc( GetProcessHeap(), 0, (strlenW(lpTitle)+1)*sizeof(WCHAR))))
-            strcpyW( ci->frameTitle, lpTitle );
+	if ((ci->frameTitle = HeapAlloc( GetProcessHeap(), 0, (lstrlenW(lpTitle)+1)*sizeof(WCHAR))))
+            lstrcpyW( ci->frameTitle, lpTitle );
     }
 
     if (ci->frameTitle)
@@ -1053,19 +1035,16 @@ static void MDI_UpdateFrameText( HWND frame, HWND hClient, BOOL repaint, LPCWSTR
 	if (ci->hwndChildMaximized)
 	{
 	    /* combine frame title and child title if possible */
-
-	    static const WCHAR lpBracket[]  = {' ','-',' ','[',0};
-	    static const WCHAR lpBracket2[]  = {']',0};
-	    int	i_frame_text_length = strlenW(ci->frameTitle);
+	    int	i_frame_text_length = lstrlenW(ci->frameTitle);
 
 	    lstrcpynW( lpBuffer, ci->frameTitle, MDI_MAXTITLELENGTH);
 
 	    if( i_frame_text_length + 6 < MDI_MAXTITLELENGTH )
             {
-		strcatW( lpBuffer, lpBracket );
+		lstrcatW( lpBuffer, L" - [" );
                 if (GetWindowTextW( ci->hwndActiveChild, lpBuffer + i_frame_text_length + 4,
                                     MDI_MAXTITLELENGTH - i_frame_text_length - 5 ))
-                    strcatW( lpBuffer, lpBracket2 );
+                    lstrcatW( lpBuffer, L"]" );
                 else
                     lpBuffer[i_frame_text_length] = 0;  /* remove bracket */
             }
@@ -1083,8 +1062,8 @@ static void MDI_UpdateFrameText( HWND frame, HWND hClient, BOOL repaint, LPCWSTR
     if (repaint)
     {
        if (!NtUserCallTwoParam((DWORD_PTR)frame,DC_ACTIVE,TWOPARAM_ROUTINE_REDRAWTITLE))
-        SetWindowPos( frame, 0,0,0,0,0, SWP_FRAMECHANGED |
-                      SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE | SWP_NOZORDER );
+        NtUserSetWindowPos( frame, 0,0,0,0,0, SWP_FRAMECHANGED |
+                            SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE | SWP_NOZORDER );
     }
 }
 
@@ -1099,22 +1078,17 @@ LRESULT WINAPI MDIClientWndProc_common( HWND hwnd, UINT message, WPARAM wParam, 
 {
     MDICLIENTINFO *ci = NULL;
 
-    TRACE("%p %04x (%s) %08lx %08lx\n", hwnd, message, SPY_GetMsgName(message, hwnd), wParam, lParam);
+    TRACE("%p %04x (%s) %08Ix %08Ix\n", hwnd, message, SPY_GetMsgName(message, hwnd), wParam, lParam);
+
+    NtUserSetWindowFNID( hwnd, MAKE_FNID(NTUSER_WNDPROC_MDICLIENT) );
 
     if (!(ci = get_client_info( hwnd )))
     {
-#ifdef __REACTOS__
         if (message == WM_NCCREATE)
         {
-          if (!(ci = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*ci))))
-             return FALSE;
-           SetWindowLongPtrW( hwnd, GWLP_MDIWND, (LONG_PTR)ci );
-           ci->hBmpClose = 0;
-           NtUserSetWindowFNID( hwnd, FNID_MDICLIENT); // wine uses WIN_ISMDICLIENT
+            if (!(ci = HeapAlloc( GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*ci) ))) return 0;
+            NtUserSetMDIClientInfo( hwnd, ci );
         }
-#else
-        if (message == WM_NCCREATE) win_set_flags( hwnd, WIN_ISMDICLIENT, 0 );
-#endif
         return unicode ? DefWindowProcW( hwnd, message, wParam, lParam ) :
                          DefWindowProcA( hwnd, message, wParam, lParam );
     }
@@ -1155,8 +1129,8 @@ LRESULT WINAPI MDIClientWndProc_common( HWND hwnd, UINT message, WPARAM wParam, 
 
           HeapFree( GetProcessHeap(), 0, ci->child );
           HeapFree( GetProcessHeap(), 0, ci->frameTitle );
-#ifdef __REACTOS__
           HeapFree( GetProcessHeap(), 0, ci );
+#ifdef __REACTOS__
           SetWindowLongPtrW( hwnd, GWLP_MDIWND, 0 );
 #endif
           return 0;
@@ -1173,7 +1147,7 @@ LRESULT WINAPI MDIClientWndProc_common( HWND hwnd, UINT message, WPARAM wParam, 
       case WM_MDIACTIVATE:
       {
         if( ci->hwndActiveChild != (HWND)wParam )
-	    SetWindowPos((HWND)wParam, 0,0,0,0,0, SWP_NOSIZE | SWP_NOMOVE);
+	    NtUserSetWindowPos( (HWND)wParam, 0,0,0,0,0, SWP_NOSIZE | SWP_NOMOVE );
         return 0;
       }
 
@@ -1216,7 +1190,7 @@ LRESULT WINAPI MDIClientWndProc_common( HWND hwnd, UINT message, WPARAM wParam, 
 
       case WM_MDIICONARRANGE:
 	ci->mdiFlags |= MDIF_NEEDUPDATE;
-        ArrangeIconicWindows( hwnd );
+        NtUserArrangeIconicWindows( hwnd );
 	ci->sbRecalc = SB_BOTH+1;
 #ifdef __REACTOS__
 	PostMessageA( hwnd, WM_MDICALCCHILDSCROLL, 0, 0 ); //// ReactOS: Post not send!
@@ -1226,7 +1200,7 @@ LRESULT WINAPI MDIClientWndProc_common( HWND hwnd, UINT message, WPARAM wParam, 
         return 0;
 
       case WM_MDIMAXIMIZE:
-	ShowWindow( (HWND)wParam, SW_MAXIMIZE );
+	NtUserShowWindow( (HWND)wParam, SW_MAXIMIZE );
         return 0;
 
       case WM_MDINEXT: /* lParam != 0 means previous window */
@@ -1234,13 +1208,13 @@ LRESULT WINAPI MDIClientWndProc_common( HWND hwnd, UINT message, WPARAM wParam, 
         HWND hwnd = wParam ? WIN_GetFullHandle((HWND)wParam) : ci->hwndActiveChild;
         HWND next = MDI_GetWindow( ci, hwnd, !lParam, 0 );
         MDI_SwitchActiveChild( ci, next, TRUE );
-        if(!lParam)
-            SetWindowPos(hwnd, HWND_BOTTOM, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE);
+        if (!lParam)
+            NtUserSetWindowPos( hwnd, HWND_BOTTOM, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE );
 	break;
       }
 
       case WM_MDIRESTORE:
-        ShowWindow( (HWND)wParam, SW_SHOWNORMAL );
+        NtUserShowWindow( (HWND)wParam, SW_SHOWNORMAL );
         return 0;
 
       case WM_MDISETMENU:
@@ -1251,7 +1225,7 @@ LRESULT WINAPI MDIClientWndProc_common( HWND hwnd, UINT message, WPARAM wParam, 
 
       case WM_MDITILE:
 	ci->mdiFlags |= MDIF_NEEDUPDATE;
-        ShowScrollBar( hwnd, SB_BOTH, FALSE );
+        NtUserShowScrollBar( hwnd, SB_BOTH, FALSE );
         MDITile( hwnd, ci, wParam );
         ci->mdiFlags &= ~MDIF_NEEDUPDATE;
         return 0;
@@ -1265,7 +1239,7 @@ LRESULT WINAPI MDIClientWndProc_common( HWND hwnd, UINT message, WPARAM wParam, 
 
       case WM_SETFOCUS:
           if (ci->hwndActiveChild && !IsIconic( ci->hwndActiveChild ))
-              SetFocus( ci->hwndActiveChild );
+              NtUserSetFocus( ci->hwndActiveChild );
           return 0;
 
       case WM_NCACTIVATE:
@@ -1307,8 +1281,8 @@ LRESULT WINAPI MDIClientWndProc_common( HWND hwnd, UINT message, WPARAM wParam, 
 
 	    TRACE("notification from %p (%li,%li)\n",child,pt.x,pt.y);
 
-            if( child && child != hwnd && child != ci->hwndActiveChild )
-                SetWindowPos(child, 0,0,0,0,0, SWP_NOSIZE | SWP_NOMOVE );
+            if (child && child != hwnd && child != ci->hwndActiveChild)
+                NtUserSetWindowPos( child, 0,0,0,0,0, SWP_NOSIZE | SWP_NOMOVE );
             break;
             }
 
@@ -1322,11 +1296,11 @@ LRESULT WINAPI MDIClientWndProc_common( HWND hwnd, UINT message, WPARAM wParam, 
 	{
 	    RECT	rect;
 
-	    SetRect(&rect, 0, 0, LOWORD(lParam), HIWORD(lParam));
+            SetRect(&rect, 0, 0, LOWORD(lParam), HIWORD(lParam));
 	    AdjustWindowRectEx(&rect, GetWindowLongPtrA(ci->hwndActiveChild, GWL_STYLE),
                                0, GetWindowLongPtrA(ci->hwndActiveChild, GWL_EXSTYLE) );
-	    MoveWindow(ci->hwndActiveChild, rect.left, rect.top,
-			 rect.right - rect.left, rect.bottom - rect.top, 1);
+	    NtUserMoveWindow( ci->hwndActiveChild, rect.left, rect.top,
+                              rect.right - rect.left, rect.bottom - rect.top, 1 );
 	}
 	else
             MDI_PostUpdate(hwnd, ci, SB_BOTH+1);
@@ -1406,7 +1380,7 @@ LRESULT WINAPI DefFrameProcW( HWND hwnd, HWND hwndMDIClient,
 {
     MDICLIENTINFO *ci = get_client_info( hwndMDIClient );
 
-    TRACE("%p %p %04x (%s) %08lx %08lx\n", hwnd, hwndMDIClient, message, SPY_GetMsgName(message, hwnd), wParam, lParam);
+    TRACE("%p %p %04x (%s) %08Ix %08Ix\n", hwnd, hwndMDIClient, message, SPY_GetMsgName(message, hwnd), wParam, lParam);
 
     if (ci)
     {
@@ -1460,11 +1434,11 @@ LRESULT WINAPI DefFrameProcW( HWND hwnd, HWND hwndMDIClient,
 	    return 1; /* success. FIXME: check text length */
 
         case WM_SETFOCUS:
-	    SetFocus(hwndMDIClient);
+	    NtUserSetFocus( hwndMDIClient );
 	    break;
 
         case WM_SIZE:
-            MoveWindow(hwndMDIClient, 0, 0, LOWORD(lParam), HIWORD(lParam), TRUE);
+            NtUserMoveWindow( hwndMDIClient, 0, 0, LOWORD(lParam), HIWORD(lParam), TRUE );
             break;
 
         case WM_NEXTMENU:
@@ -1475,17 +1449,12 @@ LRESULT WINAPI DefFrameProcW( HWND hwnd, HWND hwndMDIClient,
                 {
                     /* control menu is between the frame system menu and
                      * the first entry of menu bar */
-//                    WND *wndPtr = WIN_GetPtr(hwnd);
-
-                    if( (wParam == VK_LEFT && GetMenu(hwnd) == next_menu->hmenuIn) ||
-                        (wParam == VK_RIGHT && GetSubMenu(GetMenu(hwnd), 0) == next_menu->hmenuIn) )
+                    if ((wParam == VK_LEFT && GetMenu(hwnd) == next_menu->hmenuIn) ||
+                        (wParam == VK_RIGHT && NtUserGetWindowSysSubMenu( hwnd ) == next_menu->hmenuIn))
                     {
-//                        WIN_ReleasePtr(wndPtr);
-//                        wndPtr = WIN_GetPtr(ci->hwndActiveChild);
-                        next_menu->hmenuNext = GetSubMenu(GetMenu(ci->hwndActiveChild), 0);
+                        next_menu->hmenuNext = NtUserGetWindowSysSubMenu( ci->hwndActiveChild );
                         next_menu->hwndNext = ci->hwndActiveChild;
                     }
-//                    WIN_ReleasePtr(wndPtr);
                 }
                 return 0;
             }
@@ -1504,7 +1473,7 @@ LRESULT WINAPI DefMDIChildProcA( HWND hwnd, UINT message,
     HWND client = GetParent(hwnd);
     MDICLIENTINFO *ci = get_client_info( client );
 
-    TRACE("%p %04x (%s) %08lx %08lx\n", hwnd, message, SPY_GetMsgName(message, hwnd), wParam, lParam);
+    TRACE("%p %04x (%s) %08Ix %08Ix\n", hwnd, message, SPY_GetMsgName(message, hwnd), wParam, lParam);
 
     hwnd = WIN_GetFullHandle( hwnd );
     if (!ci) return DefWindowProcA( hwnd, message, wParam, lParam );
@@ -1545,7 +1514,7 @@ LRESULT WINAPI DefMDIChildProcW( HWND hwnd, UINT message,
     HWND client = GetParent(hwnd);
     MDICLIENTINFO *ci = get_client_info( client );
 
-    TRACE("%p %04x (%s) %08lx %08lx\n", hwnd, message, SPY_GetMsgName(message, hwnd), wParam, lParam);
+    TRACE("%p %04x (%s) %08Ix %08Ix\n", hwnd, message, SPY_GetMsgName(message, hwnd), wParam, lParam);
 
     hwnd = WIN_GetFullHandle( hwnd );
     if (!ci) return DefWindowProcW( hwnd, message, wParam, lParam );
@@ -1637,7 +1606,7 @@ LRESULT WINAPI DefMDIChildProcW( HWND hwnd, UINT message,
                 SendMessageW( hMaxChild, WM_SETREDRAW, FALSE, 0 );
 
                 MDI_RestoreFrameMenu( GetParent(client), hMaxChild, ci->hBmpClose );
-                ShowWindow( hMaxChild, SW_SHOWNOACTIVATE );
+                NtUserShowWindow( hMaxChild, SW_SHOWNOACTIVATE );
 
                 SendMessageW( hMaxChild, WM_SETREDRAW, TRUE, 0 );
             }
@@ -1670,9 +1639,7 @@ LRESULT WINAPI DefMDIChildProcW( HWND hwnd, UINT message,
 
             if( wParam == VK_LEFT )  /* switch to frame system menu */
             {
-//                WND *wndPtr = WIN_GetPtr( parent );
-                next_menu->hmenuNext = GetSubMenu( GetMenu(parent), 0 );
-//                WIN_ReleasePtr( wndPtr );
+                next_menu->hmenuNext = NtUserGetWindowSysSubMenu( parent );
             }
             if( wParam == VK_RIGHT )  /* to frame menu bar */
             {
@@ -1717,7 +1684,7 @@ HWND WINAPI CreateMDIWindowA(
     HINSTANCE hInstance, /* [in] Handle to application instance */
     LPARAM lParam)         /* [in] Application-defined value */
 {
-    TRACE("(%s,%s,%08lx,%d,%d,%d,%d,%p,%p,%08lx)\n",
+    TRACE("(%s,%s,%08lx,%d,%d,%d,%d,%p,%p,%08Ix)\n",
           debugstr_a(lpClassName),debugstr_a(lpWindowName),dwStyle,X,Y,
           nWidth,nHeight,hWndParent,hInstance,lParam);
 
@@ -1745,7 +1712,7 @@ HWND WINAPI CreateMDIWindowW(
     HINSTANCE hInstance, /* [in] Handle to application instance */
     LPARAM lParam)         /* [in] Application-defined value */
 {
-    TRACE("(%s,%s,%08lx,%d,%d,%d,%d,%p,%p,%08lx)\n",
+    TRACE("(%s,%s,%08lx,%d,%d,%d,%d,%p,%p,%08Ix)\n",
           debugstr_w(lpClassName), debugstr_w(lpWindowName), dwStyle, X, Y,
           nWidth, nHeight, hWndParent, hInstance, lParam);
 
@@ -1768,13 +1735,13 @@ BOOL WINAPI TranslateMDISysAccel( HWND hwndClient, LPMSG msg )
 
         /* translate if the Ctrl key is down and Alt not. */
 
-        if( (GetKeyState(VK_CONTROL) & 0x8000) && !(GetKeyState(VK_MENU) & 0x8000))
+        if( (NtUserGetKeyState(VK_CONTROL) & 0x8000) && !(NtUserGetKeyState(VK_MENU) & 0x8000))
         {
             switch( msg->wParam )
             {
             case VK_F6:
             case VK_TAB:
-                wParam = ( GetKeyState(VK_SHIFT) & 0x8000 ) ? SC_NEXTWINDOW : SC_PREVWINDOW;
+                wParam = ( NtUserGetKeyState(VK_SHIFT) & 0x8000 ) ? SC_NEXTWINDOW : SC_PREVWINDOW;
                 break;
             case VK_F4:
             case VK_RBUTTON:
@@ -1787,7 +1754,7 @@ BOOL WINAPI TranslateMDISysAccel( HWND hwndClient, LPMSG msg )
             default:
                 return FALSE;
             }
-            TRACE("wParam = %04lx\n", wParam);
+            TRACE("wParam = %04Ix\n", wParam);
             SendMessageW(ci->hwndActiveChild, WM_SYSCOMMAND, wParam, msg->wParam);
             return TRUE;
         }
@@ -1800,15 +1767,25 @@ BOOL WINAPI TranslateMDISysAccel( HWND hwndClient, LPMSG msg )
  */
 void WINAPI CalcChildScroll( HWND hwnd, INT scroll )
 {
+#ifndef __REACTOS__ /* not implemented */
+    DPI_AWARENESS_CONTEXT context;
+#endif
     SCROLLINFO info;
     RECT childRect, clientRect;
     HWND *list;
     DWORD style;
+#ifdef __REACTOS__
     WINDOWINFO WindowInfo;
+#endif
+
+#ifndef __REACTOS__ /* not implemented */
+    context = SetThreadDpiAwarenessContext( GetWindowDpiAwarenessContext( hwnd ));
+#endif
 
     GetClientRect( hwnd, &clientRect );
     SetRectEmpty( &childRect );
 
+#ifdef __REACTOS__
    /* The rectangle returned by GetClientRect always has 0,0 as top left
     * because it is in client coordinates. The rectangles returned by
     * GetWindowRect are in screen coordinates to make this complicated.
@@ -1822,6 +1799,7 @@ void WINAPI CalcChildScroll( HWND hwnd, INT scroll )
         ERR("Can't get window info\n");
         return;
     }
+#endif
 
     TRACE("CalcChildScroll 1\n");
     if ((list = WIN_ListChildren( hwnd )))
@@ -1833,18 +1811,20 @@ void WINAPI CalcChildScroll( HWND hwnd, INT scroll )
             if (style & WS_MAXIMIZE)
             {
                 HeapFree( GetProcessHeap(), 0, list );
-                ShowScrollBar( hwnd, SB_BOTH, FALSE );
+                NtUserShowScrollBar( hwnd, SB_BOTH, FALSE );
                 ERR("CalcChildScroll 2\n");
-                return;
+                goto done;
             }
             if (style & WS_VISIBLE)
             {
                 RECT rect;
+#ifdef __REACTOS__
                 GetWindowRect( list[i], &rect );
                 OffsetRect(&rect, -WindowInfo.rcClient.left,
                                   -WindowInfo.rcClient.top);
-                //WIN_GetRectangles( list[i], COORDS_PARENT, &rect, NULL );
-                TRACE("CalcChildScroll L\n");
+#else
+                NtUserGetChildRect( list[i], &rect );
+#endif
                 UnionRect( &childRect, &rect, &childRect );
             }
         }
@@ -1871,11 +1851,15 @@ void WINAPI CalcChildScroll( HWND hwnd, INT scroll )
                         if (style & (WS_HSCROLL | WS_VSCROLL))
                         {
                             info.nMin = childRect.left;
+#ifdef __REACTOS__
                             info.nMax = childRect.right;
                             info.nPage = 1 + clientRect.right - clientRect.left;
-                            //info.nMax = childRect.right - clientRect.right;
-                            //info.nPos = clientRect.left - childRect.left;
                             SetScrollInfo(hwnd, SB_HORZ, &info, TRUE);
+#else
+                            info.nMax = childRect.right - clientRect.right;
+                            info.nPos = clientRect.left - childRect.left;
+                            NtUserSetScrollInfo(hwnd, SB_HORZ, &info, TRUE);
+#endif
                         }
 			if (scroll == SB_HORZ) break;
 			/* fall through */
@@ -1883,14 +1867,25 @@ void WINAPI CalcChildScroll( HWND hwnd, INT scroll )
                         if (style & (WS_HSCROLL | WS_VSCROLL))
                         {
                             info.nMin = childRect.top;
+#ifdef __REACTOS__
                             info.nMax = childRect.bottom;
                             info.nPage = 1 + clientRect.bottom - clientRect.top;
-                            //info.nMax = childRect.bottom - clientRect.bottom;
-                            //info.nPos = clientRect.top - childRect.top;
                             SetScrollInfo(hwnd, SB_VERT, &info, TRUE);
+#else
+                            info.nMax = childRect.bottom - clientRect.bottom;
+                            info.nPos = clientRect.top - childRect.top;
+                            NtUserSetScrollInfo(hwnd, SB_VERT, &info, TRUE);
+#endif
                         }
 			break;
     }
+
+done:
+#ifndef __REACTOS__ /* not implemented */
+    SetThreadDpiAwarenessContext( context );
+#else
+    return;
+#endif
 }
 
 
@@ -1900,10 +1895,16 @@ void WINAPI CalcChildScroll( HWND hwnd, INT scroll )
 void WINAPI ScrollChildren(HWND hWnd, UINT uMsg, WPARAM wParam,
                              LPARAM lParam)
 {
+#ifndef __REACTOS__ /* not implemented */
+    DPI_AWARENESS_CONTEXT context;
+#endif
     INT newPos = -1;
     INT curPos, length, minPos, maxPos, shift;
     RECT rect;
 
+#ifndef __REACTOS__ /* not implemented */
+    context = SetThreadDpiAwarenessContext( GetWindowDpiAwarenessContext( hWnd ));
+#endif
     GetClientRect( hWnd, &rect );
 
     switch(uMsg)
@@ -1921,7 +1922,7 @@ void WINAPI ScrollChildren(HWND hWnd, UINT uMsg, WPARAM wParam,
 	shift = GetSystemMetrics(SM_CXVSCROLL);
         break;
     default:
-        return;
+        goto done;
     }
 
     switch( wParam )
@@ -1944,7 +1945,7 @@ void WINAPI ScrollChildren(HWND hWnd, UINT uMsg, WPARAM wParam,
 			break;
 
 	case SB_THUMBTRACK:
-			return;
+			goto done;
 
 	case SB_TOP:
 			newPos = minPos;
@@ -1954,7 +1955,7 @@ void WINAPI ScrollChildren(HWND hWnd, UINT uMsg, WPARAM wParam,
 			break;
 	case SB_ENDSCROLL:
 			CalcChildScroll(hWnd,(uMsg == WM_VSCROLL)?SB_VERT:SB_HORZ);
-			return;
+			goto done;
     }
 
     if( newPos > maxPos )
@@ -1966,13 +1967,20 @@ void WINAPI ScrollChildren(HWND hWnd, UINT uMsg, WPARAM wParam,
     SetScrollPos(hWnd, (uMsg == WM_VSCROLL)?SB_VERT:SB_HORZ , newPos, TRUE);
 
     if( uMsg == WM_VSCROLL )
-	ScrollWindowEx(hWnd ,0 ,curPos - newPos, NULL, NULL, 0, NULL,
-			SW_INVALIDATE | SW_ERASE | SW_SCROLLCHILDREN );
+	NtUserScrollWindowEx( hWnd ,0 ,curPos - newPos, NULL, NULL, 0, NULL,
+                              SW_INVALIDATE | SW_ERASE | SW_SCROLLCHILDREN );
     else
-	ScrollWindowEx(hWnd ,curPos - newPos, 0, NULL, NULL, 0, NULL,
-			SW_INVALIDATE | SW_ERASE | SW_SCROLLCHILDREN );
+	NtUserScrollWindowEx( hWnd ,curPos - newPos, 0, NULL, NULL, 0, NULL,
+                              SW_INVALIDATE | SW_ERASE | SW_SCROLLCHILDREN );
+done:
+#ifndef __REACTOS__ /* not implemented */
+    SetThreadDpiAwarenessContext( context );
+#else
+    return;
+#endif
 }
 
+#ifdef __REACTOS__
 /******************************************************************************
  *		CascadeWindows (USER32.@) Cascades MDI child windows
  *
@@ -2403,7 +2411,7 @@ WORD WINAPI TileChildWindows( HWND parent, UINT flags )
 {
     return TileWindows( parent, flags, NULL, 0, NULL );
 }
-
+#endif
 
 /************************************************************************
  *              "More Windows..." functionality
@@ -2434,11 +2442,11 @@ static INT_PTR WINAPI MDI_MoreWindowsDlgProc (HWND hDlg, UINT iMsg, WPARAM wPara
            {
                WCHAR buffer[MDI_MAXTITLELENGTH];
 
-               if (!InternalGetWindowText( ci->child[i], buffer, sizeof(buffer)/sizeof(WCHAR) ))
+               if (!NtUserInternalGetWindowText(ci->child[i], buffer, ARRAY_SIZE(buffer)))
                    continue;
                SendMessageW(hListBox, LB_ADDSTRING, 0, (LPARAM)buffer );
                SendMessageW(hListBox, LB_SETITEMDATA, i, (LPARAM)ci->child[i] );
-               length = strlenW(buffer);  /* FIXME: should use GetTextExtentPoint */
+               length = lstrlenW(buffer);  /* FIXME: should use GetTextExtentPoint */
                if (length > widest)
                    widest = length;
            }

--- a/win32ss/user/user32/windows/spy.c
+++ b/win32ss/user/user32/windows/spy.c
@@ -20,6 +20,7 @@
  */
 
 #include <user32.h>
+#include <wine-compat.h>
 
 #include <wine/commctrl.h>
 #include <commdlg.h>
@@ -30,28 +31,8 @@ WINE_DEFAULT_DEBUG_CHANNEL(message);
 
 #define SPY_MAX_MSGNUM   WM_USER
 #define SPY_INDENT_UNIT  4  /* 4 spaces */
-#undef ARRAYSIZE
-#define ARRAYSIZE(a) ((sizeof(a) / sizeof((a)[0])))
 
 #define DEBUG_SPY 0
-
-static const char * const ClassLongOffsetNames[] =
-{
-    "GCLP_MENUNAME",      /*  -8 */
-    "GCLP_HBRBACKGROUND", /* -10 */
-    "GCLP_HCURSOR",       /* -12 */
-    "GCLP_HICON",         /* -14 */
-    "GCLP_HMODULE",       /* -16 */
-    "GCL_CBWNDEXTRA",     /* -18 */
-    "GCL_CBCLSEXTRA",     /* -20 */
-    "?",
-    "GCLP_WNDPROC",       /* -24 */
-    "GCL_STYLE",          /* -26 */
-    "?",
-    "?",
-    "GCW_ATOM",           /* -32 */
-    "GCLP_HICONSM",       /* -34 */
-};
 
 static const char * const MessageTypeNames[SPY_MAX_MSGNUM + 1] =
 {
@@ -482,13 +463,30 @@ static const char * const MessageTypeNames[SPY_MAX_MSGNUM + 1] =
     "WM_ENTERSIZEMOVE",         /* 0x0231 */
     "WM_EXITSIZEMOVE",          /* 0x0232 */
     "WM_DROPFILES",             /* 0x0233 */
-    "WM_MDIREFRESHMENU", NULL, NULL, NULL,
-    /* 0x0238*/
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    "WM_MDIREFRESHMENU",        /* 0x0234 */
+    NULL, NULL, NULL,
+    "WM_POINTERDEVICECHANGE",   /* 0x0238 */
+    "WM_POINTERDEVICEINRANGE",  /* 0x0239 */
+    "WM_POINTERDEVICEOUTOFRANGE", /* 0x023a */
+    NULL, NULL, NULL, NULL, NULL,
 
     /* 0x0240 */
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    "WM_TOUCH",                 /* 0x0240 */
+    "WM_NCPOINTERUPDATE",       /* 0x0241 */
+    "WM_NCPOINTERDOWN",         /* 0x0242 */
+    "WM_NCPOINTERUP",           /* 0x0243 */
+    NULL,
+    "WM_POINTERUPDATE",         /* 0x0245 */
+    "WM_POINTERDOWN",           /* 0x0246 */
+    "WM_POINTERUP",             /* 0x0247 */
+    NULL,
+    "WM_POINTERENTER",          /* 0x0249 */
+    "WM_POINTERLEAVE",          /* 0x024a */
+    "WM_POINTERACTIVATE",       /* 0x024b */
+    "WM_POINTERCAPTURECHANGED", /* 0x024c */
+    "WM_TOUCHHITTESTING",       /* 0x024d */
+    "WM_POINTERWHEEL",          /* 0x024e */
+    "WM_POINTERHWHEEL",         /* 0x024f */
 
     /* 0x0250 */
     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
@@ -561,7 +559,13 @@ static const char * const MessageTypeNames[SPY_MAX_MSGNUM + 1] =
     "WM_TABLET_FIRST+31",       /* 0x02de */
     "WM_TABLET_LAST",           /* 0x02df */
 
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    "WM_DPICHANGED",            /* 0x02e0 */
+    NULL,
+    "WM_DPICHANGED_BEFOREPARENT",/* 0x02e2 */
+    "WM_DPICHANGED_AFTERPARENT",/* 0x02e3 */
+    "WM_GETDPISCALEDSIZE",      /* 0x02e4 */
+    NULL, NULL, NULL,
+
     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
@@ -1120,9 +1124,8 @@ static const char * const CCMMessageTypeNames[SPY_MAX_CCMMSGNUM + 1] =
     "CCM_SETNOTIFYWINDOW"
 };
 
-#define SPY_MAX_WINEMSGNUM   9
-
 #ifndef __REACTOS__
+#define SPY_MAX_WINEMSGNUM   (WM_WINE_SETPIXELFORMAT - WM_WINE_DESTROYWINDOW)
 static const char * const WINEMessageTypeNames[SPY_MAX_WINEMSGNUM + 1] =
 {
     "WM_WINE_DESTROYWINDOW",
@@ -1130,10 +1133,22 @@ static const char * const WINEMessageTypeNames[SPY_MAX_WINEMSGNUM + 1] =
     "WM_WINE_SHOWWINDOW",
     "WM_WINE_SETPARENT",
     "WM_WINE_SETWINDOWLONG",
-    "WM_WINE_ENABLEWINDOW",
+    "WM_WINE_SETSTYLE",
     "WM_WINE_SETACTIVEWINDOW",
     "WM_WINE_KEYBOARD_LL_HOOK",
     "WM_WINE_MOUSE_LL_HOOK",
+    "WM_WINE_IME_NOTIFY",
+    "WM_WINE_WINDOW_STATE_CHANGED",
+    "WM_WINE_UPDATEWINDOWSTATE",
+    "WM_WINE_TRACKMOUSEEVENT",
+    "WM_WINE_SETPIXELFORMAT",
+};
+
+#define SPY_MAX_WINE_DRIVER_MSGNUM (WM_WINE_SETCURSOR - WM_WINE_CLIPCURSOR)
+static const char * const wine_driver_message_type_names[SPY_MAX_WINE_DRIVER_MSGNUM + 1] =
+{
+    "WM_WINE_CLIPCURSOR",
+    "WM_WINE_SETCURSOR",
 };
 #endif
 
@@ -1643,9 +1658,6 @@ static const USER_MSG propsht_array[] = {
           USM(PSM_SETTITLEW           ,0),
           USM(PSM_SETFINISHTEXTW      ,0),
 };
-static const WCHAR PropSheetInfoStr[] =
-    {'P','r','o','p','e','r','t','y','S','h','e','e','t','I','n','f','o',0 };
-
 static const USER_MSG updown_array[] = {
           USM(UDM_SETRANGE            ,0),
           USM(UDM_GETRANGE            ,0),
@@ -1750,14 +1762,16 @@ static const USER_MSG richedit_array[] = {
 #undef USM
 
 static const CONTROL_CLASS cc_array[] = {
-    {WC_COMBOBOXEXW,    comboex_array,  ARRAYSIZE(comboex_array) },
-    {WC_PROPSHEETW,     propsht_array,  ARRAYSIZE(propsht_array) },
-    {REBARCLASSNAMEW,   rebar_array,    ARRAYSIZE(rebar_array) },
-    {TOOLBARCLASSNAMEW, toolbar_array,  ARRAYSIZE(toolbar_array) },
-    {TOOLTIPS_CLASSW,   tooltips_array, ARRAYSIZE(tooltips_array) },
-    {UPDOWN_CLASSW,     updown_array,   ARRAYSIZE(updown_array) },
-    {RICHEDIT_CLASS20W, richedit_array, ARRAYSIZE(richedit_array) },
-    {0, 0, 0} };
+    {WC_COMBOBOXEXW,    comboex_array,  ARRAY_SIZE(comboex_array)},
+    {WC_PROPSHEETW,     propsht_array,  ARRAY_SIZE(propsht_array)},
+    {REBARCLASSNAMEW,   rebar_array,    ARRAY_SIZE(rebar_array)},
+    {TOOLBARCLASSNAMEW, toolbar_array,  ARRAY_SIZE(toolbar_array)},
+    {TOOLTIPS_CLASSW,   tooltips_array, ARRAY_SIZE(tooltips_array)},
+    {UPDOWN_CLASSW,     updown_array,   ARRAY_SIZE(updown_array)},
+    {RICHEDIT_CLASS20W, richedit_array, ARRAY_SIZE(richedit_array)},
+    {MSFTEDIT_CLASS,    richedit_array, ARRAY_SIZE(richedit_array)},
+    {0, 0, 0}
+};
 
 
 /************************************************************************/
@@ -2019,14 +2033,20 @@ typedef struct
     WCHAR      wnd_name[16];     /* window name for message            */
 } SPY_INSTANCE;
 
+#ifdef __REACTOS__
 static int indent_tls_index = TLS_OUT_OF_INDEXES;
+#endif
 
 /***********************************************************************
  *           get_indent_level
  */
 static inline INT_PTR get_indent_level(void)
 {
+#ifdef __REACTOS__
     return (INT_PTR)TlsGetValue( indent_tls_index );
+#else
+    return get_user_thread_info()->spy_indent;
+#endif
 }
 
 
@@ -2035,7 +2055,11 @@ static inline INT_PTR get_indent_level(void)
  */
 static inline void set_indent_level( INT_PTR level )
 {
+#ifdef __REACTOS__
     TlsSetValue( indent_tls_index, (void *)level );
+#else
+    get_user_thread_info()->spy_indent = level;
+#endif
 }
 
 
@@ -2067,7 +2091,10 @@ static const char *SPY_GetMsgInternal( UINT msg )
 #ifndef __REACTOS__
     if (msg >= WM_WINE_DESTROYWINDOW && msg <= WM_WINE_DESTROYWINDOW + SPY_MAX_WINEMSGNUM)
         return WINEMessageTypeNames[msg-WM_WINE_DESTROYWINDOW];
+    if (msg >= WM_WINE_CLIPCURSOR && msg <= WM_WINE_CLIPCURSOR + SPY_MAX_WINE_DRIVER_MSGNUM)
+        return wine_driver_message_type_names[msg-WM_WINE_CLIPCURSOR];
 #endif
+
     return NULL;
 }
 
@@ -2091,23 +2118,6 @@ static const USER_MSG *SPY_Bsearch_Msg( const USER_MSG *msgs, UINT count, UINT c
 }
 
 /***********************************************************************
- *           SPY_GetClassLongOffsetName
- *
- * Gets the name of a class long offset.
- */
-const char *SPY_GetClassLongOffsetName( INT offset )
-{
-    INT index;
-    if (offset < 0 && offset % 2 == 0 && ((index = -(offset + 8) / 2) <
-	sizeof(ClassLongOffsetNames) / sizeof(*ClassLongOffsetNames)))
-    {
-        return ClassLongOffsetNames[index];
-    }
-
-    return "?";
-}
-
-/***********************************************************************
  *           SPY_GetClassName
  *
  *  Sets the value of "wnd_class" member of the instance structure.
@@ -2116,11 +2126,11 @@ static void SPY_GetClassName( SPY_INSTANCE *sp_e )
 {
     /* special code to detect a property sheet dialog   */
     if ((GetClassLongPtrW(sp_e->msg_hwnd, GCW_ATOM) == (ULONG_PTR)WC_DIALOG) &&
-        (GetPropW(sp_e->msg_hwnd, PropSheetInfoStr))) {
-        strcpyW(sp_e->wnd_class, WC_PROPSHEETW);
+        (GetPropW(sp_e->msg_hwnd, L"PropertySheetInfo"))) {
+        lstrcpyW(sp_e->wnd_class, WC_PROPSHEETW);
     }
     else {
-        GetClassNameW(sp_e->msg_hwnd, sp_e->wnd_class, sizeof(sp_e->wnd_class)/sizeof(WCHAR));
+        GetClassNameW(sp_e->msg_hwnd, sp_e->wnd_class, ARRAY_SIZE(sp_e->wnd_class));
     }
 }
 
@@ -2154,8 +2164,13 @@ static void SPY_GetMsgStuff( SPY_INSTANCE *sp_e )
         TRACE("looking class %s\n", debugstr_w(sp_e->wnd_class));
 #endif
 
+#ifdef __REACTOS__
         while (cc_array[i].classname &&
-               strcmpiW(cc_array[i].classname, sp_e->wnd_class) != 0) i++;
+               _wcsicmp(cc_array[i].classname, sp_e->wnd_class) != 0) i++;
+#else
+        while (cc_array[i].classname &&
+               wcsicmp(cc_array[i].classname, sp_e->wnd_class) != 0) i++;
+#endif
 
         if (cc_array[i].classname)
         {
@@ -2172,9 +2187,9 @@ static void SPY_GetMsgStuff( SPY_INSTANCE *sp_e )
             }
         }
         if (sp_e->msgnum >= WM_USER && sp_e->msgnum <= WM_APP)
-            sprintf( sp_e->msg_name, "WM_USER+%d", sp_e->msgnum - WM_USER );
+            snprintf( sp_e->msg_name, sizeof(sp_e->msg_name), "WM_USER+%d", sp_e->msgnum - WM_USER );
         else
-            sprintf( sp_e->msg_name, "%04x", sp_e->msgnum );
+            snprintf( sp_e->msg_name, sizeof(sp_e->msg_name), "%04x", sp_e->msgnum );
     }
     else
     {
@@ -2195,12 +2210,12 @@ static void SPY_GetWndName( SPY_INSTANCE *sp_e )
 
     SPY_GetClassName( sp_e );
 
-    len = InternalGetWindowText(sp_e->msg_hwnd, sp_e->wnd_name, sizeof(sp_e->wnd_name)/sizeof(WCHAR));
+    len = NtUserInternalGetWindowText( sp_e->msg_hwnd, sp_e->wnd_name, ARRAY_SIZE(sp_e->wnd_name) );
     if(!len) /* get class name */
     {
         LPWSTR dst = sp_e->wnd_name;
         LPWSTR src = sp_e->wnd_class;
-        int n = sizeof(sp_e->wnd_name)/sizeof(WCHAR) - 3;
+        int n = ARRAY_SIZE(sp_e->wnd_name) - 3;
         *dst++ = '{';
         while ((n-- > 0) && *src) *dst++ = *src++;
         *dst++ = '}';
@@ -2218,7 +2233,7 @@ static void SPY_GetWndName( SPY_INSTANCE *sp_e )
 const char *SPY_GetMsgName( UINT msg, HWND hWnd )
 {
     SPY_INSTANCE ext_sp_e;
-    DWORD save_error = GetLastError();
+    DWORD save_error = RtlGetLastWin32Error();
 
     ext_sp_e.msgnum = msg;
     ext_sp_e.msg_hwnd   = hWnd;
@@ -2226,7 +2241,7 @@ const char *SPY_GetMsgName( UINT msg, HWND hWnd )
     ext_sp_e.wParam = 0;
     ext_sp_e.wnd_class[0] = 0;
     SPY_GetMsgStuff(&ext_sp_e);
-    SetLastError( save_error );
+    RtlSetLastWin32Error( save_error );
     return wine_dbg_sprintf("%s", ext_sp_e.msg_name);
 }
 
@@ -2250,7 +2265,7 @@ const char *SPY_GetVKeyName(WPARAM wParam)
  */
 static const SPY_NOTIFY *SPY_Bsearch_Notify( UINT code)
 {
-    int low = 0, high = ARRAYSIZE(spnfy_array) - 1;
+    int low = 0, high = ARRAY_SIZE(spnfy_array) - 1;
 
     while (low <= high)
     {
@@ -2355,7 +2370,7 @@ static void SPY_DumpStructure(const SPY_INSTANCE *sp_e, BOOL enter)
             }
         case SBM_SETRANGE:
             if (!enter && (sp_e->msgnum == SBM_SETRANGE)) break;
-            TRACE("min=%d max=%d\n", (INT)sp_e->wParam, (INT)sp_e->lParam);
+            TRACE("min=%d max=%ld\n", (int)sp_e->wParam, sp_e->lParam);
             break;
         case SBM_GETRANGE:
             if ((enter && (sp_e->msgnum == SBM_GETRANGE)) ||
@@ -2474,9 +2489,20 @@ static void SPY_DumpStructure(const SPY_INSTANCE *sp_e, BOOL enter)
             }
             break;
         case WM_NCCALCSIZE:
+            if (!sp_e->wParam)
             {
                 RECT *rc = (RECT *)sp_e->lParam;
-                TRACE("Rect (%s)\n", wine_dbgstr_rect(rc));
+                TRACE("Rect %s\n", wine_dbgstr_rect(rc));
+            }
+            else
+            {
+                NCCALCSIZE_PARAMS *nc = (NCCALCSIZE_PARAMS *)sp_e->lParam;
+                TRACE("Rects %s %s %s\n", wine_dbgstr_rect(nc->rgrc),
+                      wine_dbgstr_rect(nc->rgrc + 1), wine_dbgstr_rect(nc->rgrc + 2));
+                if (nc->lppos)
+                    TRACE("WINDOWPOS hwnd=%p, after=%p, at (%d,%d) w=%d h=%d, flags=0x%08x\n",
+                          nc->lppos->hwnd, nc->lppos->hwndInsertAfter, nc->lppos->x, nc->lppos->y,
+                          nc->lppos->cx, nc->lppos->cy, nc->lppos->flags);
             }
             break;
         case WM_NOTIFY:
@@ -2491,17 +2517,16 @@ static void SPY_DumpStructure(const SPY_INSTANCE *sp_e, BOOL enter)
                 p = SPY_Bsearch_Notify( pnmh->code );
                 if (p) {
                     TRACE("NMHDR hwndFrom=%p idFrom=0x%08lx code=%s<0x%08x>, extra=0x%x\n",
-                          pnmh->hwndFrom, pnmh->idFrom, p->name, pnmh->code, p->len);
+                          pnmh->hwndFrom, (long)pnmh->idFrom, p->name, pnmh->code, p->len);
                     dumplen = p->len;
 
                     /* for CUSTOMDRAW, dump all the data for TOOLBARs */
                     if (pnmh->code == NM_CUSTOMDRAW) {
                         /* save and restore error code over the next call */
-                        save_error = GetLastError();
-                        GetClassNameW(pnmh->hwndFrom, from_class,
-                                      sizeof(from_class)/sizeof(WCHAR));
-                        SetLastError(save_error);
-                        if (strcmpW(TOOLBARCLASSNAMEW, from_class) == 0)
+                        save_error = RtlGetLastWin32Error();
+                        GetClassNameW(pnmh->hwndFrom, from_class, ARRAY_SIZE(from_class));
+                        RtlSetLastWin32Error(save_error);
+                        if (wcscmp(TOOLBARCLASSNAMEW, from_class) == 0)
                             dumplen = sizeof(NMTBCUSTOMDRAW)-sizeof(NMHDR);
                     } else if ( pnmh->code >= HDN_ENDDRAG
                                 && pnmh->code <= HDN_ITEMCHANGINGA ) {
@@ -2509,12 +2534,12 @@ static void SPY_DumpStructure(const SPY_INSTANCE *sp_e, BOOL enter)
                     }
                     if (dumplen > 0) {
                         q = (UINT *)(pnmh + 1);
-                        SPY_DumpMem ("NM extra", q, (INT)dumplen);
+                        SPY_DumpMem ("NM extra", q, dumplen);
                     }
                 }
                 else
                     TRACE("NMHDR hwndFrom=%p idFrom=0x%08lx code=0x%08x\n",
-                          pnmh->hwndFrom, pnmh->idFrom, pnmh->code);
+                          pnmh->hwndFrom, (long)pnmh->idFrom, pnmh->code);
             }
             break;
         default:
@@ -2537,12 +2562,14 @@ static BOOL spy_init(void)
 
     if (!TRACE_ON(message)) return FALSE;
 
+#ifdef __REACTOS__
     if (indent_tls_index == TLS_OUT_OF_INDEXES)
     {
         DWORD index = TlsAlloc();
         if (InterlockedCompareExchange((volatile LONG *) &indent_tls_index, index, TLS_OUT_OF_INDEXES ) != TLS_OUT_OF_INDEXES)
             TlsFree( index );
     }
+#endif
 
     if (spy_exclude) return TRUE;
     exclude = HeapAlloc( GetProcessHeap(), HEAP_ZERO_MEMORY, SPY_MAX_MSGNUM + 2 );
@@ -2595,7 +2622,7 @@ void SPY_EnterMessage( INT iFlag, HWND hWnd, UINT msg,
 {
     SPY_INSTANCE sp_e;
     int indent;
-    DWORD save_error = GetLastError();
+    DWORD save_error = RtlGetLastWin32Error();
 
     if (!spy_init() || exclude_msg(msg)) return;
 
@@ -2612,8 +2639,8 @@ void SPY_EnterMessage( INT iFlag, HWND hWnd, UINT msg,
     {
     case SPY_DISPATCHMESSAGE:
         TRACE("%*s(%p) %-16s [%04x] %s dispatched  wp=%08lx lp=%08lx\n",
-                        indent, "", hWnd, debugstr_w(sp_e.wnd_name), msg,
-                        sp_e.msg_name, wParam, lParam);
+              indent, "", hWnd, debugstr_w(sp_e.wnd_name), msg,
+              sp_e.msg_name, (long)wParam, lParam);
         break;
 
     case SPY_SENDMESSAGE:
@@ -2622,11 +2649,11 @@ void SPY_EnterMessage( INT iFlag, HWND hWnd, UINT msg,
             DWORD tid = GetWindowThreadProcessId( hWnd, NULL );
 
             if (tid == GetCurrentThreadId()) strcpy( taskName, "self" );
-            else sprintf( taskName, "tid %04ld", GetCurrentThreadId() );
+            else snprintf( taskName, sizeof(taskName), "tid %04ld", GetCurrentThreadId() );
 
             TRACE("%*s(%p) %-16s [%04x] %s sent from %s wp=%08lx lp=%08lx\n",
                   indent, "", hWnd, debugstr_w(sp_e.wnd_name), msg,
-                  sp_e.msg_name, taskName, wParam, lParam );
+                  sp_e.msg_name, taskName, (long)wParam, lParam );
             SPY_DumpStructure(&sp_e, TRUE);
         }
         break;
@@ -2634,11 +2661,11 @@ void SPY_EnterMessage( INT iFlag, HWND hWnd, UINT msg,
     case SPY_DEFWNDPROC:
         if (exclude_dwp()) return;
         TRACE("%*s(%p)  DefWindowProc:[%04x] %s  wp=%08lx lp=%08lx\n",
-              indent, "", hWnd, msg, sp_e.msg_name, wParam, lParam );
+              indent, "", hWnd, msg, sp_e.msg_name, (long)wParam, lParam );
         break;
     }
     set_indent_level( indent + SPY_INDENT_UNIT );
-    SetLastError( save_error );
+    RtlSetLastWin32Error( save_error );
 }
 
 
@@ -2650,7 +2677,7 @@ void SPY_ExitMessage( INT iFlag, HWND hWnd, UINT msg, LRESULT lReturn,
 {
     SPY_INSTANCE sp_e;
     int indent;
-    DWORD save_error = GetLastError();
+    DWORD save_error = RtlGetLastWin32Error();
 
     if (!TRACE_ON(message) || exclude_msg(msg) ||
         (exclude_dwp() && iFlag == SPY_RESULT_DEFWND))
@@ -2683,5 +2710,5 @@ void SPY_ExitMessage( INT iFlag, HWND hWnd, UINT msg, LRESULT lReturn,
         SPY_DumpStructure(&sp_e, FALSE);
         break;
     }
-    SetLastError( save_error );
+    RtlSetLastWin32Error( save_error );
 }


### PR DESCRIPTION
## Purpose

This PR contains a series of patches, syncing ReactOS's USER32 to WINE 11.11.

JIRA issue: [CORE-20586](https://jira.reactos.org/browse/CORE-20586)

## Proposed changes

* `win32ss/user/user32/include/wine-compat.h`: This header file provides macros that allows using unmodified WINE code on ReactOS.

## Notes

* controls/*.c
  * WINE removed `*_class_descr` structures from control files, because they moved class registration to server-side. I wrapped them in `__REACTOS__` guards to mark them as ReactOS-specific but we can move them to `regcontrol.c`/`regcontrol.h` to minimize diff with WINE code.
* `misc/resources.c`
  * This file doesn't contain any WINE code except `LoadStringA`/`LoadStringW`. These functions are synced to Wine 11.11 while the rest of the file is kept untouched.
  * ReactOS has its own Accelerator implementation in `windows/accel.c` file, while WINE implements them in this file.
  * ReactOS has an implementation of `RegisterDeviceNotification` and `UnregisterDeviceNotification` functions in this file while they don't really belong there. I think we should move them some where else. WINE implements them in `user32/input.c` file.
* `misc/winhelp.c`
  * This file is marked as "Last sync date unknown" but it's really a fork.
  * While most of the file is a copy of WINE code, it has a different header and code style compared to WINE.
  * WINE's implementation is really incompatible with Windows and I think we should reimplement this file rather than syncing it.

## TODO

* Tests
- [ ] ~~user32_winetest~~ (Already synced to wine-10.0)

* Controls
- [x] controls/button.c
- [x] controls/combo.c
- [x] controls/edit.c
- [x] controls/icontitle.c
- [x] controls/listbox.c
- [ ] ~~controls/scrollbar.c~~ Forked
- [x] controls/static.c

* DDE
- [x] include/dde_private.h
- [x] misc/ddemisc.c
- [x] misc/ddeclient.c
- [x] misc/ddeserver.c

* Misc
- [x] misc/exticon.c
- [x] misc/resources.c
- [ ] ~~misc/winhelp.c~~ Forked

* Window
- [ ] ~~windows/cursoricon.c~~ Forked
- [ ] ~~windows/defwnd.c~~ Forked
- [ ] ~~windows/draw.c~~ Forked
- [x] windows/mdi.c
- [ ] ~~windows/menu.c~~ Forked
- [ ] ~~windows/messagebox.c~~ Forked
- [ ] ~~windows/rect.c~~ Forked
- [x] windows/spy.c
- [ ] ~~windows/text.c~~ Forked
- [ ] ~~windows/winpos.c~~ Forked

## ReactOS patches

These patches are not sent to Wine as of 11.11:

* https://github.com/reactos/reactos/commit/bc031d7389622fac5b08679bf5457e4dbf868893
* https://github.com/reactos/reactos/commit/9e8530d01a66ac9b76dc9940e182d490db45b7b9
* https://github.com/reactos/reactos/commit/8f10c7915cfdedc5754c88355d8b058c38174710
* Controls/Button
  * https://github.com/reactos/reactos/commit/558e78421bf9cc7f466b55c549d5b5128ce89f94
  * https://github.com/reactos/reactos/commit/f21871fbb886c1b15cdbd367ba2dc69d7b9d7249
* Controls/ListBox
  * ~~https://github.com/reactos/reactos/commit/a4483d79dabf0806b80579d476b1a29284e5fe96~~ (WINE handles `LBS_MULTICOLUMN` in another way)
  * https://github.com/reactos/reactos/pull/8665
  * https://github.com/reactos/reactos/issues/8316
  * https://github.com/reactos/reactos/commit/ad591d02692217b537ee137d3eff6c1a86e29c1b
* Controls/ComboBox
  * https://github.com/reactos/reactos/pull/8647
* Controls/Edit
  * IME
    * ~~https://github.com/reactos/reactos/pull/5182~~ (WINE has a different implementation)
    * ~~https://github.com/reactos/reactos/pull/5226~~ (WINE has a different implementation)
  * https://github.com/reactos/reactos/commit/9789e9c409286fe09b50f2a5f55f3a0d3fc7dba9
  * https://github.com/reactos/reactos/commit/c5465c5668c7328662340daa1e8f541660d16a7e
  * https://github.com/reactos/reactos/commit/15deddd4ea3e2811e032ecd029fd61d36c9b68b3
  * https://github.com/reactos/reactos/commit/80dbb6e6d7b773bc2c64027ea779fe7e7a753caf
  * https://github.com/reactos/reactos/commit/40dab7d5e5823ef910f1837f72dc37d916d811ef
  * https://github.com/reactos/reactos/commit/36230bb214e9e24d4be99297332e697f43e4454c
  * https://github.com/reactos/reactos/commit/e09b719f49cda54bb1c413e4fa57b5fbfb08f9b1
  * https://github.com/reactos/reactos/commit/134c7287e064e4a02694a0b80d43a31c1f99deab
  * https://github.com/reactos/reactos/commit/91dda33431ca82e6ee95633287b82ef586f072bd
  * https://github.com/reactos/reactos/pull/9115
* `misc/exticon.c`
  * https://github.com/reactos/reactos/commit/a25ff6fb7ec5d99a8c3de6046a5bc9512db017f5
  * https://github.com/reactos/reactos/issues/5207
  * https://github.com/reactos/reactos/commit/a25ff6fb7ec5d99a8c3de6046a5bc9512db017f5
  * https://github.com/reactos/reactos/pull/4262
  * https://github.com/reactos/reactos/pull/7767
  * https://github.com/reactos/reactos/commit/40737bdddb384bd2842c0cc3f6cacf3f4295731f
  * https://github.com/reactos/reactos/pull/4312
  * https://github.com/reactos/reactos/commit/60851914a84bf3f38a024de933579fa897c7e7c9
  * https://github.com/reactos/reactos/pull/5268
* MDI
  * https://github.com/reactos/reactos/commit/bc082227911e6918639d2d0cf5eb73bce4bbd0ad
  * https://github.com/reactos/reactos/commit/283d51cef9a8bced5805c7db19e30b404639a2a0

I'm not taking responsibility for sending patches to WINE but anyone who's interested can use this list.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: