### PR TITLE
[SYSSETUP] Unattended ComputerName=* means random name

### DIFF
--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -1162,7 +1162,7 @@ ComputerPageDlgProc(HWND hwndDlg,
             if (pSetupData->UnattendSetup)
             {
                 /* "*" means use random name (we have already generated it above) */
-                if (!_wcsicmp(pSetupData->ComputerName, L"*"))
+                if (pSetupData->ComputerName[0] == L'*' && !pSetupData->ComputerName[1])
                     wcscpy(pSetupData->ComputerName, ComputerName);
                 else
                     SetDlgItemTextW(hwndDlg, IDC_COMPUTERNAME, pSetupData->ComputerName);

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -8,6 +8,7 @@
  *                  Ismael Ferreras Morezuelas <swyterzone+ros@gmail.com>
  *                  Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *                  Oleg Dubinskiy <oleg.dubinskij30@gmail.com>
+ *                  Whindmar Saksit <whindsaks@proton.me>
  */
 
 /* INCLUDES *****************************************************************/
@@ -1160,9 +1161,13 @@ ComputerPageDlgProc(HWND hwndDlg,
             SetFocus(GetDlgItem(hwndDlg, IDC_COMPUTERNAME));
             if (pSetupData->UnattendSetup)
             {
-                SendMessage(GetDlgItem(hwndDlg, IDC_COMPUTERNAME), WM_SETTEXT, 0, (LPARAM)pSetupData->ComputerName);
-                SendMessage(GetDlgItem(hwndDlg, IDC_ADMINPASSWORD1), WM_SETTEXT, 0, (LPARAM)pSetupData->AdminPassword);
-                SendMessage(GetDlgItem(hwndDlg, IDC_ADMINPASSWORD2), WM_SETTEXT, 0, (LPARAM)pSetupData->AdminPassword);
+                /* "*" means use random name (we have already generated it above) */
+                if (!_wcsicmp(pSetupData->ComputerName, L"*"))
+                    wcscpy(pSetupData->ComputerName, ComputerName);
+                else
+                    SetDlgItemTextW(hwndDlg, IDC_COMPUTERNAME, pSetupData->ComputerName);
+                SetDlgItemTextW(hwndDlg, IDC_ADMINPASSWORD1, pSetupData->AdminPassword);
+                SetDlgItemTextW(hwndDlg, IDC_ADMINPASSWORD2, pSetupData->AdminPassword);
                 WriteComputerSettings(pSetupData->ComputerName, NULL);
                 SetAdministratorPassword(pSetupData->AdminPassword);
             }


### PR DESCRIPTION
Windows [supports using *](https://web.archive.org/web/20070506023846/http://www.microsoft.com/technet/prodtechnol/Windows2000Pro/deploy/unattend/sp1ch01.mspx) as "automatic" for some entries.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: