### PR TITLE
[USBHUB] Fix an off by one

### DIFF
--- a/drivers/usb/usbhub/pnp.c
+++ b/drivers/usb/usbhub/pnp.c
@@ -1392,7 +1392,7 @@ RelationsWorker:
             if (PdoExt(PdoDevice)->EnumFlags & USBHUB_ENUM_FLAG_GHOST_DEVICE)
             {
                 for (GhostPort = Port;
-                     GhostPort < DeviceRelations->Count;
+                     GhostPort + 1 < DeviceRelations->Count;
                      GhostPort++)
                 {
                     DeviceRelations->Objects[GhostPort] =

--- a/drivers/usb/usbhub/pnp.c
+++ b/drivers/usb/usbhub/pnp.c
@@ -1392,7 +1392,7 @@ RelationsWorker:
             if (PdoExt(PdoDevice)->EnumFlags & USBHUB_ENUM_FLAG_GHOST_DEVICE)
             {
                 for (GhostPort = Port;
-                     GhostPort + 1 < DeviceRelations->Count;
+                     GhostPort < DeviceRelations->Count - 1;
                      GhostPort++)
                 {
                     DeviceRelations->Objects[GhostPort] =


### PR DESCRIPTION
## Purpose

Fix an out of bounds heap read in `USBH_FdoQueryBusRelations` when compacting the ghost device list

JIRA issue: None

## Proposed changes
- Change the loop condition from `GhostPort < DeviceRelations->Count` to `GhostPort < DeviceRelations->Count - 1` so the shift never reads past the last valid entry

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: