### PR TITLE
[IPHLPAPI] Fix buffer overflow

### DIFF
--- a/dll/win32/iphlpapi/icmp.c
+++ b/dll/win32/iphlpapi/icmp.c
@@ -314,9 +314,9 @@ IcmpSendEcho2(
         return 0;
     }
 
-    // IO_STATUS_BLOCK will be stored inside ReplyBuffer (in the end)
+    // IO_STATUS_BLOCK will be stored inside ReplyBuffer
     // that's because the function may return before device request ends
-    IoStatusBlock = (PIO_STATUS_BLOCK)((PUCHAR)ReplyBuffer + ReplySize - sizeof(IO_STATUS_BLOCK));
+    IoStatusBlock = (PIO_STATUS_BLOCK)((PUCHAR)ReplyBuffer + sizeof(ICMP_ECHO_REPLY));
     ReplySize -= sizeof(IO_STATUS_BLOCK);
 
     InputBuffer = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, ReplySize);

--- a/modules/rostests/winetests/iphlpapi/iphlpapi.c
+++ b/modules/rostests/winetests/iphlpapi/iphlpapi.c
@@ -1471,10 +1471,10 @@ static void testIcmpSendEcho(void)
     /*
        NOTE: Supplying both event and apc has varying behavior across Windows versions, so not tested.
     */
-#if defined(__REACTOS__) && defined(_MSC_VER)
+#if defined(__REACTOS__)
     /* The call to IcmpSendEcho2() below with the invalid APC context causes
-     * stack corruption on WS03 and ReactOS when compiled with MSVC but not GCC. */
-    if (LOBYTE(LOWORD(GetVersion())) >= 6) {
+     * stack corruption on WS03 (causes crash in MSVC builds with /RTC1). */
+    if (is_reactos() || LOBYTE(LOWORD(GetVersion())) >= 6) {
 #endif
     ret = IcmpSendEcho2(icmp, NULL, apc, (void*)0xdeadc0de, address, senddata, sizeof(senddata), NULL, replydata2, replysz, 1000);
     error = GetLastError();
@@ -1490,7 +1490,7 @@ static void testIcmpSendEcho(void)
     ok(reply->DataSize == sizeof(senddata), "Got size: %d\n", reply->DataSize);
     /* pre-Vista, reply->Data is an offset; otherwise it's a pointer, so hardcode the offset */
     ok(!memcmp(senddata, reply + 1, min(sizeof(senddata), reply->DataSize)), "Data mismatch\n");
-#if defined(__REACTOS__) && defined(_MSC_VER)
+#if defined(__REACTOS__)
     }
 #endif
 


### PR DESCRIPTION
## Purpose

Fix a buffer overflow that happens in iphlpapi_winetest on Windows 2003 and ReactOS (fixed in Vista+).

## Proposed changes

- In IcmpSendEcho2 store the IO_STATUS_BLOCK after ICMP_ECHO_REPLY structure rather than at the end of the buffer
- Adjust the workaround to prevent a crash in iphlpapi_winetest

## Testbot runs (Filled in by Devs)

- [ ] KVM x86: https://reactos.org/testman/compare.php?ids=108908,108913 (+1 failure?)
- [ ] KVM x64: https://reactos.org/testman/compare.php?ids=108910,108914 (+2 failures?)
