### PR TITLE
[USER32] Fix crash on calling LookupIconIdFromDirectoryEx with invalid directory

### DIFF
--- a/modules/rostests/apitests/user32/LookupIconIdFromDirectoryEx.c
+++ b/modules/rostests/apitests/user32/LookupIconIdFromDirectoryEx.c
@@ -1,6 +1,8 @@
 
 #include "precomp.h"
 
+#include <ndk/umtypes.h>
+
 START_TEST(LookupIconIdFromDirectoryEx)
 {
     HRSRC hResource;
@@ -124,4 +126,12 @@ START_TEST(LookupIconIdFromDirectoryEx)
     ok(ChangeDisplaySettingsExW(NULL, &dm, NULL, 0, NULL) == DISP_CHANGE_SUCCESSFUL, "\n");
 
     FreeResource(hMem);
+
+    /* Test invalid directory */
+    StartSeh()
+        SetLastError(0xdeadbeef);
+        wResId = LookupIconIdFromDirectoryEx((PBYTE)(LONG_PTR)0xdeadbeef, TRUE, 0, 0, LR_DEFAULTSIZE);
+        ok_eq_int(wResId, 0);
+        ok_eq_ulong(GetLastError(), 0xdeadbeef);
+    EndSeh(STATUS_SUCCESS);
 }

--- a/modules/rostests/apitests/user32/LookupIconIdFromDirectoryEx.c
+++ b/modules/rostests/apitests/user32/LookupIconIdFromDirectoryEx.c
@@ -12,6 +12,14 @@ START_TEST(LookupIconIdFromDirectoryEx)
     UINT i;
     BYTE* lpResource;
 
+    /* Test invalid directory */
+    SetLastError(0xdeadbeef);
+    StartSeh();
+    wResId = LookupIconIdFromDirectoryEx((PBYTE)(LONG_PTR)0xdeadbeef, TRUE, 0, 0, LR_DEFAULTSIZE);
+    EndSeh(STATUS_SUCCESS);
+    ok_eq_int(wResId, 0);
+    ok_eq_ulong(GetLastError(), 0xdeadbeef);
+
     /* This tests assumes that default icon size is 32x32 */
 
     struct

--- a/modules/rostests/apitests/user32/precomp.h
+++ b/modules/rostests/apitests/user32/precomp.h
@@ -16,6 +16,7 @@
 #include <msgtrace.h>
 #include <user32testhelpers.h>
 #include <undocuser.h>
+#include <ndk/umtypes.h>
 
 #include "resource.h"
 

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -2623,11 +2623,20 @@ int WINAPI LookupIconIdFromDirectoryEx(
 
     TRACE("%p, %x, %i, %i, %x.\n", presbits, fIcon, cxDesired, cyDesired, Flags);
 
-    if(!(dir && !dir->idReserved && (dir->idType & 3)))
+    _SEH2_TRY
     {
-        WARN("Invalid resource.\n");
+        if(!(dir && !dir->idReserved && (dir->idType & 3)))
+        {
+            WARN("Invalid resource.\n");
+            return 0;
+        }
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ERR("Invalid resource (%p).\n", presbits);
         return 0;
     }
+    _SEH2_END;
 
     if(Flags & LR_MONOCHROME)
         bppDesired = 1;

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -2623,140 +2623,150 @@ int WINAPI LookupIconIdFromDirectoryEx(
 
     TRACE("%p, %x, %i, %i, %x.\n", presbits, fIcon, cxDesired, cyDesired, Flags);
 
-    if(!(dir && !dir->idReserved && (dir->idType & 3)))
+    /* Wrap the whole implementation in SEH in order to gracefully handle
+     * any PE resource corruption case in a simple way. */
+    _SEH2_TRY
     {
-        WARN("Invalid resource.\n");
-        return 0;
-    }
-
-    if(Flags & LR_MONOCHROME)
-        bppDesired = 1;
-    else
-    {
-        HDC icScreen;
-        icScreen = CreateICW(DISPLAYW, NULL, NULL, NULL);
-        if(!icScreen)
-            return FALSE;
-
-        bppDesired = GetDeviceCaps(icScreen, BITSPIXEL);
-        DeleteDC(icScreen);
-    }
-
-    if(!cxDesired)
-        cxDesired = Flags & LR_DEFAULTSIZE ? GetSystemMetrics(fIcon ? SM_CXICON : SM_CXCURSOR) : 256;
-    if(!cyDesired)
-        cyDesired = Flags & LR_DEFAULTSIZE ? GetSystemMetrics(fIcon ? SM_CYICON : SM_CYCURSOR) : 256;
-
-    /* Find the best match for the desired size */
-    for(i = 0; i < dir->idCount; i++)
-    {
-        entry = &dir->idEntries[i];
-        width = fIcon ? entry->ResInfo.icon.bWidth : entry->ResInfo.cursor.wWidth;
-        /* Height is twice as big in cursor resources */
-        height = fIcon ? entry->ResInfo.icon.bHeight : entry->ResInfo.cursor.wHeight/2;
-        /* 0 represents 256 */
-        if(!width) width = 256;
-        if(!height) height = 256;
-        /* Calculate the "score" (lower is better) */
-        score = 2*(abs(width - cxDesired) + abs(height - cyDesired));
-        if( score > bestScore)
-            continue;
-        /* Bigger than requested lowers the score */
-        if(width > cxDesired)
-            score -= width - cxDesired;
-        if(height > cyDesired)
-            score -= height - cyDesired;
-        if(score > bestScore)
-            continue;
-        if(score == bestScore)
+        if(!(dir && !dir->idReserved && (dir->idType & 3)))
         {
-            if(entry->wBitCount > BitCount)
+            WARN("Invalid resource.\n");
+            _SEH2_YIELD(return 0);
+        }
+
+        if(Flags & LR_MONOCHROME)
+            bppDesired = 1;
+        else
+        {
+            HDC icScreen;
+            icScreen = CreateICW(DISPLAYW, NULL, NULL, NULL);
+            if(!icScreen)
+                _SEH2_YIELD(return 0);
+
+            bppDesired = GetDeviceCaps(icScreen, BITSPIXEL);
+            DeleteDC(icScreen);
+        }
+
+        if(!cxDesired)
+            cxDesired = Flags & LR_DEFAULTSIZE ? GetSystemMetrics(fIcon ? SM_CXICON : SM_CXCURSOR) : 256;
+        if(!cyDesired)
+            cyDesired = Flags & LR_DEFAULTSIZE ? GetSystemMetrics(fIcon ? SM_CYICON : SM_CYCURSOR) : 256;
+
+        /* Find the best match for the desired size */
+        for(i = 0; i < dir->idCount; i++)
+        {
+            entry = &dir->idEntries[i];
+            width = fIcon ? entry->ResInfo.icon.bWidth : entry->ResInfo.cursor.wWidth;
+            /* Height is twice as big in cursor resources */
+            height = fIcon ? entry->ResInfo.icon.bHeight : entry->ResInfo.cursor.wHeight/2;
+            /* 0 represents 256 */
+            if(!width) width = 256;
+            if(!height) height = 256;
+            /* Calculate the "score" (lower is better) */
+            score = 2*(abs(width - cxDesired) + abs(height - cyDesired));
+            if( score > bestScore)
+                continue;
+            /* Bigger than requested lowers the score */
+            if(width > cxDesired)
+                score -= width - cxDesired;
+            if(height > cyDesired)
+                score -= height - cyDesired;
+            if(score > bestScore)
+                continue;
+            if(score == bestScore)
+            {
+                if(entry->wBitCount > BitCount)
+                    BitCount = entry->wBitCount;
+                numMatch++;
+                continue;
+            }
+            iIndex = i;
+            numMatch = 1;
+            bestScore = score;
+            BitCount = entry->wBitCount;
+        }
+
+        if(numMatch == 1)
+        {
+            /* Only one entry fits the asked dimensions */
+            _SEH2_YIELD(return dir->idEntries[iIndex].wResId);
+        }
+
+        /* Avoid paletted icons on non-paletted device */
+        if (bppDesired > 8 && BitCount > 8)
+            notPaletted = TRUE;
+
+        BitCount = 0;
+        iIndex = -1;
+        /* Now find the entry with the best depth */
+        for(i = 0; i < dir->idCount; i++)
+        {
+            entry = &dir->idEntries[i];
+            width = fIcon ? entry->ResInfo.icon.bWidth : entry->ResInfo.cursor.wWidth;
+            height = fIcon ? entry->ResInfo.icon.bHeight : entry->ResInfo.cursor.wHeight/2;
+            /* 0 represents 256 */
+            if(!width) width = 256;
+            if(!height) height = 256;
+            /* Check if this is the best match we had */
+            score = 2*(abs(width - cxDesired) + abs(height - cyDesired));
+            if(width > cxDesired)
+                score -= width - cxDesired;
+            if(height > cyDesired)
+                score -= height - cyDesired;
+            if(score != bestScore)
+                continue;
+            /* Exact match? */
+            if(entry->wBitCount == bppDesired)
+                _SEH2_YIELD(return entry->wResId);
+            /* We take the highest possible but smaller  than the display depth */
+            if((entry->wBitCount > BitCount) && (entry->wBitCount < bppDesired))
+            {
+                /* Avoid paletted icons on non paletted devices */
+                if ((entry->wBitCount <= 8) && notPaletted)
+                    continue;
+                iIndex = i;
                 BitCount = entry->wBitCount;
-            numMatch++;
-            continue;
+            }
         }
-        iIndex = i;
-        numMatch = 1;
-        bestScore = score;
-        BitCount = entry->wBitCount;
-    }
 
-    if(numMatch == 1)
-    {
-        /* Only one entry fits the asked dimensions */
-        return dir->idEntries[iIndex].wResId;
-    }
+        if(iIndex >= 0)
+            _SEH2_YIELD(return dir->idEntries[iIndex].wResId);
 
-    /* Avoid paletted icons on non-paletted device */
-    if (bppDesired > 8 && BitCount > 8)
-        notPaletted = TRUE;
-
-    BitCount = 0;
-    iIndex = -1;
-    /* Now find the entry with the best depth */
-    for(i = 0; i < dir->idCount; i++)
-    {
-        entry = &dir->idEntries[i];
-        width = fIcon ? entry->ResInfo.icon.bWidth : entry->ResInfo.cursor.wWidth;
-        height = fIcon ? entry->ResInfo.icon.bHeight : entry->ResInfo.cursor.wHeight/2;
-        /* 0 represents 256 */
-        if(!width) width = 256;
-        if(!height) height = 256;
-        /* Check if this is the best match we had */
-        score = 2*(abs(width - cxDesired) + abs(height - cyDesired));
-        if(width > cxDesired)
-            score -= width - cxDesired;
-        if(height > cyDesired)
-            score -= height - cyDesired;
-        if(score != bestScore)
-            continue;
-        /* Exact match? */
-        if(entry->wBitCount == bppDesired)
-            return entry->wResId;
-        /* We take the highest possible but smaller  than the display depth */
-        if((entry->wBitCount > BitCount) && (entry->wBitCount < bppDesired))
+        /* No inferior or equal depth available. Get the smallest bigger one */
+        BitCount = 0xFFFF;
+        iIndex = -1;
+        for(i = 0; i < dir->idCount; i++)
         {
-            /* Avoid paletted icons on non paletted devices */
-            if ((entry->wBitCount <= 8) && notPaletted)
+            entry = &dir->idEntries[i];
+            width = fIcon ? entry->ResInfo.icon.bWidth : entry->ResInfo.cursor.wWidth;
+            height = fIcon ? entry->ResInfo.icon.bHeight : entry->ResInfo.cursor.wHeight/2;
+            /* 0 represents 256 */
+            if(!width) width = 256;
+            if(!height) height = 256;
+            /* Check if this is the best match we had */
+            score = 2*(abs(width - cxDesired) + abs(height - cyDesired));
+            if(width > cxDesired)
+                score -= width - cxDesired;
+            if(height > cyDesired)
+                score -= height - cyDesired;
+            if(score != bestScore)
                 continue;
-            iIndex = i;
-            BitCount = entry->wBitCount;
+            /* Check the bit depth */
+            if(entry->wBitCount < BitCount)
+            {
+                if((entry->wBitCount <= 8) && notPaletted)
+                    continue;
+                iIndex = i;
+                BitCount = entry->wBitCount;
+            }
         }
+        if (iIndex >= 0)
+            _SEH2_YIELD(return dir->idEntries[iIndex].wResId);
     }
-
-    if(iIndex >= 0)
-        return dir->idEntries[iIndex].wResId;
-
-    /* No inferior or equal depth available. Get the smallest bigger one */
-    BitCount = 0xFFFF;
-    iIndex = -1;
-    for(i = 0; i < dir->idCount; i++)
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
-        entry = &dir->idEntries[i];
-        width = fIcon ? entry->ResInfo.icon.bWidth : entry->ResInfo.cursor.wWidth;
-        height = fIcon ? entry->ResInfo.icon.bHeight : entry->ResInfo.cursor.wHeight/2;
-        /* 0 represents 256 */
-        if(!width) width = 256;
-        if(!height) height = 256;
-        /* Check if this is the best match we had */
-        score = 2*(abs(width - cxDesired) + abs(height - cyDesired));
-        if(width > cxDesired)
-            score -= width - cxDesired;
-        if(height > cyDesired)
-            score -= height - cyDesired;
-        if(score != bestScore)
-            continue;
-        /* Check the bit depth */
-        if(entry->wBitCount < BitCount)
-        {
-            if((entry->wBitCount <= 8) && notPaletted)
-                continue;
-            iIndex = i;
-            BitCount = entry->wBitCount;
-        }
+        ERR("Invalid resource (0x%p)\n", presbits);
     }
-    if (iIndex >= 0)
-        return dir->idEntries[iIndex].wResId;
+    _SEH2_END;
 
     return 0;
 }


### PR DESCRIPTION
## Purpose

Calling `LookupIconIdFromDirectoryEx` with invalid pointer crashes the caller while it should fail peacefully. This patch adds an exception handler to prevent the crash, to match the behavior on Windows.

Windows: _Tests on lines 19, 20 and 21 are passing._

<img width="712" height="639" alt="image" src="https://github.com/user-attachments/assets/5b4468bb-60ea-4202-9df8-5e73ebdaea45" />

ReactOS: _Tests on lines 19 and 20 are failing._

<img width="700" height="472" alt="image" src="https://github.com/user-attachments/assets/35666c92-1046-427e-b71b-209c40f69eb9" />

Without `StartSeh()` in the test, it would crash with this:
```
(ntoskrnl/mm/mmfault.c:148) Address: deadbeef
Unhandled exception
ExceptionCode:    c0000005
Faulting Address: DEADBEEF
CS:EIP 1b:77a5dfcd
DS 23 ES 23 FS 3b GS 0
EAX: deadbeef   EBX: 004b20f8   ECX: 00234000
EDX: deadbeef   EBP: 0022f8b8   ESI: 00231fb0   ESP: 0022f850
EDI: 0047d93e   EFLAGS: 00010282
Address:
<user32.dll:3dfcd> (X:\reactos\system32\user32.dll@77a20000)
Frames:
<user32_apitest.exe:49365> (X:\reactos\bin\user32_apitest.exe@400000)
<user32_apitest.exe:6ce57> (X:\reactos\bin\user32_apitest.exe@400000)
<user32_apitest.exe:6d513> (X:\reactos\bin\user32_apitest.exe@400000)
<user32_apitest.exe:6eec6> (X:\reactos\bin\user32_apitest.exe@400000)
<user32_apitest.exe:6ef3d> (X:\reactos\bin\user32_apitest.exe@400000)
<kernel32.dll:11be1> (X:\reactos\system32\kernel32.dll@7c5e0000)
```

After the patch: _Tests on lines 19, 20 and 21 are passing._

<img width="707" height="506" alt="image" src="https://github.com/user-attachments/assets/ff848073-287d-4ba6-a117-ff91b828e1aa" />

Recorded logs:
```
(ntoskrnl/mm/mmfault.c:148) Address: deadbeef
err:(win32ss/user/user32/windows/cursoricon.c:2636) Invalid resource (DEADBEEF).
```

JIRA issue: [CORE-19544](https://jira.reactos.org/browse/CORE-19544)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: