### PR TITLE
[USER32] Fix GetDisplayConfigBufferSizes

### DIFF
--- a/win32ss/user/user32_vista/wine/sysparams.c
+++ b/win32ss/user/user32_vista/wine/sysparams.c
@@ -215,9 +215,14 @@ GetDisplayConfigBufferSizes(
     UINT32 *numPathArrayElements,
     UINT32 *numModeInfoArrayElements)
 {
-  *numPathArrayElements = 0;
-  *numModeInfoArrayElements = 0;
-  return 0;
+    /* Validate parameters */
+    if ((numPathArrayElements == NULL) || (numModeInfoArrayElements == NULL))
+    {
+        return ERROR_INVALID_PARAMETER;
+    }
+
+    /* We don't support WDDM yet */
+    return ERROR_NOT_SUPPORTED;
 }
 
 LONG


### PR DESCRIPTION
## Purpose

Fixes crash in user32_winetest on NT6 builds.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108895,108896
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108864,108891
