### PR TITLE
[ROSAUTOTEST] Fix handling of empty test lists

### DIFF
--- a/modules/rostests/rosautotest/CPipe.cpp
+++ b/modules/rostests/rosautotest/CPipe.cpp
@@ -61,7 +61,7 @@ CPipe::CPipe()
 
     // Prepare the OVERLAPPED structure for reading.
     ZeroMemory(&m_ReadOverlapped, sizeof(m_ReadOverlapped));
-    m_ReadOverlapped.hEvent = CreateEventW(NULL, TRUE, TRUE, NULL);
+    m_ReadOverlapped.hEvent = CreateEventW(NULL, TRUE, FALSE, NULL);
     if (!m_ReadOverlapped.hEvent)
     {
         FATAL("CreateEvent failed\n");
@@ -164,6 +164,9 @@ CPipe::Read(PVOID Buffer, DWORD NumberOfBytesToRead, PDWORD NumberOfBytesRead, D
         FATAL("Trying to read from a closed read pipe\n");
     }
 
+    RtlZeroMemory(&m_ReadOverlapped, FIELD_OFFSET(OVERLAPPED, hEvent));
+    ResetEvent(m_ReadOverlapped.hEvent);
+
     if (ReadFile(m_hReadPipe, Buffer, NumberOfBytesToRead, NumberOfBytesRead, &m_ReadOverlapped))
     {
         // The asynchronous read request could be satisfied immediately.
@@ -199,6 +202,7 @@ CPipe::Read(PVOID Buffer, DWORD NumberOfBytesToRead, PDWORD NumberOfBytesRead, D
         else
         {
             // This may be WAIT_TIMEOUT or an unexpected error.
+            CancelIo(m_hReadPipe);
             return dwWaitResult;
         }
     }

--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -60,6 +60,10 @@ CWineTest::GetNextFile()
     bool FoundFile = false;
     WIN32_FIND_DATAW fd;
 
+    /* Reset the test list */
+    m_ListBuffer = NULL;
+    m_ListString.clear();
+
     /* Did we already begin searching for files? */
     if (m_hFind)
     {
@@ -210,6 +214,13 @@ CWineTest::GetNextTest()
     {
         /* Perform the --list command */
         BufferSize = DoListCommand();
+
+        if ((BufferSize == 0) || (m_ListBuffer == NULL))
+        {
+            stringstream ss;
+            ss << "The --list command did not return any data for " << UnicodeToAscii(m_CurrentFile) << endl;
+            TESTEXCEPTION(ss.str());
+        }
 
         /* Move the pointer to the first test */
         pStart = strchr(m_ListBuffer, '\n');


### PR DESCRIPTION
## Purpose

Fix handling of empty test lists and a few pipe related improvements.
Fixes testruns on WHS and Vista x64 testbots.

## Testbot runs (Filled in by Devs)

- [x] WHS x86: https://reactos.org/testman/compare.php?ids=108809,108880
- [x] Vista x64: https://reactos.org/testman/compare.php?ids=108583,108879
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108863,108886
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108864,108881
