### PR TITLE
[KERNEL32] Fix flags check in IntWideCharToMultiByteUTF8

### DIFF
--- a/dll/win32/kernel32/winnls/string/nls.c
+++ b/dll/win32/kernel32/winnls/string/nls.c
@@ -504,7 +504,7 @@ IntMultiByteToWideCharUTF8(DWORD Flags,
     BOOL CharIsValid, StringIsValid = TRUE;
     const WCHAR InvalidChar = 0xFFFD;
 
-    if (Flags != 0 && Flags != MB_ERR_INVALID_CHARS)
+    if (Flags & ~(MB_ERR_INVALID_CHARS))
     {
         SetLastError(ERROR_INVALID_FLAGS);
         return 0;
@@ -1011,7 +1011,7 @@ IntWideCharToMultiByteUTF8(UINT CodePage,
     INT TempLength;
     DWORD Char;
 
-    if (Flags)
+    if (Flags & ~(WC_ERR_INVALID_CHARS))
     {
         SetLastError(ERROR_INVALID_FLAGS);
         return 0;


### PR DESCRIPTION
## Purpose

Allow WC_ERR_INVALID_CHARS and MB_PRECOMPOSED

The flags are simply ignored.
Fixes some shlwapi_winetest url test failures and a crash of ucrtbase_winetest file on NT6 builds (and possibly more, since ucrtbase and other code use this)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
