### PR TITLE
[COMCTL32] Import wine's PSN_QUERYINITIALFOCUS implementation

### DIFF
--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -37,7 +37,6 @@
  *     o WM_CONTEXTMENU
  *   - Notifications:
  *     o PSN_GETOBJECT
- *     o PSN_QUERYINITIALFOCUS
  *     o PSN_TRANSLATEACCELERATOR
  *   - Styles:
  *     o PSH_RTLREADING
@@ -195,6 +194,30 @@ static WCHAR *heap_strdupAtoW(const char *str)
 }
 
 #define add_flag(a) if (dwFlags & a) {strcat(string, #a );strcat(string," ");}
+
+#ifdef __REACTOS__
+static void PROPSHEET_SetInitialFocus(HWND hwndDlg, int index, PropSheetInfo* psInfo)
+{
+    PSHNOTIFY psn;
+    HWND focusable_item = NULL;
+    HWND initial_focus = NULL;
+
+    focusable_item = GetNextDlgTabItem(psInfo->proppage[index].hwndPage, NULL, FALSE);
+    if (!focusable_item)
+        return;
+
+    psn.hdr.code = PSN_QUERYINITIALFOCUS;
+    psn.hdr.hwndFrom = hwndDlg;
+    psn.hdr.idFrom = 0;
+    psn.lParam = 0;
+    initial_focus = (HWND)SendMessageW(psInfo->proppage[index].hwndPage, WM_NOTIFY, 0, (LPARAM)&psn);
+    if (initial_focus)
+        SetFocus(initial_focus);
+    else if (focusable_item)
+        SetFocus(focusable_item);
+}
+#endif // __REACTOS__
+
 /******************************************************************************
  *            PROPSHEET_UnImplementedFlags
  *
@@ -1523,7 +1546,9 @@ static BOOL PROPSHEET_ShowPage(HWND hwndDlg, int index, PropSheetInfo * psInfo)
 {
   HWND hwndTabCtrl;
   HWND hwndLineHeader;
+#ifndef __REACTOS__
   HWND control;
+#endif
   LPCPROPSHEETPAGEW ppshpage;
 
   TRACE("active_page %d, index %d\n", psInfo->active_page, index);
@@ -1544,10 +1569,12 @@ static BOOL PROPSHEET_ShowPage(HWND hwndDlg, int index, PropSheetInfo * psInfo)
   {
      PROPSHEET_SetTitleW(hwndDlg, psInfo->ppshheader.dwFlags,
                          psInfo->proppage[index].pszText);
+#ifndef __REACTOS__
 
      control = GetNextDlgTabItem(psInfo->proppage[index].hwndPage, NULL, FALSE);
      if(control != NULL)
          SetFocus(control);
+#endif
   }
 
   if (psInfo->active_page != -1)
@@ -1562,6 +1589,10 @@ static BOOL PROPSHEET_ShowPage(HWND hwndDlg, int index, PropSheetInfo * psInfo)
 
   psInfo->active_page = index;
   psInfo->activeValid = TRUE;
+
+#ifdef __REACTOS__
+  PROPSHEET_SetInitialFocus(hwndDlg, index, psInfo);
+#endif
 
   if (psInfo->ppshheader.dwFlags & (PSH_WIZARD97_OLD | PSH_WIZARD97_NEW) )
   {
@@ -1761,6 +1792,9 @@ static BOOL PROPSHEET_Apply(HWND hwndDlg, LPARAM lParam)
      psn.lParam   = 0;
      hwndPage = psInfo->proppage[psInfo->active_page].hwndPage;
      SendMessageW(hwndPage, WM_NOTIFY, 0, (LPARAM) &psn);
+#ifdef __REACTOS__
+     PROPSHEET_SetInitialFocus(hwndPage, psInfo->active_page, psInfo);
+#endif
   }
 
   return TRUE;
@@ -3699,7 +3733,11 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       if (psInfo->ppshheader.dwFlags & INTRNL_ANY_WIZARD)
           return FALSE;
 
+#ifdef __REACTOS__
+      return FALSE;
+#else
       return TRUE;
+#endif
     }
 
     case WM_PRINTCLIENT:

--- a/modules/rostests/winetests/comctl32/propsheet.c
+++ b/modules/rostests/winetests/comctl32/propsheet.c
@@ -1251,25 +1251,25 @@ static void test_QueryInitialFocus(void)
     tab_ctrl = (HWND)SendMessageA(hp, PSM_GETTABCONTROL, 0, 0);
 
     /* Test PSN_QUERYINITIALFOCUS gets sent on start */
-    todo_wine ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS on start.\n");
-    todo_wine ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT2, "Focus not set to IDC_PS_EDIT2.\n");
+    ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS on start.\n");
+    ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT2, "Focus not set to IDC_PS_EDIT2.\n");
 
     /* Test changing of tabs */
     edit_test_ID = IDC_PS_EDIT1;
     query_initial_focus = 0;
-    todo_wine ok(tab_ctrl != 0, "Could not test changing tabs. No tab control found.\n");
+    ok(tab_ctrl != 0, "Could not test changing tabs. No tab control found.\n");
     SendMessageA(tab_ctrl, TCM_GETITEMRECT, 1, (LPARAM) &rc);
     lp = MAKELPARAM(rc.left + ((rc.right - rc.left) / 2), rc.top + ((rc.bottom - rc.top) / 2));
     SendMessageA(tab_ctrl, WM_LBUTTONDOWN, MK_LBUTTON, lp);
-    todo_wine ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS from changing tabs.\n");
-    todo_wine ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT1, "Focus not set to IDC_PS_EDIT1.\n");
+    ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS from changing tabs.\n");
+    ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT1, "Focus not set to IDC_PS_EDIT1.\n");
 
     /* Test Apply Button */
     edit_test_ID = IDC_PS_EDIT2;
     query_initial_focus = 0;
     SendMessageA(hp, PSM_PRESSBUTTON, PSBTN_APPLYNOW, 0);
-    todo_wine ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS from apply button.\n");
-    todo_wine ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT2, "Focus not set to IDC_PS_EDIT2.\n");
+    ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS from apply button.\n");
+    ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT2, "Focus not set to IDC_PS_EDIT2.\n");
 
     DestroyWindow(hp);
 
@@ -1280,15 +1280,15 @@ static void test_QueryInitialFocus(void)
     hp = (HWND)pPropertySheetA(&psh);
 
     /* Test PSN_QUERYINITIALFOCUS gets sent on start */
-    todo_wine ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS on start.\n");
-    todo_wine ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT1, "Focus not set to IDC_PS_EDIT1.\n");
+    ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS on start.\n");
+    ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT1, "Focus not set to IDC_PS_EDIT1.\n");
 
     /* Test Next Button */
     edit_test_ID = IDC_PS_EDIT2;
     query_initial_focus = 0;
     SendMessageA(hp, PSM_PRESSBUTTON, PSBTN_NEXT, 0);
-    todo_wine ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS from next button.\n");
-    todo_wine ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT2, "Focus not set to IDC_PS_EDIT2.\n");
+    ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS from next button.\n");
+    ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT2, "Focus not set to IDC_PS_EDIT2.\n");
 
     DestroyWindow(hp);
 }

--- a/modules/rostests/winetests/comctl32/propsheet.c
+++ b/modules/rostests/winetests/comctl32/propsheet.c
@@ -1184,6 +1184,116 @@ static void test_bad_control_class(void)
     DestroyWindow((HWND)ret);
 }
 
+#ifdef __REACTOS__
+static int query_initial_focus = 0;
+static int edit_test_ID = IDC_PS_EDIT2;
+static LRESULT CALLBACK TestDlgProc(HWND hdlg, UINT uMessage, WPARAM wParam, LPARAM lParam)
+{
+    LPNMHDR lpnmhdr;
+
+    switch (uMessage)
+    {
+    case WM_NOTIFY:
+        lpnmhdr = (NMHDR *)lParam;
+        switch (lpnmhdr->code)
+        {
+        case PSN_QUERYINITIALFOCUS:
+        {
+            query_initial_focus++;
+            if (edit_test_ID == IDC_PS_EDIT1)
+                return 0;
+            SetWindowLongPtrA(hdlg, DWLP_MSGRESULT, (LONG_PTR)GetDlgItem(hdlg, IDC_PS_EDIT2));
+            return 1;
+        }
+        }
+    }
+
+    return FALSE;
+}
+
+static void test_QueryInitialFocus(void)
+{
+    PROPSHEETPAGEA psp[2];
+    PROPSHEETHEADERA psh;
+    HWND tab_ctrl = NULL;
+    HWND hp;
+    RECT rc;
+    LPARAM lp;
+
+    memset(&psh, 0, sizeof(psh));
+    memset(psp, 0, sizeof(psp));
+    psp[0].dwSize = sizeof(PROPSHEETPAGEA);
+    psp[0].dwFlags = PSP_USETITLE;
+    psp[0].hInstance = GetModuleHandleA(NULL);
+    psp[0].pszTemplate = (const char *)MAKEINTRESOURCE(IDD_PROP_PAGE_EDIT);
+    psp[0].pszIcon = NULL;
+    psp[0].pfnDlgProc = (DLGPROC) TestDlgProc;
+    psp[0].pszTitle = "Page1";
+    psp[0].lParam = 0;
+
+    psp[1].dwSize = sizeof(PROPSHEETPAGEA);
+    psp[1].dwFlags = PSP_USETITLE;
+    psp[1].hInstance = GetModuleHandleA(NULL);
+    psp[1].pszTemplate = (const char*)MAKEINTRESOURCE(IDD_PROP_PAGE_EDIT);
+    psp[1].pszIcon = NULL;
+    psp[1].pfnDlgProc = (DLGPROC) TestDlgProc;
+    psp[1].pszTitle = "Page2";
+    psp[1].lParam = 0;
+
+    psh.dwSize = sizeof(PROPSHEETHEADERA);
+    psh.dwFlags = PSH_PROPSHEETPAGE | PSH_MODELESS;
+    psh.hwndParent = GetDesktopWindow();
+    psh.pszCaption = "Modeless Property Sheet";
+    psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGEA);
+    psh.ppsp = (LPCPROPSHEETPAGEA)&psp;
+
+    hp = (HWND)pPropertySheetA(&psh);
+    tab_ctrl = (HWND)SendMessageA(hp, PSM_GETTABCONTROL, 0, 0);
+
+    /* Test PSN_QUERYINITIALFOCUS gets sent on start */
+    todo_wine ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS on start.\n");
+    todo_wine ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT2, "Focus not set to IDC_PS_EDIT2.\n");
+
+    /* Test changing of tabs */
+    edit_test_ID = IDC_PS_EDIT1;
+    query_initial_focus = 0;
+    todo_wine ok(tab_ctrl != 0, "Could not test changing tabs. No tab control found.\n");
+    SendMessageA(tab_ctrl, TCM_GETITEMRECT, 1, (LPARAM) &rc);
+    lp = MAKELPARAM(rc.left + ((rc.right - rc.left) / 2), rc.top + ((rc.bottom - rc.top) / 2));
+    SendMessageA(tab_ctrl, WM_LBUTTONDOWN, MK_LBUTTON, lp);
+    todo_wine ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS from changing tabs.\n");
+    todo_wine ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT1, "Focus not set to IDC_PS_EDIT1.\n");
+
+    /* Test Apply Button */
+    edit_test_ID = IDC_PS_EDIT2;
+    query_initial_focus = 0;
+    SendMessageA(hp, PSM_PRESSBUTTON, PSBTN_APPLYNOW, 0);
+    todo_wine ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS from apply button.\n");
+    todo_wine ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT2, "Focus not set to IDC_PS_EDIT2.\n");
+
+    DestroyWindow(hp);
+
+    edit_test_ID = IDC_PS_EDIT1;
+    query_initial_focus = 0;
+
+    psh.dwFlags = PSH_PROPSHEETPAGE | PSH_USECALLBACK | PSH_WIZARD | PSH_MODELESS;
+    hp = (HWND)pPropertySheetA(&psh);
+
+    /* Test PSN_QUERYINITIALFOCUS gets sent on start */
+    todo_wine ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS on start.\n");
+    todo_wine ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT1, "Focus not set to IDC_PS_EDIT1.\n");
+
+    /* Test Next Button */
+    edit_test_ID = IDC_PS_EDIT2;
+    query_initial_focus = 0;
+    SendMessageA(hp, PSM_PRESSBUTTON, PSBTN_NEXT, 0);
+    todo_wine ok(query_initial_focus == 1, "Did not recieve PSN_QUERYINITIALFOCUS from next button.\n");
+    todo_wine ok(GetDlgCtrlID(GetFocus()) == IDC_PS_EDIT2, "Focus not set to IDC_PS_EDIT2.\n");
+
+    DestroyWindow(hp);
+}
+#endif // __REACTOS__
+
 static void init_functions(void)
 {
     HMODULE hComCtl32 = LoadLibraryA("comctl32.dll");
@@ -1220,4 +1330,7 @@ START_TEST(propsheet)
     test_PSM_ADDPAGE();
     test_PSM_INSERTPAGE();
     test_CreatePropertySheetPage();
+#ifdef __REACTOS__
+    test_QueryInitialFocus();
+#endif
 }


### PR DESCRIPTION
## Purpose & Proposed changes

Import wine's PSN_QUERYINITIALFOCUS implementation, in order to fix navigation issues in the ReactOS GUI installer, and allow me to remove this hack:
https://github.com/reactos/reactos/blob/c296dcfa29e7f32b623d8ed3e70604a06472fda2/base/setup/reactos/drivepage.c#L1631-L1636

Note that this notification is used in few ReactOS modules, see:
https://git.reactos.org/?p=reactos.git&a=search&h=HEAD&st=grep&s=PSN_QUERYINITIALFOCUS

See also PR #9153.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109045,109058
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109027,109059