### PR TITLE
[MM/ARM3] [KMTESTS] Implement ExQueryPoolBlockSize

### DIFF
--- a/modules/rostests/kmtests/ntos_ex/ExPools.c
+++ b/modules/rostests/kmtests/ntos_ex/ExPools.c
@@ -235,6 +235,62 @@ TestPoolQuota(VOID)
 
 static
 VOID
+TestQueryPoolBlockSize(VOID)
+{
+    PVOID Memory;
+    SIZE_T Size;
+    BOOLEAN QuotaCharged;
+
+    /* Regular small block, not quota charged */
+    Memory = ExAllocatePoolWithTag(NonPagedPool, 8, 'tQbK');
+    ok(Memory != NULL, "ExAllocatePoolWithTag returned NULL\n");
+    if (!skip(Memory != NULL, "No memory\n"))
+    {
+        Size = ExQueryPoolBlockSize(Memory, &QuotaCharged);
+        ok(Size >= 8, "Size = %lu\n", (ULONG)Size);
+        ok_eq_bool(QuotaCharged, FALSE);
+        ExFreePoolWithTag(Memory, 'tQbK');
+    }
+
+    /* Quota charged block */
+    Memory = ExAllocatePoolWithQuotaTag(PagedPool | POOL_QUOTA_FAIL_INSTEAD_OF_RAISE,
+                                        sizeof(LIST_ENTRY),
+                                        'tQbK');
+    ok(Memory != NULL, "ExAllocatePoolWithQuotaTag returned NULL\n");
+    if (!skip(Memory != NULL, "No memory\n"))
+    {
+        Size = ExQueryPoolBlockSize(Memory, &QuotaCharged);
+        ok(Size >= sizeof(LIST_ENTRY), "Size = %lu\n", (ULONG)Size);
+        ok_eq_bool(QuotaCharged, TRUE);
+        ExFreePoolWithTag(Memory, 'tQbK');
+    }
+
+    /* Big page allocation, page-aligned and tracked in the big page table */
+    Memory = ExAllocatePoolWithTag(NonPagedPool, PAGE_SIZE, 'tQbK');
+    ok(Memory != NULL, "ExAllocatePoolWithTag returned NULL\n");
+    if (!skip(Memory != NULL, "No memory\n"))
+    {
+        ok((ULONG_PTR)Memory % PAGE_SIZE == 0, "Allocation %p is not page-aligned\n", Memory);
+        Size = ExQueryPoolBlockSize(Memory, &QuotaCharged);
+        ok_eq_size(Size, PAGE_SIZE);
+        ok_eq_bool(QuotaCharged, FALSE);
+        ExFreePoolWithTag(Memory, 'tQbK');
+    }
+
+    /* A multi-page big allocation should be rounded up to whole pages */
+    Memory = ExAllocatePoolWithTag(NonPagedPool, PAGE_SIZE + 1, 'tQbK');
+    ok(Memory != NULL, "ExAllocatePoolWithTag returned NULL\n");
+    if (!skip(Memory != NULL, "No memory\n"))
+    {
+        Size = ExQueryPoolBlockSize(Memory, &QuotaCharged);
+        ok_eq_size(Size, 2 * PAGE_SIZE);
+        ok_eq_bool(QuotaCharged, FALSE);
+        ExFreePoolWithTag(Memory, 'tQbK');
+    }
+}
+
+static
+VOID
 TestBigPoolExpansion(VOID)
 {
     POOL_TYPE PoolType;
@@ -279,5 +335,6 @@ START_TEST(ExPools)
     PoolsTest();
     TestPoolTags();
     TestPoolQuota();
+    TestQueryPoolBlockSize();
     TestBigPoolExpansion();
 }

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -830,6 +830,12 @@ NTAPI
 MmIsSpecialPoolAddressFree(
     IN PVOID P);
 
+SIZE_T
+NTAPI
+MmGetSpecialPoolBlockSize(
+    _In_ PVOID PoolBlock,
+    _Out_ PBOOLEAN QuotaCharged);
+
 PVOID
 NTAPI
 MmAllocateSpecialPool(

--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -64,11 +64,6 @@ ULONGLONG MiLastPoolDumpTime;
 #define POOL_NEXT_BLOCK(x)  POOL_BLOCK((x), (x)->BlockSize)
 #define POOL_PREV_BLOCK(x)  POOL_BLOCK((x), -((x)->PreviousSize))
 
-/* Special pool flags */
-#define SPECIAL_POOL_PAGED_PTE    0x2000
-#define SPECIAL_POOL_NONPAGED_PTE 0x4000
-#define SPECIAL_POOL_PAGED        0x8000
-
 /*
  * Pool list access debug macros, similar to Arthur's pfnlist.c work.
  * Microsoft actually implements similar checks in the Windows Server 2003 SP1
@@ -1581,6 +1576,62 @@ ExpReallocateBigPageTable(
     return TRUE;
 }
 
+PPOOL_TRACKER_BIG_PAGES
+NTAPI
+ExpFindBigPageEntry(IN PVOID Va,
+                    OUT PKIRQL OldIrql)
+{
+    BOOLEAN FirstTry = TRUE;
+    SIZE_T TableSize;
+    ULONG Hash;
+    ASSERT(((ULONG_PTR)Va & POOL_BIG_TABLE_ENTRY_FREE) == 0);
+
+    /*
+     * As the table is expandable, these values must only be read after acquiring
+     * the lock to avoid a teared access during an expansion
+     */
+    Hash = ExpComputePartialHashForAddress(Va);
+    KeAcquireSpinLock(&ExpLargePoolTableLock, OldIrql);
+    Hash &= PoolBigPageTableHash;
+    TableSize = PoolBigPageTableSize;
+
+    /*
+     * Loop while trying to find this big page allocation
+     */
+    while (PoolBigPageTable[Hash].Va != Va)
+    {
+        /*
+         * Increment the size until we go past the end of the table
+         */
+        if (++Hash >= TableSize)
+        {
+            /*
+             * Is this the second time we've tried?
+             */
+            if (!FirstTry)
+            {
+                /*
+                 * It's not tracked in the table so we release the lock and bail
+                 */
+                KeReleaseSpinLock(&ExpLargePoolTableLock, *OldIrql);
+                return NULL;
+            }
+
+            /*
+             * The first time this happens, reset the hash index and try again
+             */
+            Hash = 0;
+            FirstTry = FALSE;
+        }
+    }
+
+    /*
+     * Found it, return with the lock held so the caller can safely
+     * read or modify the entry
+     */
+    return &PoolBigPageTable[Hash];
+}
+
 BOOLEAN
 NTAPI
 ExpAddTagForBigPages(IN PVOID Va,
@@ -1688,61 +1739,27 @@ ExpFindAndRemoveTagBigPages(IN PVOID Va,
                             OUT PULONG_PTR BigPages,
                             IN POOL_TYPE PoolType)
 {
-    BOOLEAN FirstTry = TRUE;
-    SIZE_T TableSize;
     KIRQL OldIrql;
-    ULONG PoolTag, Hash;
+    ULONG PoolTag;
     PPOOL_TRACKER_BIG_PAGES Entry;
-    ASSERT(((ULONG_PTR)Va & POOL_BIG_TABLE_ENTRY_FREE) == 0);
     ASSERT(!(PoolType & SESSION_POOL_MASK));
 
-    //
-    // As the table is expandable, these values must only be read after acquiring
-    // the lock to avoid a teared access during an expansion
-    //
-    Hash = ExpComputePartialHashForAddress(Va);
-    KeAcquireSpinLock(&ExpLargePoolTableLock, &OldIrql);
-    Hash &= PoolBigPageTableHash;
-    TableSize = PoolBigPageTableSize;
-
-    //
-    // Loop while trying to find this big page allocation
-    //
-    while (PoolBigPageTable[Hash].Va != Va)
+    Entry = ExpFindBigPageEntry(Va, &OldIrql);
+    if (Entry == NULL)
     {
         //
-        // Increment the size until we go past the end of the table
+        // This means it was never inserted into the pool table and it
+        // received the special "BIG" tag -- return that and return 0
+        // so that the code can ask Mm for the page count instead
         //
-        if (++Hash >= TableSize)
-        {
-            //
-            // Is this the second time we've tried?
-            //
-            if (!FirstTry)
-            {
-                //
-                // This means it was never inserted into the pool table and it
-                // received the special "BIG" tag -- return that and return 0
-                // so that the code can ask Mm for the page count instead
-                //
-                KeReleaseSpinLock(&ExpLargePoolTableLock, OldIrql);
-                *BigPages = 0;
-                return ' GIB';
-            }
-
-            //
-            // The first time this happens, reset the hash index and try again
-            //
-            Hash = 0;
-            FirstTry = FALSE;
-        }
+        *BigPages = 0;
+        return ' GIB';
     }
 
     //
     // Now capture all the information we need from the entry, since after we
     // release the lock, the data can change
     //
-    Entry = &PoolBigPageTable[Hash];
     *BigPages = Entry->NumberOfPages;
     PoolTag = Entry->Key;
 
@@ -2951,8 +2968,8 @@ ExQueryPoolBlockSize(_In_ PVOID PoolBlock,
                      _Out_ PBOOLEAN QuotaCharged)
 {
     PPOOL_HEADER Entry;
+    PPOOL_TRACKER_BIG_PAGES BigPageEntry;
     KIRQL OldIrql;
-    ULONG i;
 
     /*
      * Special pool blocks don't have a normal pool header next to them
@@ -2961,20 +2978,7 @@ ExQueryPoolBlockSize(_In_ PVOID PoolBlock,
      */
     if ((ExpPoolFlags & POOL_FLAG_SPECIAL_POOL) && MmIsSpecialPoolAddress(PoolBlock))
     {
-        PPOOL_HEADER Header;
-
-        if (PAGE_ALIGN(PoolBlock) == PoolBlock)
-        {
-            Header = (PPOOL_HEADER)((PUCHAR)PoolBlock + PAGE_SIZE - sizeof(POOL_HEADER));
-        }
-        else
-        {
-            Header = PAGE_ALIGN(PoolBlock);
-        }
-
-        /* Special pool allocations are never quota charged */
-        *QuotaCharged = FALSE;
-        return Header->Ulong1 & ~SPECIAL_POOL_PAGED & 0xFFFF;
+        return MmGetSpecialPoolBlockSize(PoolBlock, QuotaCharged);
     }
 
     /*
@@ -2983,33 +2987,23 @@ ExQueryPoolBlockSize(_In_ PVOID PoolBlock,
      */
     if (PAGE_ALIGN(PoolBlock) == PoolBlock)
     {
-        KeAcquireSpinLock(&ExpLargePoolTableLock, &OldIrql);
-        for (i = 0; i < PoolBigPageTableSize; i++)
+        BigPageEntry = ExpFindBigPageEntry(PoolBlock, &OldIrql);
+        if (BigPageEntry != NULL)
         {
-            if (PoolBigPageTable[i].Va == PoolBlock)
-            {
-                SIZE_T NumberOfPages = PoolBigPageTable[i].NumberOfPages;
-                KeReleaseSpinLock(&ExpLargePoolTableLock, OldIrql);
+            SIZE_T NumberOfPages = BigPageEntry->NumberOfPages;
+            KeReleaseSpinLock(&ExpLargePoolTableLock, OldIrql);
 
-                /*
-                 * Big page allocations are never quota charged
-                 */
-                *QuotaCharged = FALSE;
-                return NumberOfPages * PAGE_SIZE;
-            }
+            /* Big page allocations are never quota charged */
+            *QuotaCharged = FALSE;
+            return NumberOfPages * PAGE_SIZE;
         }
-        KeReleaseSpinLock(&ExpLargePoolTableLock, OldIrql);
 
-        /*
-         * It isn't tracked so we can't find out its size
-         */
+        /* It isn't tracked so we can't find out its size */
         *QuotaCharged = FALSE;
         return 0;
     }
 
-    /*
-     * Regular pool block. The size lives in the header right before it
-     */
+    /* Regular pool block. The size lives in the header right before it */
     Entry = PoolBlock;
     Entry--;
     *QuotaCharged = ((Entry->PoolType - 1) & QUOTA_POOL_MASK) ? TRUE : FALSE;

--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -64,6 +64,11 @@ ULONGLONG MiLastPoolDumpTime;
 #define POOL_NEXT_BLOCK(x)  POOL_BLOCK((x), (x)->BlockSize)
 #define POOL_PREV_BLOCK(x)  POOL_BLOCK((x), -((x)->PreviousSize))
 
+/* Special pool flags */
+#define SPECIAL_POOL_PAGED_PTE    0x2000
+#define SPECIAL_POOL_NONPAGED_PTE 0x4000
+#define SPECIAL_POOL_PAGED        0x8000
+
 /*
  * Pool list access debug macros, similar to Arthur's pfnlist.c work.
  * Microsoft actually implements similar checks in the Windows Server 2003 SP1
@@ -2926,18 +2931,89 @@ ExFreePool(PVOID P)
 }
 
 /*
- * @unimplemented
+ * @implemented
+ *
+ * @param[in] PoolBlock
+ * Pointer to the start of a pool allocation that is returned by
+ * ExAllocatePoolWithTag
+ *
+ * @param[out] QuotaCharged
+ * Gets TRUE if the allocation was charged against the calling
+ * process pool quota, FALSE otherwise.
+ *
+ * @return
+ * The size in bytes of the pool block. Returns 0 if the block is a
+ * big page allocation that could not be found
  */
 SIZE_T
 NTAPI
-ExQueryPoolBlockSize(IN PVOID PoolBlock,
-                     OUT PBOOLEAN QuotaCharged)
+ExQueryPoolBlockSize(_In_ PVOID PoolBlock,
+                     _Out_ PBOOLEAN QuotaCharged)
 {
-    //
-    // Not implemented
-    //
-    UNIMPLEMENTED;
-    return FALSE;
+    PPOOL_HEADER Entry;
+    KIRQL OldIrql;
+    ULONG i;
+
+    /*
+     * Special pool blocks don't have a normal pool header next to them
+     * and can be page-aligned or not depending on whether they are under/overrun
+     * catched, so they need to be checked before anything else
+     */
+    if ((ExpPoolFlags & POOL_FLAG_SPECIAL_POOL) && MmIsSpecialPoolAddress(PoolBlock))
+    {
+        PPOOL_HEADER Header;
+
+        if (PAGE_ALIGN(PoolBlock) == PoolBlock)
+        {
+            Header = (PPOOL_HEADER)((PUCHAR)PoolBlock + PAGE_SIZE - sizeof(POOL_HEADER));
+        }
+        else
+        {
+            Header = PAGE_ALIGN(PoolBlock);
+        }
+
+        /* Special pool allocations are never quota charged */
+        *QuotaCharged = FALSE;
+        return Header->Ulong1 & ~SPECIAL_POOL_PAGED & 0xFFFF;
+    }
+
+    /*
+     * Since big page allocations are page-aligned and have no pool header,
+     * look them up in the big page tracking table instead
+     */
+    if (PAGE_ALIGN(PoolBlock) == PoolBlock)
+    {
+        KeAcquireSpinLock(&ExpLargePoolTableLock, &OldIrql);
+        for (i = 0; i < PoolBigPageTableSize; i++)
+        {
+            if (PoolBigPageTable[i].Va == PoolBlock)
+            {
+                SIZE_T NumberOfPages = PoolBigPageTable[i].NumberOfPages;
+                KeReleaseSpinLock(&ExpLargePoolTableLock, OldIrql);
+
+                /*
+                 * Big page allocations are never quota charged
+                 */
+                *QuotaCharged = FALSE;
+                return NumberOfPages * PAGE_SIZE;
+            }
+        }
+        KeReleaseSpinLock(&ExpLargePoolTableLock, OldIrql);
+
+        /*
+         * It isn't tracked so we can't find out its size
+         */
+        *QuotaCharged = FALSE;
+        return 0;
+    }
+
+    /*
+     * Regular pool block. The size lives in the header right before it
+     */
+    Entry = PoolBlock;
+    Entry--;
+    *QuotaCharged = ((Entry->PoolType - 1) & QUOTA_POOL_MASK) ? TRUE : FALSE;
+    return Entry->BlockSize * POOL_BLOCK_SIZE;
 }
 
 /*

--- a/ntoskrnl/mm/ARM3/special.c
+++ b/ntoskrnl/mm/ARM3/special.c
@@ -118,6 +118,46 @@ MmIsSpecialPoolAddressFree(PVOID P)
     return TRUE;
 }
 
+/*************************************************************************
+ *                MmGetSpecialPoolBlockSize
+ *
+ * @param[in] PoolBlock
+ * Pointer to the start of a special pool allocation
+ *
+ * @param[out] QuotaCharged
+ * Always set to FALSE since special pool allocations are never quota
+ * charged
+ *
+ * @return
+ * The size in bytes of the requested allocation
+ *
+ */
+SIZE_T
+NTAPI
+MmGetSpecialPoolBlockSize(
+    _In_ PVOID PoolBlock,
+    _Out_ PBOOLEAN QuotaCharged)
+{
+    PPOOL_HEADER Header;
+
+    ASSERT(MmIsSpecialPoolAddress(PoolBlock));
+
+    /* Data sits at the start or the end of the page depending on if
+       we are catching underruns or overruns */
+    if (PAGE_ALIGN(PoolBlock) == PoolBlock)
+    {
+        Header = (PPOOL_HEADER)((PUCHAR)PoolBlock + PAGE_SIZE - sizeof(POOL_HEADER));
+    }
+    else
+    {
+        Header = PAGE_ALIGN(PoolBlock);
+    }
+
+    /* Special pool allocations are never quota charged */
+    *QuotaCharged = FALSE;
+    return Header->Ulong1 & ~SPECIAL_POOL_PAGED & 0xFFFF;
+}
+
 VOID
 NTAPI
 MiInitializeSpecialPool(VOID)

--- a/sdk/lib/3rdparty/freetype/CMakeLists.txt
+++ b/sdk/lib/3rdparty/freetype/CMakeLists.txt
@@ -54,5 +54,5 @@ if(CMAKE_C_COMPILER_ID STREQUAL "MSVC" AND (ARCH STREQUAL "amd64" OR ARCH STREQU
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(freetype PRIVATE -fno-builtin-malloc)
+    target_compile_options(freetype PRIVATE -fno-builtin-malloc -Wno-array-parameter)
 endif()

--- a/sdk/lib/3rdparty/freetype/CMakeLists.txt
+++ b/sdk/lib/3rdparty/freetype/CMakeLists.txt
@@ -54,5 +54,5 @@ if(CMAKE_C_COMPILER_ID STREQUAL "MSVC" AND (ARCH STREQUAL "amd64" OR ARCH STREQU
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(freetype PRIVATE -fno-builtin-malloc -Wno-array-parameter)
+    target_compile_options(freetype PRIVATE -fno-builtin-malloc)
 endif()


### PR DESCRIPTION
## Purpose
Implements `ExQueryPoolBlockSize` in `ntoskrnl\mm\ARM3\expool.c`.
JIRA issue: None

## Proposed changes
- Implement `ExQueryPoolBlockSize` in `ntoskrnl/mm/ARM3/expool.c`, covering
  regular pool blocks, big page allocations, and special pool blocks
- Add `MmGetSpecialPoolBlockSize` to `mm.h`
- Implement `ExpFindBigPageEntry` in `expool.c` and update `ExpAddTagForBigPages` to use it (so it shrinked)
- Implement `MmGetSpecialPoolBlockSize` in `special.c`
- Add a test for it in `ExPools.c` (results below)
- Change the annotation to SAL2 and add Doxygen documentation

## Testbot runs (Filled in by Devs)
- [ ] KVM x86:
- [ ] KVM x64:

<img width="595" height="102" alt="image" src="https://github.com/user-attachments/assets/4fe98d85-7f1b-493e-a3a2-29164ce0c1a4" />