### PR TITLE
[APPHELP] Fix handling of NT paths in SdbGetFileAttributes

### DIFF
--- a/dll/appcompat/apphelp/sdbfileattr.c
+++ b/dll/appcompat/apphelp/sdbfileattr.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PROJECT:     ReactOS Application compatibility module
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     Query file attributes used to match exe's
@@ -288,13 +288,25 @@ BOOL WINAPI SdbGetFileAttributes(LPCWSTR path, PATTRINFO *attr_info_ret, LPDWORD
         DWORD info_size;
         ULONG export_dir_size;
         PIMAGE_EXPORT_DIRECTORY export_dir;
+        LPCWSTR dos_path;
 
-        info_size = GetFileVersionInfoSizeW(path, NULL);
+        /* Check if the caller passed an NT style path (full path, prefixed wih "\\??\\") */
+        if (!wcsncmp(path, L"\\??\\", 4) && (path[4] != UNICODE_NULL) && (path[5] == L':'))
+        {
+            /* Skip NT prefix, if it is present (GetFileVersionInfoSizeW doesn't handle NT paths) */
+            dos_path = path + 4;
+        }
+        else
+        {
+            dos_path = path;
+        }
+
+        info_size = GetFileVersionInfoSizeW(dos_path, NULL);
         if (info_size != 0)
         {
             UINT page_size = 0;
             file_info = SdbAlloc(info_size);
-            GetFileVersionInfoW(path, 0, info_size, file_info);
+            GetFileVersionInfoW(dos_path, 0, info_size, file_info);
             VerQueryValueW(file_info, str_tinfo, (LPVOID)&lang_page, &page_size);
             StringCchPrintfW(translation, ARRAYSIZE(translation), str_trans, lang_page->language, lang_page->code_page);
         }

--- a/modules/rostests/apitests/apphelp/apphelp.c
+++ b/modules/rostests/apitests/apphelp/apphelp.c
@@ -867,6 +867,24 @@ static void test_crc_imp(size_t len, DWORD expected)
     }
     if (ret)
         pSdbFreeFileAttributes(pattrinfo);
+
+    /* Test with a fake NT path */
+    WCHAR prefixed_path[MAX_PATH];
+    wcscpy(prefixed_path, L"\\??\\");
+    wcscat(prefixed_path, path);
+    ret = pSdbGetFileAttributes(prefixed_path, &pattrinfo, &num);
+    winetest_ok(ret == FALSE, "expected SdbGetFileAttributes to fail.\n");
+    if (ret)
+        pSdbFreeFileAttributes(pattrinfo);
+
+    /* Test with a full NT path */
+    GetCurrentDirectoryW(ARRAYSIZE(prefixed_path) - 4, prefixed_path + 4);
+    wcscat(prefixed_path, L"\\");
+    wcscat(prefixed_path, path);
+    ret = pSdbGetFileAttributes(prefixed_path, &pattrinfo, &num);
+    winetest_ok(ret != FALSE || broken(ret == FALSE) /* 2k3/Vista */, "expected SdbGetFileAttributes to succeed.\n");
+    if (ret)
+        pSdbFreeFileAttributes(pattrinfo);
 }
 
 static void test_crc2_imp(DWORD len, int fill, DWORD expected)

--- a/modules/rostests/apitests/version/CMakeLists.txt
+++ b/modules/rostests/apitests/version/CMakeLists.txt
@@ -1,9 +1,11 @@
 
 list(APPEND SOURCE
+    GetFileVersionInfoSize.c
     VerQueryValue.c
     precomp.h)
 
 list(APPEND PCH_SKIP_SOURCE
+    resource.rc
     testlist.c)
 
 add_executable(version_apitest

--- a/modules/rostests/apitests/version/GetFileVersionInfoSize.c
+++ b/modules/rostests/apitests/version/GetFileVersionInfoSize.c
@@ -1,0 +1,51 @@
+/*
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for GetFileVersionInfoSize[A/W]
+ * COPYRIGHT:   Copyright 2024 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include "precomp.h"
+
+void Test_GetFileVersionInfoSizeA(void)
+{
+    CHAR ModuleFileName[MAX_PATH];
+    CHAR PathBuffer[MAX_PATH];
+    DWORD Result;
+
+    /* Test getting the version info size for this executable */
+    GetModuleFileNameA(NULL, ModuleFileName, ARRAYSIZE(ModuleFileName));
+    Result = GetFileVersionInfoSizeA(ModuleFileName, NULL);
+    ok((Result > 1000) && (Result < 2000), "Unexpected result: %lu\n", Result);
+
+    /* Test support for NT path prefix */
+    strcpy(PathBuffer, "\\??\\");
+    strcat(PathBuffer, ModuleFileName);
+    Result = GetFileVersionInfoSizeA(PathBuffer, NULL);
+    ok_eq_ulong(Result, 0);
+}
+
+void Test_GetFileVersionInfoSizeW(void)
+{
+    WCHAR ModuleFileName[MAX_PATH];
+    WCHAR PathBuffer[MAX_PATH];
+    DWORD Result;
+
+    /* Test getting the version info size for this executable */
+    GetModuleFileNameW(NULL, ModuleFileName, ARRAYSIZE(ModuleFileName));
+    Result = GetFileVersionInfoSizeW(ModuleFileName, NULL);
+    ok((Result > 1000) && (Result < 2000), "Unexpected result: %lu\n", Result);
+
+    /* Test support for NT path prefix */
+    wcscpy(PathBuffer, L"\\??\\");
+    wcscat(PathBuffer, ModuleFileName);
+    Result = GetFileVersionInfoSizeW(PathBuffer, NULL);
+    ok_eq_ulong(Result, 0);
+}
+
+
+START_TEST(GetFileVersionInfoSize)
+{
+    Test_GetFileVersionInfoSizeA();
+    Test_GetFileVersionInfoSizeW();
+}

--- a/modules/rostests/apitests/version/resource.rc
+++ b/modules/rostests/apitests/version/resource.rc
@@ -1,0 +1,5 @@
+#define REACTOS_VERSION_DLL
+#define REACTOS_STR_FILE_DESCRIPTION  "API test for version.dll"
+#define REACTOS_STR_INTERNAL_NAME     "version_apitest"
+#define REACTOS_STR_ORIGINAL_FILENAME "version_apitest.exe"
+#include <reactos/version.rc>


### PR DESCRIPTION
## Purpose

Fix handling of NT paths in SdbGetFileAttributes by skipping it, before calling GetFileVersionInfoSizeW.
Also add related tests to validate that SdbGetFileAttributes handles NT paths, but GetFileVersionInfoSizeW does not.

## Testbot runs (Filled in by Devs)

- [x] WHS x86: https://reactos.org/testman/compare.php?ids=108972,108998
- [x] Vista x64: https://reactos.org/testman/compare.php?ids=109002,109016
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108999,109001
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109009,109010
