### PR TITLE
[CMD] Add support for the NT CHOICE command syntax

### DIFF
--- a/base/shell/cmd/choice.c
+++ b/base/shell/cmd/choice.c
@@ -103,12 +103,13 @@ CommandChoice (LPTSTR param)
 {
     LPTSTR lpOptions;
     TCHAR Options[6];
-    LPTSTR lpText    = NULL;
+    LPTSTR lpText   = NULL, lpTextParam = NULL;
+    UINT   iSkipTextIndex = 0, iTextIndex;
     BOOL   bNoPrompt = FALSE;
     BOOL   bCaseSensitive = FALSE;
     BOOL   bTimeout = FALSE;
     INT    nTimeout = 0;
-    TCHAR  cDefault = _T('\0');
+    TCHAR  cDefault = _T('\0'), cDefParam = _T('\0');
     INPUT_RECORD ir;
     LPTSTR p, np;
     LPTSTR *arg;
@@ -129,25 +130,6 @@ CommandChoice (LPTSTR param)
         return 0;
     }
 
-    /* retrieve text */
-    p = param;
-
-    while (TRUE)
-    {
-        if (*p == _T('\0'))
-            break;
-
-        if (*p != _T('/'))
-        {
-            lpText = p;
-                break;
-        }
-        np = _tcschr (p, _T(' '));
-        if (!np)
-            break;
-        p = np + 1;
-    }
-
     /* build parameter array */
     arg = split (param, &argc, FALSE, FALSE);
 
@@ -159,13 +141,25 @@ CommandChoice (LPTSTR param)
             if (_tcsnicmp (arg[i], _T("/c"), 2) == 0)
             {
                 if (arg[i][2] == _T(':'))
-                    lpOptions = &arg[i][3];
-                else
-                    lpOptions = &arg[i][2];
+                    lpOptions = &arg[i][3];                 /* "/c:XYZ" (DOS and NT6) */
+                else if (arg[i][2])
+                    lpOptions = &arg[i][2];                 /* "/cXYZ" (DOS) */
+                else if (i + 1 < argc && *arg[i + 1] != _T('/'))
+                    lpOptions = arg[iSkipTextIndex = ++i];  /* "/c XYZ" (NT6) */
 
-                if (_tcslen (lpOptions) == 0)
+                if (!*lpOptions)
                 {
                     ConErrResPuts(STRING_CHOICE_ERROR);
+                    freep (arg);
+                    return 1;
+                }
+            }
+            else if (_tcsnicmp (arg[i], _T("/m"), 2) == 0)  /* "/m msg" (NT6) */
+            {
+                lpText = lpTextParam = arg[++i];
+                if (i >= argc || *lpTextParam == _T('/'))
+                {
+                    ConErrResPrintf(STRING_CHOICE_ERROR_OPTION, arg[--i]);
                     freep (arg);
                     return 1;
                 }
@@ -174,13 +168,25 @@ CommandChoice (LPTSTR param)
             {
                 bNoPrompt = TRUE;
             }
-            else if (_tcsnicmp (arg[i], _T("/s"), 2) == 0)
+            else if (_tcsnicmp (arg[i], _T("/s"), 2) == 0) /* DOS */
             {
                 bCaseSensitive = TRUE;
             }
+            else if (_tcsnicmp (arg[i], _T("/cs"), 3) == 0) /* NT6 */
+            {
+                bCaseSensitive = TRUE;
+            }
+            else if (_tcsnicmp (arg[i], _T("/d"), 2) == 0)  /* "/d:X" and "/d X" (NT6) */
+            {
+                if (arg[i][2] == _T(':'))
+                    cDefault = cDefParam = arg[i][3];
+                else if (i + 1 < argc)
+                    cDefault = cDefParam = arg[iSkipTextIndex = ++i][0];
+            }
             else if (_tcsnicmp (arg[i], _T("/t"), 2) == 0)
             {
-                LPTSTR s;
+                LPTSTR s, end;
+                TCHAR cSaveDefault = cDefault;
 
                 if (arg[i][2] == _T(':'))
                 {
@@ -195,12 +201,25 @@ CommandChoice (LPTSTR param)
 
                 if (*s != _T(','))
                 {
+                    /* Just a number (NT6 syntax) */
+                    cDefault = cSaveDefault;
+                    if (arg[i][2] == _T(':'))
+                        s = &arg[i][3];
+                    else if (i + 1 < argc)
+                        s = arg[iSkipTextIndex = ++i];
+
+                    _tcstol(s, &end, 10);
+                    if (end > s && !*end)
+                        goto parse_timeout_seconds;
+
+                failed_parse_timeout:
                     ConErrResPuts(STRING_CHOICE_ERROR_TXT);
                     freep (arg);
                     return 1;
                 }
 
                 s++;
+            parse_timeout_seconds:
                 nTimeout = _ttoi(s);
                 bTimeout = TRUE;
             }
@@ -213,6 +232,33 @@ CommandChoice (LPTSTR param)
         }
     }
 
+    if (bTimeout)
+    {
+        if (!cDefault) /* NT6 /t synax used without /d */
+            goto failed_parse_timeout;
+        if (nTimeout < 0 || (cDefParam && nTimeout > 9999)) /* DOS seems to be limited to 99, no ">" validation */
+            goto failed_parse_timeout;
+        if (IsKeyInString(lpOptions, cDefault, bCaseSensitive) < 0) /* cDefault must exist in lpOptions */
+            goto failed_parse_timeout;
+    }
+
+    /* retrieve text */
+    for (p = param, iTextIndex = 0; !lpTextParam; ++iTextIndex)
+    {
+        if (*p == _T('\0'))
+            break;
+
+        if (*p != _T('/') && (!iSkipTextIndex || iTextIndex > iSkipTextIndex))
+        {
+            lpText = p;
+            break;
+        }
+        np = _tcschr (p, _T(' '));
+        if (!np)
+            break;
+        p = np + 1;
+    }
+
     /* print text */
     if (lpText)
         ConOutPrintf (_T("%s"), lpText);
@@ -220,7 +266,8 @@ CommandChoice (LPTSTR param)
     /* print options */
     if (bNoPrompt == FALSE)
     {
-        ConOutPrintf (_T("[%c"), lpOptions[0]);
+        LPCTSTR prefix = lpText && lpText == lpTextParam ? _T(" ") : _T("");
+        ConOutPrintf (_T("%s[%c"), prefix, lpOptions[0]);
 
         for (i = 1; (unsigned)i < _tcslen (lpOptions); i++)
             ConOutPrintf (_T(",%c"), lpOptions[i]);

--- a/base/shell/cmd/choice.c
+++ b/base/shell/cmd/choice.c
@@ -141,26 +141,26 @@ CommandChoice (LPTSTR param)
             if (_tcsnicmp (arg[i], _T("/c"), 2) == 0)
             {
                 if (arg[i][2] == _T(':'))
-                    lpOptions = &arg[i][3];                 /* "/c:XYZ" (DOS and NT6) */
+                    lpOptions = &arg[i][3];                 /* "/c:XYZ" (DOS and NT) */
                 else if (arg[i][2])
                     lpOptions = &arg[i][2];                 /* "/cXYZ" (DOS) */
                 else if (i + 1 < argc && *arg[i + 1] != _T('/'))
-                    lpOptions = arg[iSkipTextIndex = ++i];  /* "/c XYZ" (NT6) */
+                    lpOptions = arg[iSkipTextIndex = ++i];  /* "/c XYZ" (NT) */
 
                 if (!*lpOptions)
                 {
                     ConErrResPuts(STRING_CHOICE_ERROR);
-                    freep (arg);
+                    freep(arg);
                     return 1;
                 }
             }
-            else if (_tcsnicmp (arg[i], _T("/m"), 2) == 0)  /* "/m msg" (NT6) */
+            else if (_tcsnicmp (arg[i], _T("/m"), 2) == 0)  /* "/m msg" (NT) */
             {
                 lpText = lpTextParam = arg[++i];
                 if (i >= argc || *lpTextParam == _T('/'))
                 {
                     ConErrResPrintf(STRING_CHOICE_ERROR_OPTION, arg[--i]);
-                    freep (arg);
+                    freep(arg);
                     return 1;
                 }
             }
@@ -172,16 +172,18 @@ CommandChoice (LPTSTR param)
             {
                 bCaseSensitive = TRUE;
             }
-            else if (_tcsnicmp (arg[i], _T("/cs"), 3) == 0) /* NT6 */
+            else if (_tcsnicmp (arg[i], _T("/cs"), 3) == 0) /* NT */
             {
                 bCaseSensitive = TRUE;
             }
-            else if (_tcsnicmp (arg[i], _T("/d"), 2) == 0)  /* "/d:X" and "/d X" (NT6) */
+            else if (_tcsnicmp (arg[i], _T("/d"), 2) == 0)  /* "/d:X" and "/d X" (NT) */
             {
                 if (arg[i][2] == _T(':'))
                     cDefault = cDefParam = arg[i][3];
                 else if (i + 1 < argc)
                     cDefault = cDefParam = arg[iSkipTextIndex = ++i][0];
+                else
+                    goto invalid_parameter_format;
             }
             else if (_tcsnicmp (arg[i], _T("/t"), 2) == 0)
             {
@@ -201,7 +203,7 @@ CommandChoice (LPTSTR param)
 
                 if (*s != _T(','))
                 {
-                    /* Just a number (NT6 syntax) */
+                    /* Just a number (NT syntax) */
                     cDefault = cSaveDefault;
                     if (arg[i][2] == _T(':'))
                         s = &arg[i][3];
@@ -225,6 +227,7 @@ CommandChoice (LPTSTR param)
             }
             else if (arg[i][0] == _T('/'))
             {
+            invalid_parameter_format:
                 ConErrResPrintf(STRING_CHOICE_ERROR_OPTION, arg[i]);
                 freep (arg);
                 return 1;
@@ -234,11 +237,11 @@ CommandChoice (LPTSTR param)
 
     if (bTimeout)
     {
-        if (!cDefault) /* NT6 /t synax used without /d */
+        if (!cDefault) /* NT /t synax used without /d */
             goto failed_parse_timeout;
         if (nTimeout < 0 || (cDefParam && nTimeout > 9999)) /* DOS seems to be limited to 99, no ">" validation */
             goto failed_parse_timeout;
-        if (IsKeyInString(lpOptions, cDefault, bCaseSensitive) < 0) /* cDefault must exist in lpOptions */
+        if (IsKeyInString(lpOptions, cDefault, bCaseSensitive) < 0) /* The default must exist in the list of options */
             goto failed_parse_timeout;
     }
 


### PR DESCRIPTION
This makes our built-in choice command compatible with how choice is implemented on NT5.2+ (isn't included in Windows XP and below[^1]), while retaining compatibility with how it worked in DOS/9x.

- Changes /C and /T to also support the NT syntax.
- Adds the /CS, /D and /M switches.

JIRA issue: [CORE-20043](https://jira.reactos.org/browse/CORE-20043)

[^1]: It is however included in the Windows NT 4 Resouce Kit.

Notes:
- This should stop our own remaster.cmd script from throwing errors when running on ROS.
- I realize I'm parsing the timeout string twice. I did it this way to keep the manipulation of the timeout variables in one place. The new parsing step is just to validate that the user entered just a valid number.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: