### PR TITLE
[RTL_UNITTEST] Call RtlpInitialize in RtlVirtualUnwind test

### DIFF
--- a/modules/rostests/apitests/rtl/amd64/RtlVirtualUnwind.c
+++ b/modules/rostests/apitests/rtl/amd64/RtlVirtualUnwind.c
@@ -533,6 +533,7 @@ static VOID Test_SpareCode(VOID)
 
 START_TEST(RtlVirtualUnwind)
 {
+    RtlpInitialize();
     Test_PushNonvol();
     Test_AllocSmall();
     Test_AllocLargeScaled();


### PR DESCRIPTION
## Purpose

Initialize RTL to prevents a critical section timeout.
Addendum to PR #9236 

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108944,108955
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108945,108958
