### PR TITLE
[MSPAINT] Support monochrome

### DIFF
--- a/base/applications/mspaint/CMakeLists.txt
+++ b/base/applications/mspaint/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND SOURCE
     dialogs.cpp
     dib.cpp
     drawing.cpp
+    floyd.cpp
     fullscreen.cpp
     history.cpp
     main.cpp
@@ -31,7 +32,7 @@ file(GLOB mspaint_rc_deps img/*.*)
 add_rc_deps(rsrc.rc ${mspaint_rc_deps})
 add_executable(mspaint ${SOURCE} rsrc.rc)
 set_module_type(mspaint win32gui UNICODE)
-target_link_libraries(mspaint uuid cpprt atl_classes)
+target_link_libraries(mspaint uuid cppstl atl_classes)
 set_target_cpp_properties(mspaint WITH_EXCEPTIONS)
 add_importlibs(mspaint comdlg32 shell32 user32 gdi32 advapi32 comctl32 msvcrt kernel32 rpcrt4 shlwapi ntdll)
 add_pch(mspaint precomp.h SOURCE)

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -314,8 +314,6 @@ BOOL CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
              imageModel.GetDC(), rcImageDraw.left, rcImageDraw.top, SRCCOPY);
 
     // Draw overlay #1 on hdcMem1
-    SetTextColor(hdcMem1, RGB(255, 255, 255));
-    SetBkColor(hdcMem1, RGB(0, 0, 0));
     toolsModel.OnDrawOverlayOnImage(hdcMem1);
 
     // Transfer the bits with stretch (hdcMem0 <-- hdcMem1)

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -314,6 +314,8 @@ BOOL CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
              imageModel.GetDC(), rcImageDraw.left, rcImageDraw.top, SRCCOPY);
 
     // Draw overlay #1 on hdcMem1
+    SetTextColor(hdcMem1, RGB(255, 255, 255));
+    SetBkColor(hdcMem1, RGB(0, 0, 0));
     toolsModel.OnDrawOverlayOnImage(hdcMem1);
 
     // Transfer the bits with stretch (hdcMem0 <-- hdcMem1)
@@ -439,7 +441,7 @@ VOID CCanvasWindow::OnHVScroll(WPARAM wParam, INT fnBar)
             si.nPos += si.nPage;
             break;
     }
-    si.nPos = max(min(si.nPos, si.nMax), si.nMin);
+    si.nPos = __max(__min(si.nPos, si.nMax), si.nMin);
     SetScrollInfo(fnBar, &si);
     Invalidate();
 }
@@ -630,10 +632,10 @@ LRESULT CCanvasWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
     }
 
     // Limit bitmap size
-    cxImage = max(1, cxImage);
-    cyImage = max(1, cyImage);
-    cxImage = min(MAXWORD, cxImage);
-    cyImage = min(MAXWORD, cyImage);
+    cxImage = __max(1, cxImage);
+    cyImage = __max(1, cyImage);
+    cxImage = __min(MAXWORD, cxImage);
+    cyImage = __min(MAXWORD, cyImage);
 
     // Display new size
     CStringW strSize;

--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -206,17 +206,17 @@ LRESULT CAttributesDialog::OnEdit1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
         if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
-            newWidth = max(1, (int)(wcstod(tempS, NULL) * g_xDpi));
+            newWidth = __max(1, (int)(wcstod(tempS, NULL) * g_xDpi));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
-            newWidth = max(1, (int)(wcstod(tempS, NULL) * PpcmFromDpi(g_xDpi)));
+            newWidth = __max(1, (int)(wcstod(tempS, NULL) * PpcmFromDpi(g_xDpi)));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
-            newWidth = max(1, _wtoi(tempS));
+            newWidth = __max(1, _wtoi(tempS));
         }
         Edit_SetModify(hWndCtl, FALSE);
     }
@@ -231,17 +231,17 @@ LRESULT CAttributesDialog::OnEdit2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
         if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
-            newHeight = max(1, (int)(wcstod(tempS, NULL) * g_yDpi));
+            newHeight = __max(1, (int)(wcstod(tempS, NULL) * g_yDpi));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
-            newHeight = max(1, (int)(wcstod(tempS, NULL) * PpcmFromDpi(g_yDpi)));
+            newHeight = __max(1, (int)(wcstod(tempS, NULL) * PpcmFromDpi(g_yDpi)));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
-            newHeight = max(1, _wtoi(tempS));
+            newHeight = __max(1, _wtoi(tempS));
         }
         Edit_SetModify(hWndCtl, FALSE);
     }
@@ -375,7 +375,7 @@ void CFontsDialog::InitToolbar()
     ::SendMessageW(hwndToolbar, TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
     ::SendMessageW(hwndToolbar, TB_SETBITMAPSIZE, 0, MAKELPARAM(16, 16));
     ::SendMessageW(hwndToolbar, TB_SETBUTTONWIDTH, 0, MAKELPARAM(20, 20));
-    
+
     TBADDBITMAP AddBitmap;
     AddBitmap.hInst = g_hinstExe;
     AddBitmap.nID = IDB_FONTSTOOLBAR;

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -66,9 +66,7 @@ CreateColorDIB(int width, int height, COLORREF rgb)
     if (!ret)
         return NULL;
 
-    if (rgb)
-        FillDIBByColor(ret, rgb);
-
+    FillDIBByColor(ret, rgb);
     return ret;
 }
 
@@ -112,7 +110,10 @@ HBITMAP CopyDIBImage(HBITMAP hbm, INT cx, INT cy, INT stretchMode, COLORREF rgbC
 
     BITMAP bm;
     if (!::GetObjectW(hbm, sizeof(bm), &bm))
+    {
+        ::DeleteObject(hbmNew);
         return NULL;
+    }
 
     if (cx == 0 || cy == 0)
     {

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -110,10 +110,17 @@ HBITMAP CopyMonoImage(HBITMAP hbm, INT cx, INT cy, INT stretchMode)
     return hbmNew;
 }
 
-HBITMAP CopyDIBImage(HBITMAP hbm, INT cx, INT cy, INT stretchMode)
+HBITMAP CopyDIBImage(HBITMAP hbm, INT cx, INT cy, INT stretchMode, COLORREF rgbColor)
 {
+    HBITMAP hbmNew = (HBITMAP)CopyImage(hbm, IMAGE_BITMAP, cx, cy, LR_CREATEDIBSECTION);
+    if (!hbmNew)
+        return NULL;
     if (stretchMode == STRETCH_HALFTONE)
-        return (HBITMAP)CopyImage(hbm, IMAGE_BITMAP, cx, cy, LR_CREATEDIBSECTION);
+    {
+        if (rgbColor != CLR_INVALID)
+            FillDIBByColor(hbmNew, rgbColor);
+        return hbmNew;
+    }
 
     BITMAP bm;
     if (!::GetObjectW(hbm, sizeof(bm), &bm))
@@ -127,7 +134,6 @@ HBITMAP CopyDIBImage(HBITMAP hbm, INT cx, INT cy, INT stretchMode)
 
     HDC hdc1 = ::CreateCompatibleDC(NULL);
     HDC hdc2 = ::CreateCompatibleDC(NULL);
-    HBITMAP hbmNew = CreateDIBWithProperties(cx, cy);
     HGDIOBJ hbm1Old = ::SelectObject(hdc1, hbm);
     HGDIOBJ hbm2Old = ::SelectObject(hdc2, hbmNew);
     ::SetStretchBltMode(hdc2, stretchMode);
@@ -136,6 +142,10 @@ HBITMAP CopyDIBImage(HBITMAP hbm, INT cx, INT cy, INT stretchMode)
     ::SelectObject(hdc2, hbm2Old);
     ::DeleteDC(hdc1);
     ::DeleteDC(hdc2);
+
+    if (rgbColor != CLR_INVALID)
+        FillDIBByColor(hbmNew, rgbColor);
+
     return hbmNew;
 }
 
@@ -271,6 +281,8 @@ HBITMAP InitializeImage(LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile)
 
 HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile)
 {
+    paletteModel.SetColorInfo(hBitmap);
+
     // update image
     canvasWindow.updateScrollPos();
     imageModel.PushImageForUndo(hBitmap);
@@ -302,23 +314,40 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile)
             return InitializeImage(name, &find, TRUE);
     }
 
+    LPCWSTR pchDotExt = PathFindExtensionW(name);
+    BOOL bBMP = !lstrcmpiW(pchDotExt, L".bmp") || !lstrcmpiW(pchDotExt, L".dib");
+
     // load the image
-    CImageDx img;
+    HBITMAP hBitmap;
     float xDpi = 0, yDpi = 0;
-    HRESULT hr = img.LoadDx(name, &xDpi, &yDpi);
-    if (FAILED(hr) && fIsMainFile)
+    if (bBMP)
     {
-        imageModel.ClearHistory();
-        hr = img.LoadDx(name, &xDpi, &yDpi);
+        hBitmap = LoadBitmapFromFile(name, &xDpi, &yDpi);
+        if (!hBitmap)
+        {
+            ShowError(IDS_LOADERRORTEXT, name);
+            return NULL;
+        }
     }
-    if (FAILED(hr))
+    else
     {
-        ATLTRACE("hr: 0x%08lX\n", hr);
-        ShowError(IDS_LOADERRORTEXT, name);
-        return NULL;
+        CImageDx img;
+        HRESULT hr = img.LoadDx(name, &xDpi, &yDpi);
+        if (FAILED(hr) && fIsMainFile)
+        {
+            imageModel.ClearHistory();
+            hr = img.LoadDx(name, &xDpi, &yDpi);
+        }
+        if (FAILED(hr))
+        {
+            ATLTRACE("hr: 0x%08lX\n", hr);
+            ShowError(IDS_LOADERRORTEXT, name);
+            return NULL;
+        }
+
+        hBitmap = img.Detach();
     }
 
-    HBITMAP hBitmap = img.Detach();
     if (!fIsMainFile)
         return hBitmap;
 
@@ -337,17 +366,20 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile)
     return hBitmap;
 }
 
-HBITMAP Rotate90DegreeBlt(HDC hDC1, INT cx, INT cy, BOOL bRight, BOOL bMono)
+HBITMAP Rotate90DegreeBitmap(HBITMAP hbm, BOOL bRight)
 {
-    HBITMAP hbm2;
-    if (bMono)
-        hbm2 = ::CreateBitmap(cy, cx, 1, 1, NULL);
-    else
-        hbm2 = CreateDIBWithProperties(cy, cx);
+    BITMAP bm;
+    if (!GetObjectW(hbm, sizeof(bm), &bm))
+        return NULL;
+
+    const LONG cx = bm.bmWidth, cy = bm.bmHeight;
+    HBITMAP hbm2 = CopyDIBImage(hbm, cy, cx, STRETCH_DELETESCANS);
     if (!hbm2)
         return NULL;
 
+    HDC hDC1 = CreateCompatibleDC(NULL);
     HDC hDC2 = CreateCompatibleDC(NULL);
+    HGDIOBJ hbm1Old = SelectObject(hDC1, hbm);
     HGDIOBJ hbm2Old = SelectObject(hDC2, hbm2);
     if (bRight)
     {
@@ -372,7 +404,9 @@ HBITMAP Rotate90DegreeBlt(HDC hDC1, INT cx, INT cy, BOOL bRight, BOOL bMono)
         }
     }
     SelectObject(hDC2, hbm2Old);
+    SelectObject(hDC1, hbm1Old);
     DeleteDC(hDC2);
+    DeleteDC(hDC1);
     return hbm2;
 }
 
@@ -396,11 +430,8 @@ HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical, BOOL bMono)
     if (dx == 0 && dy == 0)
         return CopyDIBImage(hbm);
 
-    HBITMAP hbmNew;
-    if (bMono)
-        hbmNew = CreateMonoBitmap(cx + dx, cy + dy, FALSE);
-    else
-        hbmNew = CreateColorDIB(cx + dx, cy + dy, RGB(255, 255, 255));
+    HBITMAP hbmNew = CopyDIBImage(hbm, cx + dx, cy + dy, STRETCH_DELETESCANS,
+                                  paletteModel.GetBgColor());
     if (!hbmNew)
         return NULL;
 
@@ -437,7 +468,7 @@ HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical, BOOL bMono)
 HBITMAP getSubImage(HBITMAP hbmWhole, const RECT& rcPartial)
 {
     CRect rc = rcPartial;
-    HBITMAP hbmPart = CreateDIBWithProperties(rc.Width(), rc.Height());
+    HBITMAP hbmPart = CopyDIBImage(hbmWhole, rc.Width(), rc.Height());
     if (!hbmPart)
         return NULL;
 
@@ -467,10 +498,174 @@ void putSubImage(HBITMAP hbmWhole, const RECT& rcPartial, HBITMAP hbmPart)
     ::DeleteDC(hDC2);
 }
 
+void FillDIBByColor(HBITMAP hbm, COLORREF rgbColor)
+{
+    BITMAP bm;
+    if (!GetObjectW(hbm, sizeof(bm), &bm))
+        return;
+
+    HDC hDC = CreateCompatibleDC(NULL);
+    HGDIOBJ hbmOld = SelectObject(hDC, hbm);
+    for (LONG y = 0; y < bm.bmHeight; ++y)
+    {
+        for (LONG x = 0; x < bm.bmWidth; ++x)
+        {
+            SetPixelV(hDC, x, y, rgbColor);
+        }
+    }
+    SelectObject(hDC, hbmOld);
+    DeleteDC(hDC);
+}
+
 struct BITMAPINFODX : BITMAPINFO
 {
     RGBQUAD bmiColorsAdditional[256 - 1];
 };
+
+const float INCHES_PER_METER = 0.0254f;
+
+HBITMAP LoadBitmapFromFile(LPCWSTR filename, float* xDpi, float* yDpi)
+{
+    if (!filename)
+        return nullptr;
+
+    HANDLE hFile = CreateFileW(filename, GENERIC_READ, FILE_SHARE_READ, nullptr,
+                               OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (hFile == INVALID_HANDLE_VALUE)
+        return nullptr;
+
+    HBITMAP hBitmap = nullptr;
+    DWORD bytesRead = 0;
+
+    // Load BITMAPFILEHEADER
+    BITMAPFILEHEADER bfh;
+    if (!ReadFile(hFile, &bfh, sizeof(bfh), &bytesRead, nullptr) || bytesRead != sizeof(bfh) ||
+        bfh.bfType != 0x4D42)
+    {
+        CloseHandle(hFile);
+        return nullptr;
+    }
+
+    // Load header size
+    DWORD headerSize = 0;
+    if (!ReadFile(hFile, &headerSize, sizeof(headerSize), &bytesRead, nullptr) ||
+        bytesRead != sizeof(headerSize))
+    {
+        CloseHandle(hFile);
+        return nullptr;
+    }
+
+    SetFilePointer(hFile, sizeof(BITMAPFILEHEADER), nullptr, FILE_BEGIN);
+
+    DWORD infoSize = bfh.bfOffBits - sizeof(BITMAPFILEHEADER);
+    PBITMAPINFO pBi = (PBITMAPINFO)malloc(infoSize);
+    if (!pBi)
+    {
+        CloseHandle(hFile);
+        return nullptr;
+    }
+
+    if (!ReadFile(hFile, pBi, infoSize, &bytesRead, nullptr) || bytesRead != infoSize)
+    {
+        free(pBi);
+        CloseHandle(hFile);
+        return nullptr;
+    }
+
+    float localXDpi = 96.0f;
+    float localYDpi = 96.0f;
+    if (headerSize >= sizeof(BITMAPINFOHEADER))
+    {
+        PBITMAPINFOHEADER pBih = &(pBi->bmiHeader);
+        localXDpi =
+            (pBih->biXPelsPerMeter > 0) ? (pBih->biXPelsPerMeter * INCHES_PER_METER) : 96.0f;
+        localYDpi =
+            (pBih->biYPelsPerMeter > 0) ? (pBih->biYPelsPerMeter * INCHES_PER_METER) : 96.0f;
+    }
+
+    if (xDpi)
+        *xDpi = localXDpi;
+    if (yDpi)
+        *yDpi = localYDpi;
+
+    PVOID pBits = nullptr;
+    HDC hDC = GetDC(nullptr);
+    hBitmap = CreateDIBSection(hDC, pBi, DIB_RGB_COLORS, &pBits, nullptr, 0);
+    ReleaseDC(nullptr, hDC);
+
+    if (hBitmap && pBits)
+    {
+        SetFilePointer(hFile, bfh.bfOffBits, nullptr, FILE_BEGIN);
+        DWORD bitsSize = bfh.bfSize - bfh.bfOffBits;
+        ReadFile(hFile, pBits, bitsSize, &bytesRead, nullptr);
+    }
+
+    free(pBi);
+    CloseHandle(hFile);
+    return hBitmap;
+}
+
+BOOL SaveBitmapToFile(HBITMAP hBitmap, LPCWSTR filename, float xDpi, float yDpi)
+{
+    if (!hBitmap || !filename)
+        return FALSE;
+
+    BITMAP bm;
+    if (!GetObject(hBitmap, sizeof(BITMAP), &bm))
+        return FALSE;
+
+    BITMAPINFOHEADER bih = { 0 };
+    bih.biSize = sizeof(BITMAPINFOHEADER);
+    bih.biWidth = bm.bmWidth;
+    bih.biHeight = bm.bmHeight;
+    bih.biPlanes = 1;
+    bih.biBitCount = bm.bmBitsPixel;
+    bih.biCompression = BI_RGB;
+
+    bih.biXPelsPerMeter = static_cast<LONG>(std::round(xDpi / INCHES_PER_METER));
+    bih.biYPelsPerMeter = static_cast<LONG>(std::round(yDpi / INCHES_PER_METER));
+
+    DWORD rowSize = ((bm.bmWidth * bm.bmBitsPixel + 31) / 32) * 4;
+    bih.biSizeImage = rowSize * bm.bmHeight;
+
+    BITMAPFILEHEADER bfh = { 0 };
+    bfh.bfType = 0x4D42; // "BM"
+    bfh.bfOffBits = sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER);
+    bfh.bfSize = bfh.bfOffBits + bih.biSizeImage;
+
+    PVOID pBits = malloc(bih.biSizeImage);
+    if (!pBits)
+        return FALSE;
+
+    HDC hDC = GetDC(nullptr);
+    if (!GetDIBits(hDC, hBitmap, 0, bm.bmHeight, pBits, (PBITMAPINFO)&bih, DIB_RGB_COLORS))
+    {
+        ReleaseDC(nullptr, hDC);
+        free(pBits);
+        return FALSE;
+    }
+    ReleaseDC(nullptr, hDC);
+
+    HANDLE hFile = CreateFileW(filename, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
+                               FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (hFile == INVALID_HANDLE_VALUE)
+    {
+        free(pBits);
+        return FALSE;
+    }
+
+    DWORD bytesWritten = 0;
+    BOOL bOK = WriteFile(hFile, &bfh, sizeof(bfh), &bytesWritten, nullptr) &&
+               WriteFile(hFile, &bih, sizeof(bih), &bytesWritten, nullptr) &&
+               WriteFile(hFile, pBits, bih.biSizeImage, &bytesWritten, nullptr);
+    CloseHandle(hFile);
+    free(pBits);
+
+    if (!bOK)
+        DeleteFileW(filename);
+
+    return bOK;
+}
 
 HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
 {
@@ -605,92 +800,264 @@ HBITMAP BitmapFromHEMF(HENHMETAFILE hEMF)
     return hbm;
 }
 
+static inline BOOL IsPerfectBlack(const RGBQUAD* color)
+{
+    return !color->rgbBlue && !color->rgbGreen && !color->rgbRed;
+}
+
+static inline BOOL IsPerfectWhite(const RGBQUAD* color)
+{
+    return color->rgbBlue + color->rgbGreen + color->rgbRed == 255 * 3;
+}
+
 BOOL IsBitmapBlackAndWhite(HBITMAP hbm)
+{
+    BITMAP bm;
+    if (!::GetObjectW(hbm, sizeof(bm), &bm) && (bm.bmBitsPixel != 1))
+        return FALSE;
+
+    RGBQUAD colors[2];
+    HDC hDC = CreateCompatibleDC(NULL);
+    HGDIOBJ hbmOld = SelectObject(hDC, hbm);
+    INT ret = GetDIBColorTable(hDC, 0, (UINT)_countof(colors), colors);
+    SelectObject(hDC, hbmOld);
+    DeleteDC(hDC);
+
+    if (ret != 2)
+        return FALSE;
+
+    return ((IsPerfectBlack(&colors[0]) || IsPerfectWhite(&colors[0])) &&
+            (IsPerfectBlack(&colors[1]) || IsPerfectWhite(&colors[1])));
+}
+
+/**
+ * @brief Packs a flat index image into a stride-aligned packed-pixel buffer.
+ *
+ * Converts a per-pixel index array (one byte per pixel) into the packed format
+ * required by Windows DIBs: 8 bpp is a straight byte copy, 4 bpp packs two
+ * nibbles per byte (high nibble first), and 1 bpp packs eight pixels per byte
+ * (MSB first).  The destination buffer is zeroed before packing so unused
+ * padding bits are always zero.
+ *
+ * @param indexImg  Source buffer; one byte per pixel, row-major, no padding.
+ * @param W         Image width in pixels.
+ * @param H         Image height in pixels.
+ * @param nBpp      Bits per pixel of the destination format (1, 4, or 8).
+ * @param dstBuf    Destination buffer; must be at least @p dstStride * @p H bytes.
+ * @param dstStride Row stride of the destination buffer in bytes (DWORD-aligned).
+ */
+static void
+PackIndexImage(const BYTE* indexImg, SIZE_T W, SIZE_T H, INT nBpp, PBYTE dstBuf, INT dstStride)
+{
+    ZeroMemory(dstBuf, dstStride * H);
+
+    for (SIZE_T y = 0; y < H; ++y)
+    {
+        const BYTE* src = indexImg + y * W;
+        PBYTE dst = dstBuf + y * dstStride;
+
+        switch (nBpp)
+        {
+            case 8:
+                CopyMemory(dst, src, W);
+                break;
+            case 4:
+                for (SIZE_T x = 0; x < W; ++x)
+                {
+                    BYTE v = src[x] & 0x0F;
+                    if (x & 1)
+                        dst[x >> 1] |= v;
+                    else
+                        dst[x >> 1] |= (v << 4);
+                }
+                break;
+            case 1:
+                for (SIZE_T x = 0; x < W; ++x)
+                {
+                    if (src[x])
+                        dst[x >> 3] |= (BYTE)(0x80 >> (x & 7));
+                }
+                break;
+        }
+    }
+}
+
+/**
+ * @brief Fills a palette array with a standard color set for the given bit depth.
+ *
+ * - 1 bpp: two entries - black and white.
+ * - 4 bpp: the 16-color Windows standard palette (RGBQUAD / BGRA order).
+ * - 8 bpp: 216-entry 6 x 6 x 6 RGB color cube followed by 40 evenly-spaced
+ *          grayscale entries (256 entries total).
+ *
+ * @param nBpp    Bit depth that determines the palette size (1, 4, or 8).
+ * @param palette Output array; must hold at least @c (1 << nBpp) RGBQUAD entries.
+ */
+static void BuildPalette(INT nBpp, RGBQUAD* palette)
+{
+    if (nBpp == 1)
+    {
+        palette[0] = { 0,   0,   0,   0 }; // Black
+        palette[1] = { 255, 255, 255, 0 }; // White
+    }
+    else if (nBpp == 4)
+    {
+        // Windows standard 16 colors (BGRA)
+        static const RGBQUAD win16[16] = {
+            {   0,   0,   0, 0 }, {   0,   0, 128, 0 }, {   0, 128,   0, 0 }, {   0, 128, 128, 0 },
+            { 128,   0,   0, 0 }, { 128,   0, 128, 0 }, { 128, 128,   0, 0 }, { 192, 192, 192, 0 },
+            { 128, 128, 128, 0 }, {   0,   0, 255, 0 }, {   0, 255,   0, 0 }, {   0, 255, 255, 0 },
+            { 255,   0,   0, 0 }, { 255,   0, 255, 0 }, { 255, 255,   0, 0 }, { 255, 255, 255, 0 },
+        };
+        for (INT i = 0; i < 16; ++i)
+            palette[i] = win16[i];
+    }
+    else if (nBpp == 8)
+    {
+        // 6 x 6 x 6 color cubes (216 colors)
+        static const BYTE step6[6] = { 0, 51, 102, 153, 204, 255 };
+        INT idx = 0;
+        for (INT ri = 0; ri < 6; ++ri)
+        {
+            for (INT gi = 0; gi < 6; ++gi)
+            {
+                for (INT bi = 0; bi < 6; ++bi)
+                {
+                    palette[idx++] = { step6[bi], step6[gi], step6[ri], 0 };
+                }
+            }
+        }
+
+        // 40 grayscale colors
+        for (INT i = 0; i < 40; ++i, ++idx)
+        {
+            BYTE v = (BYTE)((i * 255 + 19) / 39); // 0..255
+            palette[idx] = { v, v, v, 0 };
+        }
+    }
+}
+
+/**
+ * @brief Creates a new DIB with a reduced color depth from an existing bitmap.
+ *
+ * Reads the source bitmap as a 24-bit BGR DIB, optionally applies
+ * Floyd-Steinberg dithering to map pixels to a standard palette, packs the
+ * result into the target bit depth, and returns a new @c HBITMAP.
+ *
+ * @param hBitmap  Handle to the source bitmap.  Must not be @c NULL.
+ * @param nBpp     Desired bit depth of the output bitmap (1, 4, 8, or 24).
+ * @return         Handle to the newly created bitmap, or @c NULL on failure.
+ *                 The caller is responsible for destroying the returned handle
+ *                 with @c DeleteObject.
+ */
+HBITMAP CreateNBppBitmap(HBITMAP hBitmap, INT nBpp)
 {
     CWaitCursor waitCursor;
 
+    if (!hBitmap)
+        return NULL;
+
+    if (nBpp == 32)
+        nBpp = 24; // We don't support 32-bpp
+
+    if (nBpp != 1 && nBpp != 4 && nBpp != 8 && nBpp != 24)
+        return NULL;
+
     BITMAP bm;
-    if (!::GetObjectW(hbm, sizeof(bm), &bm))
-        return FALSE;
+    if (!GetObject(hBitmap, sizeof(bm), &bm))
+        return NULL;
 
-    if (bm.bmBitsPixel == 1)
-        return TRUE;
+    const SIZE_T W = bm.bmWidth, H = bm.bmHeight;
+    if (W <= 0 || H <= 0 || W > MAXLONG || H > MAXLONG)
+        return NULL;
 
-    BITMAPINFOEX bmi;
-    ZeroMemory(&bmi, sizeof(bmi));
-    bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
-    bmi.bmiHeader.biWidth = bm.bmWidth;
-    bmi.bmiHeader.biHeight = bm.bmHeight;
-    bmi.bmiHeader.biPlanes = 1;
-    bmi.bmiHeader.biBitCount = 24;
+    const SIZE_T srcStride = WIDTHBYTES(W * 24);
+    CHeapPtr<BYTE, CLocalAllocator> srcBuf;
+    if (!srcBuf.Allocate(srcStride * H))
+        return NULL;
 
-    DWORD widthbytes = WIDTHBYTES(24 * bm.bmWidth);
-    DWORD cbBits = widthbytes * bm.bmHeight;
-    LPBYTE pbBits = new BYTE[cbBits];
+    BITMAPINFOHEADER bihSrc = {};
+    bihSrc.biSize     = sizeof(bihSrc);
+    bihSrc.biWidth    = (LONG)W;
+    bihSrc.biHeight   = -(LONG)H; // Top-down
+    bihSrc.biPlanes   = 1;
+    bihSrc.biBitCount = 24;
 
-    HDC hdc = ::CreateCompatibleDC(NULL);
-    ::GetDIBits(hdc, hbm, 0, bm.bmHeight, pbBits, &bmi, DIB_RGB_COLORS);
-    ::DeleteDC(hdc);
+    BITMAPINFO biSrc = {};
+    biSrc.bmiHeader = bihSrc;
 
-    BOOL bBlackAndWhite = TRUE;
-    for (LONG y = 0; y < bm.bmHeight; ++y)
+    HDC hScreenDC = GetDC(NULL);
+    if (!hScreenDC)
+        return NULL;
+
+    BOOL bGot = ((SIZE_T)GetDIBits(hScreenDC, hBitmap, 0, H, srcBuf, &biSrc, DIB_RGB_COLORS) == H);
+    ReleaseDC(NULL, hScreenDC);
+    if (!bGot)
+        return NULL;
+
+    if (nBpp == 24)
     {
-        LPBYTE pbLine = &pbBits[widthbytes * y];
-        for (LONG x = 0; x < bm.bmWidth; ++x)
-        {
-            BYTE Blue = *pbLine++;
-            BYTE Green = *pbLine++;
-            BYTE Red = *pbLine++;
-            COLORREF rgbColor = RGB(Red, Green, Blue);
-            if (rgbColor != RGB(0, 0, 0) && rgbColor != RGB(255, 255, 255))
-            {
-                bBlackAndWhite = FALSE;
-                goto Finish;
-            }
-        }
+        PVOID pBits = NULL;
+        HDC hdc = GetDC(NULL);
+        HBITMAP hbmResult = CreateDIBSection(hdc, &biSrc, DIB_RGB_COLORS, &pBits, NULL, 0);
+        ReleaseDC(NULL, hdc);
+        if (hbmResult && pBits)
+            CopyMemory(pBits, srcBuf, srcStride * H);
+        return hbmResult;
     }
 
-Finish:
-    delete[] pbBits;
+    const INT nColors = 1 << nBpp;
+    CHeapPtr<RGBQUAD, CLocalAllocator> palette;
+    if (!palette.Allocate(nColors))
+        return NULL;
 
-    return bBlackAndWhite;
+    BuildPalette(nBpp, palette);
+
+    CHeapPtr<BYTE, CLocalAllocator> indexImg;
+    if (!indexImg.Allocate(W * H))
+        return NULL;
+    FloydSteinberg(srcBuf, srcStride, W, H, palette, nColors, indexImg);
+
+    const SIZE_T dstStride = WIDTHBYTES(W * nBpp);
+    CHeapPtr<BYTE, CLocalAllocator> dstBuf;
+    if (!dstBuf.Allocate(dstStride * H))
+        return NULL;
+    PackIndexImage(indexImg, W, H, nBpp, dstBuf, dstStride);
+
+    const SIZE_T biBytes = sizeof(BITMAPINFOHEADER) + nColors * sizeof(RGBQUAD);
+    CHeapPtr<BYTE, CLocalAllocator> biMem;
+    if (!biMem.Allocate(biBytes))
+        return NULL;
+
+    PBITMAPINFO pBI = reinterpret_cast<PBITMAPINFO>((PBYTE)biMem);
+    pBI->bmiHeader.biSize         = sizeof(BITMAPINFOHEADER);
+    pBI->bmiHeader.biWidth        = (LONG)W;
+    pBI->bmiHeader.biHeight       = -(LONG)H; // Top-down
+    pBI->bmiHeader.biPlanes       = 1;
+    pBI->bmiHeader.biBitCount     = (WORD)nBpp;
+    pBI->bmiHeader.biCompression  = BI_RGB;
+    pBI->bmiHeader.biSizeImage    = (DWORD)(dstStride * H);
+    pBI->bmiHeader.biClrUsed      = (DWORD)nColors;
+    pBI->bmiHeader.biClrImportant = (DWORD)nColors;
+    for (INT i = 0; i < nColors; i++)
+        pBI->bmiColors[i] = palette[i];
+
+    PVOID pBits = NULL;
+    HBITMAP hbmResult = NULL;
+    HDC hdc = GetDC(NULL);
+    if (hdc)
+    {
+        hbmResult = CreateDIBSection(hdc, pBI, DIB_RGB_COLORS, &pBits, NULL, 0);
+        ReleaseDC(NULL, hdc);
+    }
+
+    if (hbmResult && pBits)
+        CopyMemory(pBits, dstBuf, (size_t)dstStride * H);
+
+    return hbmResult;
 }
 
 HBITMAP ConvertToBlackAndWhite(HBITMAP hbm)
 {
-    CWaitCursor waitCursor;
-
-    BITMAP bm;
-    if (!::GetObjectW(hbm, sizeof(bm), &bm))
-        return NULL;
-
-    BITMAPINFOEX bmi;
-    ZeroMemory(&bmi, sizeof(bmi));
-    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-    bmi.bmiHeader.biWidth = bm.bmWidth;
-    bmi.bmiHeader.biHeight = bm.bmHeight;
-    bmi.bmiHeader.biPlanes = 1;
-    bmi.bmiHeader.biBitCount = 1;
-    bmi.bmiColors[1].rgbBlue = 255;
-    bmi.bmiColors[1].rgbGreen = 255;
-    bmi.bmiColors[1].rgbRed = 255;
-    HDC hdc = ::CreateCompatibleDC(NULL);
-    LPVOID pvMonoBits;
-    HBITMAP hMonoBitmap = ::CreateDIBSection(hdc, &bmi, DIB_RGB_COLORS, &pvMonoBits, NULL, 0);
-    if (!hMonoBitmap)
-    {
-        ::DeleteDC(hdc);
-        return NULL;
-    }
-
-    HBITMAP hNewBitmap = CreateDIBWithProperties(bm.bmWidth, bm.bmHeight);
-    if (hNewBitmap)
-    {
-        ::GetDIBits(hdc, hbm, 0, bm.bmHeight, pvMonoBits, &bmi, DIB_RGB_COLORS);
-        ::SetDIBits(hdc, hNewBitmap, 0, bm.bmHeight, pvMonoBits, &bmi, DIB_RGB_COLORS);
-    }
-    ::DeleteObject(hMonoBitmap);
-    ::DeleteDC(hdc);
-
-    return hNewBitmap;
+    return CreateNBppBitmap(hbm, 1);
 }

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -26,6 +26,12 @@ COLORREF QuadToRGBValue(const RGBQUAD& quad)
     return RGB(quad.rgbRed, quad.rgbGreen, quad.rgbBlue);
 }
 
+RGBQUAD RGBValueToQuad(COLORREF rgbColor)
+{
+    RGBQUAD quad = { GetBValue(rgbColor), GetGValue(rgbColor), GetRValue(rgbColor) };
+    return quad;
+}
+
 // Convert DPI (dots per inch) into PPCM (pixels per centimeter)
 float PpcmFromDpi(float dpi)
 {

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -529,13 +529,14 @@ HRESULT LoadBitmapFromFile(HBITMAP* phBitmap, LPCWSTR filename, float* xDpi, flo
     BITMAPFILEHEADER bfh;
     DWORD bytesRead;
     if (!ReadFile(hFile, &bfh, sizeof(bfh), &bytesRead, nullptr) ||
-        bytesRead != sizeof(bfh) || bfh.bfType != 0x4D42)
+        bytesRead != sizeof(bfh) || bfh.bfType != 0x4D42 ||
+        bfh.bfOffBits < sizeof(bfh) || bfh.bfSize < bfh.bfOffBits)
     {
         CloseHandle(hFile);
         return E_FAIL;
     }
 
-    DWORD headerSize = 0;
+    DWORD headerSize;
     if (!ReadFile(hFile, &headerSize, sizeof(headerSize), &bytesRead, nullptr) ||
         bytesRead != sizeof(headerSize))
     {
@@ -560,8 +561,7 @@ HRESULT LoadBitmapFromFile(HBITMAP* phBitmap, LPCWSTR filename, float* xDpi, flo
         return E_FAIL;
     }
 
-    float localXDpi = 96.0f;
-    float localYDpi = 96.0f;
+    float localXDpi = 96.0f, localYDpi = 96.0f;
     if (headerSize >= sizeof(BITMAPINFOHEADER))
     {
         PBITMAPINFOHEADER pBih = &(pBi->bmiHeader);
@@ -798,7 +798,7 @@ HBITMAP BitmapFromHEMF(HENHMETAFILE hEMF)
 BOOL IsBitmapBlackAndWhite(HBITMAP hbm)
 {
     BITMAP bm;
-    if (!::GetObjectW(hbm, sizeof(bm), &bm) && (bm.bmBitsPixel != 1))
+    if (!::GetObjectW(hbm, sizeof(bm), &bm) || (bm.bmBitsPixel != 1))
         return FALSE;
 
     RGBQUAD colors[2];

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -304,7 +304,8 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile)
     LPCWSTR pchDotExt = PathFindExtensionW(name);
     BOOL bBMP = !lstrcmpiW(pchDotExt, L".bmp") || !lstrcmpiW(pchDotExt, L".dib");
 
-    // load the image
+    // Load the image
+    // NOTE: CImageDx::LoadDx won't keep BMP color info.
     HBITMAP hBitmap;
     float xDpi = 0, yDpi = 0;
     HRESULT hr;

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -60,7 +60,7 @@ CreateMonoBitmap(int width, int height, BOOL bWhite)
         return NULL;
 
     if (bWhite)
-        FillDIBByColor(hbm, RGB(255, 255, 255));
+        FillBitmapByColor(hbm, RGB(255, 255, 255));
 
     return hbm;
 }
@@ -72,7 +72,7 @@ CreateColorDIB(int width, int height, COLORREF rgb)
     if (!ret)
         return NULL;
 
-    FillDIBByColor(ret, rgb);
+    FillBitmapByColor(ret, rgb);
     return ret;
 }
 
@@ -132,7 +132,7 @@ HBITMAP CopyDIBImage(HBITMAP hbm, INT cx, INT cy, INT stretchMode, COLORREF rgbC
         ::DeleteDC(hdc2);
     }
 
-    FillDIBByColor(hbmNew, rgbColor);
+    FillBitmapByColor(hbmNew, rgbColor);
     return hbmNew;
 }
 
@@ -491,7 +491,7 @@ void putSubImage(HBITMAP hbmWhole, const RECT& rcPartial, HBITMAP hbmPart)
     ::DeleteDC(hDC2);
 }
 
-void FillDIBByColor(HBITMAP hbm, COLORREF rgbColor)
+void FillBitmapByColor(HBITMAP hbm, COLORREF rgbColor)
 {
     BITMAP bm;
     if (rgbColor == CLR_INVALID || !GetObjectW(hbm, sizeof(bm), &bm))

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -21,6 +21,11 @@ struct BITMAPINFOEX : BITMAPINFO
 
 /* FUNCTIONS ********************************************************/
 
+COLORREF QuadToRGBValue(const RGBQUAD& quad)
+{
+    return RGB(quad.rgbRed, quad.rgbGreen, quad.rgbBlue);
+}
+
 // Convert DPI (dots per inch) into PPCM (pixels per centimeter)
 float PpcmFromDpi(float dpi)
 {
@@ -49,14 +54,7 @@ CreateMonoBitmap(int width, int height, BOOL bWhite)
         return NULL;
 
     if (bWhite)
-    {
-        HDC hdc = CreateCompatibleDC(NULL);
-        HGDIOBJ hbmOld = SelectObject(hdc, hbm);
-        RECT rc = { 0, 0, width, height };
-        FillRect(hdc, &rc, (HBRUSH)GetStockObject(WHITE_BRUSH));
-        SelectObject(hdc, hbmOld);
-        DeleteDC(hdc);
-    }
+        FillDIBByColor(hbm, RGB(255, 255, 255));
 
     return hbm;
 }
@@ -69,17 +67,7 @@ CreateColorDIB(int width, int height, COLORREF rgb)
         return NULL;
 
     if (rgb)
-    {
-        HDC hdc = CreateCompatibleDC(NULL);
-        HGDIOBJ hbmOld = SelectObject(hdc, ret);
-        RECT rc;
-        SetRect(&rc, 0, 0, width, height);
-        HBRUSH hbr = CreateSolidBrush(rgb);
-        FillRect(hdc, &rc, hbr);
-        DeleteObject(hbr);
-        SelectObject(hdc, hbmOld);
-        DeleteDC(hdc);
-    }
+        FillDIBByColor(ret, rgb);
 
     return ret;
 }
@@ -115,10 +103,10 @@ HBITMAP CopyDIBImage(HBITMAP hbm, INT cx, INT cy, INT stretchMode, COLORREF rgbC
     HBITMAP hbmNew = (HBITMAP)CopyImage(hbm, IMAGE_BITMAP, cx, cy, LR_CREATEDIBSECTION);
     if (!hbmNew)
         return NULL;
+
     if (stretchMode == STRETCH_HALFTONE)
     {
-        if (rgbColor != CLR_INVALID)
-            FillDIBByColor(hbmNew, rgbColor);
+        FillDIBByColor(hbmNew, rgbColor);
         return hbmNew;
     }
 
@@ -143,9 +131,7 @@ HBITMAP CopyDIBImage(HBITMAP hbm, INT cx, INT cy, INT stretchMode, COLORREF rgbC
     ::DeleteDC(hdc1);
     ::DeleteDC(hdc2);
 
-    if (rgbColor != CLR_INVALID)
-        FillDIBByColor(hbmNew, rgbColor);
-
+    FillDIBByColor(hbmNew, rgbColor);
     return hbmNew;
 }
 
@@ -320,32 +306,33 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile)
     // load the image
     HBITMAP hBitmap;
     float xDpi = 0, yDpi = 0;
+    HRESULT hr;
     if (bBMP)
     {
-        hBitmap = LoadBitmapFromFile(name, &xDpi, &yDpi);
-        if (!hBitmap)
+        hr = LoadBitmapFromFile(&hBitmap, name, &xDpi, &yDpi);
+        if (FAILED(hr) && fIsMainFile)
         {
-            ShowError(IDS_LOADERRORTEXT, name);
-            return NULL;
+            imageModel.ClearHistory();
+            hr = LoadBitmapFromFile(&hBitmap, name, &xDpi, &yDpi);
         }
     }
     else
     {
         CImageDx img;
-        HRESULT hr = img.LoadDx(name, &xDpi, &yDpi);
+        hr = img.LoadDx(name, &xDpi, &yDpi);
         if (FAILED(hr) && fIsMainFile)
         {
             imageModel.ClearHistory();
             hr = img.LoadDx(name, &xDpi, &yDpi);
         }
-        if (FAILED(hr))
-        {
-            ATLTRACE("hr: 0x%08lX\n", hr);
-            ShowError(IDS_LOADERRORTEXT, name);
-            return NULL;
-        }
-
         hBitmap = img.Detach();
+    }
+
+    if (FAILED(hr))
+    {
+        ATLTRACE("hr: 0x%08lX\n", hr);
+        ShowError(IDS_LOADERRORTEXT, name);
+        return NULL;
     }
 
     if (!fIsMainFile)
@@ -410,7 +397,7 @@ HBITMAP Rotate90DegreeBitmap(HBITMAP hbm, BOOL bRight)
     return hbm2;
 }
 
-HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical, BOOL bMono)
+HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical)
 {
     CWaitCursor waitCursor;
 
@@ -501,18 +488,16 @@ void putSubImage(HBITMAP hbmWhole, const RECT& rcPartial, HBITMAP hbmPart)
 void FillDIBByColor(HBITMAP hbm, COLORREF rgbColor)
 {
     BITMAP bm;
-    if (!GetObjectW(hbm, sizeof(bm), &bm))
+    if (rgbColor == CLR_INVALID || !GetObjectW(hbm, sizeof(bm), &bm))
         return;
 
     HDC hDC = CreateCompatibleDC(NULL);
     HGDIOBJ hbmOld = SelectObject(hDC, hbm);
-    for (LONG y = 0; y < bm.bmHeight; ++y)
-    {
-        for (LONG x = 0; x < bm.bmWidth; ++x)
-        {
-            SetPixelV(hDC, x, y, rgbColor);
-        }
-    }
+    HBRUSH hbr = CreateSolidBrush(rgbColor);
+    HGDIOBJ hbrOld = SelectObject(hDC, hbr);
+    RECT rc = { 0, 0, bm.bmWidth, bm.bmHeight };
+    FillRect(hDC, &rc, hbr);
+    SelectObject(hDC, hbrOld);
     SelectObject(hDC, hbmOld);
     DeleteDC(hDC);
 }
@@ -524,35 +509,34 @@ struct BITMAPINFODX : BITMAPINFO
 
 const float INCHES_PER_METER = 0.0254f;
 
-HBITMAP LoadBitmapFromFile(LPCWSTR filename, float* xDpi, float* yDpi)
+HRESULT LoadBitmapFromFile(HBITMAP* phBitmap, LPCWSTR filename, float* xDpi, float* yDpi)
 {
+    *phBitmap = nullptr;
     if (!filename)
-        return nullptr;
+        return E_UNEXPECTED;
 
     HANDLE hFile = CreateFileW(filename, GENERIC_READ, FILE_SHARE_READ, nullptr,
                                OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (hFile == INVALID_HANDLE_VALUE)
-        return nullptr;
+        return HRESULT_FROM_WIN32(GetLastError());
 
     HBITMAP hBitmap = nullptr;
-    DWORD bytesRead = 0;
 
-    // Load BITMAPFILEHEADER
     BITMAPFILEHEADER bfh;
-    if (!ReadFile(hFile, &bfh, sizeof(bfh), &bytesRead, nullptr) || bytesRead != sizeof(bfh) ||
-        bfh.bfType != 0x4D42)
+    DWORD bytesRead;
+    if (!ReadFile(hFile, &bfh, sizeof(bfh), &bytesRead, nullptr) ||
+        bytesRead != sizeof(bfh) || bfh.bfType != 0x4D42)
     {
         CloseHandle(hFile);
-        return nullptr;
+        return E_FAIL;
     }
 
-    // Load header size
     DWORD headerSize = 0;
     if (!ReadFile(hFile, &headerSize, sizeof(headerSize), &bytesRead, nullptr) ||
         bytesRead != sizeof(headerSize))
     {
         CloseHandle(hFile);
-        return nullptr;
+        return E_FAIL;
     }
 
     SetFilePointer(hFile, sizeof(BITMAPFILEHEADER), nullptr, FILE_BEGIN);
@@ -562,14 +546,14 @@ HBITMAP LoadBitmapFromFile(LPCWSTR filename, float* xDpi, float* yDpi)
     if (!pBi)
     {
         CloseHandle(hFile);
-        return nullptr;
+        return E_OUTOFMEMORY;
     }
 
     if (!ReadFile(hFile, pBi, infoSize, &bytesRead, nullptr) || bytesRead != infoSize)
     {
         free(pBi);
         CloseHandle(hFile);
-        return nullptr;
+        return E_FAIL;
     }
 
     float localXDpi = 96.0f;
@@ -590,29 +574,35 @@ HBITMAP LoadBitmapFromFile(LPCWSTR filename, float* xDpi, float* yDpi)
 
     PVOID pBits = nullptr;
     HDC hDC = GetDC(nullptr);
-    hBitmap = CreateDIBSection(hDC, pBi, DIB_RGB_COLORS, &pBits, nullptr, 0);
+    *phBitmap = hBitmap = CreateDIBSection(hDC, pBi, DIB_RGB_COLORS, &pBits, nullptr, 0);
     ReleaseDC(nullptr, hDC);
 
-    if (hBitmap && pBits)
+    BOOL bOK = FALSE;
+    if (hBitmap)
     {
         SetFilePointer(hFile, bfh.bfOffBits, nullptr, FILE_BEGIN);
         DWORD bitsSize = bfh.bfSize - bfh.bfOffBits;
-        ReadFile(hFile, pBits, bitsSize, &bytesRead, nullptr);
+        bOK = ReadFile(hFile, pBits, bitsSize, &bytesRead, nullptr) && bitsSize == bytesRead;
+        if (!bOK)
+        {
+            DeleteObject(hBitmap);
+            *phBitmap = NULL;
+        }
     }
 
     free(pBi);
     CloseHandle(hFile);
-    return hBitmap;
+    return (bOK ? S_OK : E_FAIL);
 }
 
-BOOL SaveBitmapToFile(HBITMAP hBitmap, LPCWSTR filename, float xDpi, float yDpi)
+HRESULT SaveBitmapToFile(HBITMAP hBitmap, LPCWSTR filename, float xDpi, float yDpi)
 {
     if (!hBitmap || !filename)
-        return FALSE;
+        return E_INVALIDARG;
 
     BITMAP bm;
     if (!GetObject(hBitmap, sizeof(BITMAP), &bm))
-        return FALSE;
+        return E_FAIL;
 
     BITMAPINFOHEADER bih = { 0 };
     bih.biSize = sizeof(BITMAPINFOHEADER);
@@ -622,8 +612,8 @@ BOOL SaveBitmapToFile(HBITMAP hBitmap, LPCWSTR filename, float xDpi, float yDpi)
     bih.biBitCount = bm.bmBitsPixel;
     bih.biCompression = BI_RGB;
 
-    bih.biXPelsPerMeter = static_cast<LONG>(std::round(xDpi / INCHES_PER_METER));
-    bih.biYPelsPerMeter = static_cast<LONG>(std::round(yDpi / INCHES_PER_METER));
+    bih.biXPelsPerMeter = static_cast<LONG>(round(xDpi / INCHES_PER_METER));
+    bih.biYPelsPerMeter = static_cast<LONG>(round(yDpi / INCHES_PER_METER));
 
     DWORD rowSize = ((bm.bmWidth * bm.bmBitsPixel + 31) / 32) * 4;
     bih.biSizeImage = rowSize * bm.bmHeight;
@@ -635,14 +625,14 @@ BOOL SaveBitmapToFile(HBITMAP hBitmap, LPCWSTR filename, float xDpi, float yDpi)
 
     PVOID pBits = malloc(bih.biSizeImage);
     if (!pBits)
-        return FALSE;
+        return E_OUTOFMEMORY;
 
     HDC hDC = GetDC(nullptr);
     if (!GetDIBits(hDC, hBitmap, 0, bm.bmHeight, pBits, (PBITMAPINFO)&bih, DIB_RGB_COLORS))
     {
         ReleaseDC(nullptr, hDC);
         free(pBits);
-        return FALSE;
+        return E_FAIL;
     }
     ReleaseDC(nullptr, hDC);
 
@@ -650,11 +640,12 @@ BOOL SaveBitmapToFile(HBITMAP hBitmap, LPCWSTR filename, float xDpi, float yDpi)
                                FILE_ATTRIBUTE_NORMAL, nullptr);
     if (hFile == INVALID_HANDLE_VALUE)
     {
+        DWORD error = GetLastError();
         free(pBits);
-        return FALSE;
+        return HRESULT_FROM_WIN32(error);
     }
 
-    DWORD bytesWritten = 0;
+    DWORD bytesWritten;
     BOOL bOK = WriteFile(hFile, &bfh, sizeof(bfh), &bytesWritten, nullptr) &&
                WriteFile(hFile, &bih, sizeof(bih), &bytesWritten, nullptr) &&
                WriteFile(hFile, pBits, bih.biSizeImage, &bytesWritten, nullptr);
@@ -664,7 +655,7 @@ BOOL SaveBitmapToFile(HBITMAP hBitmap, LPCWSTR filename, float xDpi, float yDpi)
     if (!bOK)
         DeleteFileW(filename);
 
-    return bOK;
+    return (bOK ? S_OK : E_FAIL);
 }
 
 HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
@@ -800,16 +791,6 @@ HBITMAP BitmapFromHEMF(HENHMETAFILE hEMF)
     return hbm;
 }
 
-static inline BOOL IsPerfectBlack(const RGBQUAD* color)
-{
-    return !color->rgbBlue && !color->rgbGreen && !color->rgbRed;
-}
-
-static inline BOOL IsPerfectWhite(const RGBQUAD* color)
-{
-    return color->rgbBlue + color->rgbGreen + color->rgbRed == 255 * 3;
-}
-
 BOOL IsBitmapBlackAndWhite(HBITMAP hbm)
 {
     BITMAP bm;
@@ -826,8 +807,9 @@ BOOL IsBitmapBlackAndWhite(HBITMAP hbm)
     if (ret != 2)
         return FALSE;
 
-    return ((IsPerfectBlack(&colors[0]) || IsPerfectWhite(&colors[0])) &&
-            (IsPerfectBlack(&colors[1]) || IsPerfectWhite(&colors[1])));
+    const COLORREF clr0 = QuadToRGBValue(colors[0]), clr1 = QuadToRGBValue(colors[1]);
+    return (clr0 == RGB(0, 0, 0) || clr0 == RGB(255, 255, 255)) &&
+           (clr1 == RGB(0, 0, 0) || clr1 == RGB(255, 255, 255));
 }
 
 /**
@@ -903,7 +885,8 @@ static void BuildPalette(INT nBpp, RGBQUAD* palette)
     else if (nBpp == 4)
     {
         // Windows standard 16 colors (BGRA)
-        static const RGBQUAD win16[16] = {
+        static const RGBQUAD win16[16] =
+        {
             {   0,   0,   0, 0 }, {   0,   0, 128, 0 }, {   0, 128,   0, 0 }, {   0, 128, 128, 0 },
             { 128,   0,   0, 0 }, { 128,   0, 128, 0 }, { 128, 128,   0, 0 }, { 192, 192, 192, 0 },
             { 128, 128, 128, 0 }, {   0,   0, 255, 0 }, {   0, 255,   0, 0 }, {   0, 255, 255, 0 },
@@ -935,6 +918,11 @@ static void BuildPalette(INT nBpp, RGBQUAD* palette)
             palette[idx] = { v, v, v, 0 };
         }
     }
+}
+
+HBITMAP ConvertToBlackAndWhite(HBITMAP hbm)
+{
+    return CreateNBppBitmap(hbm, 1);
 }
 
 /**
@@ -1055,9 +1043,4 @@ HBITMAP CreateNBppBitmap(HBITMAP hBitmap, INT nBpp)
         CopyMemory(pBits, dstBuf, (size_t)dstStride * H);
 
     return hbmResult;
-}
-
-HBITMAP ConvertToBlackAndWhite(HBITMAP hbm)
-{
-    return CreateNBppBitmap(hbm, 1);
 }

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -511,7 +511,7 @@ struct BITMAPINFODX : BITMAPINFO
     RGBQUAD bmiColorsAdditional[256 - 1];
 };
 
-const float INCHES_PER_METER = 0.0254f;
+#define INCHES_PER_METER 0.0254f
 
 HRESULT LoadBitmapFromFile(HBITMAP* phBitmap, LPCWSTR filename, float* xDpi, float* yDpi)
 {

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -926,11 +926,6 @@ static void BuildPalette(INT nBpp, RGBQUAD* palette)
     }
 }
 
-HBITMAP ConvertToBlackAndWhite(HBITMAP hbm)
-{
-    return CreateNBppBitmap(hbm, 1);
-}
-
 /**
  * @brief Creates a new DIB with a reduced color depth from an existing bitmap.
  *

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -397,7 +397,7 @@ HBITMAP Rotate90DegreeBitmap(HBITMAP hbm, BOOL bRight)
     return hbm2;
 }
 
-HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical)
+HBITMAP SkewDIB(HBITMAP hbm, INT nDegree, BOOL bVertical)
 {
     CWaitCursor waitCursor;
 
@@ -422,7 +422,9 @@ HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical)
     if (!hbmNew)
         return NULL;
 
+    HDC hDC1 = CreateCompatibleDC(NULL);
     HDC hDC2 = CreateCompatibleDC(NULL);
+    HGDIOBJ hbm1Old = SelectObject(hDC1, hbm);
     HGDIOBJ hbm2Old = SelectObject(hDC2, hbmNew);
     if (bVertical)
     {
@@ -448,7 +450,9 @@ HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical)
     }
 
     SelectObject(hDC2, hbm2Old);
+    SelectObject(hDC1, hbm1Old);
     DeleteDC(hDC2);
+    DeleteDC(hDC1);
     return hbmNew;
 }
 

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -55,12 +55,30 @@ CreateDIBWithProperties(int width, int height)
 HBITMAP
 CreateMonoBitmap(int width, int height, BOOL bWhite)
 {
-    HBITMAP hbm = CreateBitmap(width, height, 1, 1, NULL);
-    if (hbm == NULL)
+    struct MONO_DIB
+    {
+        BITMAPINFOHEADER bih;
+        RGBQUAD          colors[2];
+    } dib = {};
+
+    dib.bih.biSize         = sizeof(dib.bih);
+    dib.bih.biWidth        = width;
+    dib.bih.biHeight       = height;
+    dib.bih.biPlanes       = 1;
+    dib.bih.biBitCount     = 1;
+    dib.bih.biCompression  = BI_RGB;
+    dib.bih.biClrUsed      = 2;
+    dib.bih.biClrImportant = 2;
+    dib.colors[0] = RGBValueToQuad(paletteModel.GetPrimaryColor());
+    dib.colors[1] = RGBValueToQuad(paletteModel.GetSecondaryColor());
+
+    PVOID pvBits;
+    HBITMAP hbm = CreateDIBSection(NULL, (PBITMAPINFO)&dib, DIB_RGB_COLORS, &pvBits, NULL, 0);
+    if (!hbm)
         return NULL;
 
     if (bWhite)
-        FillBitmapByColor(hbm, RGB(255, 255, 255));
+        FillBitmapByColor(hbm, paletteModel.GetSecondaryColor());
 
     return hbm;
 }

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -112,16 +112,19 @@ HBITMAP CopyDIBImage(HBITMAP hbm, INT cx, INT cy, INT stretchMode, COLORREF rgbC
         cy = bm.bmHeight;
     }
 
-    HDC hdc1 = ::CreateCompatibleDC(NULL);
-    HDC hdc2 = ::CreateCompatibleDC(NULL);
-    HGDIOBJ hbm1Old = ::SelectObject(hdc1, hbm);
-    HGDIOBJ hbm2Old = ::SelectObject(hdc2, hbmNew);
-    ::SetStretchBltMode(hdc2, stretchMode);
-    ::StretchBlt(hdc2, 0, 0, cx, cy, hdc1, 0, 0, bm.bmWidth, bm.bmHeight, SRCCOPY);
-    ::SelectObject(hdc1, hbm1Old);
-    ::SelectObject(hdc2, hbm2Old);
-    ::DeleteDC(hdc1);
-    ::DeleteDC(hdc2);
+    if (rgbColor == CLR_INVALID && (cx != bm.bmWidth || cy != bm.bmHeight))
+    {
+        HDC hdc1 = ::CreateCompatibleDC(NULL);
+        HDC hdc2 = ::CreateCompatibleDC(NULL);
+        HGDIOBJ hbm1Old = ::SelectObject(hdc1, hbm);
+        HGDIOBJ hbm2Old = ::SelectObject(hdc2, hbmNew);
+        ::SetStretchBltMode(hdc2, stretchMode);
+        ::StretchBlt(hdc2, 0, 0, cx, cy, hdc1, 0, 0, bm.bmWidth, bm.bmHeight, SRCCOPY);
+        ::SelectObject(hdc1, hbm1Old);
+        ::SelectObject(hdc2, hbm2Old);
+        ::DeleteDC(hdc1);
+        ::DeleteDC(hdc2);
+    }
 
     FillDIBByColor(hbmNew, rgbColor);
     return hbmNew;

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -98,22 +98,13 @@ HBITMAP CopyMonoImage(HBITMAP hbm, INT cx, INT cy, INT stretchMode)
 
 HBITMAP CopyDIBImage(HBITMAP hbm, INT cx, INT cy, INT stretchMode, COLORREF rgbColor)
 {
+    BITMAP bm;
+    if (!::GetObjectW(hbm, sizeof(bm), &bm))
+        return NULL;
+ 
     HBITMAP hbmNew = (HBITMAP)CopyImage(hbm, IMAGE_BITMAP, cx, cy, LR_CREATEDIBSECTION);
     if (!hbmNew)
         return NULL;
-
-    if (stretchMode == STRETCH_HALFTONE)
-    {
-        FillDIBByColor(hbmNew, rgbColor);
-        return hbmNew;
-    }
-
-    BITMAP bm;
-    if (!::GetObjectW(hbm, sizeof(bm), &bm))
-    {
-        ::DeleteObject(hbmNew);
-        return NULL;
-    }
 
     if (cx == 0 || cy == 0)
     {
@@ -669,7 +660,7 @@ HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
     CWaitCursor waitCursor;
 
     BITMAP bm;
-    if (!GetObjectW(hBitmap, sizeof(BITMAP), &bm))
+    if (!GetObjectW(hBitmap, sizeof(bm), &bm))
         return NULL;
 
     BITMAPINFODX bmi;
@@ -797,10 +788,17 @@ HBITMAP BitmapFromHEMF(HENHMETAFILE hEMF)
     return hbm;
 }
 
-BOOL IsBitmapBlackAndWhite(HBITMAP hbm)
+INT GetBitmapBpp(HBITMAP hbm)
 {
     BITMAP bm;
-    if (!::GetObjectW(hbm, sizeof(bm), &bm) || (bm.bmBitsPixel != 1))
+    if (!::GetObjectW(hbm, sizeof(bm), &bm))
+        return 0;
+    return bm.bmBitsPixel;
+}
+
+BOOL IsBitmapBlackAndWhite(HBITMAP hbm)
+{
+    if (GetBitmapBpp(hbm) != 1)
         return FALSE;
 
     RGBQUAD colors[2];

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -12,7 +12,6 @@ HBITMAP CreateDIBWithProperties(int width, int height);
 HBITMAP CreateMonoBitmap(int width, int height, BOOL bWhite);
 HBITMAP CreateColorDIB(int width, int height, COLORREF rgb);
 HBITMAP CachedBufferDIB(HBITMAP hbm, int minimalWidth, int minimalHeight);
-HBITMAP ConvertToBlackAndWhite(HBITMAP hbm);
 HBITMAP CreateNBppBitmap(HBITMAP hBitmap, INT nBpp);
 
 HBITMAP CopyMonoImage(HBITMAP hbm, INT cx = 0, INT cy = 0, INT stretchMode = STRETCH_HALFTONE);

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -12,6 +12,7 @@ HBITMAP CreateDIBWithProperties(int width, int height);
 HBITMAP CreateMonoBitmap(int width, int height, BOOL bWhite);
 HBITMAP CreateColorDIB(int width, int height, COLORREF rgb);
 HBITMAP CachedBufferDIB(HBITMAP hbm, int minimalWidth, int minimalHeight);
+INT GetBitmapBpp(HBITMAP hbm);
 HBITMAP CreateNBppBitmap(HBITMAP hBitmap, INT nBpp);
 
 HBITMAP CopyMonoImage(HBITMAP hbm, INT cx = 0, INT cy = 0, INT stretchMode = STRETCH_HALFTONE);

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -13,14 +13,20 @@ HBITMAP CreateMonoBitmap(int width, int height, BOOL bWhite);
 HBITMAP CreateColorDIB(int width, int height, COLORREF rgb);
 HBITMAP CachedBufferDIB(HBITMAP hbm, int minimalWidth, int minimalHeight);
 HBITMAP ConvertToBlackAndWhite(HBITMAP hbm);
+HBITMAP CreateNBppBitmap(HBITMAP hBitmap, INT nBpp);
 
 HBITMAP CopyMonoImage(HBITMAP hbm, INT cx = 0, INT cy = 0, INT stretchMode = STRETCH_HALFTONE);
-HBITMAP CopyDIBImage(HBITMAP hbm, INT cx = 0, INT cy = 0, INT stretchMode = STRETCH_HALFTONE);
+HBITMAP CopyDIBImage(HBITMAP hbm, INT cx = 0, INT cy = 0, INT stretchMode = STRETCH_HALFTONE,
+                     COLORREF rgbColor = CLR_INVALID);
 
 int GetDIBWidth(HBITMAP hbm);
 int GetDIBHeight(HBITMAP hbm);
 
-BOOL SaveDIBToFile(HBITMAP hBitmap, LPCWSTR FileName, BOOL fIsMainFile, REFGUID guidFileType = GUID_NULL);
+BOOL SaveDIBToFile(HBITMAP hBitmap, LPCWSTR FileName, BOOL fIsMainFile,
+                   REFGUID guidFileType = GUID_NULL);
+
+HBITMAP LoadBitmapFromFile(LPCWSTR filename, float* xDpi, float* yDpi);
+BOOL SaveBitmapToFile(HBITMAP hBitmap, LPCWSTR filename, float xDpi, float yDpi);
 
 HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile);
 
@@ -29,7 +35,7 @@ void SetFileInfo(LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isAFile);
 HBITMAP InitializeImage(LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile);
 HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile);
 
-HBITMAP Rotate90DegreeBlt(HDC hDC1, INT cx, INT cy, BOOL bRight, BOOL bMono);
+HBITMAP Rotate90DegreeBitmap(HBITMAP hbm, BOOL bRight);
 
 HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical, BOOL bMono = FALSE);
 
@@ -42,3 +48,4 @@ HBITMAP BitmapFromClipboardDIB(HGLOBAL hGlobal);
 HBITMAP BitmapFromHEMF(HENHMETAFILE hEMF);
 HBITMAP getSubImage(HBITMAP hbmWhole, const RECT& rcPartial);
 void putSubImage(HBITMAP hbmWhole, const RECT& rcPartial, HBITMAP hbmPart);
+void FillDIBByColor(HBITMAP hbm, COLORREF rgbColor);

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+COLORREF QuadToRGBValue(const RGBQUAD& quad);
+RGBQUAD RGBValueToQuad(COLORREF rgbColor);
 BOOL IsBitmapBlackAndWhite(HBITMAP hbm);
 HBITMAP CreateDIBWithProperties(int width, int height);
 HBITMAP CreateMonoBitmap(int width, int height, BOOL bWhite);
@@ -49,4 +51,3 @@ HBITMAP BitmapFromHEMF(HENHMETAFILE hEMF);
 HBITMAP getSubImage(HBITMAP hbmWhole, const RECT& rcPartial);
 void putSubImage(HBITMAP hbmWhole, const RECT& rcPartial, HBITMAP hbmPart);
 void FillDIBByColor(HBITMAP hbm, COLORREF rgbColor);
-COLORREF QuadToRGBValue(const RGBQUAD& quad);

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -37,7 +37,7 @@ HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCWSTR name, LPWIN32_FIND_DATAW pFoun
 
 HBITMAP Rotate90DegreeBitmap(HBITMAP hbm, BOOL bRight);
 
-HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical);
+HBITMAP SkewDIB(HBITMAP hbm, INT nDegree, BOOL bVertical);
 
 float PpcmFromDpi(float dpi);
 

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -50,4 +50,4 @@ HBITMAP BitmapFromClipboardDIB(HGLOBAL hGlobal);
 HBITMAP BitmapFromHEMF(HENHMETAFILE hEMF);
 HBITMAP getSubImage(HBITMAP hbmWhole, const RECT& rcPartial);
 void putSubImage(HBITMAP hbmWhole, const RECT& rcPartial, HBITMAP hbmPart);
-void FillDIBByColor(HBITMAP hbm, COLORREF rgbColor);
+void FillBitmapByColor(HBITMAP hbm, COLORREF rgbColor);

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -25,8 +25,8 @@ int GetDIBHeight(HBITMAP hbm);
 BOOL SaveDIBToFile(HBITMAP hBitmap, LPCWSTR FileName, BOOL fIsMainFile,
                    REFGUID guidFileType = GUID_NULL);
 
-HBITMAP LoadBitmapFromFile(LPCWSTR filename, float* xDpi, float* yDpi);
-BOOL SaveBitmapToFile(HBITMAP hBitmap, LPCWSTR filename, float xDpi, float yDpi);
+HRESULT LoadBitmapFromFile(HBITMAP* phBitmap, LPCWSTR filename, float* xDpi, float* yDpi);
+HRESULT SaveBitmapToFile(HBITMAP hBitmap, LPCWSTR filename, float xDpi, float yDpi);
 
 HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile);
 
@@ -37,7 +37,7 @@ HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCWSTR name, LPWIN32_FIND_DATAW pFoun
 
 HBITMAP Rotate90DegreeBitmap(HBITMAP hbm, BOOL bRight);
 
-HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical, BOOL bMono = FALSE);
+HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical);
 
 float PpcmFromDpi(float dpi);
 
@@ -49,3 +49,4 @@ HBITMAP BitmapFromHEMF(HENHMETAFILE hEMF);
 HBITMAP getSubImage(HBITMAP hbmWhole, const RECT& rcPartial);
 void putSubImage(HBITMAP hbmWhole, const RECT& rcPartial, HBITMAP hbmPart);
 void FillDIBByColor(HBITMAP hbm, COLORREF rgbColor);
+COLORREF QuadToRGBValue(const RGBQUAD& quad);

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -18,14 +18,14 @@ CreateGeometricPen(COLORREF rgbColor, INT thickness)
     logbrush.lbStyle = BS_SOLID;
     logbrush.lbColor = rgbColor;
     logbrush.lbHatch = 0;
-    return ExtCreatePen(PS_GEOMETRIC | PS_SOLID | PS_ENDCAP_ROUND | PS_JOIN_ROUND, thickness, &logbrush, 0, NULL);
+    return ExtCreatePen(PS_GEOMETRIC | PS_SOLID | PS_ENDCAP_ROUND | PS_JOIN_ROUND, thickness, &logbrush, 0, nullptr);
 }
 
 void
 Line(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, int thickness)
 {
     HPEN oldPen = (HPEN) SelectObject(hdc, CreatePen(PS_SOLID, thickness, color));
-    MoveToEx(hdc, x1, y1, NULL);
+    MoveToEx(hdc, x1, y1, nullptr);
     LineTo(hdc, x2, y2);
     SetPixelV(hdc, x2, y2, color);
     DeleteObject(SelectObject(hdc, oldPen));
@@ -36,7 +36,7 @@ Line(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, INT thickness)
 {
     HGDIOBJ oldPen = SelectObject(hdc, CreateGeometricPen(0, thickness));
     BeginPath(hdc);
-    MoveToEx(hdc, x1, y1, NULL);
+    MoveToEx(hdc, x1, y1, nullptr);
     LineTo(hdc, x2, y2);
     EndPath(hdc);
     SetPolyFillMode(hdc, WINDING);
@@ -309,7 +309,7 @@ Erase(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG radius)
 void
 Erase(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, LONG radius)
 {
-    LONG b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
+    LONG b = __max(1, __max(labs(x2 - x1), labs(y2 - y1)));
 
     for (LONG a = 0; a <= b; a++)
     {
@@ -323,7 +323,7 @@ Erase(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, LONG radius)
 void
 Replace(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, LONG radius)
 {
-    LONG b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
+    LONG b = __max(1, __max(labs(x2 - x1), labs(y2 - y1)));
 
     for (LONG a = 0; a <= b; a++)
     {
@@ -344,7 +344,7 @@ Replace(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, L
 void
 Replace(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, HBRUSH hBgBrush, LONG radius)
 {
-    LONG b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
+    LONG b = __max(1, __max(labs(x2 - x1), labs(y2 - y1)));
 
     for (LONG a = 0; a <= b; a++)
     {
@@ -397,7 +397,7 @@ Airbrush(HDC hdc, LONG x, LONG y, HBRUSH hBrush, LONG r)
 static void
 BrushInternal(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, LONG style, INT thickness)
 {
-    LONG a, b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
+    LONG a, b = __max(1, __max(labs(x2 - x1), labs(y2 - y1)));
     switch ((BrushStyle)style)
     {
         case BrushStyleRound:
@@ -569,7 +569,7 @@ ColorKeyedMaskBlt(HDC hdcDest, int nXDest, int nYDest, int nWidth, int nHeight,
     HBITMAP hbmTempColor, hbmTempMask;
     HGDIOBJ hbmOld1, hbmOld2;
 
-    if (hbmMask == NULL)
+    if (hbmMask == nullptr)
     {
         if (keyColor == CLR_INVALID)
         {
@@ -592,7 +592,7 @@ ColorKeyedMaskBlt(HDC hdcDest, int nXDest, int nYDest, int nWidth, int nHeight,
 
     hTempDC1 = ::CreateCompatibleDC(hdcDest);
     hTempDC2 = ::CreateCompatibleDC(hdcDest);
-    hbmTempMask = ::CreateBitmap(nWidth, nHeight, 1, 1, NULL);
+    hbmTempMask = ::CreateBitmap(nWidth, nHeight, 1, 1, nullptr);
     hbmTempColor = CreateColorDIB(nWidth, nHeight, RGB(255, 255, 255));
 
     // hbmTempMask <-- hbmMask (stretched)
@@ -649,8 +649,7 @@ void DrawXorRect(HDC hdc, const RECT *prc)
 
 HBRUSH CreateDitherBrush(COLORREF color, COLORREF monoColor0, COLORREF monoColor1)
 {
-    // 8x8 Bayer ordered dithering matrix (0 to 63)
-    static const BYTE s_bayerMatrix[8][8] =
+    static const BYTE bayer[8][8] =
     {
         {  0, 32,  8, 40,  2, 34, 10, 42 },
         { 48, 16, 56, 24, 50, 18, 58, 26 },
@@ -661,54 +660,40 @@ HBRUSH CreateDitherBrush(COLORREF color, COLORREF monoColor0, COLORREF monoColor
         { 15, 47,  7, 39, 13, 45,  5, 37 },
         { 63, 31, 55, 23, 61, 29, 53, 21 },
     };
-    INT sum = GetRValue(color) + GetGValue(color) + GetBValue(color);
-    INT brightness = sum / 3;
-    if (brightness < 0)
-        brightness = 0;
-    if (brightness >= 255)
-        brightness = 256; // White out
 
-    BITMAPINFO bmi = {};
-    bmi.bmiHeader.biSize     = sizeof(bmi.bmiHeader);
-    bmi.bmiHeader.biWidth    = 8;
-    bmi.bmiHeader.biHeight   = -8; // Top-down
-    bmi.bmiHeader.biPlanes   = 1;
-    bmi.bmiHeader.biBitCount = 24;
-
-    const BYTE b0 = GetBValue(monoColor0), g0 = GetGValue(monoColor0), r0 = GetRValue(monoColor0);
-    const BYTE b1 = GetBValue(monoColor1), g1 = GetGValue(monoColor1), r1 = GetRValue(monoColor1);
-
-    BYTE pixels[8 * 8 * 3];
-    for (INT y = 0; y < 8; ++y)
+    struct DIB1BPP8x8
     {
-        INT index = y * (3 * CHAR_BIT);
-        for (INT x = 0; x < 8; ++x)
+        BITMAPINFOHEADER bih;
+        RGBQUAD          colors[2];
+        BYTE             bits[8 * 4]; // 1bpp, stride=4, height=8
+    } dib = {};
+
+    dib.bih.biSize         = sizeof(dib.bih);
+    dib.bih.biWidth        = 8;
+    dib.bih.biHeight       = 8; // bottom-up
+    dib.bih.biPlanes       = 1;
+    dib.bih.biBitCount     = 1;
+    dib.bih.biCompression  = BI_RGB;
+    dib.bih.biClrUsed      = 2;
+    dib.bih.biClrImportant = 2;
+    dib.bih.biSizeImage    = sizeof(dib.bits);
+
+    dib.colors[0] = { GetBValue(monoColor0), GetGValue(monoColor0), GetRValue(monoColor0), 0 };
+    dib.colors[1] = { GetBValue(monoColor1), GetGValue(monoColor1), GetRValue(monoColor1), 0 };
+
+    const int brightness = (GetRValue(color) + GetGValue(color) + GetBValue(color)) / 3;
+
+    for (int y = 0; y < 8; ++y)
+    {
+        BYTE row = 0;
+        for (int x = 0; x < 8; ++x)
         {
-            const INT threshold = s_bayerMatrix[y][x] * 255 / 63;
+            const int threshold = bayer[y][x] * 255 / 63;
             if (brightness > threshold)
-            {
-                pixels[index++] = b1; // Blue
-                pixels[index++] = g1; // Green
-                pixels[index++] = r1; // Red
-            }
-            else
-            {
-                pixels[index++] = b0; // Blue
-                pixels[index++] = g0; // Green
-                pixels[index++] = r0; // Red
-            }
+                row |= BYTE(1u << (7 - x));
         }
+        dib.bits[y * 4] = row;
     }
 
-    HDC hdc = GetDC(NULL);
-    HBITMAP hBitmap = CreateDIBitmap(hdc, &bmi.bmiHeader, CBM_INIT, pixels, &bmi, DIB_RGB_COLORS);
-    ReleaseDC(NULL, hdc);
-
-    if (!hBitmap)
-        return NULL;
-
-    HBRUSH hBrush = CreatePatternBrush(hBitmap);
-    DeleteObject(hBitmap);
-
-    return hBrush;
+    return CreateDIBPatternBrushPt(&dib, DIB_RGB_COLORS);
 }

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -18,14 +18,15 @@ CreateGeometricPen(COLORREF rgbColor, INT thickness)
     logbrush.lbStyle = BS_SOLID;
     logbrush.lbColor = rgbColor;
     logbrush.lbHatch = 0;
-    return ExtCreatePen(PS_GEOMETRIC | PS_SOLID | PS_ENDCAP_ROUND | PS_JOIN_ROUND, thickness, &logbrush, 0, nullptr);
+    return ExtCreatePen(PS_GEOMETRIC | PS_SOLID | PS_ENDCAP_ROUND | PS_JOIN_ROUND, thickness,
+                        &logbrush, 0, nullptr);
 }
 
 void
 Line(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, int thickness)
 {
     HPEN oldPen = (HPEN) SelectObject(hdc, CreatePen(PS_SOLID, thickness, color));
-    MoveToEx(hdc, x1, y1, nullptr);
+    MoveToEx(hdc, x1, y1, NULL);
     LineTo(hdc, x2, y2);
     SetPixelV(hdc, x2, y2, color);
     DeleteObject(SelectObject(hdc, oldPen));
@@ -36,7 +37,7 @@ Line(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, HBRUSH hBrush, INT thickness)
 {
     HGDIOBJ oldPen = SelectObject(hdc, CreateGeometricPen(0, thickness));
     BeginPath(hdc);
-    MoveToEx(hdc, x1, y1, nullptr);
+    MoveToEx(hdc, x1, y1, NULL);
     LineTo(hdc, x2, y2);
     EndPath(hdc);
     SetPolyFillMode(hdc, WINDING);
@@ -569,7 +570,7 @@ ColorKeyedMaskBlt(HDC hdcDest, int nXDest, int nYDest, int nWidth, int nHeight,
     HBITMAP hbmTempColor, hbmTempMask;
     HGDIOBJ hbmOld1, hbmOld2;
 
-    if (hbmMask == nullptr)
+    if (!hbmMask)
     {
         if (keyColor == CLR_INVALID)
         {
@@ -592,7 +593,7 @@ ColorKeyedMaskBlt(HDC hdcDest, int nXDest, int nYDest, int nWidth, int nHeight,
 
     hTempDC1 = ::CreateCompatibleDC(hdcDest);
     hTempDC2 = ::CreateCompatibleDC(hdcDest);
-    hbmTempMask = ::CreateBitmap(nWidth, nHeight, 1, 1, nullptr);
+    hbmTempMask = ::CreateBitmap(nWidth, nHeight, 1, 1, NULL);
     hbmTempColor = CreateColorDIB(nWidth, nHeight, RGB(255, 255, 255));
 
     // hbmTempMask <-- hbmMask (stretched)
@@ -649,6 +650,7 @@ void DrawXorRect(HDC hdc, const RECT *prc)
 
 HBRUSH CreateDitherBrush(COLORREF color, COLORREF monoColor0, COLORREF monoColor1)
 {
+    // 8x8 Bayer ordered dithering matrix (0 to 63)
     static const BYTE bayer[8][8] =
     {
         {  0, 32,  8, 40,  2, 34, 10, 42 },

--- a/base/applications/mspaint/floyd.cpp
+++ b/base/applications/mspaint/floyd.cpp
@@ -1,0 +1,139 @@
+/*
+ * PROJECT:    PAINT for ReactOS
+ * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
+ * PURPOSE:    Floyd Steinberg's error diffusion
+ * COPYRIGHT:  Copyright 2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include "precomp.h"
+
+/**
+ * @brief Finds the palette entry whose RGB value is closest to a given color.
+ *
+ * Uses squared Euclidean distance in RGB space.  The search short-circuits on
+ * an exact match (distance == 0).
+ *
+ * @param r        Red component of the input color (0-255).
+ * @param g        Green component of the input color (0-255).
+ * @param b        Blue component of the input color (0-255).
+ * @param palette  Array of candidate palette entries.
+ * @param nColors  Number of entries in @p palette.
+ * @return         Zero-based index of the nearest palette entry.
+ */
+static inline INT FindNearestColor(INT r, INT g, INT b, const RGBQUAD* palette, INT nColors)
+{
+    INT bestIdx  = 0;
+    DWORD bestDist = UINT_MAX;
+    for (INT i = 0; i < nColors; i++)
+    {
+        const INT dr = r - (INT)palette[i].rgbRed;
+        const INT dg = g - (INT)palette[i].rgbGreen;
+        const INT db = b - (INT)palette[i].rgbBlue;
+        const DWORD dist = (DWORD)(dr*dr + dg*dg + db*db);
+        if (dist < bestDist)
+        {
+            bestDist = dist;
+            bestIdx = i;
+            if (dist == 0)
+                break;
+        }
+    }
+    return bestIdx;
+}
+
+typedef struct tagERR_RGB
+{
+    float r;
+    float g;
+    float b;
+} ERR_RGB, *PERR_RGB;
+
+/**
+ * @brief Quantizes a 24-bit BGR image to a palette using serpentine
+ *        Floyd-Steinberg error diffusion.
+ *
+ * Each pixel's quantization error is distributed to its unprocessed neighbors
+ * with the standard 7/16, 3/16, 5/16, 1/16 weights.  Rows are scanned
+ * alternately left-to-right and right-to-left (serpentine order) to suppress
+ * the vertical stripe artifacts that arise from unidirectional scanning.
+ *
+ * @param srcBuf    Source image data; 24-bit BGR, top-down.
+ * @param srcStride Row stride of @p srcBuf in bytes (must be DWORD-aligned).
+ * @param W         Image width in pixels.
+ * @param H         Image height in pixels.
+ * @param palette   Palette to quantize against.
+ * @param nColors   Number of entries in @p palette.
+ * @param indexImg  Output buffer; one byte per pixel, row-major, no padding.
+ *                  Must be at least @p W * @p H bytes.
+ */
+void FloydSteinberg(const BYTE* srcBuf, INT srcStride, SIZE_T W, SIZE_T H,
+                    const RGBQUAD* palette, INT nColors, PBYTE indexImg)
+{
+    if (!W || !H || !srcBuf || !palette || nColors <= 0 || !indexImg)
+        return;
+
+    if (W > ((SIZE_T)-1) / H)
+        return;
+    const SIZE_T pixelCount = W * H;
+    if (pixelCount > ((SIZE_T)-1) / sizeof(ERR_RGB))
+        return;
+    const SIZE_T errSize = pixelCount * sizeof(ERR_RGB);
+
+    PERR_RGB err = (PERR_RGB)LocalAlloc(LPTR, errSize);
+    if (!err)
+        return;
+
+    for (SIZE_T y = 0; y < H; y++)
+    {
+        const BOOL leftToRight = (y & 1) == 0;
+        const SIZE_T xStart = leftToRight ? 0      : W - 1;
+        const SIZE_T xEnd   = leftToRight ? W - 1  : 0;
+        const SIZE_T xStep  = leftToRight ? 1       : (SIZE_T)-1;
+
+        for (SIZE_T x = xStart; ; x += xStep)
+        {
+            const BYTE* px = srcBuf + y * srcStride + x * 3;
+            const float fr = (float)px[2] + err[y*W + x].r;
+            const float fg = (float)px[1] + err[y*W + x].g;
+            const float fb = (float)px[0] + err[y*W + x].b;
+
+            const INT ir = (INT)__max(0.f, __min(255.f, fr));
+            const INT ig = (INT)__max(0.f, __min(255.f, fg));
+            const INT ib = (INT)__max(0.f, __min(255.f, fb));
+
+            const INT idx = FindNearestColor(ir, ig, ib, palette, nColors);
+            indexImg[y * W + x] = (BYTE)idx;
+
+            const float er = fr - (float)palette[idx].rgbRed;
+            const float eg = fg - (float)palette[idx].rgbGreen;
+            const float eb = fb - (float)palette[idx].rgbBlue;
+
+#define SPREAD(nx, ny, w) do { \
+    if ((nx) < W && (ny) < H) { \
+        ERR_RGB& e = err[ny * W + nx]; \
+        e.r += er * (w); e.g += eg * (w); e.b += eb * (w); \
+    } \
+} while (0)
+            if (leftToRight)
+            {
+                SPREAD(x + 1, y,     7.f/16);
+                SPREAD(x - 1, y + 1, 3.f/16);
+                SPREAD(x,     y + 1, 5.f/16);
+                SPREAD(x + 1, y + 1, 1.f/16);
+            }
+            else
+            {
+                SPREAD(x - 1, y,     7.f/16);
+                SPREAD(x + 1, y + 1, 3.f/16);
+                SPREAD(x,     y + 1, 5.f/16);
+                SPREAD(x - 1, y + 1, 1.f/16);
+            }
+#undef SPREAD
+
+            if (x == xEnd)
+                break;
+        }
+    }
+
+    LocalFree(err);
+}

--- a/base/applications/mspaint/floyd.cpp
+++ b/base/applications/mspaint/floyd.cpp
@@ -43,9 +43,7 @@ static inline INT FindNearestColor(INT r, INT g, INT b, const RGBQUAD* palette, 
 
 typedef struct tagERR_RGB
 {
-    float r;
-    float g;
-    float b;
+    float r, g, b;
 } ERR_RGB, *PERR_RGB;
 
 /**

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -124,7 +124,7 @@ void ImageModel::ClearHistory()
 
 void ImageModel::PushImageForUndo()
 {
-    HBITMAP hbm = CopyBitmap();
+    HBITMAP hbm = CloneDIB();
     if (hbm == NULL)
     {
         ShowOutOfMemory();
@@ -196,8 +196,8 @@ void ImageModel::Crop(int nWidth, int nHeight, int nOffsetX, int nOffsetY)
     if (nHeight <= 0)
         nHeight = 1;
 
-    // Create a white HBITMAP
-    HBITMAP hbmNew = CreateColorDIB(nWidth, nHeight, RGB(255, 255, 255));
+    // Create new HBITMAP
+    HBITMAP hbmNew = CloneDIB(nWidth, nHeight, paletteModel.GetBgColor());
     if (!hbmNew)
     {
         ShowOutOfMemory();
@@ -207,9 +207,9 @@ void ImageModel::Crop(int nWidth, int nHeight, int nOffsetX, int nOffsetY)
 
     // Put the master image as a sub-image
     RECT rcPart = { -nOffsetX, -nOffsetY, GetWidth() - nOffsetX, GetHeight() - nOffsetY };
-    HBITMAP hbmOld = imageModel.LockBitmap();
+    HBITMAP hbmOld = LockBitmap();
     putSubImage(hbmNew, rcPart, hbmOld);
-    imageModel.UnlockBitmap(hbmOld);
+    UnlockBitmap(hbmOld);
 
     // Push it
     PushImageForUndo(hbmNew);
@@ -235,7 +235,7 @@ void ImageModel::StretchSkew(int nStretchPercentX, int nStretchPercentY, int nSk
     INT newHeight = oldHeight * nStretchPercentY / 100;
     if (oldWidth != newWidth || oldHeight != newHeight)
     {
-        HBITMAP hbm0 = CopyDIBImage(m_hbmMaster, newWidth, newHeight);
+        HBITMAP hbm0 = CloneDIB(newWidth, newHeight, paletteModel.GetBgColor());
         PushImageForUndo(hbm0);
     }
     if (nSkewDegX)
@@ -297,8 +297,10 @@ void ImageModel::RotateNTimes90Degrees(int iN)
         case 1:
         case 3:
         {
-            HBITMAP hbm = Rotate90DegreeBlt(m_hDrawingDC, GetWidth(), GetHeight(), iN == 1, FALSE);
-            PushImageForUndo(hbm);
+            HBITMAP hbmOld = LockBitmap();
+            HBITMAP hbmNew = Rotate90DegreeBitmap(hbmOld, iN == 1);
+            UnlockBitmap(hbmOld);
+            PushImageForUndo(hbmNew);
             break;
         }
         case 2:
@@ -314,16 +316,16 @@ void ImageModel::RotateNTimes90Degrees(int iN)
 
 void ImageModel::Clamp(POINT& pt) const
 {
-    pt.x = max(0, min(pt.x, GetWidth()));
-    pt.y = max(0, min(pt.y, GetHeight()));
+    pt.x = __max(0, __min(pt.x, GetWidth()));
+    pt.y = __max(0, __min(pt.y, GetHeight()));
 }
 
-HBITMAP ImageModel::CopyBitmap()
+HBITMAP ImageModel::CloneDIB(INT width, INT height, COLORREF rgbColor)
 {
-    HBITMAP hBitmap = LockBitmap();
-    HBITMAP ret = CopyDIBImage(hBitmap);
-    UnlockBitmap(hBitmap);
-    return ret;
+    HBITMAP hbmOld = imageModel.LockBitmap();
+    HBITMAP hbmNew = CopyDIBImage(hbmOld, width, height, STRETCH_DELETESCANS, rgbColor);
+    imageModel.UnlockBitmap(hbmOld);
+    return hbmNew;
 }
 
 BOOL ImageModel::IsBlackAndWhite()

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -347,7 +347,7 @@ BOOL ImageModel::IsBlackAndWhite()
 void ImageModel::PushBlackAndWhite()
 {
     HBITMAP hBitmap = LockBitmap();
-    HBITMAP hNewBitmap = ConvertToBlackAndWhite(hBitmap);
+    HBITMAP hNewBitmap = CreateNBppBitmap(hBitmap, 1);
     UnlockBitmap(hBitmap);
 
     PushImageForUndo(hNewBitmap);

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -3,7 +3,7 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    Undo and redo functionality
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
- *             Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *             Copyright 2023-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include "precomp.h"
@@ -80,6 +80,7 @@ void ImageModel::Undo(BOOL bClearRedo)
     m_currInd = (m_currInd + HISTORYSIZE - 1) % HISTORYSIZE; // Go previous
     ATLASSERT(m_hbmMaster != NULL);
     SwapPart();
+    paletteModel.SetColorInfo(m_hbmMaster);
     ::SelectObject(m_hDrawingDC, m_hbmMaster); // Re-select
 
     m_undoSteps--;
@@ -102,6 +103,7 @@ void ImageModel::Redo()
     ATLASSERT(m_hbmMaster != NULL);
     SwapPart();
     m_currInd = (m_currInd + 1) % HISTORYSIZE; // Go next
+    paletteModel.SetColorInfo(m_hbmMaster);
     ::SelectObject(m_hDrawingDC, m_hbmMaster); // Re-select
 
     m_redoSteps--;
@@ -150,6 +152,8 @@ void ImageModel::PushImageForUndo(HBITMAP hbm)
     part.clear();
     part.m_hbmImage = m_hbmMaster;
     m_hbmMaster = hbm;
+    paletteModel.SetColorInfo(hbm);
+
     ::SelectObject(m_hDrawingDC, m_hbmMaster); // Re-select
 
     PushDone();

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -239,17 +239,21 @@ void ImageModel::StretchSkew(int nStretchPercentX, int nStretchPercentY, int nSk
     INT newHeight = oldHeight * nStretchPercentY / 100;
     if (oldWidth != newWidth || oldHeight != newHeight)
     {
-        HBITMAP hbm0 = CloneDIB(newWidth, newHeight, paletteModel.GetBgColor());
+        HBITMAP hbm0 = CloneDIB(newWidth, newHeight);
         PushImageForUndo(hbm0);
     }
     if (nSkewDegX)
     {
-        HBITMAP hbm1 = SkewDIB(m_hDrawingDC, m_hbmMaster, nSkewDegX, FALSE);
+        HBITMAP hbmOld = LockBitmap();
+        HBITMAP hbm1 = SkewDIB(hbmOld, nSkewDegX, FALSE);
+        UnlockBitmap(hbmOld);
         PushImageForUndo(hbm1);
     }
     if (nSkewDegY)
     {
-        HBITMAP hbm2 = SkewDIB(m_hDrawingDC, m_hbmMaster, nSkewDegY, TRUE);
+        HBITMAP hbmOld = LockBitmap();
+        HBITMAP hbm2 = SkewDIB(hbmOld, nSkewDegY, TRUE);
+        UnlockBitmap(hbmOld);
         PushImageForUndo(hbm2);
     }
     NotifyImageChanged();
@@ -326,9 +330,9 @@ void ImageModel::Clamp(POINT& pt) const
 
 HBITMAP ImageModel::CloneDIB(INT width, INT height, COLORREF rgbColor)
 {
-    HBITMAP hbmOld = imageModel.LockBitmap();
+    HBITMAP hbmOld = LockBitmap();
     HBITMAP hbmNew = CopyDIBImage(hbmOld, width, height, STRETCH_DELETESCANS, rgbColor);
-    imageModel.UnlockBitmap(hbmOld);
+    UnlockBitmap(hbmOld);
     return hbmNew;
 }
 

--- a/base/applications/mspaint/history.h
+++ b/base/applications/mspaint/history.h
@@ -40,7 +40,8 @@ public:
     void StretchSkew(int nStretchPercentX, int nStretchPercentY, int nSkewDegX = 0, int nSkewDegY = 0);
     int GetWidth() const;
     int GetHeight() const;
-    HBITMAP CopyBitmap();
+    int GetBpp() const;
+    HBITMAP CloneDIB(INT width = 0, INT height = 0, COLORREF rgbColor = CLR_INVALID);
     HBITMAP LockBitmap();
     void UnlockBitmap(HBITMAP hbmLocked);
     void InvertColors();

--- a/base/applications/mspaint/history.h
+++ b/base/applications/mspaint/history.h
@@ -3,6 +3,7 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    Undo and redo functionality
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
+ *             Copyright 2023-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once

--- a/base/applications/mspaint/lang/bg-BG.rc
+++ b/base/applications/mspaint/lang/bg-BG.rc
@@ -275,4 +275,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/cs-CZ.rc
+++ b/base/applications/mspaint/lang/cs-CZ.rc
@@ -275,4 +275,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/de-DE.rc
+++ b/base/applications/mspaint/lang/de-DE.rc
@@ -274,4 +274,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/en-GB.rc
+++ b/base/applications/mspaint/lang/en-GB.rc
@@ -274,4 +274,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/en-US.rc
+++ b/base/applications/mspaint/lang/en-US.rc
@@ -275,4 +275,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/es-ES.rc
+++ b/base/applications/mspaint/lang/es-ES.rc
@@ -277,4 +277,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/et-EE.rc
+++ b/base/applications/mspaint/lang/et-EE.rc
@@ -274,4 +274,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/eu-ES.rc
+++ b/base/applications/mspaint/lang/eu-ES.rc
@@ -275,4 +275,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/fr-FR.rc
+++ b/base/applications/mspaint/lang/fr-FR.rc
@@ -275,4 +275,8 @@ BEGIN
     IDS_SAVEERROR "Échec lors de la sauvegarde dans le fichier :\n\n%s"
     IDS_CANTSENDMAIL "Échec lors de l'envoi d'un mail."
     IDS_LOSECOLOR "Les informations de couleurs vont être perdues dans cette opération. Êtes-vous sûr de continuer ?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/he-IL.rc
+++ b/base/applications/mspaint/lang/he-IL.rc
@@ -277,4 +277,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/hr-HR.rc
+++ b/base/applications/mspaint/lang/hr-HR.rc
@@ -276,4 +276,8 @@ BEGIN
     IDS_SAVEERROR "Neuspješno spremanje bitmape u datoteku:\n\n%s"
     IDS_CANTSENDMAIL "Neuspješno slanje e-pošte."
     IDS_LOSECOLOR "Informacije o boji će biti izgubljene u ovoj operaciji. Želite li nastaviti?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/hu-HU.rc
+++ b/base/applications/mspaint/lang/hu-HU.rc
@@ -275,4 +275,8 @@ BEGIN
     IDS_SAVEERROR "Nem sikerült a bitkép mentése az alábbi fájlba:\n\n%s"
     IDS_CANTSENDMAIL "Nem sikerült az email küldése."
     IDS_LOSECOLOR "A színinformációk el fognak veszni a művelet során. Biztosan folytatja?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/id-ID.rc
+++ b/base/applications/mspaint/lang/id-ID.rc
@@ -274,4 +274,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/it-IT.rc
+++ b/base/applications/mspaint/lang/it-IT.rc
@@ -276,4 +276,8 @@ BEGIN
     IDS_SAVEERROR "Impossibile salvare la bitmap nel file:\n\n%s"
     IDS_CANTSENDMAIL "Impossibile inviare l'email."
     IDS_LOSECOLOR "Le informazioni sul colore saranno perse con quest'operazione. Sei sicuro di procedere?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/ja-JP.rc
+++ b/base/applications/mspaint/lang/ja-JP.rc
@@ -276,4 +276,8 @@ BEGIN
     IDS_SAVEERROR "次のファイルとして画像を保存するのに失敗しました:\n\n%s"
     IDS_CANTSENDMAIL "メール送信に失敗しました。"
     IDS_LOSECOLOR "この操作を行うと色情報が失われます。続行しますか？"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/nl-NL.rc
+++ b/base/applications/mspaint/lang/nl-NL.rc
@@ -274,4 +274,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/no-NO.rc
+++ b/base/applications/mspaint/lang/no-NO.rc
@@ -274,4 +274,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/pl-PL.rc
+++ b/base/applications/mspaint/lang/pl-PL.rc
@@ -277,4 +277,8 @@ BEGIN
     IDS_SAVEERROR "Nie można zapisać bitmapy do pliku:\n\n%s"
     IDS_CANTSENDMAIL "Nie można wysłać wiadomości e-mail."
     IDS_LOSECOLOR "Informacje o kolorach zostaną utracone podczas tej operacji. Czy na pewno chcesz kontynuować?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/pt-BR.rc
+++ b/base/applications/mspaint/lang/pt-BR.rc
@@ -275,4 +275,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/pt-PT.rc
+++ b/base/applications/mspaint/lang/pt-PT.rc
@@ -275,4 +275,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/ro-RO.rc
+++ b/base/applications/mspaint/lang/ro-RO.rc
@@ -276,4 +276,8 @@ BEGIN
     IDS_SAVEERROR "Nu s-a putut salva imaginea bitmap („hartă de biți”) în fișierul:\n\n%s"
     IDS_CANTSENDMAIL "Nu s-a putut trimite un e-mail."
     IDS_LOSECOLOR "În această operațiune informațiile legate de culoare vor fi pierdute. Sunteți sigur că veți continua?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/ru-RU.rc
+++ b/base/applications/mspaint/lang/ru-RU.rc
@@ -278,4 +278,8 @@ BEGIN
     IDS_SAVEERROR "Не удалось сохранить точечный рисунок в файл:\n\n%s"
     IDS_CANTSENDMAIL "Не удалось отправить письмо."
     IDS_LOSECOLOR "В результате этой операции сведения о цвете будут потеряны. Продолжить?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/sk-SK.rc
+++ b/base/applications/mspaint/lang/sk-SK.rc
@@ -274,4 +274,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/sq-AL.rc
+++ b/base/applications/mspaint/lang/sq-AL.rc
@@ -274,4 +274,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/sv-SE.rc
+++ b/base/applications/mspaint/lang/sv-SE.rc
@@ -275,4 +275,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/tr-TR.rc
+++ b/base/applications/mspaint/lang/tr-TR.rc
@@ -276,4 +276,8 @@ BEGIN
     IDS_SAVEERROR "Bit eşlemi dosyaya kaydedilemedi:\n\n%s"
     IDS_CANTSENDMAIL "Posta gönderilemedi."
     IDS_LOSECOLOR "Bu işlem sırasında renk bilgisi kaybolacaktır. Devam edeceğinizden emin misiniz?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/uk-UA.rc
+++ b/base/applications/mspaint/lang/uk-UA.rc
@@ -276,4 +276,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/vi-VN.rc
+++ b/base/applications/mspaint/lang/vi-VN.rc
@@ -274,4 +274,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/zh-CN.rc
+++ b/base/applications/mspaint/lang/zh-CN.rc
@@ -277,4 +277,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/zh-HK.rc
+++ b/base/applications/mspaint/lang/zh-HK.rc
@@ -275,4 +275,8 @@ BEGIN
     IDS_SAVEERROR "Failed to save the bitmap to file:\n\n%s"
     IDS_CANTSENDMAIL "Failed to send a mail."
     IDS_LOSECOLOR "The color information will be lost in this operation. Are you sure to proceed?"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/lang/zh-TW.rc
+++ b/base/applications/mspaint/lang/zh-TW.rc
@@ -275,4 +275,8 @@ BEGIN
     IDS_SAVEERROR "無法儲存點陣圖到檔案：\n\n%s"
     IDS_CANTSENDMAIL "無法傳送郵件。"
     IDS_LOSECOLOR "這個操作會導致色彩資訊丟失。您確定要繼續嗎？"
+    IDS_MONOBMP "Monochrome Bitmap (*.bmp;*.dib)"
+    IDS_4BPPBMP "16-Color Bitmap (*.bmp;*.dib)"
+    IDS_8BPPBMP "256-Color Bitmap (*.bmp;*.dib)"
+    IDS_24BPPBMP "24-bit Color Bitmap (*.bmp;*.dib)"
 END

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -300,7 +300,7 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
     sfn.lpstrFile = pszFile;
     sfn.nMaxFile  = cchMaxFile;
 
-    // Set filter index
+    // Set filter index (1-base)
     PWSTR dotext = PathFindExtensionW(pszFile);
     if (!lstrcmpiW(dotext, L".bmp") || !lstrcmpiW(dotext, L".dib")) // BMP format?
     {

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -299,7 +299,6 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
     sfn.lpstrFile = pszFile;
     sfn.nMaxFile  = cchMaxFile;
 
-
     if (!::GetSaveFileNameW(&sfn))
         return FALSE;
 
@@ -1201,16 +1200,11 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                     imageModel.ClearHistory();
                     break;
                 }
-                if (nBpp != -1)
+                if (nBpp != -1 && GetBitmapBpp(hbmSelection) != nBpp)
                 {
-                    BITMAP bm;
-                    GetObjectW(hbmSelection, sizeof(bm), &bm);
-                    if (bm.bmBitsPixel != nBpp)
-                    {
-                        HBITMAP hbmNew = CreateNBppBitmap(hbmSelection, nBpp);
-                        DeleteObject(hbmSelection);
-                        hbmSelection = hbmNew;
-                    }
+                    HBITMAP hbmNew = CreateNBppBitmap(hbmSelection, nBpp);
+                    DeleteObject(hbmSelection);
+                    hbmSelection = hbmNew;
                 }
                 SaveDIBToFile(hbmSelection, szFileName, FALSE);
                 DeleteObject(hbmSelection);

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -147,7 +147,7 @@ BOOL OpenMailer(HWND hWnd, LPCWSTR pszPathName)
             }
         }
 
-        // Use the temporary file 
+        // Use the temporary file
         pszPathName = g_szMailTempFile;
     }
 
@@ -203,6 +203,14 @@ BOOL OpenMailer(HWND hWnd, LPCWSTR pszPathName)
     return FALSE; // Failure
 }
 
+BOOL CMainWindow::ConfirmLoseColor()
+{
+    CStringW strText(MAKEINTRESOURCEW(IDS_LOSECOLOR));
+    CStringW strTitle(MAKEINTRESOURCEW(IDS_PROGRAMNAME));
+    INT id = MessageBox(strText, strTitle, MB_ICONINFORMATION | MB_YESNOCANCEL);
+    return (id == IDYES);
+}
+
 BOOL CMainWindow::GetOpenFileName(IN OUT LPWSTR pszFile, INT cchMaxFile)
 {
     static OPENFILENAMEW ofn = { 0 };
@@ -235,18 +243,32 @@ BOOL CMainWindow::GetOpenFileName(IN OUT LPWSTR pszFile, INT cchMaxFile)
     return ::GetOpenFileNameW(&ofn);
 }
 
-BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile)
+BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pnBpp)
 {
     static OPENFILENAMEW sfn = { 0 };
     static CStringW strFilter;
+    static DWORD cNonBmpFilters = 0;
+
+    if (pnBpp)
+        *pnBpp = -1;
 
     if (sfn.lStructSize == 0)
     {
         // Get the export filter
         CSimpleArray<GUID> aguidFileTypesE;
-        CImage::GetExporterFilterString(strFilter, aguidFileTypesE, NULL,
-                                        CImage::excludeDefaultSave, L'|');
+        DWORD dwExclude = CImage::excludeDefaultSave | CImage::excludeBMP;
+        CImage::GetExporterFilterString(strFilter, aguidFileTypesE, NULL, dwExclude, L'|');
+
+        strFilter.Replace(L"||", L"|");
+
+        // FIXME: Add more
+        strFilter += CStringW(MAKEINTRESOURCEW(IDS_MONOBMP));
+        strFilter += L"|*.bmp;*.dib|";
+        strFilter += CStringW(MAKEINTRESOURCEW(IDS_24BPPBMP));
+        strFilter += L"|*.bmp;*.dib||";
+
         strFilter.Replace(L'|', UNICODE_NULL);
+        cNonBmpFilters = aguidFileTypesE.GetSize();
 
         // Initializing the OPENFILENAME structure for GetSaveFileName
         ZeroMemory(&sfn, sizeof(sfn));
@@ -276,7 +298,25 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile)
 
     sfn.lpstrFile = pszFile;
     sfn.nMaxFile  = cchMaxFile;
-    return ::GetSaveFileNameW(&sfn);
+    if (!::GetSaveFileNameW(&sfn))
+        return FALSE;
+
+    if (pnBpp && sfn.nFilterIndex - 1 >= cNonBmpFilters)
+    {
+        INT delta = (sfn.nFilterIndex - 1) - cNonBmpFilters;
+        // FIXME: Add more
+        switch (delta)
+        {
+            case 0: // Mono (IDS_MONOBMP)
+                *pnBpp = 1;
+                break;
+            case 1: // 24-bpp Color (IDS_24BPPBMP)
+                *pnBpp = 24;
+                break;
+        }
+    }
+
+    return TRUE;
 }
 
 BOOL CMainWindow::ChooseColor(IN OUT COLORREF *prgbColor)
@@ -421,9 +461,32 @@ void CMainWindow::saveImage(BOOL overwrite)
     if (g_isAFile && overwrite)
     {
         imageModel.SaveImage(g_szFileName);
+        return;
     }
-    else if (GetSaveFileName(g_szFileName, _countof(g_szFileName)))
+
+    INT nBpp;
+    if (GetSaveFileName(g_szFileName, _countof(g_szFileName), &nBpp))
     {
+        if (nBpp != -1)
+        {
+            HBITMAP hbmNew = nullptr;
+            HBITMAP hbmOld = imageModel.LockBitmap();
+            BITMAP bm;
+            GetObjectW(hbmOld, sizeof(bm), &bm);
+            BOOL bDiffer = (bm.bmBitsPixel != nBpp);
+            if (bDiffer)
+                hbmNew = CreateNBppBitmap(hbmOld, nBpp);
+            imageModel.UnlockBitmap(hbmOld);
+
+            if (bDiffer && hbmNew)
+            {
+                if (nBpp < bm.bmBitsPixel && !mainWindow.ConfirmLoseColor())
+                    return;
+
+                imageModel.PushImageForUndo(hbmNew);
+            }
+        }
+
         imageModel.SaveImage(g_szFileName);
     }
 }
@@ -763,6 +826,13 @@ LRESULT CMainWindow::OnInitMenuPopup(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
     CheckMenuItem(menu, IDM_COLORSOLDPALETTE,    CHECKED_IF(paletteModel.SelectedPalette() == PAL_OLDTYPE));
     CheckMenuItem(menu, IDM_COLORSGRAYSCALE,     CHECKED_IF(paletteModel.SelectedPalette() == PAL_GRAYSCALE));
     CheckMenuItem(menu, IDM_COLORSMONOCHROME,    CHECKED_IF(paletteModel.SelectedPalette() == PAL_MONOCHROME));
+
+    BOOL bMono = (paletteModel.GetBpp() == 1);
+    EnableMenuItem(menu, IDM_COLORSEDITPALETTE, ENABLED_IF(!bMono));
+    EnableMenuItem(menu, IDM_COLORSMODERNPALETTE, ENABLED_IF(!bMono));
+    EnableMenuItem(menu, IDM_COLORSOLDPALETTE, ENABLED_IF(!bMono));
+    EnableMenuItem(menu, IDM_COLORSGRAYSCALE, ENABLED_IF(!bMono));
+
     return 0;
 }
 
@@ -1094,7 +1164,9 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         {
             WCHAR szFileName[MAX_LONG_PATH];
             ::LoadStringW(g_hinstExe, IDS_DEFAULTFILENAME, szFileName, _countof(szFileName));
-            if (GetSaveFileName(szFileName, _countof(szFileName)))
+
+            INT nBpp;
+            if (GetSaveFileName(szFileName, _countof(szFileName), &nBpp))
             {
                 HBITMAP hbmSelection = selectionModel.GetSelectionContents();
                 if (!hbmSelection)
@@ -1102,6 +1174,17 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                     ShowOutOfMemory();
                     imageModel.ClearHistory();
                     break;
+                }
+                if (nBpp != -1)
+                {
+                    BITMAP bm;
+                    GetObjectW(hbmSelection, sizeof(bm), &bm);
+                    if (bm.bmBitsPixel != nBpp)
+                    {
+                        HBITMAP hbmNew = CreateNBppBitmap(hbmSelection, nBpp);
+                        DeleteObject(hbmSelection);
+                        hbmSelection = hbmNew;
+                    }
                 }
                 SaveDIBToFile(hbmSelection, szFileName, FALSE);
                 DeleteObject(hbmSelection);
@@ -1207,13 +1290,26 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 CWaitCursor waitCursor;
                 if (attributesDialog.m_bBlackAndWhite && !imageModel.IsBlackAndWhite())
                 {
-                    CStringW strText(MAKEINTRESOURCEW(IDS_LOSECOLOR));
-                    CStringW strTitle(MAKEINTRESOURCEW(IDS_PROGRAMNAME));
-                    INT id = MessageBox(strText, strTitle, MB_ICONINFORMATION | MB_YESNOCANCEL);
-                    if (id != IDYES)
-                        break;
+                    if (mainWindow.ConfirmLoseColor())
+                    {
+                        HBITMAP hbmOld = imageModel.LockBitmap();
+                        HBITMAP hbmNew = CreateNBppBitmap(hbmOld, 1);
+                        imageModel.UnlockBitmap(hbmOld);
 
-                    imageModel.PushBlackAndWhite();
+                        imageModel.PushImageForUndo(hbmNew);
+                        paletteModel.SetColorInfo(hbmNew);
+                        imageModel.ClearHistory();
+                    }
+                }
+                else if (!attributesDialog.m_bBlackAndWhite && imageModel.IsBlackAndWhite())
+                {
+                    HBITMAP hbmOld = imageModel.LockBitmap();
+                    HBITMAP hbmNew = CreateNBppBitmap(hbmOld, 24);
+                    imageModel.UnlockBitmap(hbmOld);
+
+                    imageModel.PushImageForUndo(hbmNew);
+                    paletteModel.SetColorInfo(hbmNew);
+                    imageModel.ClearHistory();
                 }
 
                 if (imageModel.GetWidth() != attributesDialog.newWidth ||

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -3,7 +3,7 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    The main window and wWinMain etc.
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
- *             Copyright 2017-2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *             Copyright 2017-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *             Copyright 2018 Stanislav Motylkov <x86corez@gmail.com>
  */
 
@@ -207,7 +207,7 @@ BOOL CMainWindow::ConfirmLoseColor()
 {
     CStringW strText(MAKEINTRESOURCEW(IDS_LOSECOLOR));
     CStringW strTitle(MAKEINTRESOURCEW(IDS_PROGRAMNAME));
-    INT id = MessageBox(strText, strTitle, MB_ICONINFORMATION | MB_YESNOCANCEL);
+    INT id = MessageBox(strText, strTitle, MB_ICONWARNING | MB_YESNOCANCEL);
     return (id == IDYES);
 }
 
@@ -819,13 +819,26 @@ LRESULT CMainWindow::OnInitMenuPopup(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
     EnableMenuItem(menu, IDM_IMAGEDELETEIMAGE, ENABLED_IF(!selectionModel.m_bShow));
     CheckMenuItem(menu, IDM_IMAGEDRAWOPAQUE, CHECKED_IF(!toolsModel.IsBackgroundTransparent()));
 
-    //
     // Palette menu
-    //
-    CheckMenuItem(menu, IDM_COLORSMODERNPALETTE, CHECKED_IF(paletteModel.SelectedPalette() == PAL_MODERN));
-    CheckMenuItem(menu, IDM_COLORSOLDPALETTE,    CHECKED_IF(paletteModel.SelectedPalette() == PAL_OLDTYPE));
-    CheckMenuItem(menu, IDM_COLORSGRAYSCALE,     CHECKED_IF(paletteModel.SelectedPalette() == PAL_GRAYSCALE));
-    CheckMenuItem(menu, IDM_COLORSMONOCHROME,    CHECKED_IF(paletteModel.SelectedPalette() == PAL_MONOCHROME));
+    switch (paletteModel.SelectedPalette())
+    {
+        case PAL_MODERN:
+            CheckMenuRadioItem(menu, IDM_COLORSMODERNPALETTE, IDM_COLORSMONOCHROME,
+                               IDM_COLORSMODERNPALETTE, MF_BYCOMMAND);
+            break;
+        case PAL_OLDTYPE:
+            CheckMenuRadioItem(menu, IDM_COLORSMODERNPALETTE, IDM_COLORSMONOCHROME,
+                               IDM_COLORSOLDPALETTE, MF_BYCOMMAND);
+            break;
+        case PAL_GRAYSCALE:
+            CheckMenuRadioItem(menu, IDM_COLORSMODERNPALETTE, IDM_COLORSMONOCHROME,
+                               IDM_COLORSGRAYSCALE, MF_BYCOMMAND);
+            break;
+        case PAL_MONOCHROME:
+            CheckMenuRadioItem(menu, IDM_COLORSMODERNPALETTE, IDM_COLORSMONOCHROME,
+                               IDM_COLORSMONOCHROME, MF_BYCOMMAND);
+            break;
+    }
 
     BOOL bMono = (paletteModel.GetBpp() == 1);
     EnableMenuItem(menu, IDM_COLORSEDITPALETTE, ENABLED_IF(!bMono));
@@ -1297,8 +1310,6 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                         imageModel.UnlockBitmap(hbmOld);
 
                         imageModel.PushImageForUndo(hbmNew);
-                        paletteModel.SetColorInfo(hbmNew);
-                        imageModel.ClearHistory();
                     }
                 }
                 else if (!attributesDialog.m_bBlackAndWhite && imageModel.IsBlackAndWhite())
@@ -1308,8 +1319,6 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                     imageModel.UnlockBitmap(hbmOld);
 
                     imageModel.PushImageForUndo(hbmNew);
-                    paletteModel.SetColorInfo(hbmNew);
-                    imageModel.ClearHistory();
                 }
 
                 if (imageModel.GetWidth() != attributesDialog.newWidth ||

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -331,10 +331,9 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
                 case 3: *pnBpp = 24; break; // 24-bpp Color
             }
         }
-        else
+        else if (!lstrcmpiW(PathFindExtensionW(sfn.lpstrFile), L".gif")) // GIF
         {
-            if (!lstrcmpiW(PathFindExtensionW(sfn.lpstrFile), L".gif")) // GIF
-                *pnBpp = 8;
+            *pnBpp = 8;
         }
     }
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -306,10 +306,10 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
     {
         switch (paletteModel.GetBpp())
         {
-            case  1: sfn.nFilterIndex = (cNonBmpFilters + 1) + 0; break;
-            case  4: sfn.nFilterIndex = (cNonBmpFilters + 1) + 1; break;
-            case  8: sfn.nFilterIndex = (cNonBmpFilters + 1) + 2; break;
-            case 24: sfn.nFilterIndex = (cNonBmpFilters + 1) + 3; break;
+            case  1: sfn.nFilterIndex = (cNonBmpFilters + 1) + 0; break; // Mono
+            case  4: sfn.nFilterIndex = (cNonBmpFilters + 1) + 1; break; // 4-bpp Color
+            case  8: sfn.nFilterIndex = (cNonBmpFilters + 1) + 2; break; // 8-bpp Color
+            case 24: sfn.nFilterIndex = (cNonBmpFilters + 1) + 3; break; // 24-bpp Color
         }
     }
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -248,7 +248,7 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
     static OPENFILENAMEW sfn = { 0 };
     static CStringW strFilter;
     static DWORD cNonBmpFilters = 0;
-    static const INT strings[] = { IDS_MONOBMP, IDS_4BPPBMP, IDS_8BPPBMP, IDS_24BPPBMP };
+    static const INT bmpFilters[] = { IDS_MONOBMP, IDS_4BPPBMP, IDS_8BPPBMP, IDS_24BPPBMP };
 
     if (pnBpp)
         *pnBpp = -1;
@@ -263,7 +263,7 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
         strFilter.Replace(L"||", L"|");
 
         // Append BMP filters
-        for (auto ids : strings)
+        for (auto ids : bmpFilters)
         {
             strFilter += CStringW(MAKEINTRESOURCEW(ids));
             strFilter += L"|*.bmp;*.dib|";

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -248,6 +248,7 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
     static OPENFILENAMEW sfn = { 0 };
     static CStringW strFilter;
     static DWORD cNonBmpFilters = 0;
+    static const INT strings[] = { IDS_MONOBMP, IDS_4BPPBMP, IDS_8BPPBMP, IDS_24BPPBMP };
 
     if (pnBpp)
         *pnBpp = -1;
@@ -258,14 +259,14 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
         CSimpleArray<GUID> aguidFileTypesE;
         DWORD dwExclude = CImage::excludeDefaultSave | CImage::excludeBMP;
         CImage::GetExporterFilterString(strFilter, aguidFileTypesE, NULL, dwExclude, L'|');
-
         strFilter.Replace(L"||", L"|");
 
-        // FIXME: Add more
-        strFilter += CStringW(MAKEINTRESOURCEW(IDS_MONOBMP));
-        strFilter += L"|*.bmp;*.dib|";
-        strFilter += CStringW(MAKEINTRESOURCEW(IDS_24BPPBMP));
-        strFilter += L"|*.bmp;*.dib||";
+        for (auto ids : strings)
+        {
+            strFilter += CStringW(MAKEINTRESOURCEW(ids));
+            strFilter += L"|*.bmp;*.dib|";
+        }
+        strFilter += L'|';
 
         strFilter.Replace(L'|', UNICODE_NULL);
         cNonBmpFilters = aguidFileTypesE.GetSize();
@@ -299,26 +300,33 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
     sfn.lpstrFile = pszFile;
     sfn.nMaxFile  = cchMaxFile;
 
+    PWSTR dotext = PathFindExtensionW(pszFile);
+    if (!lstrcmpiW(dotext, L".bmp") || !lstrcmpiW(dotext, L".dib")) // BMP format?
+    {
+        switch (paletteModel.GetBpp())
+        {
+            case  1: sfn.nFilterIndex = cNonBmpFilters + 1; break;
+            case  4: sfn.nFilterIndex = cNonBmpFilters + 2; break;
+            case  8: sfn.nFilterIndex = cNonBmpFilters + 3; break;
+            case 24: sfn.nFilterIndex = cNonBmpFilters + 4; break;
+        }
+    }
+
     if (!::GetSaveFileNameW(&sfn))
         return FALSE;
 
-    // extension is lowercase
-    ::CharLowerW(PathFindExtensionW(sfn.lpstrFile));
+    ::CharLowerW(PathFindExtensionW(sfn.lpstrFile)); // lowercase extension
 
     if (pnBpp)
     {
         if (sfn.nFilterIndex - 1 >= cNonBmpFilters)
         {
-            INT delta = (sfn.nFilterIndex - 1) - cNonBmpFilters;
-            // FIXME: Add more
-            switch (delta)
+            switch ((sfn.nFilterIndex - 1) - cNonBmpFilters)
             {
-                case 0: // Mono (IDS_MONOBMP)
-                    *pnBpp = 1;
-                    break;
-                case 1: // 24-bpp Color (IDS_24BPPBMP)
-                    *pnBpp = 24;
-                    break;
+                case 0: *pnBpp = 1;  break; // Mono
+                case 1: *pnBpp = 4;  break; // 4-bpp Color
+                case 2: *pnBpp = 8;  break; // 8-bpp Color
+                case 3: *pnBpp = 24; break; // 24-bpp Color
             }
         }
         else

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -300,6 +300,7 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
     sfn.lpstrFile = pszFile;
     sfn.nMaxFile  = cchMaxFile;
 
+    // Set filter index
     PWSTR dotext = PathFindExtensionW(pszFile);
     if (!lstrcmpiW(dotext, L".bmp") || !lstrcmpiW(dotext, L".dib")) // BMP format?
     {
@@ -317,6 +318,7 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
 
     ::CharLowerW(PathFindExtensionW(sfn.lpstrFile)); // lowercase extension
 
+    // Set BPP
     if (pnBpp)
     {
         if (sfn.nFilterIndex - 1 >= cNonBmpFilters) // BMP

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -319,7 +319,7 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
 
     if (pnBpp)
     {
-        if (sfn.nFilterIndex - 1 >= cNonBmpFilters)
+        if (sfn.nFilterIndex - 1 >= cNonBmpFilters) // BMP
         {
             switch ((sfn.nFilterIndex - 1) - cNonBmpFilters)
             {

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -301,6 +301,9 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
     if (!::GetSaveFileNameW(&sfn))
         return FALSE;
 
+    // extension is lowercase
+    ::CharLowerW(PathFindExtensionW(sfn.lpstrFile));
+
     if (pnBpp)
     {
         if (sfn.nFilterIndex - 1 >= cNonBmpFilters)

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -301,18 +301,26 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
     if (!::GetSaveFileNameW(&sfn))
         return FALSE;
 
-    if (pnBpp && sfn.nFilterIndex - 1 >= cNonBmpFilters)
+    if (pnBpp)
     {
-        INT delta = (sfn.nFilterIndex - 1) - cNonBmpFilters;
-        // FIXME: Add more
-        switch (delta)
+        if (sfn.nFilterIndex - 1 >= cNonBmpFilters)
         {
-            case 0: // Mono (IDS_MONOBMP)
-                *pnBpp = 1;
-                break;
-            case 1: // 24-bpp Color (IDS_24BPPBMP)
-                *pnBpp = 24;
-                break;
+            INT delta = (sfn.nFilterIndex - 1) - cNonBmpFilters;
+            // FIXME: Add more
+            switch (delta)
+            {
+                case 0: // Mono (IDS_MONOBMP)
+                    *pnBpp = 1;
+                    break;
+                case 1: // 24-bpp Color (IDS_24BPPBMP)
+                    *pnBpp = 24;
+                    break;
+            }
+        }
+        else
+        {
+            if (!lstrcmpiW(PathFindExtensionW(sfn.lpstrFile), L".gif")) // GIF
+                *pnBpp = 8;
         }
     }
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -298,6 +298,8 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
 
     sfn.lpstrFile = pszFile;
     sfn.nMaxFile  = cchMaxFile;
+
+
     if (!::GetSaveFileNameW(&sfn))
         return FALSE;
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -305,10 +305,10 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
     {
         switch (paletteModel.GetBpp())
         {
-            case  1: sfn.nFilterIndex = cNonBmpFilters + 1; break;
-            case  4: sfn.nFilterIndex = cNonBmpFilters + 2; break;
-            case  8: sfn.nFilterIndex = cNonBmpFilters + 3; break;
-            case 24: sfn.nFilterIndex = cNonBmpFilters + 4; break;
+            case  1: sfn.nFilterIndex = (cNonBmpFilters + 1) + 0; break;
+            case  4: sfn.nFilterIndex = (cNonBmpFilters + 1) + 1; break;
+            case  8: sfn.nFilterIndex = (cNonBmpFilters + 1) + 2; break;
+            case 24: sfn.nFilterIndex = (cNonBmpFilters + 1) + 3; break;
         }
     }
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -323,9 +323,9 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
         {
             switch ((sfn.nFilterIndex - 1) - cNonBmpFilters)
             {
-                case 0: *pnBpp = 1;  break; // Mono
-                case 1: *pnBpp = 4;  break; // 4-bpp Color
-                case 2: *pnBpp = 8;  break; // 8-bpp Color
+                case 0: *pnBpp =  1; break; // Mono
+                case 1: *pnBpp =  4; break; // 4-bpp Color
+                case 2: *pnBpp =  8; break; // 8-bpp Color
                 case 3: *pnBpp = 24; break; // 24-bpp Color
             }
         }

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -259,17 +259,17 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pn
         CSimpleArray<GUID> aguidFileTypesE;
         DWORD dwExclude = CImage::excludeDefaultSave | CImage::excludeBMP;
         CImage::GetExporterFilterString(strFilter, aguidFileTypesE, NULL, dwExclude, L'|');
+        cNonBmpFilters = aguidFileTypesE.GetSize();
         strFilter.Replace(L"||", L"|");
 
+        // Append BMP filters
         for (auto ids : strings)
         {
             strFilter += CStringW(MAKEINTRESOURCEW(ids));
             strFilter += L"|*.bmp;*.dib|";
         }
-        strFilter += L'|';
 
         strFilter.Replace(L'|', UNICODE_NULL);
-        cNonBmpFilters = aguidFileTypesE.GetSize();
 
         // Initializing the OPENFILENAME structure for GetSaveFileName
         ZeroMemory(&sfn, sizeof(sfn));

--- a/base/applications/mspaint/main.h
+++ b/base/applications/mspaint/main.h
@@ -3,7 +3,7 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    The main window
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
- *             Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *             Copyright 2023-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once

--- a/base/applications/mspaint/main.h
+++ b/base/applications/mspaint/main.h
@@ -31,7 +31,7 @@ public:
 
     HWND DoCreate();
     BOOL GetOpenFileName(IN OUT LPWSTR pszFile, INT cchMaxFile);
-    BOOL GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile);
+    BOOL GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile, PINT pnBpp = nullptr);
     BOOL ChooseColor(IN OUT COLORREF *prgbColor);
     VOID TrackPopupMenu(POINT ptScreen, INT iSubMenu);
     BOOL CanUndo() const;
@@ -57,5 +57,6 @@ private:
     void saveImage(BOOL overwrite);
     void InsertSelectionFromHBITMAP(HBITMAP bitmap, HWND window);
     BOOL ConfirmSave();
+    BOOL ConfirmLoseColor();
     void ProcessFileMenu(HMENU hPopupMenu);
 };

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -363,7 +363,6 @@ struct SmoothDrawTool : ToolBase
 
     void OnDrawOverlayOnImage(HDC hdc) override
     {
-        ToolBase::OnDrawOverlayOnImage(hdc);
         for (SIZE_T i = 1; i < s_cPoints; ++i)
         {
             OnDraw(hdc, m_bLeftButton, s_pPoints[i - 1], s_pPoints[i]);
@@ -387,8 +386,6 @@ struct SelectionBaseTool : ToolBase
 
     void OnDrawOverlayOnImage(HDC hdc) override
     {
-        ToolBase::OnDrawOverlayOnImage(hdc);
-
         if (selectionModel.IsLanded() || !selectionModel.m_bShow)
             return;
 
@@ -752,7 +749,6 @@ struct AirBrushTool : SmoothDrawTool
 
     void OnDrawOverlayOnImage(HDC hdc) override
     {
-        ToolBase::OnDrawOverlayOnImage(hdc);
         srand(m_dwTick);
         SmoothDrawTool::OnDrawOverlayOnImage(hdc);
     }
@@ -774,7 +770,6 @@ struct TextTool : ToolBase
 {
     void OnDrawOverlayOnImage(HDC hdc) override
     {
-        ToolBase::OnDrawOverlayOnImage(hdc);
         if (canvasWindow.m_drawing)
         {
             CRect& rc = selectionModel.m_rc;
@@ -904,7 +899,6 @@ struct LineTool : TwoPointDrawTool
 {
     void OnDrawOverlayOnImage(HDC hdc) override
     {
-        ToolBase::OnDrawOverlayOnImage(hdc);
         if (!m_bDrawing)
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
@@ -995,7 +989,6 @@ struct RectTool : TwoPointDrawTool
 {
     void OnDrawOverlayOnImage(HDC hdc) override
     {
-        ToolBase::OnDrawOverlayOnImage(hdc);
         if (!m_bDrawing)
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
@@ -1107,7 +1100,6 @@ struct EllipseTool : TwoPointDrawTool
 {
     void OnDrawOverlayOnImage(HDC hdc) override
     {
-        ToolBase::OnDrawOverlayOnImage(hdc);
         if (!m_bDrawing)
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
@@ -1124,7 +1116,6 @@ struct RRectTool : TwoPointDrawTool
 {
     void OnDrawOverlayOnImage(HDC hdc) override
     {
-        ToolBase::OnDrawOverlayOnImage(hdc);
         if (!m_bDrawing)
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
@@ -1198,6 +1189,8 @@ void ToolsModel::OnEndDraw(BOOL bCancel)
 
 void ToolsModel::OnDrawOverlayOnImage(HDC hdc)
 {
+    SetTextColor(hdc, paletteModel.GetPrimaryColor());
+    SetBkColor(hdc, paletteModel.GetSecondaryColor());
     m_pToolObject->OnDrawOverlayOnImage(hdc);
 }
 

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -59,8 +59,8 @@ void getBoundaryOfPoints(RECT& rcBoundary, SIZE_T cPoints, const POINT *pPoints)
     while (cPoints-- > 0)
     {
         LONG x = pPoints->x, y = pPoints->y;
-        ptMin = { min(x, ptMin.x), min(y, ptMin.y) };
-        ptMax = { max(x, ptMax.x), max(y, ptMax.y) };
+        ptMin = { __min(x, ptMin.x), __min(y, ptMin.y) };
+        ptMax = { __max(x, ptMax.x), __max(y, ptMax.y) };
         ++pPoints;
     }
 
@@ -363,6 +363,7 @@ struct SmoothDrawTool : ToolBase
 
     void OnDrawOverlayOnImage(HDC hdc) override
     {
+        ToolBase::OnDrawOverlayOnImage(hdc);
         for (SIZE_T i = 1; i < s_cPoints; ++i)
         {
             OnDraw(hdc, m_bLeftButton, s_pPoints[i - 1], s_pPoints[i]);
@@ -386,6 +387,8 @@ struct SelectionBaseTool : ToolBase
 
     void OnDrawOverlayOnImage(HDC hdc) override
     {
+        ToolBase::OnDrawOverlayOnImage(hdc);
+
         if (selectionModel.IsLanded() || !selectionModel.m_bShow)
             return;
 
@@ -749,6 +752,7 @@ struct AirBrushTool : SmoothDrawTool
 
     void OnDrawOverlayOnImage(HDC hdc) override
     {
+        ToolBase::OnDrawOverlayOnImage(hdc);
         srand(m_dwTick);
         SmoothDrawTool::OnDrawOverlayOnImage(hdc);
     }
@@ -770,6 +774,7 @@ struct TextTool : ToolBase
 {
     void OnDrawOverlayOnImage(HDC hdc) override
     {
+        ToolBase::OnDrawOverlayOnImage(hdc);
         if (canvasWindow.m_drawing)
         {
             CRect& rc = selectionModel.m_rc;
@@ -899,6 +904,7 @@ struct LineTool : TwoPointDrawTool
 {
     void OnDrawOverlayOnImage(HDC hdc) override
     {
+        ToolBase::OnDrawOverlayOnImage(hdc);
         if (!m_bDrawing)
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
@@ -989,6 +995,7 @@ struct RectTool : TwoPointDrawTool
 {
     void OnDrawOverlayOnImage(HDC hdc) override
     {
+        ToolBase::OnDrawOverlayOnImage(hdc);
         if (!m_bDrawing)
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
@@ -1100,6 +1107,7 @@ struct EllipseTool : TwoPointDrawTool
 {
     void OnDrawOverlayOnImage(HDC hdc) override
     {
+        ToolBase::OnDrawOverlayOnImage(hdc);
         if (!m_bDrawing)
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)
@@ -1116,6 +1124,7 @@ struct RRectTool : TwoPointDrawTool
 {
     void OnDrawOverlayOnImage(HDC hdc) override
     {
+        ToolBase::OnDrawOverlayOnImage(hdc);
         if (!m_bDrawing)
             return;
         if (GetAsyncKeyState(VK_SHIFT) < 0)

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -1192,6 +1192,7 @@ void ToolsModel::OnDrawOverlayOnImage(HDC hdc)
     SetTextColor(hdc, paletteModel.GetPrimaryColor());
     SetBkColor(hdc, paletteModel.GetSecondaryColor());
     m_pToolObject->OnDrawOverlayOnImage(hdc);
+    GdiFlush();
 }
 
 void ToolsModel::OnDrawOverlayOnCanvas(HDC hdc)

--- a/base/applications/mspaint/palette.cpp
+++ b/base/applications/mspaint/palette.cpp
@@ -156,6 +156,9 @@ LRESULT CPaletteWindow::OnRButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, B
 
 LRESULT CPaletteWindow::OnLButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
+    if (paletteModel.GetBpp() == 1)
+        return 0;
+
     INT iColor = DoHitTest(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
     COLORREF rgbColor = paletteModel.GetFgColor();
     if (iColor != -1 && mainWindow.ChooseColor(&rgbColor))
@@ -168,6 +171,9 @@ LRESULT CPaletteWindow::OnLButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam,
 
 LRESULT CPaletteWindow::OnRButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
+    if (paletteModel.GetBpp() == 1)
+        return 0;
+
     INT iColor = DoHitTest(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
     COLORREF rgbColor = paletteModel.GetBgColor();
     if (iColor != -1 && mainWindow.ChooseColor(&rgbColor))

--- a/base/applications/mspaint/palette.cpp
+++ b/base/applications/mspaint/palette.cpp
@@ -3,7 +3,7 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    Window procedure of the palette window
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
- *             Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *             Copyright 2023-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include "precomp.h"
@@ -156,7 +156,7 @@ LRESULT CPaletteWindow::OnRButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, B
 
 LRESULT CPaletteWindow::OnLButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    if (paletteModel.GetBpp() == 1)
+    if (!paletteModel.IsEditable())
         return 0;
 
     INT iColor = DoHitTest(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
@@ -171,7 +171,7 @@ LRESULT CPaletteWindow::OnLButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam,
 
 LRESULT CPaletteWindow::OnRButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    if (paletteModel.GetBpp() == 1)
+    if (!paletteModel.IsEditable())
         return 0;
 
     INT iColor = DoHitTest(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));

--- a/base/applications/mspaint/palette.h
+++ b/base/applications/mspaint/palette.h
@@ -3,6 +3,7 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    Window procedure of the palette window
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
+ *             Copyright 2023-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -12,6 +12,11 @@ PaletteModel paletteModel;
 
 /* FUNCTIONS ********************************************************/
 
+static inline COLORREF QuadToRGB(const RGBQUAD& quad)
+{
+    return RGB(quad.rgbRed, quad.rgbGreen, quad.rgbBlue);
+}
+
 PaletteModel::PaletteModel()
 {
     m_fgColor = RGB(0, 0, 0);
@@ -119,4 +124,48 @@ void PaletteModel::NotifyPaletteChanged()
 {
     if (paletteWindow.IsWindow())
         paletteWindow.Invalidate(FALSE);
+}
+
+void PaletteModel::SetColorInfo(HBITMAP hbm)
+{
+    static RGBQUAD colors[256];
+
+    if (hbm == NULL)
+    {
+        SetColorTable(24, 0, nullptr);
+    }
+
+    BITMAP bm;
+    GetObjectW(hbm, sizeof(bm), &bm);
+
+    HDC hDC = CreateCompatibleDC(NULL);
+    HGDIOBJ hbmOld = SelectObject(hDC, hbm);
+    UINT cColors = GetDIBColorTable(hDC, 0, (UINT)_countof(colors), colors);
+    SelectObject(hDC, hbmOld);
+    DeleteDC(hDC);
+
+    SetColorTable(bm.bmBitsPixel, cColors, colors);
+    if (bm.bmBitsPixel == 1)
+        SetPrimaryColors(QuadToRGB(colors[0]), QuadToRGB(colors[1]));
+    else
+        SetPrimaryColors(RGB(0, 0, 0), RGB(255, 255, 255));
+}
+
+void PaletteModel::SetColorTable(UINT bpp, UINT cColors, RGBQUAD* colors)
+{
+    m_bpp = bpp;
+    SelectPalette((bpp == 1) ? PAL_MONOCHROME : PAL_MODERN);
+}
+
+UINT PaletteModel::GetBpp() const
+{
+    return m_bpp;
+}
+
+void PaletteModel::SetPrimaryColors(COLORREF color0, COLORREF color1)
+{
+    m_primaryColor = color0;
+    m_secondaryColor = color1;
+    toolsModel.DeleteBrushes();
+    paletteWindow.Invalidate(TRUE);
 }

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -12,11 +12,6 @@ PaletteModel paletteModel;
 
 /* FUNCTIONS ********************************************************/
 
-static inline COLORREF QuadToRGB(const RGBQUAD& quad)
-{
-    return RGB(quad.rgbRed, quad.rgbGreen, quad.rgbBlue);
-}
-
 PaletteModel::PaletteModel()
 {
     m_fgColor = RGB(0, 0, 0);
@@ -27,6 +22,11 @@ PaletteModel::PaletteModel()
 PAL_TYPE PaletteModel::SelectedPalette()
 {
     return m_nSelectedPalette;
+}
+
+BOOL PaletteModel::IsEditable() const
+{
+    return m_nSelectedPalette == PAL_MODERN || m_nSelectedPalette == PAL_OLDTYPE;
 }
 
 void PaletteModel::SelectPalette(PAL_TYPE nPalette)
@@ -130,11 +130,6 @@ void PaletteModel::SetColorInfo(HBITMAP hbm)
 {
     static RGBQUAD colors[256];
 
-    if (hbm == NULL)
-    {
-        SetColorTable(24, 0, nullptr);
-    }
-
     BITMAP bm;
     GetObjectW(hbm, sizeof(bm), &bm);
 
@@ -145,27 +140,39 @@ void PaletteModel::SetColorInfo(HBITMAP hbm)
     DeleteDC(hDC);
 
     SetColorTable(bm.bmBitsPixel, cColors, colors);
-    if (bm.bmBitsPixel == 1)
-        SetPrimaryColors(QuadToRGB(colors[0]), QuadToRGB(colors[1]));
-    else
-        SetPrimaryColors(RGB(0, 0, 0), RGB(255, 255, 255));
 }
 
 void PaletteModel::SetColorTable(UINT bpp, UINT cColors, RGBQUAD* colors)
 {
     m_bpp = bpp;
-    SelectPalette((bpp == 1) ? PAL_MONOCHROME : PAL_MODERN);
-}
 
-UINT PaletteModel::GetBpp() const
-{
-    return m_bpp;
+    PAL_TYPE palette = SelectedPalette();
+    if (bpp == 1)
+    {
+        if (palette != PAL_MONOCHROME)
+            SelectPalette(PAL_MONOCHROME);
+
+        if (cColors >= 2)
+            SetPrimaryColors(QuadToRGBValue(colors[0]), QuadToRGBValue(colors[1]));
+        else
+            SetPrimaryColors(RGB(0, 0, 0), RGB(255, 255, 255));
+    }
+    else
+    {
+        if (palette == PAL_MONOCHROME)
+            SelectPalette(PAL_MODERN);
+
+        SetPrimaryColors(RGB(0, 0, 0), RGB(255, 255, 255));
+    }
 }
 
 void PaletteModel::SetPrimaryColors(COLORREF color0, COLORREF color1)
 {
-    m_primaryColor = color0;
-    m_secondaryColor = color1;
-    toolsModel.DeleteBrushes();
-    paletteWindow.Invalidate(TRUE);
+    if (m_primaryColor != color0 || m_secondaryColor != color1)
+    {
+        m_primaryColor = color0;
+        m_secondaryColor = color1;
+        toolsModel.DeleteBrushes();
+        paletteWindow.Invalidate(TRUE);
+    }
 }

--- a/base/applications/mspaint/palettemodel.h
+++ b/base/applications/mspaint/palettemodel.h
@@ -3,6 +3,7 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    Keep track of palette data, notify listeners
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
+ *             Copyright 2021-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once
@@ -44,9 +45,10 @@ public:
     void SetFgColor(COLORREF newColor);
     COLORREF GetBgColor() const;
     void SetBgColor(COLORREF newColor);
-    UINT GetBpp() const;
     void SetColorInfo(HBITMAP hbm);
     void SetPrimaryColors(COLORREF color0, COLORREF color1);
+    UINT GetBpp() const { return m_bpp; }
     COLORREF GetPrimaryColor() const { return m_primaryColor; }
     COLORREF GetSecondaryColor() const { return m_secondaryColor; }
+    BOOL IsEditable() const;
 };

--- a/base/applications/mspaint/palettemodel.h
+++ b/base/applications/mspaint/palettemodel.h
@@ -26,9 +26,13 @@ private:
     PAL_TYPE m_nSelectedPalette;
     COLORREF m_fgColor;
     COLORREF m_bgColor;
+    UINT m_bpp = 24;
+    COLORREF m_primaryColor = RGB(0, 0, 0);
+    COLORREF m_secondaryColor = RGB(255, 255, 255);
 
     void NotifyColorChanged();
     void NotifyPaletteChanged();
+    void SetColorTable(UINT bpp, UINT cColors, RGBQUAD* colors);
 
 public:
     PaletteModel();
@@ -40,4 +44,9 @@ public:
     void SetFgColor(COLORREF newColor);
     COLORREF GetBgColor() const;
     void SetBgColor(COLORREF newColor);
+    UINT GetBpp() const;
+    void SetColorInfo(HBITMAP hbm);
+    void SetPrimaryColors(COLORREF color0, COLORREF color1);
+    COLORREF GetPrimaryColor() const { return m_primaryColor; }
+    COLORREF GetSecondaryColor() const { return m_secondaryColor; }
 };

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -30,7 +30,7 @@
 #include <commctrl.h>
 #include <stdlib.h>
 #define _USE_MATH_DEFINES /* for M_PI */
-#include <math.h>
+#include <cmath>
 #include <shellapi.h>
 #include <htmlhelp.h>
 #include <strsafe.h>
@@ -152,3 +152,6 @@ extern CToolSettingsWindow toolSettingsWindow;
 extern CPaletteWindow paletteWindow;
 extern CCanvasWindow canvasWindow;
 extern CTextEditWindow textEditWindow;
+
+void FloydSteinberg(const BYTE* srcBuf, INT srcStride, SIZE_T W, SIZE_T H,
+                    const RGBQUAD* palette, INT nColors, PBYTE indexImg);

--- a/base/applications/mspaint/resource.h
+++ b/base/applications/mspaint/resource.h
@@ -231,3 +231,7 @@
 #define IDS_SAVEERROR   941
 #define IDS_CANTSENDMAIL 942
 #define IDS_LOSECOLOR   943
+#define IDS_MONOBMP     944
+#define IDS_4BPPBMP     945
+#define IDS_8BPPBMP     946
+#define IDS_24BPPBMP    947

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -316,28 +316,17 @@ void SelectionModel::StretchSkew(int nStretchPercentX, int nStretchPercentY, int
         AttachHBITMAP(&hbmMask, CopyMonoImage(hbmMask, newWidth, newHeight));
     }
 
-    HGDIOBJ hbmOld;
-    HDC hDC = ::CreateCompatibleDC(NULL);
-
     if (nSkewDegX)
     {
-        hbmOld = ::SelectObject(hDC, hbmColor);
-        AttachHBITMAP(&hbmColor, SkewDIB(hDC, hbmColor, nSkewDegX, FALSE));
-        ::SelectObject(hDC, hbmMask);
-        AttachHBITMAP(&hbmMask, SkewDIB(hDC, hbmMask, nSkewDegX, FALSE));
-        ::SelectObject(hDC, hbmOld);
+        AttachHBITMAP(&hbmColor, SkewDIB(hbmColor, nSkewDegX, FALSE));
+        AttachHBITMAP(&hbmMask, SkewDIB(hbmMask, nSkewDegX, FALSE));
     }
 
     if (nSkewDegY)
     {
-        hbmOld = ::SelectObject(hDC, hbmColor);
-        AttachHBITMAP(&hbmColor, SkewDIB(hDC, hbmColor, nSkewDegY, TRUE));
-        ::SelectObject(hDC, hbmMask);
-        AttachHBITMAP(&hbmMask, SkewDIB(hDC, hbmMask, nSkewDegY, TRUE));
-        ::SelectObject(hDC, hbmOld);
+        AttachHBITMAP(&hbmColor, SkewDIB(hbmColor, nSkewDegY, TRUE));
+        AttachHBITMAP(&hbmMask, SkewDIB(hbmMask, nSkewDegY, TRUE));
     }
-
-    ::DeleteDC(hDC);
 
     InsertFromHBITMAP(hbmColor, m_rc.left, m_rc.top, hbmMask);
 

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -324,7 +324,7 @@ void SelectionModel::StretchSkew(int nStretchPercentX, int nStretchPercentY, int
         hbmOld = ::SelectObject(hDC, hbmColor);
         AttachHBITMAP(&hbmColor, SkewDIB(hDC, hbmColor, nSkewDegX, FALSE));
         ::SelectObject(hDC, hbmMask);
-        AttachHBITMAP(&hbmMask, SkewDIB(hDC, hbmMask, nSkewDegX, FALSE, TRUE));
+        AttachHBITMAP(&hbmMask, SkewDIB(hDC, hbmMask, nSkewDegX, FALSE));
         ::SelectObject(hDC, hbmOld);
     }
 
@@ -333,7 +333,7 @@ void SelectionModel::StretchSkew(int nStretchPercentX, int nStretchPercentY, int
         hbmOld = ::SelectObject(hDC, hbmColor);
         AttachHBITMAP(&hbmColor, SkewDIB(hDC, hbmColor, nSkewDegY, TRUE));
         ::SelectObject(hDC, hbmMask);
-        AttachHBITMAP(&hbmMask, SkewDIB(hDC, hbmMask, nSkewDegY, TRUE, TRUE));
+        AttachHBITMAP(&hbmMask, SkewDIB(hDC, hbmMask, nSkewDegY, TRUE));
         ::SelectObject(hDC, hbmOld);
     }
 

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -97,9 +97,11 @@ HBITMAP SelectionModel::GetSelectionContents()
         return NULL;
 
     CRect rc = { 0, 0, m_rc.Width(), m_rc.Height() };
+    HBITMAP hbmNew = imageModel.CloneDIB(rc.Width(), rc.Height(), paletteModel.GetBgColor());
+    if (!hbmNew)
+        return NULL;
 
     HDC hdcMem = ::CreateCompatibleDC(NULL);
-    HBITMAP hbmNew = CreateColorDIB(rc.Width(), rc.Height(), paletteModel.GetBgColor());
     HGDIOBJ hbmOld = ::SelectObject(hdcMem, hbmNew);
     selectionModel.DrawSelection(hdcMem, paletteModel.GetBgColor(), TRUE, rc, hbmPart);
     ::SelectObject(hdcMem, hbmOld);
@@ -240,19 +242,21 @@ void SelectionModel::RotateNTimes90Degrees(int iN)
 
             if (m_hbmColor)
             {
-                hbmOld = ::SelectObject(hdcMem, m_hbmColor);
-                hbm = Rotate90DegreeBlt(hdcMem, m_rc.Width(), m_rc.Height(), iN == 1, FALSE);
-                ::SelectObject(hdcMem, hbmOld);
-                ::DeleteObject(m_hbmColor);
-                m_hbmColor = hbm;
+                hbm = Rotate90DegreeBitmap(m_hbmColor, iN == 1);
+                if (hbm)
+                {
+                    ::DeleteObject(m_hbmColor);
+                    m_hbmColor = hbm;
+                }
             }
             if (m_hbmMask)
             {
-                hbmOld = ::SelectObject(hdcMem, m_hbmMask);
-                hbm = Rotate90DegreeBlt(hdcMem, m_rc.Width(), m_rc.Height(), iN == 1, TRUE);
-                ::SelectObject(hdcMem, hbmOld);
-                ::DeleteObject(m_hbmMask);
-                m_hbmMask = hbm;
+                hbm = Rotate90DegreeBitmap(m_hbmMask, iN == 1);
+                if (hbm)
+                {
+                    ::DeleteObject(m_hbmMask);
+                    m_hbmMask = hbm;
+                }
             }
 
             SwapWidthAndHeight();

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -96,6 +96,21 @@ HBITMAP SelectionModel::GetSelectionContents()
     if (!hbmPart)
         return NULL;
 
+    BITMAP bm;
+    GetObject(hbmPart, sizeof(bm), &bm);
+    if (bm.bmBitsPixel == 1) // Monochrome?
+    {
+        HDC hdc = CreateCompatibleDC(NULL);
+        HGDIOBJ old = SelectObject(hdc, hbmPart);
+        RGBQUAD colors[2];
+        colors[0] = RGBValueToQuad(paletteModel.GetPrimaryColor());
+        colors[1] = RGBValueToQuad(paletteModel.GetSecondaryColor());
+        SetDIBColorTable(hdc, 0, 2, colors);
+        SelectObject(hdc, old);
+        DeleteDC(hdc);
+        return hbmPart;
+    }
+
     CRect rc = { 0, 0, m_rc.Width(), m_rc.Height() };
     HBITMAP hbmNew = imageModel.CloneDIB(rc.Width(), rc.Height(), paletteModel.GetBgColor());
     if (!hbmNew)

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -118,7 +118,7 @@ HBITMAP SelectionModel::GetSelectionContents()
 
     HDC hdcMem = ::CreateCompatibleDC(NULL);
     HGDIOBJ hbmOld = ::SelectObject(hdcMem, hbmNew);
-    selectionModel.DrawSelection(hdcMem, paletteModel.GetBgColor(), TRUE, rc, hbmPart);
+    DrawSelection(hdcMem, paletteModel.GetBgColor(), TRUE, rc, hbmPart);
     ::SelectObject(hdcMem, hbmOld);
     ::DeleteDC(hdcMem);
 

--- a/base/applications/mspaint/toolsettings.h
+++ b/base/applications/mspaint/toolsettings.h
@@ -3,6 +3,7 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    Window procedure of the tool settings window
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
+ *             Copyright 2021-2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -35,6 +35,15 @@ HBRUSH ToolsModel::VirtualBrush::GetBrush(PAL_TYPE palette, COLORREF rgbColor)
     return m_hBrush;
 }
 
+void ToolsModel::VirtualBrush::Delete()
+{
+    if (m_hBrush)
+    {
+        ::DeleteObject(m_hBrush);
+        m_hBrush = nullptr;
+    }
+}
+
 ToolsModel::ToolsModel()
 {
     m_lineWidth = m_penWidth = 1;
@@ -113,31 +122,31 @@ void ToolsModel::SetBrushWidth(INT nBrushWidth)
 void ToolsModel::MakeLineThickerOrThinner(BOOL bThinner)
 {
     INT thickness = GetLineWidth();
-    SetLineWidth(bThinner ? max(1, thickness - 1) : (thickness + 1));
+    SetLineWidth(bThinner ? __max(1, thickness - 1) : (thickness + 1));
 }
 
 void ToolsModel::MakePenThickerOrThinner(BOOL bThinner)
 {
     INT thickness = GetPenWidth();
-    SetPenWidth(bThinner ? max(1, thickness - 1) : (thickness + 1));
+    SetPenWidth(bThinner ? __max(1, thickness - 1) : (thickness + 1));
 }
 
 void ToolsModel::MakeBrushThickerOrThinner(BOOL bThinner)
 {
     INT thickness = GetBrushWidth();
-    SetBrushWidth(bThinner ? max(1, thickness - 1) : (thickness + 1));
+    SetBrushWidth(bThinner ? __max(1, thickness - 1) : (thickness + 1));
 }
 
 void ToolsModel::MakeAirBrushThickerOrThinner(BOOL bThinner)
 {
     INT thickness = GetAirBrushRadius();
-    SetAirBrushRadius(bThinner ? max(1, thickness - 1) : (thickness + 1));
+    SetAirBrushRadius(bThinner ? __max(1, thickness - 1) : (thickness + 1));
 }
 
 void ToolsModel::MakeRubberThickerOrThinner(BOOL bThinner)
 {
     INT thickness = GetRubberRadius();
-    SetRubberRadius(bThinner ? max(1, thickness - 1) : (thickness + 1));
+    SetRubberRadius(bThinner ? __max(1, thickness - 1) : (thickness + 1));
 }
 
 int ToolsModel::GetShapeStyle() const
@@ -349,7 +358,8 @@ void ToolsModel::selectAll()
 HBRUSH ToolsModel::CreateBrush(PAL_TYPE palette, COLORREF color)
 {
     if (palette == PAL_MONOCHROME)
-        return CreateDitherBrush(color, RGB(0, 0, 0), RGB(255, 255, 255));
+        return CreateDitherBrush(color, paletteModel.GetPrimaryColor(),
+                                 paletteModel.GetSecondaryColor());
     else
         return ::CreateSolidBrush(color);
 }
@@ -362,4 +372,10 @@ HBRUSH ToolsModel::GetFgBrush()
 HBRUSH ToolsModel::GetBgBrush()
 {
     return m_bgBrush.GetBrush(paletteModel.SelectedPalette(), paletteModel.GetBgColor());
+}
+
+void ToolsModel::DeleteBrushes()
+{
+    m_fgBrush.Delete();
+    m_bgBrush.Delete();
 }

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -3,6 +3,7 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    Keep track of tool parameters, notify listeners
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
+ *             Copyright 2021-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include "precomp.h"

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -78,6 +78,7 @@ private:
         ~VirtualBrush();
 
         HBRUSH GetBrush(PAL_TYPE palette, COLORREF rgbColor);
+        void Delete();
     };
 
     int m_lineWidth;
@@ -163,6 +164,7 @@ public:
     HBRUSH GetFgBrush();
     HBRUSH GetBgBrush();
     static HBRUSH CreateBrush(PAL_TYPE palette, COLORREF color);
+    void DeleteBrushes();
 };
 
 extern ToolsModel toolsModel;

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -3,6 +3,7 @@
  * LICENSE:    LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:    Keep track of tool parameters, notify listeners
  * COPYRIGHT:  Copyright 2015 Benedikt Freisen <b.freisen@gmx.net>
+ *             Copyright 2021-2026 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once


### PR DESCRIPTION
## Purpose
Fully supporting monochrome mode.
JIRA issue: [CORE-15990](https://jira.reactos.org/browse/CORE-15990)

## Proposed changes

Cloning DIB `HBITMAP` will keep color information. Users can choose 1-bpp, 4-bpp, 8-bpp, and 24-bpp BMP formats when saving. The monochrome palette is enforced for monochrome bitmaps.

- Add `foyd.cpp` for Floyd Steinberg's error diffusion to quantize colors.
- Unlink `cpprt` and link `cppstl` for C++ STL.
- Use `__min` and `__max` instead of `min` and `max` for C++ STL.
- Add `IDS_MONOBMP`, `IDS_4BPPBMP`, `IDS_8BPPBMP` and `IDS_24BPPBMP` resource strings.
- Add `LoadBitmapFromFile`, `CreateNBppBitmap` and `FillBitmapByColor` functions into `dib.cpp`.
- Add handling of "Save File" filters for various BMP formats.
- Remove `ImageModel::CopyBitmap` and add `ImageModel::CloneDIB`.
- Add `GetBpp`, `SetColorInfo`, `SetPrimaryColors`, `GetPrimaryColor`, and `GetSecondaryColor` into `PaletteModel`.
- Add `ToolsModel::VirtualBrush::Delete` and `ToolsModel::DeleteBrushes`.

## Movies

Our paint on Windows:
https://github.com/user-attachments/assets/72d0d480-1e97-4257-9bee-7949a2871e7d

Our paint on ReactOS:
https://github.com/user-attachments/assets/f2c1dd6b-ff17-4e3b-8e00-bd5efe75a771
The graphical glitch is not my fault. Our GDI's bug.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: