### PR TITLE
[SETUPAPI] Create device interface related subkeys in case they don't exist yet

### DIFF
--- a/dll/win32/setupapi/devinst.c
+++ b/dll/win32/setupapi/devinst.c
@@ -2716,8 +2716,8 @@ HKEY WINAPI SetupDiCreateDeviceInterfaceRegKeyW(
      * as we don't need a ref part in key name. */
     SymbolicLink[Index + 1] = UNICODE_NULL;
 
-    /* Open device instance key */
-    rc = RegOpenKeyExW(hKey, SymbolicLink, 0, samDesired, &hDevKey);
+    /* Create device instance key */
+    rc = RegCreateKeyExW(hKey, SymbolicLink, 0, NULL, 0, samDesired, NULL, &hDevKey, NULL);
     HeapFree(GetProcessHeap(), 0, SymbolicLink);
     RegCloseKey(hKey);
     if (rc != ERROR_SUCCESS)
@@ -2727,8 +2727,8 @@ HKEY WINAPI SetupDiCreateDeviceInterfaceRegKeyW(
         return INVALID_HANDLE_VALUE;
     }
 
-    /* Open reference key */
-    rc = RegOpenKeyExW(hDevKey, ReferenceString, 0, samDesired, &hRefKey);
+    /* Create reference key */
+    rc = RegCreateKeyExW(hDevKey, ReferenceString, 0, NULL, 0, samDesired, NULL, &hRefKey, NULL);
     HeapFree(GetProcessHeap(), 0, ReferenceString);
     RegCloseKey(hDevKey);
     if (rc != ERROR_SUCCESS)


### PR DESCRIPTION
## Purpose

In `SetupDiCreateDeviceInterfaceRegKeyW()`, force creating the non-volatile device, reference and parameters subkeys of device interface in Registry if they are not created or not accessible yet.
This properly fixes audio device name string improperly set in registry and displaying audio device name system-wide. Now it's properly written not only after re-installing audio driver from Device Manager, but also during 2nd setup stage, so it's correct just right after 1st boot.
Addendum to 1ef584c44653e55b97d0de39a936fa63f36a131a (#8967) and b205c041735ab98b7825461f32be8ced38c8b05e (#7703).

JIRA issue: [CORE-20603](https://jira.reactos.org/browse/CORE-20603)

## Proposed changes

- Change `RegOpenKeyExW()` to `RegCreateKeyExW()` for device and reference subkeys.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:

## Result

:white_check_mark: Tested it properly now. The following screenshots confirm the audio device string is now properly written in Registry and is displayed in Sound Properties as well. Confirmed to be fixed both in BootCD and LiveCD. :slightly_smiling_face: 
<img width="800" height="600" alt="1" src="https://github.com/user-attachments/assets/0099ca8c-3e8a-4429-830a-01bf4cf7c6c4" />
<img width="800" height="600" alt="2" src="https://github.com/user-attachments/assets/fc88e03d-0c81-429b-bdab-958dd85e49db" />