### PR TITLE
[DOC] Update Romanian translation notes for diacritics usage

### DIFF
--- a/media/doc/Romanian translation notes.txt
+++ b/media/doc/Romanian translation notes.txt
@@ -9,7 +9,6 @@ Copyright 2023-2026 Miloiu Andrei-Valentin
      This means using uppercase Ţ instead of Ț.
      This means using lowercase ş instead of ș.
      This means using uppercase Ş instead of Ș.
-
      Some of XP/2k3sp2 fonts do lack ț and ș, Ș and Ț.
  2. We will make a correct translation both grammatically and literally.
  3. All of the accelerators and of the translations will follow the MSDN's rules as much as possible. We will keep the same XP/2003 (and newer) accelerators.

--- a/media/doc/Romanian translation notes.txt
+++ b/media/doc/Romanian translation notes.txt
@@ -1,14 +1,14 @@
 The following material is addressed (in Romanian) to Romanian translators.
 
-Copyright 2023-2026 Miloiu Andrei
+Copyright 2023-2026 Miloiu Andrei-Valentin
 
 ------------------------------------------------------------------------------
 
  1. We use only the correct Romanian language diacritics.
      This means using lowercase ţ instead of ț.
+     This means using uppercase Ţ instead of Ț.
      This means using lowercase ş instead of ș.
      This means using uppercase Ş instead of Ș.
-     This means using uppercase Ţ instead of Ț.
 
      Some of XP/2k3sp2 fonts do lack ț and ș, Ș and Ț.
  2. We will make a correct translation both grammatically and literally.

--- a/media/doc/Romanian translation notes.txt
+++ b/media/doc/Romanian translation notes.txt
@@ -8,7 +8,9 @@ Copyright 2023-2024 Miloiu Andrei
      This means using lowercase ţ instead of ț.
      This means using lowercase ş instead of ș.
      This means using uppercase Ş instead of Ș.
-     Some of XP/2k3sp2 fonts do lack ț and ș and Ș.
+     This means using uppercase Ţ instead of Ț.
+
+     Some of XP/2k3sp2 fonts do lack ț and ș, Ș and Ț.
  2. We will make a correct translation both grammatically and literally.
  3. All of the accelerators and of the translations will follow the MSDN's rules as much as possible. We will keep the same XP/2003 (and newer) accelerators.
 

--- a/media/doc/Romanian translation notes.txt
+++ b/media/doc/Romanian translation notes.txt
@@ -1,6 +1,6 @@
 The following material is addressed (in Romanian) to Romanian translators.
 
-Copyright 2023-2024 Miloiu Andrei
+Copyright 2023-2026 Miloiu Andrei
 
 ------------------------------------------------------------------------------
 


### PR DESCRIPTION
I previously forgot to add a rule for capital Ț letter. I XP/2k3+ there is Ţ.