### PR TITLE
[MSCONFIG] Disable tree view label editing (CORE-20447)

### DIFF
--- a/base/applications/msconfig/msconfig.c
+++ b/base/applications/msconfig/msconfig.c
@@ -86,6 +86,12 @@ VOID DisableAllExcept(HWND hTabDlg, UINT idExcept)
     HWND hSkip = GetDlgItem(hTabDlg, idExcept);
     for (HWND hWnd = NULL; (hWnd = FindWindowExW(hTabDlg, hWnd, NULL, NULL)) != NULL;)
         EnableWindow(hWnd, hWnd == hSkip);
+    if (idExcept == IDC_SYSTEM_TREE && hSkip)
+    {
+        LONG_PTR style = GetWindowLongPtrW(hSkip, GWL_STYLE);
+        style &= ~TVS_EDITLABELS;
+        SetWindowLongPtrW(hSkip, GWL_STYLE, style);
+    }
 }
 
 BOOL OnCreate(HWND hWnd)

--- a/base/applications/msconfig/systempage.c
+++ b/base/applications/msconfig/systempage.c
@@ -91,18 +91,10 @@ SystemPageWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
     switch (message) {
         case WM_INITDIALOG:
         {
-            HWND hTree;
             hSystemDialog = hDlg;
             SetWindowPos(hDlg, NULL, 10, 32, 0, 0, SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSIZE | SWP_NOZORDER);
             InitializeSystemDialog(hDlg);
             DisableAllExcept(hDlg, IDC_SYSTEM_TREE); // FIXME: Implement saving
-            hTree = GetDlgItem(hDlg, IDC_SYSTEM_TREE);
-            if (hTree)
-            {
-                LONG_PTR style = GetWindowLongPtrW(hTree, GWL_STYLE);
-                style &= ~TVS_EDITLABELS;
-                SetWindowLongPtrW(hTree, GWL_STYLE, style);
-            }
             return TRUE;
         }
     }

--- a/base/applications/msconfig/systempage.c
+++ b/base/applications/msconfig/systempage.c
@@ -91,10 +91,20 @@ SystemPageWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
     switch (message) {
         case WM_INITDIALOG:
         {
+            HWND hTree;
+            LONG_PTR style;
             hSystemDialog = hDlg;
             SetWindowPos(hDlg, NULL, 10, 32, 0, 0, SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSIZE | SWP_NOZORDER);
             InitializeSystemDialog(hDlg);
             DisableAllExcept(hDlg, IDC_SYSTEM_TREE); // FIXME: Implement saving
+            hTree = GetDlgItem(hDlg, IDC_SYSTEM_TREE);
+            if (hTree)
+            {
+                style = GetWindowLongPtrW(hTree, GWL_STYLE);
+                style &= ~TVS_EDITLABELS;
+                SetWindowLongPtrW(hTree, GWL_STYLE, style);
+                SetWindowPos(hTree, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+            }
             return TRUE;
         }
     }

--- a/base/applications/msconfig/systempage.c
+++ b/base/applications/msconfig/systempage.c
@@ -92,7 +92,6 @@ SystemPageWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
         case WM_INITDIALOG:
         {
             HWND hTree;
-            LONG_PTR style;
             hSystemDialog = hDlg;
             SetWindowPos(hDlg, NULL, 10, 32, 0, 0, SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSIZE | SWP_NOZORDER);
             InitializeSystemDialog(hDlg);
@@ -100,10 +99,9 @@ SystemPageWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
             hTree = GetDlgItem(hDlg, IDC_SYSTEM_TREE);
             if (hTree)
             {
-                style = GetWindowLongPtrW(hTree, GWL_STYLE);
+                LONG_PTR style = GetWindowLongPtrW(hTree, GWL_STYLE);
                 style &= ~TVS_EDITLABELS;
                 SetWindowLongPtrW(hTree, GWL_STYLE, style);
-                SetWindowPos(hTree, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
             }
             return TRUE;
         }


### PR DESCRIPTION

## Purpose
This PR removes the `TVS_EDITLABELS` style from the tree view control of the `SYSTEM.INI`/`WIN.INI` tabs. making the labels read-only as intended.

JIRA issue: [CORE-20447](https://jira.reactos.org/browse/CORE-20447)

## Proposed changes

- Removed the `TVS_EDITLABELS` window style from the tree view control.
- This prevents the UI from opening an editable text box when users click or pause on tree view items, which was misleading since editing/saving here is not implemented.
- Users are still able to edit configurations using the dedicated "Edit" button on the UI.

## TODO
none, ready for review

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: