### PR TITLE
[RTL] Fix owner range deletion traversal

### DIFF
--- a/modules/rostests/kmtests/rtl/RtlRangeList.c
+++ b/modules/rostests/kmtests/rtl/RtlRangeList.c
@@ -408,6 +408,49 @@ TestIsAvailable(
     ok_eq_ulong(RangeList->Stamp, StartStamp);
 }
 
+static
+void
+TestDeleteOwnersRanges(void)
+{
+    NTSTATUS Status;
+    RTL_RANGE_LIST RangeList;
+    RTL_RANGE Ranges[4];
+    ULONG Index, StartStamp;
+
+    RtlInitializeRangeList(&RangeList);
+    for (Index = 0; Index < RTL_NUMBER_OF(Ranges); Index++)
+    {
+        Ranges[Index].Start = 0x100 * (Index + 1);
+        Ranges[Index].End = Ranges[Index].Start + 0xff;
+        Ranges[Index].Attributes = 0;
+        Ranges[Index].Flags = 0;
+        Ranges[Index].UserData = &MyUserData1;
+        Ranges[Index].Owner = Index == 1 ? &MyOwner2 : &MyOwner1;
+        Status = RtlAddRangeWrapper(&RangeList, &Ranges[Index], 0);
+        ok_eq_hex(Status, STATUS_SUCCESS);
+    }
+
+    StartStamp = RangeList.Stamp;
+    Status = RtlDeleteOwnersRanges(&RangeList, &MyOwner1);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+    ok_eq_ulong(RangeList.Count, 1UL);
+    ok_eq_ulong(RangeList.Stamp, StartStamp + 3);
+    expect_range_entries(&RangeList, 1, &Ranges[1]);
+
+    Status = RtlDeleteOwnersRanges(&RangeList, &MyOwner1);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+    ok_eq_ulong(RangeList.Count, 1UL);
+    ok_eq_ulong(RangeList.Stamp, StartStamp + 3);
+
+    Status = RtlDeleteOwnersRanges(&RangeList, &MyOwner2);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+    ok_eq_ulong(RangeList.Count, 0UL);
+    ok_eq_ulong(RangeList.Stamp, StartStamp + 4);
+    expect_range_entries(&RangeList, 0, NULL);
+
+    RtlFreeRangeList(&RangeList);
+}
+
 /* Entry point ***************************************************************/
 START_TEST(RtlRangeList)
 {
@@ -453,6 +496,7 @@ START_TEST(RtlRangeList)
     TestStartEqualsEnd(&RangeList, Ranges);
     TestSharedFlag(&RangeList, Ranges);
     TestIsAvailable(&RangeList, Ranges);
+    TestDeleteOwnersRanges();
 
     Stamp = RangeList.Stamp;
 

--- a/sdk/lib/rtl/rangelist.c
+++ b/sdk/lib/rtl/rangelist.c
@@ -205,10 +205,14 @@ RtlDeleteOwnersRanges(IN OUT PRTL_RANGE_LIST RangeList,
 {
     PRTL_RANGE_ENTRY Current;
     PLIST_ENTRY Entry;
+    PLIST_ENTRY NextEntry;
 
     Entry = RangeList->ListHead.Flink;
     while (Entry != &RangeList->ListHead)
     {
+        /* Capture the successor before a removal frees this entry */
+        NextEntry = Entry->Flink;
+
         Current = CONTAINING_RECORD(Entry, RTL_RANGE_ENTRY, Entry);
         if (Current->Range.Owner == Owner)
         {
@@ -219,7 +223,7 @@ RtlDeleteOwnersRanges(IN OUT PRTL_RANGE_LIST RangeList,
             RangeList->Stamp++;
         }
 
-        Entry = Entry->Flink;
+        Entry = NextEntry;
     }
 
     return STATUS_SUCCESS;


### PR DESCRIPTION
I hit this while working on my ReactOS branch. During a PCI resource rebalance, the kernel crashed in RtlDeleteOwnersRanges after e1000e switched from legacy INTx to MSI:


<img width="1601" height="396" alt="Screenshot From 2026-07-19 19-14-50" src="https://github.com/user-attachments/assets/a87a900f-512c-47fe-bdf9-ef1be5564d1d" />


The function freed a matching range entry and then used Entry->Flink to continue the loop. Saving the next entry before the free removes that use-after-free. I also added a small test for mixed-owner and consecutive deletions

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: