### PR TITLE
[SHELL32] Fix Click-n-Type install from RAPPS (Retry)

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1098,6 +1098,12 @@ static UINT SHELL_FindExecutable(LPCWSTR lpPath, LPCWSTR lpFile, LPCWSTR lpVerb,
         lstrcpyW(lpResult, xlpFile);
         /* The file was found in lpPath or one of the directories in the system-wide search path */
     }
+    /* Handle cases like CORE-20508 */
+    else if (SearchPathW(lpPath, lpFile, NULL, ARRAY_SIZE(xlpFile), xlpFile, NULL))
+    {
+        TRACE("SearchPathW returned non-zero\n");
+        lpFile = xlpFile;
+    }
     else
     {
         xlpFile[0] = '\0';


### PR DESCRIPTION
CORE-20508

## Purpose

_Fix case of SHELL_FindExecutable handling of installs like Click-n-Type._

JIRA issue: [CORE-20508](https://jira.reactos.org/browse/CORE-20508)

## Proposed changes

_Restore part of the logic that was removed in [42d5dfd](https://github.com/reactos/reactos/commit/42d5dfd3de5e65da6137413c98b5ab0cbc11325e)._

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108964,108966,108968 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108963,108967 LGTM