### PR TITLE
[SYSSETUP][BOOTDATA] Unattended execute GuiUnattended:DetachedProgram SetupParams:UserExecute

### DIFF
--- a/base/setup/lib/setuplib.c
+++ b/base/setup/lib/setuplib.c
@@ -235,6 +235,7 @@ InstallSetupInfFile(
     if (!IniCache)
         return;
 
+#if 0 /* If you need to put something in this section, do it after the merge with Unattend.inf */
     IniSection = IniAddSection(IniCache, L"SetupParams");
     if (IniSection)
     {
@@ -243,6 +244,7 @@ InstallSetupInfFile(
                             // L"\"%s\"", L"WinNt5.2");
         // IniAddKey(IniSection, L"Version", PathBuffer);
     }
+#endif
 
     IniSection = IniAddSection(IniCache, L"Data");
     if (IniSection)

--- a/boot/bootdata/bootcd/unattend.inf
+++ b/boot/bootdata/bootcd/unattend.inf
@@ -59,6 +59,15 @@ LocaleID = 409
 ; 3 - ReactOS Nano Server (Reserved)
 InstallationType = 0
 
+;[GuiUnattended]
+; Run a program early in 2nd-stage setup.
+;DetachedProgram=%SystemRoot%\system32\cmd.exe
+;Arguments="/C echo.Early 2nd-stage setup...&choice>nul /N /T:Y,5"
+
+;[SetupParams]
+; Run a program at the end of 2nd-stage setup.
+;UserExecute="cmd.exe /C echo.End of 2nd-stage setup...&choice>nul /N /T:Y,5"
+
 ; Enable this section to automatically launch programs after 3rd boot.
 ;[GuiRunOnce]
 ;%SystemRoot%\system32\cmd.exe

--- a/dll/win32/syssetup/globals.h
+++ b/dll/win32/syssetup/globals.h
@@ -73,6 +73,10 @@ HRESULT
 InstallOptionalComponents(
     _In_ PITEMSDATA pItemsData);
 
+HRESULT
+RunCommandAndWait(
+    _In_ PWCHAR Command);
+
 /* install */
 
 BOOL

--- a/dll/win32/syssetup/globals.h
+++ b/dll/win32/syssetup/globals.h
@@ -113,6 +113,10 @@ VOID
 SetAutoAdminLogon(VOID);
 
 /* wizard.c */
-VOID InstallWizard (VOID);
+VOID
+InstallWizard(VOID);
+
+VOID
+GetSetupInfPath(PWSTR szPath, UINT cchMax);
 
 /* EOF */

--- a/dll/win32/syssetup/install.c
+++ b/dll/win32/syssetup/install.c
@@ -4,6 +4,7 @@
  * PURPOSE:           System setup
  * FILE:              dll/win32/syssetup/install.c
  * PROGRAMER:         Eric Kohl
+ *                    Whindmar Saksit <whindsaks@proton.me>
  */
 
 /* INCLUDES *****************************************************************/
@@ -985,6 +986,26 @@ cleanup:
     return bConsoleBoot;
 }
 
+static VOID
+ProcessDetachedProgram(
+    _In_ PCWSTR pszInf)
+{
+    WCHAR szInfApp[MAX_PATH], szInfArg[MAX_PATH * 3];
+    WCHAR szCmd[ARRAYSIZE(szInfApp) + ARRAYSIZE(szInfArg)];
+    UINT cch;
+
+    if (!GetPrivateProfileStringW(L"GuiUnattended", L"DetachedProgram", L"", szInfApp, _countof(szInfApp), pszInf) || !*szInfApp)
+        return;
+    cch = ExpandEnvironmentStrings(szInfApp, szCmd, ARRAYSIZE(szCmd) - 1);
+    if (GetPrivateProfileStringW(L"GuiUnattended", L"Arguments", L"", szInfArg, _countof(szInfArg), pszInf) && cch)
+    {
+        szCmd[cch - 1] = L' ';
+        szCmd[cch] = UNICODE_NULL;
+        ExpandEnvironmentStrings(szInfArg, szCmd + cch, ARRAYSIZE(szCmd) - cch);
+    }
+    RunCommandAndWait(szCmd);
+}
+
 extern VOID
 EnableVisualTheme(
     _In_opt_ HWND hwndParent,
@@ -1038,6 +1059,9 @@ PreprocessUnattend(
 
     /* Enable the chosen theme, or use the classic theme */
     EnableVisualTheme(NULL, bDefaultThemesOff ? NULL : szValue);
+
+    if (IsInstall)
+        ProcessDetachedProgram(szPath);
 }
 
 static BOOL

--- a/dll/win32/syssetup/install.c
+++ b/dll/win32/syssetup/install.c
@@ -1029,7 +1029,7 @@ PreprocessUnattend(
 
     if (IsInstall)
     {
-        /* See also wizard.c!GetSetupInfPath()
+        /* See also wizard.c!ProcessSetupInf()
          * Retrieve the path of the setup INF */
         GetSetupInfPath(szPath, _countof(szPath));
     }

--- a/dll/win32/syssetup/install.c
+++ b/dll/win32/syssetup/install.c
@@ -991,17 +991,17 @@ ProcessDetachedProgram(
     _In_ PCWSTR pszInf)
 {
     WCHAR szInfApp[MAX_PATH], szInfArg[MAX_PATH * 3];
-    WCHAR szCmd[ARRAYSIZE(szInfApp) + ARRAYSIZE(szInfArg)];
+    WCHAR szCmd[_countof(szInfApp) + _countof(szInfArg)];
     UINT cch;
 
     if (!GetPrivateProfileStringW(L"GuiUnattended", L"DetachedProgram", L"", szInfApp, _countof(szInfApp), pszInf) || !*szInfApp)
         return;
-    cch = ExpandEnvironmentStrings(szInfApp, szCmd, ARRAYSIZE(szCmd) - 1);
+    cch = ExpandEnvironmentStrings(szInfApp, szCmd, _countof(szCmd) - 1);
     if (GetPrivateProfileStringW(L"GuiUnattended", L"Arguments", L"", szInfArg, _countof(szInfArg), pszInf) && cch)
     {
         szCmd[cch - 1] = L' ';
         szCmd[cch] = UNICODE_NULL;
-        ExpandEnvironmentStrings(szInfArg, szCmd + cch, ARRAYSIZE(szCmd) - cch);
+        ExpandEnvironmentStrings(szInfArg, szCmd + cch, _countof(szCmd) - cch);
     }
     RunCommandAndWait(szCmd);
 }
@@ -1029,10 +1029,9 @@ PreprocessUnattend(
 
     if (IsInstall)
     {
-        /* See also wizard.c!ProcessSetupInf()
+        /* See also wizard.c!GetSetupInfPath()
          * Retrieve the path of the setup INF */
-        GetSystemDirectoryW(szPath, _countof(szPath));
-        wcscat(szPath, L"\\$winnt$.inf");
+        GetSetupInfPath(szPath, _countof(szPath));
     }
     else
     {

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -53,7 +53,7 @@ typedef struct _TIMEZONE_ENTRY
 
 extern void WINAPI Control_RunDLLW(HWND hWnd, HINSTANCE hInst, LPCWSTR cmd, DWORD nCmdShow);
 
-static VOID
+VOID
 GetSetupInfPath(PWSTR szPath, UINT cchMax)
 {
     GetSystemDirectoryW(szPath, cchMax);
@@ -2749,39 +2749,32 @@ SetInstallationCompleted(IN BOOL Unattended)
     DWORD InProgress = 0;
     DWORD InstallDate;
 
-    if (RegOpenKeyExW( HKEY_LOCAL_MACHINE,
-                       L"Software\\Microsoft\\Windows NT\\CurrentVersion",
-                       0,
-                       KEY_WRITE,
-                       &hKey ) == ERROR_SUCCESS)
+    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows NT\\CurrentVersion",
+                      0, KEY_WRITE, &hKey) == ERROR_SUCCESS)
     {
         InstallDate = (DWORD)time(NULL);
-        RegSetValueExW( hKey, L"InstallDate", 0, REG_DWORD, (LPBYTE)&InstallDate, sizeof(InstallDate) );
-        RegCloseKey( hKey );
+        RegSetValueExW(hKey, L"InstallDate", 0, REG_DWORD, (LPBYTE)&InstallDate, sizeof(InstallDate));
+        RegCloseKey(hKey);
     }
 
     if (Unattended)
     {
         WCHAR szInf[MAX_PATH];
-        WCHAR szInfCmd[MAX_PATH * 4], szCmd[ARRAYSIZE(szInfCmd)];
+        WCHAR szInfCmd[MAX_PATH * 4], szCmd[_countof(szInfCmd)];
 
         GetSetupInfPath(szInf, _countof(szInf));
         if (GetPrivateProfileStringW(L"SetupParams", L"UserExecute", L"", szInfCmd, _countof(szInfCmd), szInf) && *szInfCmd)
         {
             *szCmd = UNICODE_NULL;
-            ExpandEnvironmentStringsW(szInfCmd, szCmd, ARRAYSIZE(szInfCmd));
+            ExpandEnvironmentStringsW(szInfCmd, szCmd, _countof(szInfCmd));
             RunCommandAndWait(szCmd);
         }
     }
 
-    if (RegOpenKeyExW( HKEY_LOCAL_MACHINE,
-                       L"SYSTEM\\Setup",
-                       0,
-                       KEY_WRITE,
-                       &hKey ) == ERROR_SUCCESS)
+    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SYSTEM\\Setup", 0, KEY_WRITE, &hKey) == ERROR_SUCCESS)
     {
-        RegSetValueExW( hKey, L"SystemSetupInProgress", 0, REG_DWORD, (LPBYTE)&InProgress, sizeof(InProgress) );
-        RegCloseKey( hKey );
+        RegSetValueExW(hKey, L"SystemSetupInProgress", 0, REG_DWORD, (LPBYTE)&InProgress, sizeof(InProgress));
+        RegCloseKey(hKey);
     }
 }
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -8,6 +8,7 @@
  *                  Ismael Ferreras Morezuelas <swyterzone+ros@gmail.com>
  *                  Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *                  Oleg Dubinskiy <oleg.dubinskij30@gmail.com>
+ *                  Whindmar Saksit <whindsaks@proton.me>
  */
 
 /* INCLUDES *****************************************************************/
@@ -51,6 +52,13 @@ typedef struct _TIMEZONE_ENTRY
 /* FUNCTIONS ****************************************************************/
 
 extern void WINAPI Control_RunDLLW(HWND hWnd, HINSTANCE hInst, LPCWSTR cmd, DWORD nCmdShow);
+
+static VOID
+GetSetupInfPath(PWSTR szPath, UINT cchMax)
+{
+    GetSystemDirectoryW(szPath, cchMax);
+    wcscat(szPath, L"\\$winnt$.inf");
+}
 
 static VOID
 CenterWindow(HWND hWnd)
@@ -2735,21 +2743,11 @@ ProcessPageDlgProc(HWND hwndDlg,
 
 
 static VOID
-SetInstallationCompleted(VOID)
+SetInstallationCompleted(IN BOOL Unattended)
 {
     HKEY hKey = 0;
     DWORD InProgress = 0;
     DWORD InstallDate;
-
-    if (RegOpenKeyExW( HKEY_LOCAL_MACHINE,
-                       L"SYSTEM\\Setup",
-                       0,
-                       KEY_WRITE,
-                       &hKey ) == ERROR_SUCCESS)
-    {
-        RegSetValueExW( hKey, L"SystemSetupInProgress", 0, REG_DWORD, (LPBYTE)&InProgress, sizeof(InProgress) );
-        RegCloseKey( hKey );
-    }
 
     if (RegOpenKeyExW( HKEY_LOCAL_MACHINE,
                        L"Software\\Microsoft\\Windows NT\\CurrentVersion",
@@ -2759,6 +2757,30 @@ SetInstallationCompleted(VOID)
     {
         InstallDate = (DWORD)time(NULL);
         RegSetValueExW( hKey, L"InstallDate", 0, REG_DWORD, (LPBYTE)&InstallDate, sizeof(InstallDate) );
+        RegCloseKey( hKey );
+    }
+
+    if (Unattended)
+    {
+        WCHAR szInf[MAX_PATH];
+        WCHAR szInfCmd[MAX_PATH * 4], szCmd[ARRAYSIZE(szInfCmd)];
+
+        GetSetupInfPath(szInf, _countof(szInf));
+        if (GetPrivateProfileStringW(L"SetupParams", L"UserExecute", L"", szInfCmd, _countof(szInfCmd), szInf) && *szInfCmd)
+        {
+            *szCmd = UNICODE_NULL;
+            ExpandEnvironmentStringsW(szInfCmd, szCmd, ARRAYSIZE(szInfCmd));
+            RunCommandAndWait(szCmd);
+        }
+    }
+
+    if (RegOpenKeyExW( HKEY_LOCAL_MACHINE,
+                       L"SYSTEM\\Setup",
+                       0,
+                       KEY_WRITE,
+                       &hKey ) == ERROR_SUCCESS)
+    {
+        RegSetValueExW( hKey, L"SystemSetupInProgress", 0, REG_DWORD, (LPBYTE)&InProgress, sizeof(InProgress) );
         RegCloseKey( hKey );
     }
 }
@@ -2785,7 +2807,7 @@ FinishDlgProc(HWND hwndDlg,
             if (SetupData->UnattendSetup)
             {
                 KillTimer(hwndDlg, 1);
-                SetInstallationCompleted();
+                SetInstallationCompleted(TRUE);
                 PostQuitMessage(0);
             }
 
@@ -2797,7 +2819,7 @@ FinishDlgProc(HWND hwndDlg,
 
         case WM_DESTROY:
         {
-            SetInstallationCompleted();
+            SetInstallationCompleted(FALSE);
             PostQuitMessage(0);
             return TRUE;
         }
@@ -3330,8 +3352,7 @@ ProcessSetupInf(
     pSetupData->hSetupInf = INVALID_HANDLE_VALUE;
 
     /* Retrieve the path of the setup INF */
-    GetSystemDirectoryW(szPath, _countof(szPath));
-    wcscat(szPath, L"\\$winnt$.inf");
+    GetSetupInfPath(szPath, _countof(szPath));
 
     /* Open the setup INF */
     pSetupData->hSetupInf = SetupOpenInfFileW(szPath,


### PR DESCRIPTION
This PR implements two of the three hooks that allows you to run custom applications during 2nd-stage setup (the 3rd hook is `...\$OEM$\Cmdlines.txt` but that requires file copy operations etc.)

`DetachedProgram` is [documented](https://web.archive.org/web/20090902145959/http://technet.microsoft.com/en-us/library/cc757642(WS.10).aspx) for NT4..2003 but I had a lot of trouble actually getting Windows to execute it. I successfully tested `UserExecute` on 2000, XP and 2003 but I'm still guessing a bit as to when exactly this is supposed to be executed. In all versions, `InstallDate` has been set in the registry and `SystemSetupInProgress` is still 1 so I placed our call exactly between those two points.

<img width="641" height="482" alt="XP UserExecute" src="https://github.com/user-attachments/assets/d4c992ef-2248-423a-8b3f-b0914444fccd" />

`UserExecute` is a great place to install VM Guest Additions, one reboot less and you have shared folders/clipboard on the first normal boot.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: