### PR TITLE
[RTL][NTDLL_VISTA] Implement RtlWow64GetProcessMachines

### DIFF
--- a/dll/ntdll/nt_0600/ntdll_vista.spec
+++ b/dll/ntdll/nt_0600/ntdll_vista.spec
@@ -19,6 +19,7 @@
 @ stdcall RtlRunOnceBeginInitialize(ptr long ptr)
 @ stdcall RtlRunOnceComplete(ptr long ptr)
 @ stdcall RtlRunOnceExecuteOnce(ptr ptr ptr ptr)
+@ stdcall RtlWow64GetProcessMachines(ptr ptr ptr)
 
 @ stdcall RtlConnectToSm(ptr ptr long ptr) SmConnectToSm
 @ stdcall RtlSendMsgToSm(ptr ptr) SmSendMsgToSm

--- a/sdk/lib/rtl/CMakeLists.txt
+++ b/sdk/lib/rtl/CMakeLists.txt
@@ -145,7 +145,8 @@ list(APPEND SOURCE_VISTA
     srw.c
     threadpool.c
     unicode_vista.c
-    utf8.c)
+    utf8.c
+    wow64.c)
 
 add_library(rtl_vista ${SOURCE_VISTA})
 add_pch(rtl_vista rtl_vista.h SOURCE_VISTA)

--- a/sdk/lib/rtl/wow64.c
+++ b/sdk/lib/rtl/wow64.c
@@ -1,0 +1,59 @@
+/*
+ * PROJECT:     ReactOS runtime library (RTL)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Implementation of RtlWow64GetProcessMachines
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+/* INCLUDES *****************************************************************/
+
+#include <rtl.h>
+
+#define NDEBUG
+#include <debug.h>
+
+NTSTATUS
+NTAPI
+RtlWow64GetProcessMachines(
+    _In_ HANDLE ProcessHandle,
+    _Out_ PUSHORT ProcessMachine,
+    _Out_opt_ PUSHORT NativeMachine)
+{
+    NTSTATUS Status;
+    ULONG_PTR Wow64Info;
+
+    /* Check if the caller wants the current process */
+    if (ProcessHandle == NtCurrentProcess())
+    {
+        /* Easy: process machine is current architecture */
+        *ProcessMachine  = IMAGE_FILE_MACHINE_NATIVE;
+    }
+    else if (SharedUserData->ImageNumberLow == IMAGE_FILE_MACHINE_AMD64)
+    {
+        /* Kernel architecture is AMD64, query whether the process is WOW64 */
+        Status = NtQueryInformationProcess(ProcessHandle,
+                                           ProcessWow64Information,
+                                           &Wow64Info,
+                                           sizeof(Wow64Info),
+                                           NULL);
+        if (!NT_SUCCESS(Status))
+        {
+            return Status;
+        }
+
+        *ProcessMachine = Wow64Info ? IMAGE_FILE_MACHINE_I386 : IMAGE_FILE_MACHINE_AMD64;
+    }
+    else
+    {
+        /* kernel is something else, assume no WOW64 */
+        *ProcessMachine  = IMAGE_FILE_MACHINE_NATIVE;
+    }
+
+    if (NativeMachine != NULL)
+    {
+        /* The kernel stores it's native architecture in this field */
+        *NativeMachine = SharedUserData->ImageNumberLow;
+    }
+
+    return STATUS_SUCCESS;
+}


### PR DESCRIPTION
## Purpose

Implement RtlWow64GetProcessMachines (needed by kernelbase)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108964,108989
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108986,108990