### PR TITLE
[IMM32] ImmGetRegisterWordStyleA: Change MB_PRECOMPOSED to zero

### DIFF
--- a/win32ss/user/imm32/regword.c
+++ b/win32ss/user/imm32/regword.c
@@ -257,7 +257,7 @@ ImmGetRegisterWordStyleA(
             pDestA = &lpStyleBuf[iItem];
             pDestA->dwStyle = pSrcW->dwStyle;
             StringCchLengthW(pSrcW->szDescription, _countof(pSrcW->szDescription), &cchW);
-            cchA = WideCharToMultiByte(pImeDpi->uCodePage, MB_PRECOMPOSED,
+            cchA = WideCharToMultiByte(pImeDpi->uCodePage, 0,
                                        pSrcW->szDescription, (INT)cchW,
                                        pDestA->szDescription, _countof(pDestA->szDescription),
                                        NULL, NULL);


### PR DESCRIPTION
## Purpose

The parameter was wrong.
JIRA issue: [CORE-20683](https://jira.reactos.org/browse/CORE-20683)

## Proposed changes

- Don't use `MB_PRECOMPOSED` flag for `WideCharToMultiByte`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: