### PR TITLE
[SETUPLIB] Search for unattend.inf on all drives

### DIFF
--- a/base/setup/lib/setuplib.c
+++ b/base/setup/lib/setuplib.c
@@ -5,6 +5,7 @@
  * PURPOSE:         Setup Library - Main initialization helpers
  * PROGRAMMERS:     Casper S. Hornstrup (chorns@users.sourceforge.net)
  *                  Hermes Belusca-Maito (hermes.belusca@sfr.fr)
+ *                  Whindmar Saksit <whindsaks@proton.me>
  */
 
 /* INCLUDES *****************************************************************/
@@ -24,8 +25,125 @@
 
 HANDLE ProcessHeap;
 BOOLEAN IsUnattendedSetup = FALSE;
+PCWSTR InfUnattendSignature = L"$ReactOS$";
 
 /* FUNCTIONS ****************************************************************/
+
+static int
+CompareInfFirstLineString(
+    IN HINF hInf,
+    IN PCWSTR Section,
+    IN PCWSTR Name,
+    IN PCWSTR String)
+{
+    INFCONTEXT Context;
+    PCWSTR Value;
+    int Result = STATUS_UNSUCCESSFUL;
+
+    if (!SpInfFindFirstLine(hInf, Section, Name, &Context))
+        return Result;
+
+    if (!INF_GetData(&Context, NULL, &Value))
+        return Result;
+
+    Result = _wcsicmp(Value, String);
+
+    INF_FreeData(Value);
+    return Result;
+}
+
+static BOOLEAN
+IsInfUnattendSetupEnabled(
+    IN PUSETUP_DATA pSetupData,
+    IN PCWSTR InfPath,
+    IN BOOLEAN CheckDetached)
+{
+    HINF hInf;
+    BOOLEAN Result = FALSE;
+    UINT ErrorLine;
+
+    if (!DoesFileExist(NULL, InfPath))
+        return Result;
+
+    hInf = SpInfOpenInfFile(InfPath,
+                                   NULL,
+                                   INF_STYLE_OLDNT,
+                                   pSetupData->LanguageId,
+                                   &ErrorLine);
+    if (hInf == INVALID_HANDLE_VALUE)
+        return Result;
+
+    if (CompareInfFirstLineString(hInf, L"Unattend", L"UnattendSetupEnabled", L"yes"))
+    {
+        goto abort;
+    }
+
+    /* Extra safety check for inf files not on the ISO */
+    if (CheckDetached)
+    {
+        if (CompareInfFirstLineString(hInf, L"Unattend", L"UnattendForDetached", L"yes"))
+        {
+            goto abort;
+        }
+    }
+
+    if (CompareInfFirstLineString(hInf, L"Unattend", L"Signature", InfUnattendSignature))
+    {
+        DPRINT("Signature not %ls\n", InfUnattendSignature);
+        goto abort;
+    }
+
+    Result = TRUE;
+abort:
+    SpInfCloseInfFile(hInf);
+    return Result;
+}
+
+static void
+GetDefaultUnattendInfPath(
+    IN PUSETUP_DATA pSetupData,
+    OUT PWSTR InfPath,
+    IN SIZE_T cch)
+{
+    CombinePaths(InfPath, cch, 2, pSetupData->SourcePath.Buffer, L"unattend.inf");
+}
+
+static BOOLEAN
+GetUnattendInfPath(
+    IN PUSETUP_DATA pSetupData,
+    OUT PWSTR InfPath,
+    IN SIZE_T cch)
+{
+    WCHAR Drive;
+    UINT DriveType, Types;
+
+    GetDefaultUnattendInfPath(pSetupData, InfPath, cch);
+    if (IsInfUnattendSetupEnabled(pSetupData, InfPath, FALSE))
+        return TRUE;
+
+    /* Check all DOS volumes, non-fixed first, then fixed */
+    for (Types = 0; Types <= 1; ++Types)
+    {
+        for (Drive = 'A'; Drive <= 'Z'; ++Drive)
+        {
+            WCHAR szInf[MAX_PATH], szBuffer[MAX_PATH];
+            UNICODE_STRING NtDrive;
+
+            NtDrive.Buffer = szBuffer;
+            NtDrive.MaximumLength = sizeof(szBuffer);
+            DriveType = GetNtDevicePathOfDriveNumber(Drive - 'A', &NtDrive);
+            if (DriveType <= DRIVE_NO_ROOT_DIR)
+                continue;
+            if (Types == 0 && DriveType == DRIVE_FIXED)
+                continue;
+
+            CombinePaths(szInf, ARRAYSIZE(szInf), 2, NtDrive.Buffer, L"unattend.inf");
+            if (IsInfUnattendSetupEnabled(pSetupData, szInf, TRUE))
+                return NT_SUCCESS(RtlStringCchCopyW(InfPath, cch, szInf));
+        }
+    }
+    return FALSE;
+}
 
 BOOLEAN
 NTAPI
@@ -39,12 +157,10 @@ CheckUnattendedSetup(
     PCWSTR Value;
     WCHAR UnattendInfPath[MAX_PATH];
 
-    CombinePaths(UnattendInfPath, ARRAYSIZE(UnattendInfPath), 2,
-                 pSetupData->SourcePath.Buffer, L"unattend.inf");
-
+    GetDefaultUnattendInfPath(pSetupData, UnattendInfPath, ARRAYSIZE(UnattendInfPath));
     DPRINT("UnattendInf path: '%S'\n", UnattendInfPath);
 
-    if (DoesFileExist(NULL, UnattendInfPath) == FALSE)
+    if (!GetUnattendInfPath(pSetupData, UnattendInfPath, ARRAYSIZE(UnattendInfPath)))
     {
         DPRINT("Does not exist: %S\n", UnattendInfPath);
         return IsUnattendedSetup;
@@ -77,9 +193,9 @@ CheckUnattendedSetup(
     }
 
     /* Check 'Signature' string */
-    if (_wcsicmp(Value, L"$ReactOS$") != 0)
+    if (_wcsicmp(Value, InfUnattendSignature) != 0)
     {
-        DPRINT("Signature not $ReactOS$\n");
+        DPRINT("Signature not %ls\n", InfUnattendSignature);
         INF_FreeData(Value);
         goto Quit;
     }
@@ -269,9 +385,7 @@ InstallSetupInfFile(
 #if 0
 
     /* TODO: Append the standard unattend.inf file */
-    CombinePaths(UnattendInfPath, ARRAYSIZE(UnattendInfPath), 2,
-                 pSetupData->SourcePath.Buffer, L"unattend.inf");
-    if (DoesFileExist(NULL, UnattendInfPath) == FALSE)
+    if (!GetUnattendInfPath(pSetupData, UnattendInfPath, ARRAYSIZE(UnattendInfPath)))
     {
         DPRINT("Does not exist: %S\n", UnattendInfPath);
         goto Quit;
@@ -300,9 +414,7 @@ Quit:
     IniCacheDestroy(IniCache);
 
     /* TODO: Append the standard unattend.inf file */
-    CombinePaths(UnattendInfPath, ARRAYSIZE(UnattendInfPath), 2,
-                 pSetupData->SourcePath.Buffer, L"unattend.inf");
-    if (DoesFileExist(NULL, UnattendInfPath) == FALSE)
+    if (!GetUnattendInfPath(pSetupData, UnattendInfPath, ARRAYSIZE(UnattendInfPath)))
     {
         DPRINT("Does not exist: %S\n", UnattendInfPath);
         return;

--- a/base/setup/lib/setuplib.c
+++ b/base/setup/lib/setuplib.c
@@ -31,10 +31,10 @@ PCWSTR InfUnattendSignature = L"$ReactOS$";
 
 static int
 CompareInfFirstLineString(
-    IN HINF hInf,
-    IN PCWSTR Section,
-    IN PCWSTR Name,
-    IN PCWSTR String)
+    _In_ HINF hInf,
+    _In_ PCWSTR Section,
+    _In_ PCWSTR Name,
+    _In_ PCWSTR String)
 {
     INFCONTEXT Context;
     PCWSTR Value;
@@ -54,9 +54,9 @@ CompareInfFirstLineString(
 
 static BOOLEAN
 IsInfUnattendSetupEnabled(
-    IN PUSETUP_DATA pSetupData,
-    IN PCWSTR InfPath,
-    IN BOOLEAN CheckDetached)
+    _In_ PUSETUP_DATA pSetupData,
+    _In_ PCWSTR InfPath,
+    _In_ BOOLEAN CheckDetached)
 {
     HINF hInf;
     BOOLEAN Result = FALSE;
@@ -98,18 +98,18 @@ abort:
 
 static void
 GetDefaultUnattendInfPath(
-    IN PUSETUP_DATA pSetupData,
-    OUT PWSTR InfPath,
-    IN SIZE_T cch)
+    _In_ PUSETUP_DATA pSetupData,
+    _Out_writes_(cch) PWSTR InfPath,
+    _In_ SIZE_T cch)
 {
     CombinePaths(InfPath, cch, 2, pSetupData->SourcePath.Buffer, L"unattend.inf");
 }
 
 static BOOLEAN
 GetUnattendInfPath(
-    IN PUSETUP_DATA pSetupData,
-    OUT PWSTR InfPath,
-    IN SIZE_T cch)
+    _In_ PUSETUP_DATA pSetupData,
+    _Out_ PWSTR InfPath,
+    _In_ SIZE_T cch)
 {
     WCHAR Drive;
     UINT DriveType, Types;

--- a/base/setup/lib/setuplib.c
+++ b/base/setup/lib/setuplib.c
@@ -79,12 +79,9 @@ IsInfUnattendSetupEnabled(
     }
 
     /* Extra safety check for inf files not on the ISO */
-    if (CheckDetached)
+    if (CheckDetached && CompareInfFirstLineString(hInf, L"Unattend", L"UnattendForDetached", L"yes"))
     {
-        if (CompareInfFirstLineString(hInf, L"Unattend", L"UnattendForDetached", L"yes"))
-        {
-            goto abort;
-        }
+        goto abort;
     }
 
     if (CompareInfFirstLineString(hInf, L"Unattend", L"Signature", InfUnattendSignature))

--- a/base/setup/lib/utils/filesup.c
+++ b/base/setup/lib/utils/filesup.c
@@ -11,6 +11,7 @@
 #include "precomp.h"
 #include "filesup.h"
 #include <pseh/pseh2.h>
+#include <ndk/umfuncs.h> /* Ldr */
 
 #define NDEBUG
 #include <debug.h>
@@ -1071,6 +1072,86 @@ UnMapFile(
     }
 
     return Success;
+}
+
+static UINT
+GetWin32DriveTypeOfDriveNumber(
+    IN WORD DriveNumber)
+{
+    PROCESS_DEVICEMAP_INFORMATION DeviceMap;
+    NTSTATUS Status;
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDeviceMap,
+                                       &DeviceMap.Query,
+                                       sizeof(DeviceMap.Query),
+                                       NULL);
+    if (NT_SUCCESS(Status) && ((1 << DriveNumber) & DeviceMap.Query.DriveMap) != 0)
+    {
+        UINT Type = DeviceMap.Query.DriveType[DriveNumber];
+        if (Type <= DRIVE_RAMDISK)
+            return Type;
+    }
+    return DRIVE_UNKNOWN;
+}
+
+UINT
+GetNtDevicePathOfDriveNumber(
+    IN WORD DriveNumber,
+    OUT PUNICODE_STRING pOutput)
+{
+    WCHAR szDosDevPath[] = { L'A' + DriveNumber, L':', UNICODE_NULL };
+    UINT Result = DRIVE_UNKNOWN, Type;
+    HANDLE DirectoryHandle, DeviceHandle, Kernel32;
+    PVOID pfnQDD;
+    ANSI_STRING AnsiString;
+    UNICODE_STRING String;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    ULONG ReturnLength;
+    NTSTATUS Status;
+
+    Type = GetWin32DriveTypeOfDriveNumber(DriveNumber);
+    if (Type <= DRIVE_NO_ROOT_DIR)
+        return Type;
+
+    /* Use Win32 directly if available so we match UAC etc */
+    RtlInitUnicodeString(&String, L"KERNEL32");
+    Status = LdrGetDllHandle(NULL, NULL, &String, &Kernel32);
+    if (NT_SUCCESS(Status))
+        Status = LdrLoadDll(NULL, 0, &String, &Kernel32); /* Hold a reference */
+    RtlInitAnsiString(&AnsiString, "QueryDosDeviceW");
+    if (NT_SUCCESS(Status))
+        Status = LdrGetProcedureAddress(Kernel32, &AnsiString, 0, &pfnQDD);
+    if (NT_SUCCESS(Status))
+    {
+        UINT cch = ((UINT(WINAPI*)())pfnQDD)(szDosDevPath, pOutput->Buffer, pOutput->MaximumLength / sizeof(WCHAR));
+        pOutput->Length = (cch - 1) * sizeof(WCHAR);
+        if (cch)
+            return Type;
+    }
+
+    /* Use the object directory symlink target */
+    RtlInitUnicodeString(&String, L"\\??");
+    InitializeObjectAttributes(&ObjectAttributes, &String, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    Status = NtOpenDirectoryObject(&DirectoryHandle, DIRECTORY_QUERY, &ObjectAttributes);
+    if (!NT_SUCCESS(Status))
+        return Result;
+
+    DeviceHandle = NULL;
+    RtlInitUnicodeString(&String, szDosDevPath);
+    InitializeObjectAttributes(&ObjectAttributes, &String, OBJ_CASE_INSENSITIVE, DirectoryHandle, NULL);
+    Status = NtOpenSymbolicLinkObject(&DeviceHandle, SYMBOLIC_LINK_QUERY, &ObjectAttributes);
+    if (!NT_SUCCESS(Status))
+        goto done;
+
+    Status = NtQuerySymbolicLinkObject(DeviceHandle, pOutput, &ReturnLength);
+    if (SUCCEEDED(Status))
+        Result = Type;
+
+done:
+    if (DeviceHandle)
+        NtClose(DeviceHandle);
+    NtClose(DirectoryHandle);
+    return Result;
 }
 
 /* EOF */

--- a/base/setup/lib/utils/filesup.c
+++ b/base/setup/lib/utils/filesup.c
@@ -1076,7 +1076,7 @@ UnMapFile(
 
 static UINT
 GetWin32DriveTypeOfDriveNumber(
-    IN USHORT DriveNumber)
+    _In_ USHORT DriveNumber)
 {
     PROCESS_DEVICEMAP_INFORMATION DeviceMap;
     NTSTATUS Status;
@@ -1096,8 +1096,8 @@ GetWin32DriveTypeOfDriveNumber(
 
 UINT
 GetNtDevicePathOfDriveNumber(
-    IN USHORT DriveNumber,
-    OUT PUNICODE_STRING pOutput)
+    _In_ USHORT DriveNumber,
+    _Out_ PUNICODE_STRING pOutput)
 {
     WCHAR szDosDevPath[] = { L'A' + DriveNumber, L':', UNICODE_NULL };
     UINT Result = DRIVE_UNKNOWN, Type;

--- a/base/setup/lib/utils/filesup.c
+++ b/base/setup/lib/utils/filesup.c
@@ -1076,7 +1076,7 @@ UnMapFile(
 
 static UINT
 GetWin32DriveTypeOfDriveNumber(
-    IN WORD DriveNumber)
+    IN USHORT DriveNumber)
 {
     PROCESS_DEVICEMAP_INFORMATION DeviceMap;
     NTSTATUS Status;
@@ -1096,14 +1096,13 @@ GetWin32DriveTypeOfDriveNumber(
 
 UINT
 GetNtDevicePathOfDriveNumber(
-    IN WORD DriveNumber,
+    IN USHORT DriveNumber,
     OUT PUNICODE_STRING pOutput)
 {
     WCHAR szDosDevPath[] = { L'A' + DriveNumber, L':', UNICODE_NULL };
     UINT Result = DRIVE_UNKNOWN, Type;
     HANDLE DirectoryHandle, DeviceHandle, Kernel32;
-    PVOID pfnQDD;
-    ANSI_STRING AnsiString;
+    UINT (WINAPI *pfnQueryDosDeviceW)(PCWSTR,PWSTR,DWORD);
     UNICODE_STRING String;
     OBJECT_ATTRIBUTES ObjectAttributes;
     ULONG ReturnLength;
@@ -1117,13 +1116,14 @@ GetNtDevicePathOfDriveNumber(
     RtlInitUnicodeString(&String, L"KERNEL32");
     Status = LdrGetDllHandle(NULL, NULL, &String, &Kernel32);
     if (NT_SUCCESS(Status))
-        Status = LdrLoadDll(NULL, 0, &String, &Kernel32); /* Hold a reference */
-    RtlInitAnsiString(&AnsiString, "QueryDosDeviceW");
-    if (NT_SUCCESS(Status))
-        Status = LdrGetProcedureAddress(Kernel32, &AnsiString, 0, &pfnQDD);
+    {
+        ANSI_STRING AnsiString;
+        RtlInitAnsiString(&AnsiString, "QueryDosDeviceW");
+        Status = LdrGetProcedureAddress(Kernel32, &AnsiString, 0, (PVOID*)&pfnQueryDosDeviceW);
+    }
     if (NT_SUCCESS(Status))
     {
-        UINT cch = ((UINT(WINAPI*)())pfnQDD)(szDosDevPath, pOutput->Buffer, pOutput->MaximumLength / sizeof(WCHAR));
+        UINT cch = pfnQueryDosDeviceW(szDosDevPath, pOutput->Buffer, pOutput->MaximumLength / sizeof(WCHAR));
         pOutput->Length = (cch - 1) * sizeof(WCHAR);
         if (cch)
             return Type;

--- a/base/setup/lib/utils/filesup.h
+++ b/base/setup/lib/utils/filesup.h
@@ -126,7 +126,7 @@ do {    \
 
 UINT
 GetNtDevicePathOfDriveNumber(
-    IN WORD DriveNumber,
-    OUT PUNICODE_STRING pOutput);
+    _In_ USHORT DriveNumber,
+    _Out_ PUNICODE_STRING pOutput);
 
 /* EOF */

--- a/base/setup/lib/utils/filesup.h
+++ b/base/setup/lib/utils/filesup.h
@@ -124,4 +124,9 @@ do {    \
     NtClose(FileHandle);                        \
 } while (0)
 
+UINT
+GetNtDevicePathOfDriveNumber(
+    IN WORD DriveNumber,
+    OUT PUNICODE_STRING pOutput);
+
 /* EOF */


### PR DESCRIPTION
## Purpose

This allows any ISO (nightly etc.) to perform unattended installations without having to manually rebuild the ISO with your modified unattend.inf file, you simply have to have your custom unattend.inf file present in the root of any drive in the machine (and with a special value set in this .inf to enable this feature).

Notes:
- It tries to use `QueryDosDevice` if kernel32 is loaded so the drive map matches the existing user logon session. If not available, it emulates a simplified version of `QueryDosDevice` which should be enough when booted directly into phase 1 setup.
- I added the long overdue (IMHO) `CompareInfFirstLineString` helper function because there is way too much repetitive Inf/strcmp code in this file already. I'm not converting any existing usage in the PR to keep the diff simple.
- The name of the new "UnattendForDetached" inf value is up for discussion if anyone has a better suggestion.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: