### PR TITLE
[ROSTESTS] Add USER32 Control Gallery

### DIFF
--- a/modules/rostests/win32/user32/CMakeLists.txt
+++ b/modules/rostests/win32/user32/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(biditext)
+add_subdirectory(controls)
 add_subdirectory(editalign)
 add_subdirectory(menuaccels)
 add_subdirectory(messagebox)

--- a/modules/rostests/win32/user32/CMakeLists.txt
+++ b/modules/rostests/win32/user32/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(biditext)
+add_subdirectory(controls)
 add_subdirectory(dialog_initvisible)
 add_subdirectory(editalign)
 add_subdirectory(menuaccels)

--- a/modules/rostests/win32/user32/controls/CMakeLists.txt
+++ b/modules/rostests/win32/user32/controls/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(user32_control_gallery
+               main.c
+               navhost.c
+               pagehost.c
+               pages/button.c
+               pages/edit.c
+               pages/combo.c
+               pages/icontitle.c
+               pages/listbox.c
+               pages/mdi.c
+               pages/scrollbar.c
+               pages/static.c)
+
+set_module_type(user32_control_gallery win32gui UNICODE)
+add_importlibs(user32_control_gallery gdi32 user32 msvcrt kernel32 ntdll)
+add_rostests_file(TARGET user32_control_gallery SUBDIR suppl)

--- a/modules/rostests/win32/user32/controls/controls.h
+++ b/modules/rostests/win32/user32/controls/controls.h
@@ -1,0 +1,105 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#pragma once
+
+#define OEMRESOURCE
+#include <windows.h>
+
+typedef enum _PAGES
+{
+    PAGE_BUTTONS,
+    PAGE_COMBO,
+    PAGE_EDIT,
+    PAGE_ICONTITLE,
+    PAGE_LISTBOX,
+    PAGE_MDI,
+    PAGE_SCROLLBAR,
+    PAGE_STATIC,
+    PAGE_MAX
+} PAGE_ID;
+
+typedef struct _PAGE_HOST* PPAGE_HOST;
+typedef LRESULT (*PFN_PAGE_PROC)(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+
+typedef struct _PAGE
+{
+    PAGE_ID Id;
+    LPCWSTR Title;
+    PFN_PAGE_PROC PageProc;
+} PAGE, *PPAGE;
+
+typedef struct _PAGE_HOST
+{
+    HWND Wnd;
+    HWND WndParent;
+    PPAGE PageData;
+    PVOID UserData;
+} PAGE_HOST, *PPAGE_HOST;
+
+typedef struct _NAVIGATOR
+{
+    HWND WndParent;
+    RECT ClientRect;
+    HWND WndNavigationList;
+    UINT CurrentPage;
+    UINT PageCount;
+    PPAGE_HOST Pages[PAGE_MAX];
+} NAVIGATOR, *PNAVIGATOR;
+
+/* Helper function */
+static inline
+HWND
+CreateChild(
+    int Id,
+    LPCTSTR ClassName,
+    LPCTSTR Text,
+    DWORD Style,
+    int x,
+    int y,
+    int cx,
+    int cy,
+    HWND Parent)
+{
+    return CreateWindowEx(
+        0,
+        ClassName,
+        Text,
+        WS_CHILD | WS_VISIBLE | Style,
+        x, y, cx, cy,
+        Parent,
+        (HMENU)(INT_PTR)Id,
+        GetModuleHandle(NULL),
+        NULL);
+}
+
+/* navigation */
+#define IDC_NAVIGATION_LIST 1000
+#define IDC_NAVIGATION_PAGE_HOST 1001
+
+PNAVIGATOR CreateNavigationHost(HINSTANCE hInst, HWND Parent, PPAGE Pages, UINT PageCount);
+void NavigateTo(PNAVIGATOR Nav, PAGE_ID Id);
+void UpdateSize(PNAVIGATOR Nav);
+void DestroyNavigationHost(PNAVIGATOR Nav);
+
+PPAGE_HOST CreatePageHost(HINSTANCE hInst, HWND Parent, int x, int y, int cx, int cy, PPAGE PageData);
+LRESULT CallPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+void ShowPage(PPAGE_HOST PageHost);
+void HidePage(PPAGE_HOST PageHost);
+void DestroyPageHost(PPAGE_HOST PageHost);
+
+/* pages */
+LRESULT ButtonPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT EditPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT ComboPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT IconTitlePageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT ListBoxPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT MdiPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT ScrollBarPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT StaticPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+
+#define IDC_STATIC -1

--- a/modules/rostests/win32/user32/controls/controls.h
+++ b/modules/rostests/win32/user32/controls/controls.h
@@ -1,0 +1,107 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#pragma once
+
+#define OEMRESOURCE
+#include <windows.h>
+
+typedef enum _PAGES
+{
+    PAGE_BUTTONS,
+    PAGE_COMBO,
+    PAGE_EDIT,
+    PAGE_ICONTITLE,
+    PAGE_LISTBOX,
+    PAGE_MDI,
+    PAGE_SCROLLBAR,
+    PAGE_STATIC,
+    PAGE_MAX
+} PAGE_ID;
+
+typedef struct _PAGE_HOST* PPAGE_HOST;
+typedef LRESULT (*PFN_PAGE_PROC)(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+
+typedef struct _PAGE
+{
+    PAGE_ID Id;
+    LPCWSTR Title;
+    PFN_PAGE_PROC PageProc;
+} PAGE, *PPAGE;
+
+typedef struct _PAGE_HOST
+{
+    HWND Wnd;
+    HWND WndParent;
+    PPAGE PageData;
+    PVOID UserData;
+} PAGE_HOST, *PPAGE_HOST;
+
+typedef struct _NAVIGATOR
+{
+    HWND WndParent;
+    RECT ClientRect;
+    HWND WndNavigationList;
+    UINT CurrentPage;
+    UINT PageCount;
+    PPAGE_HOST Pages[PAGE_MAX];
+} NAVIGATOR, *PNAVIGATOR;
+
+/* Helper function */
+static inline
+HWND
+CreateChild(
+    int Id,
+    LPCTSTR ClassName,
+    LPCTSTR Text,
+    DWORD Style,
+    int x,
+    int y,
+    int cx,
+    int cy,
+    HWND Parent)
+{
+    return CreateWindowEx(
+        0,
+        ClassName,
+        Text,
+        WS_CHILD | WS_VISIBLE | Style,
+        x, y, cx, cy,
+        Parent,
+        (HMENU)(INT_PTR)Id,
+        GetModuleHandle(NULL),
+        NULL);
+}
+
+/* navigation */
+#define IDC_NAVIGATION_LIST 1000
+#define IDC_NAVIGATION_PAGE_HOST 1001
+
+PNAVIGATOR CreateNavigationHost(HINSTANCE hInst, HWND Parent, PPAGE Pages, UINT PageCount);
+void NavigateTo(PNAVIGATOR Nav, PAGE_ID Id);
+void UpdateSize(PNAVIGATOR Nav);
+void DestroyNavigationHost(PNAVIGATOR Nav);
+
+PPAGE_HOST CreatePageHost(HINSTANCE hInst, HWND Parent, int x, int y, int cx, int cy, PPAGE PageData);
+LRESULT CallPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+void ShowPage(PPAGE_HOST PageHost);
+void HidePage(PPAGE_HOST PageHost);
+void DestroyPageHost(PPAGE_HOST PageHost);
+
+/* pages */
+LRESULT ButtonPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT EditPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT ComboPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT IconTitlePageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT ListBoxPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT MdiPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT ScrollBarPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT StaticPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam);
+
+#ifndef IDC_STATIC
+#define IDC_STATIC (-1)
+#endif

--- a/modules/rostests/win32/user32/controls/main.c
+++ b/modules/rostests/win32/user32/controls/main.c
@@ -1,0 +1,112 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "controls.h"
+
+static PAGE g_Pages[] =
+{
+    { PAGE_BUTTONS,     L"Buttons",         ButtonPageProc },
+    { PAGE_COMBO,       L"Combo Boxes",     ComboPageProc },
+    { PAGE_EDIT,        L"Edit Controls",   EditPageProc },
+    { PAGE_ICONTITLE,   L"Icon Title",      IconTitlePageProc },
+    { PAGE_LISTBOX,     L"List Boxes",      ListBoxPageProc },
+    { PAGE_MDI,         L"MDI",             MdiPageProc },
+    { PAGE_SCROLLBAR,   L"Scroll Bars",     ScrollBarPageProc },
+    { PAGE_STATIC,      L"Static",          StaticPageProc },
+};
+
+static
+LRESULT CALLBACK
+WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg)
+    {
+        case WM_CREATE:
+        {
+            HINSTANCE hInst = ((LPCREATESTRUCT)lParam)->hInstance;
+            PNAVIGATOR Navigator = CreateNavigationHost(hInst, hwnd, g_Pages, _countof(g_Pages));
+            if (Navigator == NULL)
+            {
+                PostQuitMessage(-1);
+                return -1;
+            }
+            SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)Navigator);
+            break;
+        }
+
+        case WM_COMMAND:
+        {
+            PNAVIGATOR Navigator = (PNAVIGATOR)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+            if (LOWORD(wParam) == IDC_NAVIGATION_LIST && HIWORD(wParam) == LBN_SELCHANGE)
+            {
+                int Sel = SendMessageW(Navigator->WndNavigationList, LB_GETCURSEL, 0, 0);
+                if (Sel != LB_ERR)
+                {
+                    NavigateTo(Navigator, (PAGE_ID)Sel);
+                }
+            }
+            break;
+        }
+
+        case WM_SIZE:
+        {
+            PNAVIGATOR Navigator = (PNAVIGATOR)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+            UpdateSize(Navigator);
+            break;
+        }
+
+        case WM_DESTROY:
+        {
+            PNAVIGATOR Navigator = (PNAVIGATOR)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+            DestroyNavigationHost(Navigator);
+            PostQuitMessage(0);
+            break;
+        }
+    }
+
+    return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+
+INT
+WINAPI
+wWinMain(HINSTANCE hInst,
+         HINSTANCE hPrev,
+         LPWSTR Cmd,
+         int iCmd)
+{
+    WNDCLASS wc = {0};
+    HWND hwnd;
+    MSG msg;
+
+    wc.lpfnWndProc = WndProc;
+    wc.hInstance = hInst;
+    wc.lpszClassName = L"User32Gallery";
+    RegisterClass(&wc);
+
+    hwnd = CreateWindowEx(
+        0,
+        wc.lpszClassName,
+        L"USER32 Control Gallery",
+        WS_OVERLAPPEDWINDOW,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        640,
+        400,
+        NULL,
+        NULL,
+        hInst,
+        NULL);
+    ShowWindow(hwnd, iCmd);
+
+    while (GetMessage(&msg, NULL, 0, 0))
+    {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+
+    return 0;
+}

--- a/modules/rostests/win32/user32/controls/navhost.c
+++ b/modules/rostests/win32/user32/controls/navhost.c
@@ -1,0 +1,104 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "controls.h"
+
+PNAVIGATOR CreateNavigationHost(HINSTANCE hInst, HWND Parent, PPAGE Pages, UINT PageCount)
+{
+    PPAGE Page;
+    PPAGE_HOST PageHost;
+    PNAVIGATOR Nav;
+    int x, y, cx, cy;
+
+    if (PageCount > PAGE_MAX) return NULL;
+
+    Nav = (PNAVIGATOR)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(NAVIGATOR));
+    if (!Nav) return NULL;
+
+    Nav->WndParent = Parent;
+    GetClientRect(Parent, &Nav->ClientRect);
+
+    x = Nav->ClientRect.left;
+    y = Nav->ClientRect.top;
+    cx = 140;
+    cy = Nav->ClientRect.bottom - Nav->ClientRect.top;
+    Nav->WndNavigationList = CreateChild(IDC_NAVIGATION_LIST,
+                                         L"LISTBOX", NULL, LBS_NOTIFY,
+                                         x, y, cx, cy,
+                                         Parent);
+
+    Nav->PageCount = PageCount;
+    x += cx;
+    cx = Nav->ClientRect.right - Nav->ClientRect.left - cx;
+    for (UINT i = 0; i < PageCount; i++)
+    {
+        Page = &Pages[i];
+        SendMessageW(Nav->WndNavigationList, LB_ADDSTRING, 0, (LPARAM)Page->Title);
+        PageHost = CreatePageHost(hInst, Nav->WndParent,
+                                  x, y, cx, cy,
+                                  Page);
+        if (!PageHost)
+        {
+            for (UINT j = 0; j < i; j++)
+                DestroyPageHost(Nav->Pages[j]);
+            DestroyWindow(Nav->WndNavigationList);
+            HeapFree(GetProcessHeap(), 0, Nav);
+            return NULL;
+        }
+        Nav->Pages[i] = PageHost;
+    }
+
+    SendMessageW(Nav->WndNavigationList, LB_SETCURSEL, 0, 0);
+    Nav->CurrentPage = 0;
+    ShowPage(Nav->Pages[0]);
+
+    return Nav;
+}
+
+void NavigateTo(PNAVIGATOR Nav, PAGE_ID Id)
+{
+    HidePage(Nav->Pages[Nav->CurrentPage]);
+    ShowPage(Nav->Pages[Id]);
+    Nav->CurrentPage = Id;
+}
+
+void UpdateSize(PNAVIGATOR Nav)
+{
+    int x, y, cx, cy;
+
+    GetClientRect(Nav->WndParent, &Nav->ClientRect);
+
+    x = Nav->ClientRect.left;
+    y = Nav->ClientRect.top;
+    cx = 140;
+    cy = Nav->ClientRect.bottom - y;
+    SetWindowPos(Nav->WndNavigationList, NULL, x, y, cx, cy, SWP_NOZORDER);
+
+    x += cx;
+    cx = Nav->ClientRect.right - x;
+    for (UINT i = 0; i < Nav->PageCount; i++)
+    {
+        if (Nav->Pages[i])
+            SetWindowPos(Nav->Pages[i]->Wnd, NULL, x, y, cx, cy, SWP_NOZORDER);
+    }
+}
+
+void DestroyNavigationHost(PNAVIGATOR Nav)
+{
+    if (!Nav) return;
+
+    for (UINT i = 0; i < Nav->PageCount; i++)
+    {
+        if (Nav->Pages[i])
+        {
+            DestroyPageHost(Nav->Pages[i]);
+        }
+    }
+
+    DestroyWindow(Nav->WndNavigationList);
+    HeapFree(GetProcessHeap(), 0, Nav);
+}

--- a/modules/rostests/win32/user32/controls/pagehost.c
+++ b/modules/rostests/win32/user32/controls/pagehost.c
@@ -1,0 +1,105 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "controls.h"
+
+static ATOM g_Atom = 0;
+
+static
+LRESULT CALLBACK
+WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    LRESULT Result;
+    PPAGE_HOST PageHost;
+    if (msg == WM_CREATE)
+    {
+        PageHost = (PPAGE_HOST)((LPCREATESTRUCT)lParam)->lpCreateParams;
+        PageHost->Wnd = hwnd;
+        SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)PageHost);
+    }
+    else
+    {
+        PageHost = (PPAGE_HOST)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+    }
+
+    if (PageHost)
+        Result = CallPageProc(PageHost, msg, wParam, lParam);
+    if (Result == FALSE)
+        Result = DefWindowProc(hwnd, msg, wParam, lParam);
+    return Result;
+}
+
+static inline
+ATOM
+RegisterPageHost(HINSTANCE hInst)
+{
+    if (g_Atom)
+        return g_Atom;
+    WNDCLASSW wc = {0};
+    wc.lpfnWndProc = (WNDPROC)WndProc;
+    wc.hInstance = hInst;
+    wc.lpszClassName = L"PageHost";
+    wc.hbrBackground = GetSysColorBrush(COLOR_3DFACE);
+    wc.hCursor = LoadCursorW(NULL, IDC_ARROW);
+    g_Atom = RegisterClassW(&wc);
+    return g_Atom;
+}
+
+PPAGE_HOST
+CreatePageHost(HINSTANCE hInst,
+               HWND Parent,
+               int x, int y, int cx, int cy,
+               PPAGE PageData)
+{
+    PPAGE_HOST PageHost;
+
+    if (!RegisterPageHost(hInst)) return NULL;
+
+    PageHost = (PPAGE_HOST)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(PAGE_HOST));
+    if (!PageHost) return NULL;
+
+    PageHost->WndParent = Parent;
+    PageHost->PageData = PageData;
+    PageHost->Wnd = CreateWindowExW(0, L"PageHost", NULL, WS_CHILD,
+                                    x, y, cx, cy,
+                                    Parent, NULL, hInst, PageHost);
+    if (!PageHost->Wnd)
+    {
+        HeapFree(GetProcessHeap(), 0, PageHost);
+        return NULL;
+    }
+
+    return PageHost;
+}
+
+LRESULT
+CallPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    if (!PageHost || !PageHost->PageData || !PageHost->PageData->PageProc)
+        return FALSE;
+    return PageHost->PageData->PageProc(PageHost, msg, wParam, lParam);
+}
+
+void
+ShowPage(PPAGE_HOST PageHost)
+{
+    ShowWindow(PageHost->Wnd, SW_SHOW);
+}
+
+void
+HidePage(PPAGE_HOST PageHost)
+{
+    ShowWindow(PageHost->Wnd, SW_HIDE);
+}
+
+void
+DestroyPageHost(PPAGE_HOST PageHost)
+{
+    if (!PageHost) return;
+    DestroyWindow(PageHost->Wnd);
+    HeapFree(GetProcessHeap(), 0, PageHost);
+}

--- a/modules/rostests/win32/user32/controls/pagehost.c
+++ b/modules/rostests/win32/user32/controls/pagehost.c
@@ -1,0 +1,107 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "controls.h"
+
+static ATOM g_Atom = 0;
+
+static
+LRESULT CALLBACK
+WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    LRESULT Result = FALSE;
+    PPAGE_HOST PageHost;
+    if (msg == WM_CREATE)
+    {
+        PageHost = (PPAGE_HOST)((LPCREATESTRUCT)lParam)->lpCreateParams;
+        if (PageHost == NULL)
+            return FALSE;
+        PageHost->Wnd = hwnd;
+        SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)PageHost);
+    }
+    else
+    {
+        PageHost = (PPAGE_HOST)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+    }
+
+    if (PageHost)
+        Result = CallPageProc(PageHost, msg, wParam, lParam);
+    if (Result == FALSE)
+        Result = DefWindowProc(hwnd, msg, wParam, lParam);
+    return Result;
+}
+
+static inline
+ATOM
+RegisterPageHost(HINSTANCE hInst)
+{
+    if (g_Atom)
+        return g_Atom;
+    WNDCLASSW wc = {0};
+    wc.lpfnWndProc = (WNDPROC)WndProc;
+    wc.hInstance = hInst;
+    wc.lpszClassName = L"PageHost";
+    wc.hbrBackground = GetSysColorBrush(COLOR_3DFACE);
+    wc.hCursor = LoadCursorW(NULL, IDC_ARROW);
+    g_Atom = RegisterClassW(&wc);
+    return g_Atom;
+}
+
+PPAGE_HOST
+CreatePageHost(HINSTANCE hInst,
+               HWND Parent,
+               int x, int y, int cx, int cy,
+               PPAGE PageData)
+{
+    PPAGE_HOST PageHost;
+
+    if (!RegisterPageHost(hInst)) return NULL;
+
+    PageHost = (PPAGE_HOST)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(PAGE_HOST));
+    if (!PageHost) return NULL;
+
+    PageHost->WndParent = Parent;
+    PageHost->PageData = PageData;
+    PageHost->Wnd = CreateWindowExW(0, L"PageHost", NULL, WS_CHILD,
+                                    x, y, cx, cy,
+                                    Parent, NULL, hInst, PageHost);
+    if (!PageHost->Wnd)
+    {
+        HeapFree(GetProcessHeap(), 0, PageHost);
+        return NULL;
+    }
+
+    return PageHost;
+}
+
+LRESULT
+CallPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    if (!PageHost || !PageHost->PageData || !PageHost->PageData->PageProc)
+        return FALSE;
+    return PageHost->PageData->PageProc(PageHost, msg, wParam, lParam);
+}
+
+void
+ShowPage(PPAGE_HOST PageHost)
+{
+    ShowWindow(PageHost->Wnd, SW_SHOW);
+}
+
+void
+HidePage(PPAGE_HOST PageHost)
+{
+    ShowWindow(PageHost->Wnd, SW_HIDE);
+}
+
+void
+DestroyPageHost(PPAGE_HOST PageHost)
+{
+    if (!PageHost) return;
+    DestroyWindow(PageHost->Wnd);
+    HeapFree(GetProcessHeap(), 0, PageHost);
+}

--- a/modules/rostests/win32/user32/controls/pages/button.c
+++ b/modules/rostests/win32/user32/controls/pages/button.c
@@ -1,0 +1,26 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "../controls.h"
+
+/*
+ * +----------------------------------------+
+ * | [  Normal  ]          O Radiobutton 1  |
+ * | [  Default ]          O Radiobutton 2  |
+ * | [ Disabled ]          O Radiobutton 3  |
+ * |                                        |
+ * | [ ] Checkbox         [ Image Button ]  |
+ * | [x] Auto Checkbox    [ Icon Button  ]  |
+ * | [o] Three-state                        |
+ * +----------------------------------------+
+ */
+
+LRESULT
+ButtonPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    return FALSE;
+}

--- a/modules/rostests/win32/user32/controls/pages/button.c
+++ b/modules/rostests/win32/user32/controls/pages/button.c
@@ -7,20 +7,221 @@
 
 #include "../controls.h"
 
-/*
- * +----------------------------------------+
- * | [  Normal  ]          O Radiobutton 1  |
- * | [  Default ]          O Radiobutton 2  |
- * | [ Disabled ]          O Radiobutton 3  |
- * |                                        |
- * | [ ] Checkbox         [ Image Button ]  |
- * | [x] Auto Checkbox    [ Icon Button  ]  |
- * | [o] Three-state                        |
- * +----------------------------------------+
- */
+#define IDC_NORMAL_BUTTON 2001
+#define IDC_DEFAULT_BUTTON 2002
+#define IDC_DISABLED_BUTTON 2003
+
+#define IDC_CHECKBOX 2004
+#define IDC_AUTOCHECKBOX 2005
+#define IDC_THREESTATE_CHECKBOX 2006
+
+#define IDC_RADIOBUTTON1 2007
+#define IDC_RADIOBUTTON2 2008
+#define IDC_RADIOBUTTON3 2009
+
+#define IDC_IMAGE_BUTTON 2010
+#define IDC_ICON_BUTTON 2011
+
+typedef struct _BUTTON_PAGE_DATA
+{
+    HWND hNormalButton;
+    HWND hDefaultButton;
+    HWND hDisabledButton;
+
+    HWND hCheckbox;
+    HWND hAutoCheckbox;
+    HWND hThreeStateCheckbox;
+
+    HWND hRadioButton1;
+    HWND hRadioButton2;
+    HWND hRadioButton3;
+
+    HWND hImageButton;
+    HBITMAP hImage;
+
+    HWND hIconButton;
+    HICON hIcon;
+} BUTTON_PAGE_DATA, *PBUTTON_PAGE_DATA;
+
+static LRESULT
+InitPage(HWND Parent, PBUTTON_PAGE_DATA PageData)
+{
+    /* Buttons */
+    PageData->hNormalButton =
+        CreateChild(IDC_NORMAL_BUTTON, L"BUTTON", L"Normal", BS_PUSHBUTTON,
+                    20, 20, 100, 30,
+                    Parent);
+    PageData->hDefaultButton =
+        CreateChild(IDC_DEFAULT_BUTTON, L"BUTTON", L"Default", BS_DEFPUSHBUTTON,
+                    20, 60, 100, 30,
+                    Parent);
+    PageData->hDisabledButton =
+        CreateChild(IDC_DISABLED_BUTTON, L"BUTTON", L"Disabled",
+                    BS_PUSHBUTTON | WS_DISABLED,
+                    20, 100, 100, 30,
+                    Parent);
+
+    /* Image button */
+    PageData->hImageButton =
+        CreateChild(IDC_IMAGE_BUTTON, L"BUTTON", L"Image Button", BS_BITMAP,
+                    20, 140, 45, 45,
+                    Parent);
+    PageData->hImage = LoadBitmapW(NULL, MAKEINTRESOURCEW(OBM_TRTYPE));
+    SendMessage(PageData->hImageButton, BM_SETIMAGE, IMAGE_BITMAP, (LPARAM)PageData->hImage);
+
+    /* Icon button */
+    PageData->hIconButton =
+        CreateChild(IDC_ICON_BUTTON,
+                    L"BUTTON", L"Icon Button", BS_ICON,
+                    75, 140, 45, 45,
+                    Parent);
+    PageData->hIcon = LoadIconW(NULL, MAKEINTRESOURCEW(OIC_WINLOGO));
+    SendMessage(PageData->hIconButton, BM_SETIMAGE, IMAGE_ICON, (LPARAM)PageData->hIcon);
+
+    /* Groupbox */
+    CreateChild(0, L"BUTTON", L"GroupBox Demo", BS_GROUPBOX,
+                20, 200, 200, 150,
+                Parent);
+
+    /* Checkboxes */
+    PageData->hCheckbox =
+        CreateChild(IDC_CHECKBOX, L"BUTTON", L"Checkbox", BS_CHECKBOX,
+                    150, 20, 140, 30,
+                    Parent);
+    PageData->hAutoCheckbox =
+        CreateChild(IDC_AUTOCHECKBOX, L"BUTTON", L"Auto Checkbox", BS_AUTOCHECKBOX,
+                    150, 60, 140, 30,
+                    Parent);
+    PageData->hThreeStateCheckbox =
+        CreateChild(IDC_THREESTATE_CHECKBOX, L"BUTTON", L"Three-state", BS_AUTO3STATE,
+                    150, 100, 140, 30,
+                    Parent);
+
+    /* Radio buttons */
+    PageData->hRadioButton1 =
+        CreateChild(IDC_RADIOBUTTON1, L"BUTTON", L"Radiobutton 1", BS_RADIOBUTTON,
+                    300, 20, 140, 30,
+                    Parent);
+    PageData->hRadioButton2 =
+        CreateChild(IDC_RADIOBUTTON2, L"BUTTON", L"Radiobutton 2", BS_RADIOBUTTON,
+                    300, 60, 140, 30,
+                    Parent);
+    PageData->hRadioButton3 =
+        CreateChild(IDC_RADIOBUTTON3, L"BUTTON", L"Radiobutton 3", BS_RADIOBUTTON,
+                    300, 100, 140, 30,
+                    Parent);
+
+    return TRUE;
+}
+
+static
+LRESULT
+OnCommand(PPAGE_HOST PageHost, PBUTTON_PAGE_DATA PageData, int Id)
+{
+    switch (Id)
+    {
+        case IDC_NORMAL_BUTTON:
+            SetWindowText(PageData->hNormalButton, L"Clicked!");
+            return TRUE;
+
+        case IDC_DEFAULT_BUTTON:
+            SetWindowText(PageData->hDefaultButton, L"Clicked!");
+            return TRUE;
+
+        case IDC_DISABLED_BUTTON:
+            SetWindowText(PageData->hDisabledButton, L"Clicked!");
+            return TRUE;
+
+        case IDC_CHECKBOX:
+            SetWindowText(PageData->hCheckbox, L"Clicked!");
+            return TRUE;
+
+        case IDC_RADIOBUTTON1:
+        case IDC_RADIOBUTTON2:
+        case IDC_RADIOBUTTON3:
+            CheckRadioButton(PageHost->Wnd, IDC_RADIOBUTTON1, IDC_RADIOBUTTON3, Id);
+            return TRUE;
+
+        default:
+            return FALSE;
+    }
+}
+
+static VOID
+OnSize(PBUTTON_PAGE_DATA PageData, int cx, int cy)
+{
+    HDWP hdwp;
+    int margin_x = 20;
+    int margin_y = 20;
+    int gap = 15;
+    int col_width;
+    int col1_x, col2_x, col3_x;
+    int btn_h = 28;
+
+    if (!PageData || !PageData->hNormalButton)
+        return;
+
+    /* Calculate proportional column widths */
+    col_width = (cx - (margin_x * 2) - (gap * 2)) / 3;
+    if (col_width < 90) col_width = 90;
+
+    col1_x = margin_x;
+    col2_x = col1_x + col_width + gap;
+    col3_x = col2_x + col_width + gap;
+
+    /* Defer window positions for all 12 controls */
+    hdwp = BeginDeferWindowPos(12);
+
+#define MOVE_CTRL(hwnd, x, y, w, h) \
+    if (hwnd) hdwp = DeferWindowPos(hdwp, hwnd, NULL, x, y, w, h, SWP_NOZORDER)
+
+    /* Column 1: Push Buttons */
+    MOVE_CTRL(PageData->hNormalButton,   col1_x, margin_y,                        col_width, btn_h);
+    MOVE_CTRL(PageData->hDefaultButton,  col1_x, margin_y + btn_h + gap,          col_width, btn_h);
+    MOVE_CTRL(PageData->hDisabledButton, col1_x, margin_y + (btn_h * 2) + (gap * 2), col_width, btn_h);
+
+    /* Column 2: Checkboxes */
+    MOVE_CTRL(PageData->hCheckbox,           col2_x, margin_y,                        col_width, btn_h);
+    MOVE_CTRL(PageData->hAutoCheckbox,       col2_x, margin_y + btn_h + gap,          col_width, btn_h);
+    MOVE_CTRL(PageData->hThreeStateCheckbox, col2_x, margin_y + (btn_h * 2) + (gap * 2), col_width, btn_h);
+
+    /* Column 3: Radio Buttons */
+    MOVE_CTRL(PageData->hRadioButton1, col3_x, margin_y,                        col_width, btn_h);
+    MOVE_CTRL(PageData->hRadioButton2, col3_x, margin_y + btn_h + gap,          col_width, btn_h);
+    MOVE_CTRL(PageData->hRadioButton3, col3_x, margin_y + (btn_h * 2) + (gap * 2), col_width, btn_h);
+
+#undef MOVE_CTRL
+
+    EndDeferWindowPos(hdwp);
+}
 
 LRESULT
 ButtonPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    return FALSE;
+    PBUTTON_PAGE_DATA PageData;
+    if (msg == WM_CREATE)
+    {
+        PageData = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(BUTTON_PAGE_DATA));
+        PageHost->UserData = PageData;
+        return InitPage(PageHost->Wnd, PageData);
+    }
+    else
+    {
+        PageData = (PBUTTON_PAGE_DATA)PageHost->UserData;
+    }
+
+    switch (msg)
+    {
+        case WM_COMMAND:
+            if (LOWORD(wParam) < IDC_NORMAL_BUTTON || LOWORD(wParam) > IDC_ICON_BUTTON)
+                return FALSE;
+            return OnCommand(PageHost, PageData, LOWORD(wParam));
+
+        case WM_SIZE:
+            OnSize(PageData, LOWORD(lParam), HIWORD(lParam));
+            return TRUE;
+
+        default:
+            return FALSE;
+    }
 }

--- a/modules/rostests/win32/user32/controls/pages/combo.c
+++ b/modules/rostests/win32/user32/controls/pages/combo.c
@@ -1,0 +1,35 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "../controls.h"
+
+/*
+ * +------------------------------------------------+
+ * | Drop Down Combo                               |
+ * | +--------------------------+v                 |
+ * | | Apple                    |                  |
+ * | +--------------------------+                  |
+ * |                                               |
+ * | Drop Down List                                |
+ * | +--------------------------+v                 |
+ * | | Banana                   |                  |
+ * | +--------------------------+                  |
+ * |                                               |
+ * | Simple Combo                                  |
+ * | +--------------------------+                  |
+ * | | Item 1                   |                  |
+ * | | Item 2                   |                  |
+ * | | Item 3                   |                  |
+ * | +--------------------------+                  |
+ * +------------------------------------------------+
+ */
+
+LRESULT
+ComboPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    return FALSE;
+}

--- a/modules/rostests/win32/user32/controls/pages/combo.c
+++ b/modules/rostests/win32/user32/controls/pages/combo.c
@@ -7,29 +7,305 @@
 
 #include "../controls.h"
 
-/*
- * +------------------------------------------------+
- * | Drop Down Combo                               |
- * | +--------------------------+v                 |
- * | | Apple                    |                  |
- * | +--------------------------+                  |
- * |                                               |
- * | Drop Down List                                |
- * | +--------------------------+v                 |
- * | | Banana                   |                  |
- * | +--------------------------+                  |
- * |                                               |
- * | Simple Combo                                  |
- * | +--------------------------+                  |
- * | | Item 1                   |                  |
- * | | Item 2                   |                  |
- * | | Item 3                   |                  |
- * | +--------------------------+                  |
- * +------------------------------------------------+
- */
+#define IDC_SIMPLE_COMBO        3001
+#define IDC_SORTED_COMBO        3002
+#define IDC_DROPDOWN_COMBO      3003
+#define IDC_DROPDOWNLIST_COMBO  3004
+#define IDC_DISABLED_COMBO      3005
+#define IDC_EXTENDEDUI_COMBO    3006
+#define IDC_AUTOHSCROLL_COMBO   3007
+#define IDC_UPPERCASE_COMBO     3008
+#define IDC_LOWERCASE_COMBO     3009
+#define IDC_NOINTEGRAL_COMBO    3010
+
+typedef struct _COMBOBOX_PAGE_DATA
+{
+    HWND hLblSimple;
+    HWND hSimpleCombo;
+    HWND hLblSorted;
+    HWND hSortedCombo;
+
+    HWND hLblDropdown;
+    HWND hDropdownCombo;
+    HWND hLblDropdownList;
+    HWND hDropdownListCombo;
+    HWND hLblDisabled;
+    HWND hDisabledCombo;
+    HWND hLblExtendedUI;
+    HWND hExtendedUICombo;
+
+    HWND hLblAutoHScroll;
+    HWND hAutoHScrollCombo;
+    HWND hLblUppercase;
+    HWND hUppercaseCombo;
+    HWND hLblLowercase;
+    HWND hLowercaseCombo;
+    HWND hLblNoIntegral;
+    HWND hNoIntegralCombo;
+} COMBOBOX_PAGE_DATA, *PCOMBOBOX_PAGE_DATA;
+
+static PCWSTR ComboItems[] = {
+    L"Cherry",
+    L"Date",
+    L"Grape",
+    L"Apple",
+    L"Banana",
+    L"Fig",
+    L"Elderberry",
+};
+
+static VOID
+PopulateComboBox(HWND hCombo, BOOL bSelectFirst)
+{
+    /* CBS_UPPERCASE and CBS_LOWERCASE require a writable buffer */
+    WCHAR ItemBuffer[20];
+
+    for (int i = 0; i < _countof(ComboItems); i++)
+    {
+        wcscpy(ItemBuffer, ComboItems[i]);
+        SendMessageW(hCombo, CB_ADDSTRING, 0, (LPARAM)ItemBuffer);
+    }
+
+    if (bSelectFirst)
+        SendMessageW(hCombo, CB_SETCURSEL, 0, 0);
+}
+
+static LRESULT
+InitPage(HWND Parent, PCOMBOBOX_PAGE_DATA PageData)
+{
+    PageData->hLblSimple =
+        CreateChild(IDC_STATIC, L"STATIC", L"Simple Combo:", SS_LEFT, 20, 10, 140, 15, Parent);
+    PageData->hSimpleCombo =
+        CreateChild(IDC_SIMPLE_COMBO, L"COMBOBOX", L"Simple Combo",
+                    CBS_SIMPLE | WS_VSCROLL,
+                    20, 30, 140, 320,
+                    Parent);
+    PopulateComboBox(PageData->hSimpleCombo, TRUE);
+
+    PageData->hLblDropdown =
+        CreateChild(IDC_STATIC, L"STATIC", L"Dropdown:", SS_LEFT, 180, 10, 140, 15, Parent);
+    PageData->hDropdownCombo =
+        CreateChild(IDC_DROPDOWN_COMBO, L"COMBOBOX", L"Editable Text",
+                    CBS_DROPDOWN | WS_VSCROLL,
+                    180, 30, 140, 140,
+                    Parent);
+    PopulateComboBox(PageData->hDropdownCombo, FALSE);
+
+    PageData->hLblDropdownList =
+        CreateChild(IDC_STATIC, L"STATIC", L"Dropdown List:", SS_LEFT, 180, 60, 140, 15, Parent);
+    PageData->hDropdownListCombo =
+        CreateChild(IDC_DROPDOWNLIST_COMBO, L"COMBOBOX", L"",
+                    CBS_DROPDOWNLIST | WS_VSCROLL,
+                    180, 80, 140, 140,
+                    Parent);
+    PopulateComboBox(PageData->hDropdownListCombo, TRUE);
+
+    PageData->hLblDisabled =
+        CreateChild(IDC_STATIC, L"STATIC", L"Disabled:", SS_LEFT, 180, 110, 140, 15, Parent);
+    PageData->hDisabledCombo =
+        CreateChild(IDC_DISABLED_COMBO, L"COMBOBOX", L"",
+                    CBS_DROPDOWNLIST | WS_DISABLED,
+                    180, 130, 140, 140,
+                    Parent);
+    PopulateComboBox(PageData->hDisabledCombo, TRUE);
+
+    PageData->hLblSorted =
+        CreateChild(IDC_STATIC, L"STATIC", L"Sorted List:", SS_LEFT, 180, 160, 140, 15, Parent);
+    PageData->hSortedCombo =
+        CreateChild(IDC_SORTED_COMBO, L"COMBOBOX", L"",
+                    CBS_DROPDOWNLIST | CBS_SORT | WS_VSCROLL,
+                    180, 180, 140, 140,
+                    Parent);
+    PopulateComboBox(PageData->hSortedCombo, TRUE);
+
+    PageData->hLblExtendedUI =
+        CreateChild(IDC_STATIC, L"STATIC", L"Extended UI:", SS_LEFT, 180, 210, 140, 15, Parent);
+    PageData->hExtendedUICombo =
+        CreateChild(IDC_EXTENDEDUI_COMBO, L"COMBOBOX", L"",
+                    CBS_DROPDOWNLIST | WS_VSCROLL,
+                    180, 230, 140, 140,
+                    Parent);
+    PopulateComboBox(PageData->hExtendedUICombo, TRUE);
+    SendMessageW(PageData->hExtendedUICombo, CB_SETEXTENDEDUI, TRUE, 0);
+
+    PageData->hLblAutoHScroll =
+        CreateChild(IDC_STATIC, L"STATIC", L"Auto H-Scroll:", SS_LEFT, 180, 260, 140, 15, Parent);
+    PageData->hAutoHScrollCombo =
+        CreateChild(IDC_AUTOHSCROLL_COMBO, L"COMBOBOX", L"Type a very long string here...",
+                    CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL,
+                    180, 280, 140, 140,
+                    Parent);
+    PopulateComboBox(PageData->hAutoHScrollCombo, FALSE);
+
+    PageData->hLblUppercase =
+        CreateChild(IDC_STATIC, L"STATIC", L"Uppercase:", SS_LEFT, 340, 10, 140, 15, Parent);
+    PageData->hUppercaseCombo =
+        CreateChild(IDC_UPPERCASE_COMBO, L"COMBOBOX", L"all caps",
+                    CBS_DROPDOWN | CBS_UPPERCASE | WS_VSCROLL,
+                    340, 30, 140, 140,
+                    Parent);
+    PopulateComboBox(PageData->hUppercaseCombo, FALSE);
+
+    PageData->hLblLowercase =
+        CreateChild(IDC_STATIC, L"STATIC", L"Lowercase:", SS_LEFT, 340, 60, 140, 15, Parent);
+    PageData->hLowercaseCombo =
+        CreateChild(IDC_LOWERCASE_COMBO, L"COMBOBOX", L"ALL LOWER",
+                    CBS_DROPDOWN | CBS_LOWERCASE | WS_VSCROLL,
+                    340, 80, 140, 140,
+                    Parent);
+    PopulateComboBox(PageData->hLowercaseCombo, FALSE);
+
+    PageData->hLblNoIntegral =
+        CreateChild(IDC_STATIC, L"STATIC", L"No Integral Height:", SS_LEFT, 340, 110, 140, 15, Parent);
+    PageData->hNoIntegralCombo =
+        CreateChild(IDC_NOINTEGRAL_COMBO, L"COMBOBOX", L"",
+                    CBS_DROPDOWNLIST | CBS_NOINTEGRALHEIGHT | WS_VSCROLL,
+                    340, 130, 140, 65, /* Intentional awkward height */
+                    Parent);
+    PopulateComboBox(PageData->hNoIntegralCombo, TRUE);
+
+    return TRUE;
+}
+
+static
+LRESULT
+OnCommand(PPAGE_HOST PageHost, PCOMBOBOX_PAGE_DATA PageData, int Id, int NotifyCode)
+{
+    switch (Id)
+    {
+        case IDC_SIMPLE_COMBO:
+        case IDC_SORTED_COMBO:
+        case IDC_DROPDOWN_COMBO:
+        case IDC_DROPDOWNLIST_COMBO:
+        case IDC_DISABLED_COMBO:
+        case IDC_EXTENDEDUI_COMBO:
+        case IDC_AUTOHSCROLL_COMBO:
+        case IDC_UPPERCASE_COMBO:
+        case IDC_LOWERCASE_COMBO:
+        case IDC_NOINTEGRAL_COMBO:
+            if (NotifyCode == CBN_SELCHANGE)
+            {
+                return TRUE;
+            }
+            else if (NotifyCode == CBN_EDITCHANGE)
+            {
+                return TRUE;
+            }
+            return FALSE;
+
+        default:
+            return FALSE;
+    }
+}
+
+static VOID
+OnSize(PCOMBOBOX_PAGE_DATA PageData, int cx, int cy)
+{
+    HDWP hdwp;
+    int margin_x = 20;
+    int margin_y = 15;
+    int gap = 15;
+    int label_h = 15;
+    int combo_drop_h = 140; /* Dropdown list height when popped open */
+    int col_width;
+    int col1_x, col2_x, col3_x;
+    int row_h = 42; /* Height per label + combobox row */
+    int simple_h;
+
+    if (!PageData || !PageData->hSimpleCombo)
+        return;
+
+    /* Calculate equal 3-column widths */
+    col_width = (cx - (margin_x * 2) - (gap * 2)) / 3;
+    if (col_width < 100) col_width = 100;
+
+    col1_x = margin_x;
+    col2_x = col1_x + col_width + gap;
+    col3_x = col2_x + col_width + gap;
+
+    /* Simple combo list stretches to fit available vertical space */
+    simple_h = cy - margin_y - label_h - 5 - margin_y;
+    if (simple_h < 120) simple_h = 120;
+
+    hdwp = BeginDeferWindowPos(20);
+
+#define MOVE_CTRL(hwnd, x, y, w, h) \
+    if (hwnd) hdwp = DeferWindowPos(hdwp, hwnd, NULL, x, y, w, h, SWP_NOZORDER)
+
+    /* --- COLUMN 1: Simple Combo (Expanded List) --- */
+    MOVE_CTRL(PageData->hLblSimple,   col1_x, margin_y, col_width, label_h);
+    MOVE_CTRL(PageData->hSimpleCombo, col1_x, margin_y + label_h + 3, col_width, simple_h);
+
+    /* --- COLUMN 2: Standard ComboBox Styles --- */
+    /* Row 1: Dropdown */
+    MOVE_CTRL(PageData->hLblDropdown,       col2_x, margin_y + (row_h * 0), col_width, label_h);
+    MOVE_CTRL(PageData->hDropdownCombo,     col2_x, margin_y + (row_h * 0) + label_h, col_width, combo_drop_h);
+
+    /* Row 2: Dropdown List */
+    MOVE_CTRL(PageData->hLblDropdownList,   col2_x, margin_y + (row_h * 1), col_width, label_h);
+    MOVE_CTRL(PageData->hDropdownListCombo, col2_x, margin_y + (row_h * 1) + label_h, col_width, combo_drop_h);
+
+    /* Row 3: Disabled */
+    MOVE_CTRL(PageData->hLblDisabled,       col2_x, margin_y + (row_h * 2), col_width, label_h);
+    MOVE_CTRL(PageData->hDisabledCombo,     col2_x, margin_y + (row_h * 2) + label_h, col_width, combo_drop_h);
+
+    /* Row 4: Sorted List */
+    MOVE_CTRL(PageData->hLblSorted,         col2_x, margin_y + (row_h * 3), col_width, label_h);
+    MOVE_CTRL(PageData->hSortedCombo,       col2_x, margin_y + (row_h * 3) + label_h, col_width, combo_drop_h);
+
+    /* Row 5: Extended UI */
+    MOVE_CTRL(PageData->hLblExtendedUI,     col2_x, margin_y + (row_h * 4), col_width, label_h);
+    MOVE_CTRL(PageData->hExtendedUICombo,   col2_x, margin_y + (row_h * 4) + label_h, col_width, combo_drop_h);
+
+    /* Row 6: Auto H-Scroll */
+    MOVE_CTRL(PageData->hLblAutoHScroll,    col2_x, margin_y + (row_h * 5), col_width, label_h);
+    MOVE_CTRL(PageData->hAutoHScrollCombo,  col2_x, margin_y + (row_h * 5) + label_h, col_width, combo_drop_h);
+
+    /* --- COLUMN 3: Formatting & Behavior --- */
+    /* Row 1: Uppercase */
+    MOVE_CTRL(PageData->hLblUppercase,      col3_x, margin_y + (row_h * 0), col_width, label_h);
+    MOVE_CTRL(PageData->hUppercaseCombo,    col3_x, margin_y + (row_h * 0) + label_h, col_width, combo_drop_h);
+
+    /* Row 2: Lowercase */
+    MOVE_CTRL(PageData->hLblLowercase,      col3_x, margin_y + (row_h * 1), col_width, label_h);
+    MOVE_CTRL(PageData->hLowercaseCombo,    col3_x, margin_y + (row_h * 1) + label_h, col_width, combo_drop_h);
+
+    /* Row 3: No Integral Height */
+    MOVE_CTRL(PageData->hLblNoIntegral,     col3_x, margin_y + (row_h * 2), col_width, label_h);
+    MOVE_CTRL(PageData->hNoIntegralCombo,   col3_x, margin_y + (row_h * 2) + label_h, col_width, 65);
+
+#undef MOVE_CTRL
+
+    EndDeferWindowPos(hdwp);
+}
 
 LRESULT
 ComboPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    return FALSE;
+    PCOMBOBOX_PAGE_DATA PageData;
+    if (msg == WM_CREATE)
+    {
+        PageData = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(COMBOBOX_PAGE_DATA));
+        PageHost->UserData = PageData;
+        return InitPage(PageHost->Wnd, PageData);
+    }
+    else
+    {
+        PageData = (PCOMBOBOX_PAGE_DATA)PageHost->UserData;
+    }
+
+    switch (msg)
+    {
+        case WM_COMMAND:
+            if (LOWORD(wParam) < IDC_SIMPLE_COMBO || LOWORD(wParam) > IDC_NOINTEGRAL_COMBO)
+                return FALSE;
+            return OnCommand(PageHost, PageData, LOWORD(wParam), HIWORD(wParam));
+
+        case WM_SIZE:
+            OnSize(PageData, LOWORD(lParam), HIWORD(lParam));
+            return TRUE;
+
+        default:
+            return FALSE;
+    }
 }

--- a/modules/rostests/win32/user32/controls/pages/edit.c
+++ b/modules/rostests/win32/user32/controls/pages/edit.c
@@ -1,0 +1,39 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "../controls.h"
+
+/*
+ * +------------------------------------------------+
+ * | Single Line Edit                               |
+ * | +--------------------------------------------+ |
+ * | | Hello world                                | |
+ * | +--------------------------------------------+ |
+ * |                                                |
+ * | Password Edit                                  |
+ * | +--------------------------------------------+ |
+ * | | ********                                   | |
+ * | +--------------------------------------------+ |
+ * |                                                |
+ * | Multiline Edit                                 |
+ * | +--------------------------------------------+ |
+ * | | Line 1                                     | |
+ * | | Line 2                                     | |
+ * | |                                            | |
+ * | +--------------------------------------------+ |
+ * |                                                |
+ * | +--------------------------------------------+ |
+ * | | Read-only Text                             | |
+ * | +--------------------------------------------+ |
+ * +------------------------------------------------+
+ */
+
+LRESULT
+EditPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    return FALSE;
+}

--- a/modules/rostests/win32/user32/controls/pages/edit.c
+++ b/modules/rostests/win32/user32/controls/pages/edit.c
@@ -7,33 +7,253 @@
 
 #include "../controls.h"
 
-/*
- * +------------------------------------------------+
- * | Single Line Edit                               |
- * | +--------------------------------------------+ |
- * | | Hello world                                | |
- * | +--------------------------------------------+ |
- * |                                                |
- * | Password Edit                                  |
- * | +--------------------------------------------+ |
- * | | ********                                   | |
- * | +--------------------------------------------+ |
- * |                                                |
- * | Multiline Edit                                 |
- * | +--------------------------------------------+ |
- * | | Line 1                                     | |
- * | | Line 2                                     | |
- * | |                                            | |
- * | +--------------------------------------------+ |
- * |                                                |
- * | +--------------------------------------------+ |
- * | | Read-only Text                             | |
- * | +--------------------------------------------+ |
- * +------------------------------------------------+
- */
+#define IDC_EDIT_LEFT           3001
+#define IDC_EDIT_CENTER         3002
+#define IDC_EDIT_RIGHT          3003
+#define IDC_EDIT_READONLY       3004
+#define IDC_EDIT_DISABLED       3005
+
+#define IDC_EDIT_PASSWORD       3006
+#define IDC_EDIT_NUMBER         3007
+#define IDC_EDIT_UPPERCASE      3008
+#define IDC_EDIT_LOWERCASE      3009
+#define IDC_EDIT_MAXTEXT        3010
+
+#define IDC_EDIT_MULTILINE      3011
+
+typedef struct _EDIT_PAGE_DATA
+{
+    HWND hLblLeft;
+    HWND hLeftEdit;
+    HWND hLblCenter;
+    HWND hCenterEdit;
+    HWND hLblRight;
+    HWND hRightEdit;
+    HWND hLblReadOnly;
+    HWND hReadOnlyEdit;
+    HWND hLblDisabled;
+    HWND hDisabledEdit;
+
+    HWND hLblPassword;
+    HWND hPasswordEdit;
+    HWND hLblNumber;
+    HWND hNumberEdit;
+    HWND hLblUppercase;
+    HWND hUppercaseEdit;
+    HWND hLblLowercase;
+    HWND hLowercaseEdit;
+    HWND hLblMaxText;
+    HWND hMaxTextEdit;
+
+    HWND hLblMultiline;
+    HWND hMultilineEdit;
+} EDIT_PAGE_DATA, *PEDIT_PAGE_DATA;
+
+static LRESULT
+InitPage(HWND Parent, PEDIT_PAGE_DATA PageData)
+{
+    PageData->hLblLeft =
+        CreateChild(IDC_STATIC, L"STATIC", L"Left Aligned:", SS_LEFT, 20, 15, 140, 15, Parent);
+    PageData->hLeftEdit =
+        CreateChild(IDC_EDIT_LEFT, L"EDIT", L"Left text",
+                    WS_BORDER | WS_TABSTOP | ES_LEFT | ES_AUTOHSCROLL,
+                    20, 35, 140, 25,
+                    Parent);
+
+    PageData->hLblCenter =
+        CreateChild(IDC_STATIC, L"STATIC", L"Center Aligned:", SS_LEFT, 20, 85, 140, 15, Parent);
+    PageData->hCenterEdit =
+        CreateChild(IDC_EDIT_CENTER, L"EDIT", L"Center text",
+                    WS_BORDER | WS_TABSTOP | ES_CENTER | ES_AUTOHSCROLL,
+                    20, 105, 140, 25,
+                    Parent);
+
+    PageData->hLblRight =
+        CreateChild(IDC_STATIC, L"STATIC", L"Right Aligned:", SS_LEFT, 20, 155, 140, 15, Parent);
+    PageData->hRightEdit =
+        CreateChild(IDC_EDIT_RIGHT, L"EDIT", L"Right text",
+                    WS_BORDER | WS_TABSTOP | ES_RIGHT | ES_AUTOHSCROLL,
+                    20, 175, 140, 25,
+                    Parent);
+
+    PageData->hLblReadOnly =
+        CreateChild(IDC_STATIC, L"STATIC", L"Read-Only:", SS_LEFT, 20, 225, 140, 15, Parent);
+    PageData->hReadOnlyEdit =
+        CreateChild(IDC_EDIT_READONLY, L"EDIT", L"Read-only text",
+                    WS_BORDER | WS_TABSTOP | ES_LEFT | ES_READONLY | ES_AUTOHSCROLL,
+                    20, 245, 140, 25,
+                    Parent);
+
+    PageData->hLblDisabled =
+        CreateChild(IDC_STATIC, L"STATIC", L"Disabled:", SS_LEFT, 20, 295, 140, 15, Parent);
+    PageData->hDisabledEdit =
+        CreateChild(IDC_EDIT_DISABLED, L"EDIT", L"Disabled text",
+                    WS_BORDER | WS_DISABLED | ES_LEFT | ES_AUTOHSCROLL,
+                    20, 315, 140, 25,
+                    Parent);
+
+    PageData->hLblPassword =
+        CreateChild(IDC_STATIC, L"STATIC", L"Password:", SS_LEFT, 180, 15, 140, 15, Parent);
+    PageData->hPasswordEdit =
+        CreateChild(IDC_EDIT_PASSWORD, L"EDIT", L"Secret123",
+                    WS_BORDER | WS_TABSTOP | ES_LEFT | ES_PASSWORD | ES_AUTOHSCROLL,
+                    180, 35, 140, 25,
+                    Parent);
+
+    PageData->hLblNumber =
+        CreateChild(IDC_STATIC, L"STATIC", L"Number Only:", SS_LEFT, 180, 85, 140, 15, Parent);
+    PageData->hNumberEdit =
+        CreateChild(IDC_EDIT_NUMBER, L"EDIT", L"123456",
+                    WS_BORDER | WS_TABSTOP | ES_LEFT | ES_NUMBER | ES_AUTOHSCROLL,
+                    180, 105, 140, 25,
+                    Parent);
+
+    PageData->hLblUppercase =
+        CreateChild(IDC_STATIC, L"STATIC", L"Uppercase:", SS_LEFT, 180, 155, 140, 15, Parent);
+    PageData->hUppercaseEdit =
+        CreateChild(IDC_EDIT_UPPERCASE, L"EDIT", L"all caps",
+                    WS_BORDER | WS_TABSTOP | ES_LEFT | ES_UPPERCASE | ES_AUTOHSCROLL,
+                    180, 175, 140, 25,
+                    Parent);
+
+    PageData->hLblLowercase =
+        CreateChild(IDC_STATIC, L"STATIC", L"Lowercase:", SS_LEFT, 180, 225, 140, 15, Parent);
+    PageData->hLowercaseEdit =
+        CreateChild(IDC_EDIT_LOWERCASE, L"EDIT", L"ALL LOWER",
+                    WS_BORDER | WS_TABSTOP | ES_LEFT | ES_LOWERCASE | ES_AUTOHSCROLL,
+                    180, 245, 140, 25,
+                    Parent);
+
+    PageData->hLblMaxText =
+        CreateChild(IDC_STATIC, L"STATIC", L"Max Length (5):", SS_LEFT, 180, 295, 140, 15, Parent);
+    PageData->hMaxTextEdit =
+        CreateChild(IDC_EDIT_MAXTEXT, L"EDIT", L"ABCDE",
+                    WS_BORDER | WS_TABSTOP | ES_LEFT | ES_AUTOHSCROLL,
+                    180, 315, 140, 25,
+                    Parent);
+    /* Enforce character limit natively using EM_SETLIMITTEXT */
+    SendMessageW(PageData->hMaxTextEdit, EM_SETLIMITTEXT, 5, 0);
+
+    PageData->hLblMultiline =
+        CreateChild(IDC_STATIC, L"STATIC", L"Multiline / Scroll:", SS_LEFT, 340, 15, 140, 15, Parent);
+    PageData->hMultilineEdit =
+        CreateChild(IDC_EDIT_MULTILINE, L"EDIT",
+                    L"Line 1: Standard text\r\n"
+                    L"Line 2: Multiline editor\r\n"
+                    L"Line 3: Auto-scrolling\r\n"
+                    L"Line 4: Word wrap disabled\r\n"
+                    L"Line 5: Second paragraph...\r\n"
+                    L"Line 6: Keep typing to test vertical scrolling!",
+                    WS_BORDER | WS_TABSTOP | WS_VSCROLL | WS_HSCROLL |
+                    ES_LEFT | ES_MULTILINE | ES_WANTRETURN | ES_AUTOVSCROLL | ES_AUTOHSCROLL,
+                    340, 35, 140, 305,
+                    Parent);
+
+    return TRUE;
+}
+
+static VOID
+OnSize(PEDIT_PAGE_DATA PageData, int cx, int cy)
+{
+    HDWP hdwp;
+    int margin_x = 20;
+    int margin_y = 15;
+    int gap = 20;
+    int col_fixed_w = 140;
+
+    int col1_x = margin_x;
+    int col2_x = col1_x + col_fixed_w + gap;
+    int col3_x = col2_x + col_fixed_w + gap;
+
+    /* Column 3 stretches to fill remaining width */
+    int col3_w = cx - col3_x - margin_x;
+    if (col3_w < 100) col3_w = 100;
+
+    int label_h = 15;
+
+    /* Multiline stretches to fill remaining height */
+    int multi_h = cy - margin_y - label_h - 5 - margin_y;
+    if (multi_h < 100) multi_h = 100;
+
+    if (!PageData || !PageData->hLeftEdit)
+        return;
+
+    hdwp = BeginDeferWindowPos(22);
+
+#define MOVE_CTRL(hwnd, x, y, w, h) \
+    if (hwnd) hdwp = DeferWindowPos(hdwp, hwnd, NULL, x, y, w, h, SWP_NOZORDER)
+
+    /* --- COLUMN 3 --- */
+    /* Multiline / Scroll */
+    MOVE_CTRL(PageData->hLblMultiline,  col3_x, margin_y, col3_w, label_h);
+    MOVE_CTRL(PageData->hMultilineEdit, col3_x, margin_y + 20, col3_w, multi_h);
+
+#undef MOVE_CTRL
+
+    EndDeferWindowPos(hdwp);
+}
+
+static
+LRESULT
+OnCommand(PPAGE_HOST PageHost, PEDIT_PAGE_DATA PageData, int Id, int NotifyCode)
+{
+    switch (Id)
+    {
+        case IDC_EDIT_LEFT:
+        case IDC_EDIT_CENTER:
+        case IDC_EDIT_RIGHT:
+        case IDC_EDIT_READONLY:
+        case IDC_EDIT_DISABLED:
+        case IDC_EDIT_PASSWORD:
+        case IDC_EDIT_NUMBER:
+        case IDC_EDIT_UPPERCASE:
+        case IDC_EDIT_LOWERCASE:
+        case IDC_EDIT_MAXTEXT:
+        case IDC_EDIT_MULTILINE:
+            switch (NotifyCode)
+            {
+                case EN_CHANGE:
+                    return TRUE;
+                case EN_UPDATE:
+                    return TRUE;
+                case EN_MAXTEXT:
+                    return TRUE;
+                default:
+                    return FALSE;
+            }
+
+        default:
+            return FALSE;
+    }
+}
 
 LRESULT
 EditPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    return FALSE;
+    PEDIT_PAGE_DATA PageData;
+    if (msg == WM_CREATE)
+    {
+        PageData = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(EDIT_PAGE_DATA));
+        PageHost->UserData = PageData;
+        return InitPage(PageHost->Wnd, PageData);
+    }
+    else
+    {
+        PageData = (PEDIT_PAGE_DATA)PageHost->UserData;
+    }
+
+    switch (msg)
+    {
+        case WM_COMMAND:
+            if (LOWORD(wParam) < IDC_EDIT_LEFT || LOWORD(wParam) > IDC_EDIT_MULTILINE)
+                return FALSE;
+            return OnCommand(PageHost, PageData, LOWORD(wParam), HIWORD(wParam));
+
+        case WM_SIZE:
+            OnSize(PageData, LOWORD(lParam), HIWORD(lParam));
+            return TRUE;
+
+        default:
+            return FALSE;
+    }
 }

--- a/modules/rostests/win32/user32/controls/pages/icontitle.c
+++ b/modules/rostests/win32/user32/controls/pages/icontitle.c
@@ -1,14 +1,330 @@
 /*
  * PROJECT:     ReactOS Tests
  * LICENSE:     MIT (https://spdx.org/licenses/MIT)
- * PURPOSE:     User32 Control Gallery
+ * PURPOSE:     User32 Control Gallery - IconTitle Page
  * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
  */
 
 #include "../controls.h"
 
+#define IDC_ICONTITLE_OWNER1         9101
+#define IDC_ICONTITLE_OWNER2         9102
+#define IDC_ICONTITLE_LOG_EDIT       9103
+#define IDC_ICONTITLE_BTN_CHANGE_TXT 9104
+#define IDC_ICONTITLE_BTN_TOGGLE_ACT 9105
+#define IDC_ICONTITLE_BTN_REFRESH    9106
+#define IDC_ICONTITLE_BTN_CLEAR      9107
+
+typedef struct _ICONTITLE_PAGE_DATA
+{
+    /* Left Column: Owner Windows & Popup IconTitles */
+    HWND hLabelOwner1, hOwnerWnd1, hIconTitle1;
+    HWND hLabelOwner2, hOwnerWnd2, hIconTitle2;
+
+    /* Right Column: Event Log & System Metrics Display */
+    HWND hLabelLog, hLogEdit;
+
+    /* Bottom Toolbar */
+    HWND hBtnChangeText;
+    HWND hBtnToggleActive;
+    HWND hBtnRefreshMetrics;
+    HWND hBtnClearLog;
+
+    /* State Tracking */
+    BOOL bToggleState;
+    BOOL bIsActive;
+} ICONTITLE_PAGE_DATA, *PICONTITLE_PAGE_DATA;
+
+static VOID
+LogIconTitleEvent(HWND hLogEdit, LPCWSTR szText)
+{
+    int len;
+
+    if (!hLogEdit)
+        return;
+
+    len = GetWindowTextLengthW(hLogEdit);
+    SendMessageW(hLogEdit, EM_SETSEL, len, len);
+    SendMessageW(hLogEdit, EM_REPLACESEL, FALSE, (LPARAM)szText);
+    SendMessageW(hLogEdit, EM_REPLACESEL, FALSE, (LPARAM)L"\r\n");
+}
+
+static VOID
+QueryAndLogSystemMetrics(PICONTITLE_PAGE_DATA PageData)
+{
+    WCHAR szBuffer[256];
+    LOGFONTW lf = {0};
+    int cxSpacing, cySpacing;
+
+    cxSpacing = GetSystemMetrics(SM_CXICONSPACING);
+    cySpacing = GetSystemMetrics(SM_CYICONSPACING);
+
+    SystemParametersInfoW(SPI_GETICONTITLELOGFONT, sizeof(LOGFONTW), &lf, 0);
+
+    wsprintfW(szBuffer, L"--- System Icon Title Metrics ---\r\n"
+                        L"Font Face: %s (%d pt)\r\n"
+                        L"Icon Spacing: %d x %d px\r\n"
+                        L"---------------------------------",
+              lf.lfFaceName,
+              -MulDiv(lf.lfHeight, 72, GetDeviceCaps(GetDC(PageData->hLogEdit), LOGPIXELSY)),
+              cxSpacing, cySpacing);
+
+    LogIconTitleEvent(PageData->hLogEdit, szBuffer);
+}
+
+static VOID
+PositionPopupIconTitle(HWND hParentPage, HWND hIconTitle, int x, int y, int w, int h)
+{
+    POINT pt = { x, y };
+
+    if (!hIconTitle || !IsWindow(hIconTitle))
+        return;
+
+    /* Convert page client coordinates to screen coordinates for WS_POPUP window */
+    ClientToScreen(hParentPage, &pt);
+    SetWindowPos(hIconTitle, NULL, pt.x, pt.y, w, h, SWP_NOZORDER | SWP_NOACTIVATE);
+}
+
+static LRESULT
+InitPage(HWND Parent, PICONTITLE_PAGE_DATA PageData)
+{
+    HINSTANCE hInst = (HINSTANCE)GetWindowLongPtrW(Parent, GWLP_HINSTANCE);
+
+    PageData->hLabelOwner1 =
+        CreateChild(IDC_STATIC, L"STATIC", L"Icon Owner Window #1:", SS_LEFT, 0, 0, 0, 0, Parent);
+    PageData->hOwnerWnd1 =
+        CreateChild(IDC_ICONTITLE_OWNER1,
+                    L"STATIC",
+                    L"My Computer",
+                    SS_CENTER | WS_BORDER | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+    PageData->hIconTitle1 =
+        CreateWindowExW(0,
+                        L"IconTitle",
+                        NULL,
+                        WS_POPUP | WS_VISIBLE | WS_BORDER | WS_CLIPSIBLINGS,
+                        0, 0, 0, 0,
+                        PageData->hOwnerWnd1,
+                        NULL, hInst, NULL);
+
+    PageData->hLabelOwner2 =
+        CreateChild(IDC_STATIC, L"STATIC", L"Icon Owner Window #2:", SS_LEFT, 0, 0, 0, 0, Parent);
+    PageData->hOwnerWnd2 =
+        CreateChild(IDC_ICONTITLE_OWNER2,
+                    L"STATIC",
+                    L"Recycle Bin (Double-line wrapped label demo)",
+                    SS_CENTER | WS_BORDER | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+    PageData->hIconTitle2 =
+        CreateWindowExW(0,
+                        L"IconTitle",
+                        NULL,
+                        WS_POPUP | WS_VISIBLE | WS_BORDER | WS_CLIPSIBLINGS,
+                        0, 0, 0, 0,
+                        PageData->hOwnerWnd2,
+                        NULL, hInst, NULL);
+
+    PageData->hLabelLog =
+        CreateChild(IDC_STATIC, L"STATIC", L"IconTitle Event Log:", SS_LEFT, 0, 0, 0, 0, Parent);
+    PageData->hLogEdit =
+        CreateChild(IDC_ICONTITLE_LOG_EDIT,
+                    L"EDIT", L"",
+                    WS_BORDER | WS_TABSTOP | WS_VSCROLL |
+                    ES_LEFT | ES_MULTILINE | ES_READONLY | ES_AUTOVSCROLL,
+                    0, 0, 0, 0, Parent);
+
+    PageData->hBtnChangeText =
+        CreateChild(IDC_ICONTITLE_BTN_CHANGE_TXT,
+                    L"BUTTON", L"Change Title",
+                    BS_PUSHBUTTON | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+    PageData->hBtnToggleActive =
+        CreateChild(IDC_ICONTITLE_BTN_TOGGLE_ACT,
+                    L"BUTTON", L"Toggle Active",
+                    BS_PUSHBUTTON | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+    PageData->hBtnRefreshMetrics =
+        CreateChild(IDC_ICONTITLE_BTN_REFRESH,
+                    L"BUTTON", L"Refresh Metrics",
+                    BS_PUSHBUTTON | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+    PageData->hBtnClearLog =
+        CreateChild(IDC_ICONTITLE_BTN_CLEAR,
+                    L"BUTTON", L"Clear Log",
+                    BS_PUSHBUTTON | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+
+    QueryAndLogSystemMetrics(PageData);
+
+    return TRUE;
+}
+
+static LRESULT
+OnCommand(PPAGE_HOST PageHost, PICONTITLE_PAGE_DATA PageData, int Id)
+{
+    switch (Id)
+    {
+        case IDC_ICONTITLE_BTN_CHANGE_TXT:
+            PageData->bToggleState = !PageData->bToggleState;
+
+            if (PageData->bToggleState)
+            {
+                SetWindowTextW(PageData->hOwnerWnd1, L"Network Neighborhood");
+                SetWindowTextW(PageData->hOwnerWnd2, L"Control Panel Settings");
+            }
+            else
+            {
+                SetWindowTextW(PageData->hOwnerWnd1, L"My Computer");
+                SetWindowTextW(PageData->hOwnerWnd2, L"Recycle Bin (Double-line wrapped label demo)");
+            }
+
+            /* Redraw IconTitle controls to reflect updated owner text */
+            InvalidateRect(PageData->hIconTitle1, NULL, TRUE);
+            InvalidateRect(PageData->hIconTitle2, NULL, TRUE);
+
+            LogIconTitleEvent(PageData->hLogEdit, L"Updated owner window titles & invalidated IconTitles.");
+            return TRUE;
+
+        case IDC_ICONTITLE_BTN_TOGGLE_ACT:
+            PageData->bIsActive = !PageData->bIsActive;
+
+            /* Send WM_NCACTIVATE to simulate active/inactive title bar state */
+            SendMessageW(PageData->hIconTitle1, WM_NCACTIVATE, PageData->bIsActive, 0);
+            SendMessageW(PageData->hIconTitle2, WM_NCACTIVATE, PageData->bIsActive, 0);
+
+            LogIconTitleEvent(PageData->hLogEdit,
+                              PageData->bIsActive ? L"Set IconTitle state -> ACTIVE" : L"Set IconTitle state -> INACTIVE");
+            return TRUE;
+
+        case IDC_ICONTITLE_BTN_REFRESH:
+            QueryAndLogSystemMetrics(PageData);
+            return TRUE;
+
+        case IDC_ICONTITLE_BTN_CLEAR:
+            SetWindowTextW(PageData->hLogEdit, L"");
+            return TRUE;
+
+        default:
+            return FALSE;
+    }
+}
+
+static VOID
+OnSize(HWND hWndPage, PICONTITLE_PAGE_DATA PageData, int cx, int cy)
+{
+    HDWP hdwp;
+    int margin_x = 20;
+    int margin_y = 15;
+    int gap = 10;
+    int col_width;
+    int col1_x, col2_x;
+    int toolbar_y, toolbar_h = 28;
+    int btn_w;
+    int log_h;
+
+    if (!PageData || !PageData->hLogEdit)
+        return;
+
+    /* Bottom Toolbar Calculations */
+    toolbar_y = cy - margin_y - toolbar_h;
+    btn_w = (cx - (margin_x * 2) - (gap * 3)) / 4;
+    if (btn_w < 60) btn_w = 60;
+
+    /* Column Calculations */
+    col_width = (cx - (margin_x * 3)) / 2;
+    if (col_width < 100) col_width = 100;
+
+    col1_x = margin_x;
+    col2_x = col1_x + col_width + margin_x;
+
+    log_h = toolbar_y - margin_y - 35;
+    if (log_h < 80) log_h = 80;
+
+    /* Defer window positions for child controls */
+    hdwp = BeginDeferWindowPos(8);
+
+#define MOVE_CTRL(hwnd, x, y, w, h) \
+    if (hwnd) hdwp = DeferWindowPos(hdwp, hwnd, NULL, x, y, w, h, SWP_NOZORDER)
+
+    /* Column 1: Owner Static Labels & Windows */
+    MOVE_CTRL(PageData->hLabelOwner1, col1_x, 15,  col_width, 15);
+    MOVE_CTRL(PageData->hOwnerWnd1,   col1_x, 35,  col_width, 22);
+
+    MOVE_CTRL(PageData->hLabelOwner2, col1_x, 95,  col_width, 15);
+    MOVE_CTRL(PageData->hOwnerWnd2,   col1_x, 115, col_width, 22);
+
+    /* Column 2: Log Display */
+    MOVE_CTRL(PageData->hLabelLog,    col2_x, 15,  col_width, 15);
+    MOVE_CTRL(PageData->hLogEdit,     col2_x, 35,  col_width, log_h);
+
+    /* Bottom Toolbar */
+    MOVE_CTRL(PageData->hBtnChangeText,   margin_x,                     toolbar_y, btn_w, toolbar_h);
+    MOVE_CTRL(PageData->hBtnToggleActive, margin_x + btn_w + gap,       toolbar_y, btn_w, toolbar_h);
+    MOVE_CTRL(PageData->hBtnRefreshMetrics,margin_x + (btn_w + gap) * 2, toolbar_y, btn_w, toolbar_h);
+    MOVE_CTRL(PageData->hBtnClearLog,      margin_x + (btn_w + gap) * 3, toolbar_y, btn_w, toolbar_h);
+
+#undef MOVE_CTRL
+
+    EndDeferWindowPos(hdwp);
+
+    /* Position WS_POPUP IconTitle windows using screen coordinates */
+    PositionPopupIconTitle(hWndPage, PageData->hIconTitle1, col1_x, 62, col_width, 25);
+    PositionPopupIconTitle(hWndPage, PageData->hIconTitle2, col1_x, 142, col_width, 40);
+}
+
 LRESULT
 IconTitlePageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    return FALSE;
+    PICONTITLE_PAGE_DATA PageData;
+
+    if (msg == WM_CREATE)
+    {
+        PageData = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(ICONTITLE_PAGE_DATA));
+        PageHost->UserData = PageData;
+
+        InitPage(PageHost->Wnd, PageData);
+        return TRUE;
+    }
+    else
+    {
+        PageData = (PICONTITLE_PAGE_DATA)PageHost->UserData;
+    }
+
+    switch (msg)
+    {
+        case WM_SHOWWINDOW:
+            /* Show or hide popup windows when page tab visibility changes */
+            if (PageData)
+            {
+                BOOL bShow = (BOOL)wParam;
+                if (PageData->hIconTitle1) ShowWindow(PageData->hIconTitle1, bShow ? SW_SHOW : SW_HIDE);
+                if (PageData->hIconTitle2) ShowWindow(PageData->hIconTitle2, bShow ? SW_SHOW : SW_HIDE);
+            }
+            return 0;
+
+        case WM_COMMAND:
+            return OnCommand(PageHost, PageData, LOWORD(wParam));
+
+        case WM_SIZE:
+            OnSize(PageHost->Wnd, PageData, LOWORD(lParam), HIWORD(lParam));
+            return 0;
+
+        case WM_DESTROY:
+            /* Clean up popup windows */
+            if (PageData)
+            {
+                if (PageData->hIconTitle1) DestroyWindow(PageData->hIconTitle1);
+                if (PageData->hIconTitle2) DestroyWindow(PageData->hIconTitle2);
+            }
+            return 0;
+
+        default:
+            return FALSE;
+    }
 }

--- a/modules/rostests/win32/user32/controls/pages/icontitle.c
+++ b/modules/rostests/win32/user32/controls/pages/icontitle.c
@@ -1,0 +1,14 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "../controls.h"
+
+LRESULT
+IconTitlePageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    return FALSE;
+}

--- a/modules/rostests/win32/user32/controls/pages/listbox.c
+++ b/modules/rostests/win32/user32/controls/pages/listbox.c
@@ -7,33 +7,92 @@
 
 #include "../controls.h"
 
-/*
- * +------------------------------------------------+
- * | Single Selection                              |
- * | +--------------------------------------------+ |
- * | | Item 1                                     | |
- * | | Item 2                                     | |
- * | | Item 3                                     | |
- * | +--------------------------------------------+ |
- * |                                                |
- * | Multiple Selection                            |
- * | +--------------------------------------------+ |
- * | | [ ] Item A                                 | |
- * | | [x] Item B                                 | |
- * | | [x] Item C                                 | |
- * | +--------------------------------------------+ |
- * |                                                |
- * | Extended Selection                            |
- * | +--------------------------------------------+ |
- * | | Item 1                                     | |
- * | | Item 2                                     | |
- * | | Item 3                                     | |
- * | +--------------------------------------------+ |
- * +------------------------------------------------+
- */
+typedef struct _LISTBOX_PAGE_DATA
+{
+    HWND hLblSingle;
+    HWND hSingle;
+
+    HWND hLblMultiple;
+    HWND hMultiple;
+
+    HWND hLblExtended;
+    HWND hExtended;
+} LISTBOX_PAGE_DATA, *PLISTBOX_PAGE_DATA;
+
+static PCWSTR Items[] = {
+    L"Cherry",
+    L"Date",
+    L"Grape",
+    L"Apple",
+    L"Banana",
+    L"Fig",
+    L"Elderberry",
+};
+
+static VOID
+PopulateListBox(HWND hCombo, BOOL bSelectFirst)
+{
+    for (int i = 0; i < _countof(Items); i++)
+    {
+        SendMessageW(hCombo, LB_ADDSTRING, 0, (LPARAM)Items[i]);
+    }
+
+    if (bSelectFirst)
+        SendMessageW(hCombo, LB_SETCURSEL, 0, 0);
+}
+
+
+LRESULT
+InitPage(HWND Parent, PLISTBOX_PAGE_DATA PageData)
+{
+    PageData->hLblSingle =
+        CreateChild(0, L"STATIC", L"Single ListBox", SS_LEFT, 20, 10, 200, 15, Parent);
+    PageData->hSingle =
+        CreateChild(0, L"LISTBOX", NULL, LBS_STANDARD, 20, 30, 200, 100, Parent);
+    PopulateListBox(PageData->hSingle, TRUE);
+
+    PageData->hLblMultiple =
+        CreateChild(0, L"STATIC", L"Multiple Selection ListBox", SS_LEFT, 20, 150, 200, 15, Parent);
+    PageData->hMultiple =
+        CreateChild(0, L"LISTBOX", NULL, LBS_STANDARD | LBS_MULTIPLESEL, 20, 170, 200, 100, Parent);
+    PopulateListBox(PageData->hMultiple, FALSE);
+
+    PageData->hLblExtended =
+        CreateChild(0, L"STATIC", L"Extended ListBox", SS_LEFT, 240, 10, 200, 15, Parent);
+    PageData->hExtended =
+        CreateChild(0, L"LISTBOX", NULL, LBS_STANDARD | LBS_EXTENDEDSEL, 240, 30, 200, 100, Parent);
+    PopulateListBox(PageData->hExtended, FALSE);
+
+    return TRUE;
+}
 
 LRESULT
 ListBoxPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
 {
+    switch (msg)
+    {
+        case WM_CREATE:
+        {
+            PLISTBOX_PAGE_DATA PageData;
+
+            PageData = HeapAlloc(GetProcessHeap(),
+                                 HEAP_ZERO_MEMORY,
+                                 sizeof(*PageData));
+
+            if (!PageData)
+                return FALSE;
+
+            PageHost->UserData = PageData;
+            return InitPage(PageHost->Wnd, PageData);
+        }
+
+        case WM_DESTROY:
+        {
+            PLISTBOX_PAGE_DATA PageData = (PLISTBOX_PAGE_DATA)PageHost->UserData;
+            HeapFree(GetProcessHeap(), 0, PageData);
+            return TRUE;
+        }
+    }
+
     return FALSE;
 }

--- a/modules/rostests/win32/user32/controls/pages/listbox.c
+++ b/modules/rostests/win32/user32/controls/pages/listbox.c
@@ -1,0 +1,39 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "../controls.h"
+
+/*
+ * +------------------------------------------------+
+ * | Single Selection                              |
+ * | +--------------------------------------------+ |
+ * | | Item 1                                     | |
+ * | | Item 2                                     | |
+ * | | Item 3                                     | |
+ * | +--------------------------------------------+ |
+ * |                                                |
+ * | Multiple Selection                            |
+ * | +--------------------------------------------+ |
+ * | | [ ] Item A                                 | |
+ * | | [x] Item B                                 | |
+ * | | [x] Item C                                 | |
+ * | +--------------------------------------------+ |
+ * |                                                |
+ * | Extended Selection                            |
+ * | +--------------------------------------------+ |
+ * | | Item 1                                     | |
+ * | | Item 2                                     | |
+ * | | Item 3                                     | |
+ * | +--------------------------------------------+ |
+ * +------------------------------------------------+
+ */
+
+LRESULT
+ListBoxPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    return FALSE;
+}

--- a/modules/rostests/win32/user32/controls/pages/mdi.c
+++ b/modules/rostests/win32/user32/controls/pages/mdi.c
@@ -1,0 +1,14 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "../controls.h"
+
+LRESULT
+MdiPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    return FALSE;
+}

--- a/modules/rostests/win32/user32/controls/pages/mdi.c
+++ b/modules/rostests/win32/user32/controls/pages/mdi.c
@@ -7,8 +7,275 @@
 
 #include "../controls.h"
 
+#define IDC_MDI_CLIENT      6000
+#define IDC_MDI_NEW         6001
+#define IDC_MDI_CASCADE     6002
+#define IDC_MDI_TILEHORZ    6003
+#define IDC_MDI_TILEVERT    6004
+#define IDC_MDI_ARRANGE     6005
+#define IDC_MDI_NEXT        6006
+#define IDC_MDI_CLOSE       6007
+
+typedef struct _MDI_PAGE_DATA
+{
+    /* Toolbar Action Buttons */
+    HWND hBtnNew;
+    HWND hBtnCascade;
+    HWND hBtnTileHorz;
+    HWND hBtnTileVert;
+    HWND hBtnArrange;
+    HWND hBtnNext;
+    HWND hBtnClose;
+
+    /* MDI Client Area */
+    HWND hMdiClient;
+
+    /* Child counter for unique titles */
+    UINT ChildCount;
+} MDI_PAGE_DATA, *PMDI_PAGE_DATA;
+
+static LRESULT CALLBACK
+GalleryMDIChildProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg)
+    {
+        case WM_CREATE:
+            /* Custom child window rendering/initialization can go here */
+            break;
+
+        default:
+            return DefMDIChildProcW(hWnd, msg, wParam, lParam);
+    }
+    return 0;
+}
+
+static VOID
+RegisterMDIChildClass(VOID)
+{
+    WNDCLASSW wc = {0};
+    wc.style = CS_HREDRAW | CS_VREDRAW;
+    wc.lpfnWndProc = GalleryMDIChildProc;
+    wc.hInstance = GetModuleHandleW(NULL);
+    wc.hCursor = LoadCursorW(NULL, (LPCWSTR)IDC_ARROW);
+    wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+    wc.lpszClassName = L"GalleryMDIChild";
+
+    RegisterClassW(&wc);
+}
+
+static HWND
+CreateMDIChildWindow(HWND hMdiClient, LPCWSTR szTitle, DWORD dwStyle, int x, int y, int cx, int cy)
+{
+    MDICREATESTRUCTW mcs = {0};
+    mcs.szClass = L"GalleryMDIChild";
+    mcs.szTitle = szTitle;
+    mcs.hOwner = GetModuleHandleW(NULL);
+    mcs.x = x;
+    mcs.y = y;
+    mcs.cx = cx;
+    mcs.cy = cy;
+    mcs.style = dwStyle;
+
+    return (HWND)SendMessageW(hMdiClient, WM_MDICREATE, 0, (LPARAM)&mcs);
+}
+
+static LRESULT
+InitPage(HWND Parent, PMDI_PAGE_DATA PageData)
+{
+    CLIENTCREATESTRUCT ccs = {0};
+
+    RegisterMDIChildClass();
+
+    /* Action Toolbar Buttons */
+    PageData->hBtnNew =
+        CreateChild(IDC_MDI_NEW, L"BUTTON", L"New Window",
+                    BS_PUSHBUTTON | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+    PageData->hBtnCascade =
+        CreateChild(IDC_MDI_CASCADE, L"BUTTON", L"Cascade",
+                    BS_PUSHBUTTON | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+    PageData->hBtnTileHorz =
+        CreateChild(IDC_MDI_TILEHORZ,
+                    L"BUTTON", L"Tile Horz",
+                    BS_PUSHBUTTON | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+    PageData->hBtnTileVert =
+        CreateChild(IDC_MDI_TILEVERT,
+                    L"BUTTON", L"Tile Vert",
+                    BS_PUSHBUTTON | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+
+    PageData->hBtnArrange =
+        CreateChild(IDC_MDI_ARRANGE, L"BUTTON", L"Arrange Icons",
+                    BS_PUSHBUTTON | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+    PageData->hBtnNext =
+        CreateChild(IDC_MDI_NEXT,
+                    L"BUTTON", L"Next Window",
+                    BS_PUSHBUTTON | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+    PageData->hBtnClose =
+        CreateChild(IDC_MDI_CLOSE,
+                    L"BUTTON", L"Close Active",
+                    BS_PUSHBUTTON | WS_TABSTOP,
+                    0, 0, 0, 0,
+                    Parent);
+
+    /* Create the native user32 MDICLIENT window */
+    ccs.hWindowMenu = NULL;
+    ccs.idFirstChild = 5000;
+
+    PageData->hMdiClient =
+        CreateWindowExW(WS_EX_CLIENTEDGE,
+                        L"MDICLIENT",
+                        NULL,
+                        WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_VSCROLL | WS_HSCROLL,
+                        0, 0, 0, 0,
+                        Parent,
+                        (HMENU)(UINT_PTR)IDC_MDI_CLIENT,
+                        GetModuleHandleW(NULL),
+                        &ccs);
+
+    /* Populate initial MDI children demonstrating various states */
+    PageData->ChildCount = 3;
+
+    CreateMDIChildWindow(PageData->hMdiClient, L"Document 1 (Normal)", 0, 10, 10, 200, 120);
+    CreateMDIChildWindow(PageData->hMdiClient, L"Document 2 (Normal)", 0, 40, 40, 200, 120);
+    CreateMDIChildWindow(PageData->hMdiClient, L"Document 3 (Minimized)", WS_MINIMIZE, 70, 70, 200, 120);
+
+    return TRUE;
+}
+
+static LRESULT
+OnCommand(PPAGE_HOST PageHost, PMDI_PAGE_DATA PageData, int Id)
+{
+    HWND hActive;
+    WCHAR szTitle[64];
+
+    switch (Id)
+    {
+        case IDC_MDI_NEW:
+            PageData->ChildCount++;
+            wsprintfW(szTitle, L"Document %u", PageData->ChildCount);
+            CreateMDIChildWindow(PageData->hMdiClient, szTitle, 0, 20, 20, 220, 130);
+            return TRUE;
+
+        case IDC_MDI_CASCADE:
+            SendMessageW(PageData->hMdiClient, WM_MDICASCADE, 0, 0);
+            return TRUE;
+
+        case IDC_MDI_TILEHORZ:
+            SendMessageW(PageData->hMdiClient, WM_MDITILE, MDITILE_HORIZONTAL, 0);
+            return TRUE;
+
+        case IDC_MDI_TILEVERT:
+            SendMessageW(PageData->hMdiClient, WM_MDITILE, MDITILE_VERTICAL, 0);
+            return TRUE;
+
+        case IDC_MDI_ARRANGE:
+            SendMessageW(PageData->hMdiClient, WM_MDIICONARRANGE, 0, 0);
+            return TRUE;
+
+        case IDC_MDI_NEXT:
+            hActive = (HWND)SendMessageW(PageData->hMdiClient, WM_MDIGETACTIVE, 0, 0);
+            SendMessageW(PageData->hMdiClient, WM_MDINEXT, (WPARAM)hActive, FALSE);
+            return TRUE;
+
+        case IDC_MDI_CLOSE:
+            hActive = (HWND)SendMessageW(PageData->hMdiClient, WM_MDIGETACTIVE, 0, 0);
+            if (hActive)
+                SendMessageW(PageData->hMdiClient, WM_MDIDESTROY, (WPARAM)hActive, 0);
+            return TRUE;
+
+        default:
+            return FALSE;
+    }
+}
+
+static VOID
+OnSize(PMDI_PAGE_DATA PageData, int cx, int cy)
+{
+    HDWP hdwp;
+    int margin_x = 20;
+    int btn_w, btn_h = 25;
+    int client_w, client_h;
+
+    /* Prevent sizing calculations before controls are created */
+    if (!PageData || !PageData->hMdiClient)
+        return;
+
+    /* Dynamically calculate toolbar button width to distribute evenly across 4 columns */
+    btn_w = (cx - (margin_x * 2) - 30) / 4;
+    if (btn_w < 70) btn_w = 70;
+
+    client_w = cx - (margin_x * 2);
+    if (client_w < 100) client_w = 100;
+
+    client_h = cy - 85 - 20;
+    if (client_h < 100) client_h = 100;
+
+    /* Batch window movements for smooth, flicker-free resizing */
+    hdwp = BeginDeferWindowPos(8);
+
+#define MOVE_CTRL(hwnd, x, y, w, h) \
+    if (hwnd) hdwp = DeferWindowPos(hdwp, hwnd, NULL, x, y, w, h, SWP_NOZORDER)
+
+    /* Toolbar Row 1 */
+    MOVE_CTRL(PageData->hBtnNew,      margin_x,                   15, btn_w, btn_h);
+    MOVE_CTRL(PageData->hBtnCascade,  margin_x + btn_w + 10,      15, btn_w, btn_h);
+    MOVE_CTRL(PageData->hBtnTileHorz, margin_x + (btn_w + 10)*2,  15, btn_w, btn_h);
+    MOVE_CTRL(PageData->hBtnTileVert, margin_x + (btn_w + 10)*3,  15, btn_w, btn_h);
+
+    /* Toolbar Row 2 */
+    MOVE_CTRL(PageData->hBtnArrange,  margin_x,                   45, btn_w, btn_h);
+    MOVE_CTRL(PageData->hBtnNext,     margin_x + btn_w + 10,      45, btn_w, btn_h);
+    MOVE_CTRL(PageData->hBtnClose,    margin_x + (btn_w + 10)*2,  45, btn_w, btn_h);
+
+    /* MDI Workspace Area */
+    MOVE_CTRL(PageData->hMdiClient,   margin_x,                   80, client_w, client_h);
+
+#undef MOVE_CTRL
+
+    EndDeferWindowPos(hdwp);
+}
+
 LRESULT
 MdiPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    return FALSE;
+    PMDI_PAGE_DATA PageData;
+
+    if (msg == WM_CREATE)
+    {
+        PageData = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(MDI_PAGE_DATA));
+        PageHost->UserData = PageData;
+
+        InitPage(PageHost->Wnd, PageData);
+        return TRUE;
+    }
+    else
+    {
+        PageData = (PMDI_PAGE_DATA)PageHost->UserData;
+    }
+
+    switch (msg)
+    {
+        case WM_SIZE:
+            OnSize(PageData, LOWORD(lParam), HIWORD(lParam));
+            return 0;
+
+        case WM_COMMAND:
+            if (LOWORD(wParam) < IDC_MDI_NEW || LOWORD(wParam) > IDC_MDI_CLOSE)
+                return FALSE;
+            return OnCommand(PageHost, PageData, LOWORD(wParam));
+
+        default:
+            return FALSE;
+    }
 }

--- a/modules/rostests/win32/user32/controls/pages/scrollbar.c
+++ b/modules/rostests/win32/user32/controls/pages/scrollbar.c
@@ -7,24 +7,289 @@
 
 #include "../controls.h"
 
-/*
- * +------------------------------------------------+
- * | Horizontal Scrollbar                           |
- * |                                                |
- * | <===========================================>  |
- * |                                                |
- * | Vertical Scrollbar                             |
- * |                     +---+                      |
- * |                     | ^ |                      |
- * |                     | | |                      |
- * |                     | | |                      |
- * |                     | v |                      |
- * |                     +---+                      |
- * +------------------------------------------------+
- */
+#define IDC_SCROLL_HORZ_STD     9001
+#define IDC_SCROLL_HORZ_BOTTOM  9002
+#define IDC_SCROLL_VERT_STD     9003
+#define IDC_SCROLL_SIZEGRIP     9004
+#define IDC_SCROLL_LOG_EDIT     9005
+
+typedef struct _SCROLLBAR_PAGE_DATA
+{
+    HWND hLabelHorzStd, hHorzStdScroll;
+    HWND hLabelHorzBottom, hHorzBottomScroll;
+
+    HWND hLabelVertStd, hVertStdScroll;
+    HWND hLabelSizeGrip, hSizeGripParent, hSizeGrip;
+
+    HWND hLabelLog, hLogEdit;
+} SCROLLBAR_PAGE_DATA, *PSCROLLBAR_PAGE_DATA;
+
+static VOID
+LogScrollEvent(HWND hLogEdit, LPCWSTR szText)
+{
+    int len;
+
+    if (!hLogEdit)
+        return;
+
+    len = GetWindowTextLengthW(hLogEdit);
+    SendMessageW(hLogEdit, EM_SETSEL, len, len);
+    SendMessageW(hLogEdit, EM_REPLACESEL, FALSE, (LPARAM)szText);
+    SendMessageW(hLogEdit, EM_REPLACESEL, FALSE, (LPARAM)L"\r\n");
+}
+
+static LRESULT
+InitPage(HWND Parent, PSCROLLBAR_PAGE_DATA PageData)
+{
+    SCROLLINFO si = {0};
+
+    PageData->hLabelHorzStd =
+        CreateChild(IDC_STATIC, L"STATIC", L"Standard Horizontal:", SS_LEFT, 0, 0, 0, 0, Parent);
+    PageData->hHorzStdScroll =
+        CreateChild(IDC_SCROLL_HORZ_STD,
+                    L"SCROLLBAR", NULL,
+                    SBS_HORZ | WS_TABSTOP,
+                    0, 0, 0, 0, Parent);
+
+    PageData->hLabelHorzBottom =
+        CreateChild(IDC_STATIC, L"STATIC", L"Bottom-Aligned Horz:", SS_LEFT, 0, 0, 0, 0, Parent);
+    PageData->hHorzBottomScroll =
+        CreateChild(IDC_SCROLL_HORZ_BOTTOM, L"SCROLLBAR", NULL,
+                    SBS_HORZ | SBS_BOTTOMALIGN | WS_TABSTOP,
+                    0, 0, 0, 0, Parent);
+
+    PageData->hLabelVertStd =
+        CreateChild(IDC_STATIC, L"STATIC", L"Standard Vertical:", SS_LEFT, 0, 0, 0, 0, Parent);
+    PageData->hVertStdScroll =
+        CreateChild(IDC_SCROLL_VERT_STD, L"SCROLLBAR", NULL,
+                    SBS_VERT | WS_TABSTOP,
+                    0, 0, 0, 0, Parent);
+
+    PageData->hLabelSizeGrip =
+        CreateChild(IDC_STATIC, L"STATIC", L"Size Grip Box:", SS_LEFT, 0, 0, 0, 0, Parent);
+    PageData->hSizeGripParent =
+        CreateChild(IDC_STATIC, L"STATIC", NULL,
+                    WS_BORDER | WS_CLIPSIBLINGS,
+                    0, 0, 0, 0, Parent);
+    PageData->hSizeGrip =
+        CreateChild(IDC_SCROLL_SIZEGRIP, L"SCROLLBAR", NULL,
+                    SBS_SIZEGRIP,
+                    0, 0, 50, 30, PageData->hSizeGripParent);
+
+    /* Event log */
+    PageData->hLabelLog =
+        CreateChild(IDC_STATIC, L"STATIC", L"Scroll Event Log:", SS_LEFT, 0, 0, 0, 0, Parent);
+    PageData->hLogEdit =
+        CreateChild(IDC_SCROLL_LOG_EDIT, L"EDIT", L"",
+                    WS_BORDER | WS_TABSTOP | WS_VSCROLL |
+                    ES_LEFT | ES_MULTILINE | ES_READONLY | ES_AUTOVSCROLL,
+                    0, 0, 0, 0, Parent);
+
+    /* Configure ranges and thumb page sizes using native SCROLLINFO */
+    si.cbSize = sizeof(SCROLLINFO);
+    si.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
+    si.nMin = 0;
+    si.nMax = 100;
+    si.nPage = 15;
+    si.nPos = 25;
+    SetScrollInfo(PageData->hHorzStdScroll, SB_CTL, &si, TRUE);
+    si.nPos = 60;
+    SetScrollInfo(PageData->hHorzBottomScroll, SB_CTL, &si, TRUE);
+    si.nPos = 40;
+    SetScrollInfo(PageData->hVertStdScroll, SB_CTL, &si, TRUE);
+
+    return TRUE;
+}
+
+
+static VOID
+HandleScrollNotification(HWND hScroll, WORD nScrollCode, PSCROLLBAR_PAGE_DATA PageData, LPCWSTR szBarName)
+{
+    SCROLLINFO si = {0};
+    int nOldPos, nNewPos;
+    WCHAR szLog[128];
+    LPCWSTR szCodeName = L"UNKNOWN";
+
+    si.cbSize = sizeof(SCROLLINFO);
+    si.fMask = SIF_ALL;
+    GetScrollInfo(hScroll, SB_CTL, &si);
+
+    nOldPos = si.nPos;
+    nNewPos = si.nPos;
+
+    switch (nScrollCode)
+    {
+        case SB_LINELEFT:  /* also SB_LINEUP */
+            nNewPos -= 1;
+            szCodeName = L"LINELEFT / LINEUP";
+            break;
+
+        case SB_LINERIGHT: /* also SB_LINEDOWN */
+            nNewPos += 1;
+            szCodeName = L"LINERIGHT / LINEDOWN";
+            break;
+
+        case SB_PAGELEFT:  /* also SB_PAGEUP */
+            nNewPos -= (int)si.nPage;
+            szCodeName = L"PAGELEFT / PAGEUP";
+            break;
+
+        case SB_PAGERIGHT: /* also SB_PAGEDOWN */
+            nNewPos += (int)si.nPage;
+            szCodeName = L"PAGERIGHT / PAGEDOWN";
+            break;
+
+        case SB_THUMBTRACK:
+            nNewPos = si.nTrackPos;
+            szCodeName = L"THUMBTRACK";
+            break;
+
+        case SB_THUMBPOSITION:
+            nNewPos = si.nTrackPos;
+            szCodeName = L"THUMBPOSITION";
+            break;
+
+        case SB_TOP: /* also SB_LEFT */
+            nNewPos = si.nMin;
+            szCodeName = L"TOP / LEFT";
+            break;
+
+        case SB_BOTTOM: /* also SB_RIGHT */
+            nNewPos = si.nMax;
+            szCodeName = L"BOTTOM / RIGHT";
+            break;
+
+        case SB_ENDSCROLL:
+            return; /* Ignore end-scroll events to avoid log flooding */
+    }
+
+    /* Clamp position to valid range [Min, Max - Page + 1] */
+    if (nNewPos < si.nMin)
+        nNewPos = si.nMin;
+    if (nNewPos > (int)(si.nMax - (si.nPage ? si.nPage - 1 : 0)))
+        nNewPos = si.nMax - (si.nPage ? si.nPage - 1 : 0);
+
+    /* Update scrollbar position if changed */
+    if (nNewPos != nOldPos)
+    {
+        si.fMask = SIF_POS;
+        si.nPos = nNewPos;
+        SetScrollInfo(hScroll, SB_CTL, &si, TRUE);
+    }
+
+    wsprintfW(szLog, L"[%s] %s -> Pos: %d", szBarName, szCodeName, nNewPos);
+    LogScrollEvent(PageData->hLogEdit, szLog);
+}
+
+static VOID
+OnSize(PSCROLLBAR_PAGE_DATA PageData, int cx, int cy)
+{
+    HDWP hdwp;
+    int margin_x = 20;
+    int col2_fixed_w = 120; /* Fixed width for the second column */
+    int dyn_col_width;
+    int col1_x, col2_x, col3_x;
+    int col1_w, col2_w, col3_w;
+    int vert_h, log_h;
+
+    /* Prevent sizing calculations before controls are created */
+    if (!PageData || !PageData->hLogEdit)
+        return;
+
+    /* Calculate dynamic widths for remaining columns */
+    dyn_col_width = (cx - col2_fixed_w - (margin_x * 4)) / 2;
+    if (dyn_col_width < 80) dyn_col_width = 80;
+
+    col1_w = dyn_col_width;
+    col2_w = col2_fixed_w;
+
+    col1_x = margin_x;
+    col2_x = col1_x + col1_w + margin_x;
+    col3_x = col2_x + col2_w + margin_x;
+
+    /* Have column 3 precisely fill the remaining available width */
+    col3_w = cx - col3_x - margin_x;
+    if (col3_w < 80) col3_w = 80;
+
+    /* Calculate dynamic heights based on container bounds */
+    vert_h = cy - 35 - 80;
+    if (vert_h < 100) vert_h = 100;
+
+    log_h = cy - 35 - 20;
+    if (log_h < 100) log_h = 100;
+
+    /* Batch window movements for flicker-free resizing */
+    hdwp = BeginDeferWindowPos(10);
+
+#define MOVE_CTRL(hwnd, x, y, w, h) \
+    if (hwnd) hdwp = DeferWindowPos(hdwp, hwnd, NULL, x, y, w, h, SWP_NOZORDER)
+
+    /* --- COLUMN 1: Horizontal Scrollbars --- */
+    MOVE_CTRL(PageData->hLabelHorzStd,     col1_x,  15, col1_w, 15);
+    MOVE_CTRL(PageData->hHorzStdScroll,    col1_x,  35, col1_w, 20);
+    MOVE_CTRL(PageData->hLabelHorzBottom,  col1_x,  75, col1_w, 15);
+    MOVE_CTRL(PageData->hHorzBottomScroll, col1_x,  95, col1_w, 20);
+
+    /* --- COLUMN 2: Vertical Scrollbars & Size Grip --- */
+    MOVE_CTRL(PageData->hLabelVertStd,     col2_x,  15, col2_w, 15);
+    /* Center the vertical scrollbar inside the fixed column */
+    MOVE_CTRL(PageData->hVertStdScroll,    col2_x + (col2_w / 2) - 10, 35, 20, vert_h);
+    MOVE_CTRL(PageData->hLabelSizeGrip,    col2_x,  35 + vert_h + 10, col2_w, 15);
+    MOVE_CTRL(PageData->hSizeGripParent,   col2_x,  35 + vert_h + 30, col2_w, 40);
+
+    /* --- COLUMN 3: Event Log Display --- */
+    MOVE_CTRL(PageData->hLabelLog,         col3_x,  15, col3_w, 15);
+    MOVE_CTRL(PageData->hLogEdit,          col3_x,  35, col3_w, log_h);
+
+#undef MOVE_CTRL
+
+    EndDeferWindowPos(hdwp);
+}
 
 LRESULT
 ScrollBarPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    return FALSE;
+    PSCROLLBAR_PAGE_DATA PageData;
+
+    if (msg == WM_CREATE)
+    {
+        PageData = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(SCROLLBAR_PAGE_DATA));
+        PageHost->UserData = PageData;
+
+        InitPage(PageHost->Wnd, PageData);
+        return TRUE;
+    }
+    else
+    {
+        PageData = (PSCROLLBAR_PAGE_DATA)PageHost->UserData;
+    }
+
+    switch (msg)
+    {
+        case WM_SIZE:
+            OnSize(PageData, LOWORD(lParam), HIWORD(lParam));
+            return 0;
+
+        case WM_HSCROLL:
+        case WM_VSCROLL:
+            if (lParam)
+            {
+                HWND hScroll = (HWND)lParam;
+                LPCWSTR szName = L"Scrollbar";
+
+                if (hScroll == PageData->hHorzStdScroll)
+                    szName = L"Horz Standard";
+                else if (hScroll == PageData->hHorzBottomScroll)
+                    szName = L"Horz Bottom";
+                else if (hScroll == PageData->hVertStdScroll)
+                    szName = L"Vert Standard";
+
+                HandleScrollNotification(hScroll, LOWORD(wParam), PageData, szName);
+                return TRUE;
+            }
+            return FALSE;
+
+        default:
+            return FALSE;
+    }
 }

--- a/modules/rostests/win32/user32/controls/pages/scrollbar.c
+++ b/modules/rostests/win32/user32/controls/pages/scrollbar.c
@@ -1,0 +1,30 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "../controls.h"
+
+/*
+ * +------------------------------------------------+
+ * | Horizontal Scrollbar                           |
+ * |                                                |
+ * | <===========================================>  |
+ * |                                                |
+ * | Vertical Scrollbar                             |
+ * |                     +---+                      |
+ * |                     | ^ |                      |
+ * |                     | | |                      |
+ * |                     | | |                      |
+ * |                     | v |                      |
+ * |                     +---+                      |
+ * +------------------------------------------------+
+ */
+
+LRESULT
+ScrollBarPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    return FALSE;
+}

--- a/modules/rostests/win32/user32/controls/pages/static.c
+++ b/modules/rostests/win32/user32/controls/pages/static.c
@@ -1,0 +1,14 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     User32 Control Gallery
+ * COPYRIGHT:   Copyright 2026 Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include "../controls.h"
+
+LRESULT
+StaticPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    return FALSE;
+}

--- a/modules/rostests/win32/user32/controls/pages/static.c
+++ b/modules/rostests/win32/user32/controls/pages/static.c
@@ -7,8 +7,268 @@
 
 #include "../controls.h"
 
-LRESULT
-StaticPageProc(PPAGE_HOST PageHost, UINT msg, WPARAM wParam, LPARAM lParam)
+#define IDC_STATIC_NOTIFY 100001
+
+typedef struct _STATIC_PAGE_DATA
 {
+    HWND hLeft;
+    HWND hCenter;
+    HWND hRight;
+
+    HWND hNotify;
+
+    HWND hPrefix;
+    HWND hNoPrefix;
+
+    HWND hBlackRect;
+    HWND hGrayRect;
+    HWND hWhiteRect;
+
+    HWND hBlackFrame;
+    HWND hGrayFrame;
+    HWND hWhiteFrame;
+
+    HWND hEtchedFrame;
+    HWND hEtchedHorz;
+    HWND hEtchedVert;
+
+    HWND hBitmapButton;
+    HWND hIconButton;
+} STATIC_PAGE_DATA, *PSTATIC_PAGE_DATA;
+
+static
+LRESULT
+InitPage(HWND Parent, PSTATIC_PAGE_DATA PageData)
+{
+    PageData->hLeft =
+        CreateChild(0,
+                    L"STATIC",
+                    L"Left aligned",
+                    SS_LEFT,
+                    20, 20, 400, 20,
+                    Parent);
+    PageData->hCenter =
+        CreateChild(0,
+                    L"STATIC",
+                    L"Center aligned",
+                    SS_CENTER,
+                    20, 40, 400, 20,
+                    Parent);
+    PageData->hRight =
+        CreateChild(0,
+                    L"STATIC",
+                    L"Right aligned",
+                    SS_RIGHT,
+                    20, 60, 400, 20,
+                    Parent);
+
+    PageData->hNotify =
+        CreateChild(IDC_STATIC_NOTIFY,
+                    L"STATIC",
+                    L"Click me (SS_NOTIFY)",
+                    SS_NOTIFY,
+                    20, 80, 180, 20,
+                    Parent);
+
+    PageData->hPrefix =
+        CreateChild(0,
+                    L"STATIC",
+                    L"Prefix: E&xit",
+                    SS_SIMPLE,
+                    20, 100, 180, 20,
+                    Parent);
+    PageData->hNoPrefix =
+        CreateChild(0,
+                    L"STATIC",
+                    L"NoPrefix: E&xit",
+                    SS_NOPREFIX,
+                    220, 100, 180, 20,
+                    Parent);
+
+    CreateChild(0,
+                L"Static",
+                L"A very long text here that should be ellipsed just because it's too long!",
+                SS_WORDELLIPSIS,
+                20, 120, 100, 20,
+                Parent);
+
+    PageData->hBlackRect =
+        CreateChild(0,
+                    L"STATIC",
+                    NULL,
+                    SS_BLACKRECT,
+                    20, 150, 40, 40,
+                    Parent);
+    PageData->hGrayRect =
+        CreateChild(0,
+                    L"STATIC",
+                    NULL,
+                    SS_GRAYRECT,
+                    80, 150, 40, 40,
+                    Parent);
+    PageData->hWhiteRect =
+        CreateChild(0,
+                    L"STATIC",
+                    NULL,
+                    SS_WHITERECT,
+                    140, 150, 40, 40,
+                    Parent);
+
+    PageData->hBlackFrame =
+        CreateChild(0,
+                    L"STATIC",
+                    NULL,
+                    SS_BLACKFRAME,
+                    200, 150, 40, 40,
+                    Parent);
+    PageData->hGrayFrame =
+        CreateChild(0,
+                    L"STATIC",
+                    NULL,
+                    SS_GRAYFRAME,
+                    260, 150, 40, 40,
+                    Parent);
+    PageData->hWhiteFrame =
+        CreateChild(0,
+                    L"STATIC",
+                    NULL,
+                    SS_WHITEFRAME,
+                    320, 150, 40, 40,
+                    Parent);
+
+    PageData->hEtchedFrame =
+        CreateChild(0,
+                    L"STATIC",
+                    NULL,
+                    SS_ETCHEDFRAME,
+                    20, 200, 100, 100,
+                    Parent);
+
+    PageData->hEtchedHorz =
+        CreateChild(0,
+                    L"STATIC",
+                    NULL,
+                    SS_ETCHEDHORZ,
+                    140, 200, 200, 2,
+                    Parent);
+
+    PageData->hEtchedVert =
+        CreateChild(0,
+                    L"STATIC",
+                    NULL,
+                    SS_ETCHEDVERT,
+                    140, 220, 2, 80,
+                    Parent);
+
+    PageData->hIconButton =
+        CreateChild(0,
+                    L"STATIC",
+                    NULL,
+                    SS_ICON,
+                    20, 320, 32, 32,
+                    Parent);
+    SendMessageW(PageData->hIconButton,
+                 STM_SETICON,
+                 (WPARAM)LoadIconW(NULL, IDI_INFORMATION),
+                 0);
+
+    PageData->hBitmapButton =
+        CreateChild(0,
+                    L"STATIC",
+                    NULL,
+                    SS_BITMAP,
+                    80, 320, 32, 32,
+                    Parent);
+    SendMessageW(PageData->hBitmapButton,
+                 STM_SETIMAGE,
+                 IMAGE_BITMAP,
+                 (LPARAM)LoadBitmapW(NULL,
+                                     MAKEINTRESOURCEW(OBM_CLOSE)));
+
+    return TRUE;
+}
+
+static VOID
+OnSize(PSTATIC_PAGE_DATA PageData, int cx, int cy)
+{
+    HDWP hdwp;
+    int margin_x = 20;
+    int full_w;
+    int half_w;
+
+    if (!PageData || !PageData->hLeft)
+        return;
+
+    /* Rows 1, 2, 3: Full width calculation */
+    full_w = cx - (margin_x * 2);
+    if (full_w < 100) full_w = 100;
+
+    /* Row 4 (Prefix/NoPrefix): Two equal columns */
+    half_w = (cx - (margin_x * 3)) / 2;
+    if (half_w < 50) half_w = 50;
+
+    hdwp = BeginDeferWindowPos(5);
+
+#define MOVE_CTRL(hwnd, x, y, w, h) \
+    if (hwnd) hdwp = DeferWindowPos(hdwp, hwnd, NULL, x, y, w, h, SWP_NOZORDER | SWP_NOCOPYBITS)
+
+    /* Top three rows (Full Width) */
+    MOVE_CTRL(PageData->hLeft,   margin_x, 20, full_w, 20);
+    MOVE_CTRL(PageData->hCenter, margin_x, 40, full_w, 20);
+    MOVE_CTRL(PageData->hRight,  margin_x, 60, full_w, 20);
+
+    /* "Fourth" Row pair divided in 2 equal columns */
+    MOVE_CTRL(PageData->hPrefix,   margin_x,                      100, half_w, 20);
+    MOVE_CTRL(PageData->hNoPrefix, margin_x + half_w + margin_x,  100, half_w, 20);
+
+#undef MOVE_CTRL
+
+    EndDeferWindowPos(hdwp);
+}
+
+LRESULT
+StaticPageProc(PPAGE_HOST PageHost,
+               UINT msg,
+               WPARAM wParam,
+               LPARAM lParam)
+{
+    PSTATIC_PAGE_DATA PageData;
+
+    if (msg == WM_CREATE)
+    {
+        PageData = HeapAlloc(GetProcessHeap(),
+                             HEAP_ZERO_MEMORY,
+                             sizeof(*PageData));
+
+        if (!PageData)
+            return -1;
+
+        PageHost->UserData = PageData;
+        return InitPage(PageHost->Wnd, PageData);
+    }
+
+    PageData = (PSTATIC_PAGE_DATA)PageHost->UserData;
+
+    switch (msg)
+    {
+        case WM_COMMAND:
+            if (LOWORD(wParam) == IDC_STATIC_NOTIFY)
+            {
+                SetWindowTextW(PageData->hNotify,
+                               L"Clicked!");
+                return TRUE;
+            }
+            break;
+
+        case WM_SIZE:
+            OnSize(PageData, LOWORD(lParam), HIWORD(lParam));
+            return TRUE;
+
+        case WM_DESTROY:
+            HeapFree(GetProcessHeap(), 0, PageData);
+            PageHost->UserData = NULL;
+            break;
+    }
+
     return FALSE;
 }


### PR DESCRIPTION
## Purpose

This PR implements a gallery for native USER32 controls. It can be used as a playground to test if controls are rendered correctly and they behave as they should.

This is heavily based on AI-generated codes.

<img width="680" height="432" alt="image" src="https://github.com/user-attachments/assets/2271fb86-509f-4d09-a623-83e2a352b06c" />

<img width="655" height="419" alt="image" src="https://github.com/user-attachments/assets/706ef1e2-fd6e-4849-872e-a38c88d049d6" />

<img width="669" height="429" alt="image" src="https://github.com/user-attachments/assets/b58e0737-4fc2-4f72-a779-a3eb30b7c244" />

<img width="661" height="427" alt="image" src="https://github.com/user-attachments/assets/a6351906-527b-4ae3-a866-f6a3814ac2f9" />

<img width="661" height="426" alt="image" src="https://github.com/user-attachments/assets/f851dc19-034c-4245-8e44-4051649c6873" />

<img width="658" height="426" alt="image" src="https://github.com/user-attachments/assets/1c202f4b-4667-4ade-9534-6c245ca6ccd9" />

<img width="659" height="421" alt="image" src="https://github.com/user-attachments/assets/0ef948a5-ce00-404c-ae58-a22af7f8625b" />

<img width="813" height="639" alt="Screenshot_20260724_005426" src="https://github.com/user-attachments/assets/c5099ef7-7589-42d2-852a-65f3058781d6" />

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: