### PR TITLE
[RSYM] Make the Address field ULONG

### DIFF
--- a/modules/rostests/apitests/dbghelp/data.c
+++ b/modules/rostests/apitests/dbghelp/data.c
@@ -189,19 +189,15 @@ void create_compressed_files()
 #endif
 
 #if 0
+
+#include <rossym.h> // For ROSSYM_ENTRY
+
 typedef struct _SYMBOLFILE_HEADER {
     ULONG SymbolsOffset;
     ULONG SymbolsLength;
     ULONG StringsOffset;
     ULONG StringsLength;
 } SYMBOLFILE_HEADER, *PSYMBOLFILE_HEADER;
-
-typedef struct _ROSSYM_ENTRY {
-    ULONG Address;
-    ULONG FunctionOffset;
-    ULONG FileOffset;
-    ULONG SourceLine;
-} ROSSYM_ENTRY, *PROSSYM_ENTRY;
 
 
 static int is_metadata(const char* name)
@@ -224,7 +220,7 @@ static void dump_rsym_internal(void* data)
         if (!Entry->FileOffset)
         {
             if (Entry->SourceLine)
-                printf("ERR: SOURCELINE (%D) ", Entry->SourceLine);
+                printf("ERR: SOURCELINE (%lu) ", Entry->SourceLine);
             if (is_metadata(Strings + Entry->FunctionOffset))
                 printf("metadata: %s: 0x%x\n", Strings + Entry->FunctionOffset, Entry->Address);
             else
@@ -244,7 +240,7 @@ static void dump_rsym_internal(void* data)
 void dump_rsym(const char* filename)
 {
     char* data;
-    long size, res;
+    SIZE_T size, res;
     PIMAGE_FILE_HEADER PEFileHeader;
     PIMAGE_OPTIONAL_HEADER PEOptHeader;
     PIMAGE_SECTION_HEADER PESectionHeaders;

--- a/sdk/include/reactos/rossym.h
+++ b/sdk/include/reactos/rossym.h
@@ -24,7 +24,7 @@ typedef struct _ROSSYM_HEADER {
 } ROSSYM_HEADER, *PROSSYM_HEADER;
 
 typedef struct _ROSSYM_ENTRY {
-  ULONG_PTR Address;
+  ULONG Address; /* RVA */
   ULONG FunctionOffset;
   ULONG FileOffset;
   ULONG SourceLine;

--- a/sdk/tools/rsym/rsym.h
+++ b/sdk/tools/rsym/rsym.h
@@ -157,14 +157,8 @@ typedef struct _COFF_SYMENT
 } COFF_SYMENT, *PCOFF_SYMENT;
 #pragma pack(pop)
 
-#ifdef TARGET_i386
-typedef ULONG TARGET_ULONG_PTR;
-#else
-typedef ULONGLONG TARGET_ULONG_PTR;
-#endif
-
 typedef struct _ROSSYM_ENTRY {
-  TARGET_ULONG_PTR Address;
+  ULONG Address; /* RVA */
   ULONG FunctionOffset;
   ULONG FileOffset;
   ULONG SourceLine;


### PR DESCRIPTION
## Purpose

Fix dbghelp_apitest on x64.
The field is an RVA, so there is no reason to expand it to 64 bit on x64. Fixes crash of dbghelp_apitest rsym on x64, as the test was using ULONG while dbghelp was using ULONG_PTR and rsym itself was using TARGET_ULONG_PTR.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108908,108911
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108910,108912

