### PR TITLE
[AUDIOSRV] Broadcast `winmm_devicechange` to all desktops and applications

### DIFF
--- a/base/services/audiosrv/pnp.c
+++ b/base/services/audiosrv/pnp.c
@@ -1,8 +1,9 @@
 /*
  * PROJECT:     ReactOS
- * LICENSE:     GPL - See COPYING in the top level directory
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Audio Service Plug and Play
- * COPYRIGHT:   Copyright 2007 Andrew Greenwood
+ * COPYRIGHT:   Copyright 2007 Andrew Greenwood <silverblade@reactos.org>
+ *              Copyright 2026 Vitaly Orekhov <vkvo2000@vivaldi.net>
  */
 
 #include "audiosrv.h"

--- a/base/services/audiosrv/pnp.c
+++ b/base/services/audiosrv/pnp.c
@@ -19,6 +19,7 @@
 #include <debug.h>
 
 static HDEVNOTIFY device_notification_handle = NULL;
+static UINT uWinMMDeviceChange = 0;
 
 /*
     Finds all devices within the KSCATEGORY_AUDIO category and puts them
@@ -100,6 +101,11 @@ ProcessExistingDevices(VOID)
 
     SetupDiDestroyDeviceInfoList(dev_info);
 
+    uWinMMDeviceChange = RegisterWindowMessageW(L"winmm_devicechange");
+
+    if (uWinMMDeviceChange == 0)
+        DPRINT1("Failed to register winmm_devicechange window message: GetLastError %u\n", GetLastError());
+
     return TRUE;
 }
 
@@ -115,6 +121,19 @@ ProcessDeviceArrival(DEV_BROADCAST_DEVICEINTERFACE* device)
     list_node = CreateDeviceDescriptor(device->dbcc_name, TRUE);
     AppendAudioDeviceToList(list_node);
     DestroyDeviceDescriptor(list_node);
+
+    DWORD dwInfo = BSM_ALLDESKTOPS | BSM_APPLICATIONS;
+    BroadcastSystemMessageW(BSF_POSTMESSAGE, &dwInfo, uWinMMDeviceChange, 0, 0);
+
+    return NO_ERROR;
+}
+
+DWORD
+ProcessDeviceRemovalComplete(DEV_BROADCAST_DEVICEINTERFACE* device)
+{
+    /* TODO: clean up appended audio devices */
+    DWORD dwInfo = BSM_ALLDESKTOPS | BSM_APPLICATIONS;
+    BroadcastSystemMessageW(BSF_POSTMESSAGE, &dwInfo, uWinMMDeviceChange, 0, 0);
 
     return NO_ERROR;
 }
@@ -184,7 +203,15 @@ HandleDeviceEvent(
             return ProcessDeviceArrival(incoming_device);
         }
 
-        default :
+        case DBT_DEVICEREMOVECOMPLETE:
+        {
+            DEV_BROADCAST_DEVICEINTERFACE* removed_device =
+                (DEV_BROADCAST_DEVICEINTERFACE*)lpEventData;
+            
+            return ProcessDeviceRemovalComplete(removed_device);
+        }
+
+        default:
         {
             break;
         }

--- a/base/services/audiosrv/pnp.c
+++ b/base/services/audiosrv/pnp.c
@@ -19,6 +19,7 @@
 #include <debug.h>
 
 static HDEVNOTIFY device_notification_handle = NULL;
+static UINT uWinMMDeviceChange = 0;
 
 /*
     Finds all devices within the KSCATEGORY_AUDIO category and puts them
@@ -100,6 +101,11 @@ ProcessExistingDevices(VOID)
 
     SetupDiDestroyDeviceInfoList(dev_info);
 
+    uWinMMDeviceChange = RegisterWindowMessageW(L"winmm_devicechange");
+
+    if (uWinMMDeviceChange == 0)
+        DPRINT("Failed to register winmm_devicechange window message: GetLastError %u\n", GetLastError());
+
     return TRUE;
 }
 
@@ -115,6 +121,20 @@ ProcessDeviceArrival(DEV_BROADCAST_DEVICEINTERFACE* device)
     list_node = CreateDeviceDescriptor(device->dbcc_name, TRUE);
     AppendAudioDeviceToList(list_node);
     DestroyDeviceDescriptor(list_node);
+
+    DWORD dwInfo = BSM_ALLDESKTOPS | BSM_APPLICATIONS;
+    BroadcastSystemMessageW(BSF_POSTMESSAGE, &dwInfo, uWinMMDeviceChange, 0, 0);
+
+    return NO_ERROR;
+}
+
+DWORD
+ProcessDeviceRemovalComplete(DEV_BROADCAST_DEVICEINTERFACE* device)
+{
+    /* If we need to clean up appended audio devices here,
+     * this has to be implemented as well. */
+    DWORD dwInfo = BSM_ALLDESKTOPS | BSM_APPLICATIONS;
+    BroadcastSystemMessageW(BSF_POSTMESSAGE, &dwInfo, uWinMMDeviceChange, 0, 0);
 
     return NO_ERROR;
 }
@@ -184,7 +204,15 @@ HandleDeviceEvent(
             return ProcessDeviceArrival(incoming_device);
         }
 
-        default :
+        case DBT_DEVICEREMOVECOMPLETE:
+        {
+            DEV_BROADCAST_DEVICEINTERFACE* removed_device =
+                (DEV_BROADCAST_DEVICEINTERFACE*)lpEventData;
+            
+            return ProcessDeviceRemovalComplete(removed_device);
+        }
+
+        default:
         {
             break;
         }


### PR DESCRIPTION
## Purpose

Broadcasting WinMM specific message that tells whether the `KSCATEGORY_AUDIO` devices were installed or removed. May be used by applications to refresh their audio devices lists but I had never found the examples.

JIRA issue: None

## Proposed changes

- Broadcast `winmm_devicechange` on `DBT_DEVICEREMOVECOMPLETE` and `DBT_DEVICEARRIVAL` events

## Testbot runs (Filled in by Devs)

Not applicable.

## Notes (including observed during draft time)
**Required for #8577**
While code wise it looks okay, I had never succeeded with getting at least `DBT_DEVICEARRIVAL` log line. If anyone of the reviewers confirms this code is correct, I will convert it to a ready-for-review one.
Sourced behavior was tested both on Windows XP and Server 2003 via API Monitor using Microsoft LifeCam HD-3000 as a device to trigger the message broadcast.