### PR TITLE
Fix Click-n-Type Virtual Keyboard install auto-run from RAPPS

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1080,7 +1080,16 @@ static UINT SHELL_FindExecutable(LPCWSTR lpPath, LPCWSTR lpFile, LPCWSTR lpVerb,
         search_paths[0] = curdir;
     }
 
-    lstrcpyW(xlpFile, lpFile);
+    /* Handle lpFile name that begins with a dot followed by a backslash like CORE-20508
+     * by ignoring the beginning 2 characters and continuing */
+    if (lpFile[0] == '.' && lpFile[1] == '\\')
+    {
+        lstrcpyW(xlpFile, &lpFile[2]);
+        lpFile = xlpFile;
+    }
+    else
+        lstrcpyW(xlpFile, lpFile);
+
     if (PathResolveW(xlpFile, search_paths, PRF_TRYPROGRAMEXTENSIONS | PRF_VERIFYEXISTS) ||
         PathFindOnPathW(xlpFile, search_paths))
     {


### PR DESCRIPTION
CORE-20508

## Purpose

_Fix case of SHELL_FindExecutable having an lpFile parameter beginning with dot followed by back-slash._

JIRA issue: [CORE-20508](https://jira.reactos.org/browse/CORE-20508)

## Proposed changes

_Account for lpFile parameter in SHELL_FindExecutable beginning with dot followed by back-slash._
_Remove these two characters if that is the case._

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108944,108948
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108945,108949,108952