### PR TITLE
[BROWSEUI][SHDOCVW][SHELL32] In-place browse IShellBrowser favorites

### DIFF
--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -88,6 +88,56 @@ struct ITBARSTATE
     // Note: Windows 8/10 stores the Ribbon state in ..\Explorer\Ribbon
 };
 
+static HRESULT SHELL_LoadShellLink(PCIDLIST_ABSOLUTE pidl, IShellLink **ppsl, DWORD stgm = STGM_READ)
+{
+    WCHAR buf[MAX_PATH];
+    if (!SHGetPathFromIDListW(pidl, buf))
+        return E_FAIL;
+    CComPtr<IPersistFile> ppf;
+    HRESULT hr = CoCreateInstance(CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARG(IPersistFile, &ppf));
+    if (SUCCEEDED(hr))
+        hr = ppf->Load(buf, stgm);
+    return SUCCEEDED(hr) ? ppf->QueryInterface(IID_PPV_ARG(IShellLink, ppsl)) : hr;
+}
+
+static HRESULT SHELL_GetAbsolutePidlTryLinkTarget(IShellFolder *psf, LPCITEMIDLIST pidlChild, PIDLIST_ABSOLUTE *ppidl)
+{
+    CComHeapPtr<ITEMIDLIST> pidl;
+    HRESULT hr = SHELL_GetAbsolutePidl(psf, pidlChild, &pidl);
+    if (FAILED(hr))
+        return hr;
+    // TODO: Use BHID_LinkTargetItem instead when it's implemented
+    if (SHELL_GetAttributesOf(psf, pidlChild, SFGAO_LINK) & SFGAO_LINK)
+    {
+        PIDLIST_ABSOLUTE pidlTarget;
+        CComPtr<IShellLink> psl;
+        if (SUCCEEDED(SHELL_LoadShellLink(pidl, &psl)) && SUCCEEDED(psl->GetIDList(&pidlTarget)))
+            pidl.Attach(pidlTarget);
+    }
+    *ppidl = pidl.Detach();
+    return S_OK;
+}
+
+static HRESULT SHELL_BrowseObject(IShellBrowser *psb, IShellFolder *psf, LPCITEMIDLIST pidlChild, UINT SBSP)
+{
+    CComHeapPtr<ITEMIDLIST> pidl;
+    HRESULT hr = SHELL_GetAbsolutePidlTryLinkTarget(psf, pidlChild, &pidl);
+    if (FAILED(hr))
+        return hr;
+    if (SHELL_GetAttributesOf(pidl, SFGAO_BROWSABLE | SFGAO_FOLDER) & (SFGAO_BROWSABLE | SFGAO_FOLDER))
+        return psb->BrowseObject(pidl, SBSP_ABSOLUTE | (SBSP & ~SBSP_RELATIVE));
+    return HRESULT_FROM_WIN32(ERROR_DIR_NOT_ROOT);
+}
+
+static HRESULT BrowseInplaceOrExecute(HWND hWnd, IShellFolder *psf, LPCITEMIDLIST pidlChild, IUnknown *pSite)
+{
+    CComPtr<IShellBrowser> psb;
+    HRESULT hr = IUnknown_QueryService(pSite, SID_IShellBrowser, IID_PPV_ARG(IShellBrowser, &psb));
+    if (SUCCEEDED(hr))
+        hr = SHELL_BrowseObject(psb, psf, pidlChild, SBSP_SAMEBROWSER);
+    return SUCCEEDED(hr) ? hr : SHInvokeDefaultCommand(hWnd, psf, pidlChild);
+}
+
 HRESULT IUnknown_RelayWinEvent(IUnknown * punk, HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult)
 {
     CComPtr<IWinEventHandler> menuWinEventHandler;
@@ -523,6 +573,7 @@ HRESULT STDMETHODCALLTYPE CMenuCallback::GetObject(LPSMDATA psmd, REFIID riid, v
         if (FAILED_UNEXPECTEDLY(hResult))
             return hResult;
 
+        // FIXME: Why are SMINIT_ and SMINV_ flags passed here? We perhaps want SMSET_HASEXPANDABLEFOLDERS?
         hResult = newMenu->SetShellFolder(favoritesFolder, favoritesPIDL, orderRegKey, SMSET_BOTTOM | SMINIT_CACHED | SMINV_ID);
         if (favoritesPIDL)
             ILFree(favoritesPIDL);
@@ -578,7 +629,7 @@ HRESULT STDMETHODCALLTYPE CMenuCallback::CallbackSM(LPSMDATA psmd, UINT uMsg, WP
             PostMessageW(psmd->hwnd, WM_COMMAND, psmd->uId, 0);
             break;
         case SMC_SFEXEC:
-            SHInvokeDefaultCommand(psmd->hwnd, psmd->psf, psmd->pidlItem);
+            BrowseInplaceOrExecute(psmd->hwnd, psmd->psf, psmd->pidlItem, pSite);
             break;
         case SMC_SFSELECTITEM:
             break;
@@ -633,6 +684,7 @@ CInternetToolbar::CInternetToolbar()
 
 CInternetToolbar::~CInternetToolbar()
 {
+    fMenuCallback->SetSite(NULL);
 }
 
 void CInternetToolbar::AddDockItem(IUnknown *newItem, int bandID, int flags)
@@ -705,6 +757,7 @@ HRESULT CInternetToolbar::CreateMenuBar(IShellMenu **pMenuBar)
     if (FAILED_UNEXPECTEDLY(hResult))
         return hResult;
 
+    fMenuCallback->SetSite(static_cast<IObjectWithSite*>(this));
     hResult = fMenuCallback->QueryInterface(IID_PPV_ARG(IShellMenuCallback, &callback));
     if (FAILED_UNEXPECTEDLY(hResult))
         return hResult;

--- a/dll/win32/browseui/internettoolbar.h
+++ b/dll/win32/browseui/internettoolbar.h
@@ -47,9 +47,11 @@ class CMenuCallback :
 {
 private:
     CComPtr<IShellMenu>             fFavoritesMenu;
+    IUnknown*                       pSite = NULL; // Note: Not ref-counted
 public:
     CMenuCallback();
     virtual ~CMenuCallback();
+    void SetSite(IUnknown *pNewSite) { pSite = pNewSite; }
 
     HRESULT STDMETHODCALLTYPE GetObject(LPSMDATA psmd, REFIID riid, void **ppvObject);
 public:

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -4006,25 +4006,24 @@ HRESULT GetFavsLocation(HWND hWnd, LPITEMIDLIST *pPidl)
     return hr;
 }
 
+static HRESULT AddItemToFavorites(HWND hWnd, IShellFolder *psf, LPCITEMIDLIST pidlLast)
+{
+    CComHeapPtr<WCHAR> pszURL, pszTitle;
+    HRESULT hr = SHELL_GetDisplayNameOf(psf, pidlLast, SHGDN_FORPARSING, &pszURL);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+
+    SHELL_GetDisplayNameOf(psf, pidlLast, SHGDN_NORMAL | SHGDN_INFOLDER, &pszTitle);
+    return AddUrlToFavorites(hWnd, pszURL, pszTitle ? pszTitle : PathFindFileNameW(pszURL), TRUE);
+}
+
 LRESULT CShellBrowser::OnAddToFavorites(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL &bHandled)
 {
     CComPtr<IShellFolder> pParent;
     LPCITEMIDLIST pidlLast;
     HRESULT hr = SHBindToParent(fCurrentDirectoryPIDL, IID_PPV_ARG(IShellFolder, &pParent), &pidlLast);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return hr;
-
-    STRRET strret;
-    hr = pParent->GetDisplayNameOf(pidlLast, SHGDN_FORPARSING, &strret);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return 0;
-
-    CComHeapPtr<WCHAR> pszURL;
-    hr = StrRetToStrW(&strret, NULL, &pszURL);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return 0;
-
-    AddUrlToFavorites(m_hWnd, pszURL, NULL, TRUE);
+    if (!FAILED_UNEXPECTEDLY(hr))
+        AddItemToFavorites(m_hWnd, pParent, pidlLast);
     return 0;
 }
 

--- a/dll/win32/shdocvw/CNSCBand.cpp
+++ b/dll/win32/shdocvw/CNSCBand.cpp
@@ -616,6 +616,17 @@ LRESULT CNSCBand::OnKillFocus(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHa
     return 0;
 }
 
+static HRESULT AddItemToFavorites(HWND hWnd, IShellFolder *psf, LPCITEMIDLIST pidlLast)
+{
+    CComHeapPtr<WCHAR> pszURL, pszTitle;
+    HRESULT hr = SHELL_GetDisplayNameOf(psf, pidlLast, SHGDN_FORPARSING, &pszURL);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+
+    SHELL_GetDisplayNameOf(psf, pidlLast, SHGDN_NORMAL | SHGDN_INFOLDER, &pszTitle);
+    return AddUrlToFavorites(hWnd, pszURL, pszTitle ? pszTitle : PathFindFileNameW(pszURL), TRUE);
+}
+
 HRESULT CNSCBand::_AddFavorite()
 {
     CComHeapPtr<ITEMIDLIST> pidlCurrent;
@@ -626,18 +637,7 @@ HRESULT CNSCBand::_AddFavorite()
     HRESULT hr = SHBindToParent(pidlCurrent, IID_PPV_ARG(IShellFolder, &pParent), &pidlLast);
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
-
-    STRRET strret;
-    hr = pParent->GetDisplayNameOf(pidlLast, SHGDN_FORPARSING, &strret);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return hr;
-
-    CComHeapPtr<WCHAR> pszURL;
-    hr = StrRetToStrW(&strret, NULL, &pszURL);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return hr;
-
-    return AddUrlToFavorites(m_hWnd, pszURL, NULL, TRUE);
+    return AddItemToFavorites(m_hWnd, pParent, pidlLast);
 }
 
 LRESULT CNSCBand::OnCommand(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)

--- a/dll/win32/shdocvw/utility.cpp
+++ b/dll/win32/shdocvw/utility.cpp
@@ -185,6 +185,88 @@ SHDOCVW_CreateShortcut(
     return ppf->Save(pszLnkFileName, TRUE);
 }
 
+struct ADDFAVORITEDIALOGDATA
+{
+    PWSTR pszName;
+    PCWSTR pszCaption;
+    WNDPROC pOrgProc;
+    HWND hEdit;
+    BOOL IgnoreChanges;
+};
+
+static LRESULT AddFavoriteDialogProc(
+   _In_ HWND hwnd,
+   _In_ UINT uMsg,
+   _In_ WPARAM wParam,
+   _In_ LPARAM lParam)
+{
+    ADDFAVORITEDIALOGDATA &data = *(ADDFAVORITEDIALOGDATA*)GetWindowLongPtrW(hwnd, GWLP_USERDATA);
+    NMHDR *pHdr = (NMHDR*)lParam;
+    if (uMsg == WM_NOTIFY)
+        data.IgnoreChanges |= pHdr->code == NM_CLICK || pHdr->code == NM_SETFOCUS; // Ignore changes from the tree
+    if (uMsg == WM_COMMAND && HIWORD(wParam) == EN_SETFOCUS)
+        data.IgnoreChanges = FALSE;
+    if (uMsg == WM_COMMAND && HIWORD(wParam) == EN_UPDATE && !data.IgnoreChanges)
+    {
+        SendMessageW(data.hEdit, WM_GETTEXT, MAX_PATH, (LPARAM)data.pszName); // Save user input
+        BOOL bad = FALSE;
+        for (PWSTR p = data.pszName; *p; ++p)
+            bad |= !PathIsValidCharW(*p, PATH_VALID_ELEMENT);
+        SendMessageW(hwnd, BFFM_ENABLEOK, 0, !bad);
+    }
+    return CallWindowProcW(data.pOrgProc, hwnd, uMsg, wParam, lParam);
+}
+
+static int CALLBACK AddFavoriteDialogCallback(
+   _In_ HWND hwnd,
+   _In_ UINT uMsg,
+   _In_ LPARAM lParam,
+   _In_ LPARAM lpData)
+{
+    ADDFAVORITEDIALOGDATA &data = *(ADDFAVORITEDIALOGDATA*)lpData;
+    switch (uMsg)
+    {
+    case BFFM_INITIALIZED:
+        SetWindowLongPtrW(hwnd, GWLP_USERDATA, (LONG_PTR)&data);
+        data.pOrgProc = (WNDPROC)SetWindowLongPtrW(hwnd, GWLP_WNDPROC, (LONG_PTR)AddFavoriteDialogProc);
+        data.hEdit = FindWindowExW(hwnd, NULL, L"EDIT", NULL);
+        SendMessageW(hwnd, WM_SETTEXT, 0, (LPARAM)data.pszCaption);
+        SendMessageW(hwnd, WM_NEXTDLGCTL, (WPARAM)data.hEdit, TRUE);
+        SendMessageW(data.hEdit, WM_SETTEXT, 0, (LPARAM)data.pszName); // Initialize
+        break;
+    case BFFM_SELCHANGED:
+        SendMessageW(data.hEdit, WM_SETTEXT, 0, (LPARAM)data.pszName); // Restore
+        break;
+    case BFFM_VALIDATEFAILED:
+        return TRUE;
+    }
+    return 0;
+}
+
+static HRESULT
+AddFavoriteDialog(
+    _In_ HWND hwnd,
+    _Inout_ PWSTR pszDir,
+    _Inout_ PWSTR pszTitle,
+    _In_ PCWSTR pszText)
+{
+    CComHeapPtr<ITEMIDLIST> pidlBaseDir, pidl;
+    HRESULT hr = SHParseDisplayName(pszDir, NULL, &pidlBaseDir, 0, NULL);
+    if (FAILED(hr))
+        return hr;
+
+    ADDFAVORITEDIALOGDATA data = { pszTitle, PathFindFileNameW(pszDir) };
+    UINT bif = BIF_RETURNONLYFSDIRS | BIF_EDITBOX | BIF_USENEWUI;
+    WCHAR szBuf[MAX_PATH];
+    *szBuf = UNICODE_NULL;
+    BROWSEINFOW info = { hwnd, pidlBaseDir, szBuf, pszText, bif, AddFavoriteDialogCallback, (LPARAM)&data };
+    PIDLIST_ABSOLUTE pidlResult = SHBrowseForFolderW(&info);
+    if (!pidlResult)
+        return S_FALSE;
+    pidl.Attach(pidlResult);
+    return SHGetPathFromIDListW(pidl, pszDir) ? S_OK : E_FAIL;
+}
+
 /*************************************************************************
  *      AddUrlToFavorites [SHDOCVW.106]
  */
@@ -197,33 +279,50 @@ AddUrlToFavorites(
 {
     TRACE("%p, %s, %s, %d\n", hwnd, wine_dbgstr_w(pszUrlW), wine_dbgstr_w(pszTitleW), fDisplayUI);
 
-    if (fDisplayUI)
-        FIXME("fDisplayUI\n"); // NOTE: Use SHBrowseForFolder callback
+    if (!pszUrlW || !pszTitleW)
+        return E_INVALIDARG;
 
-    if (PathIsURLW(pszUrlW))
-        FIXME("Internet Shortcut\n");
-
-    CComHeapPtr<ITEMIDLIST> pidl;
-    HRESULT hr = SHParseDisplayName(pszUrlW, NULL, &pidl, 0, NULL);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return hr;
-
-    // Get title
+    CCoInit CoInit;
+    HRESULT hr = S_OK;
+    BOOL IsUrl = PathIsURLW(pszUrlW);
+    LPCWSTR pszExt = IsUrl ? L".url" : L".lnk";
     WCHAR szTitle[MAX_PATH];
-    if (pszTitleW)
-        StringCchCopyW(szTitle, _countof(szTitle), pszTitleW);
-    else
-        ILGetDisplayNameEx(NULL, pidl, szTitle, ILGDN_NORMAL);
+    StringCchCopyW(szTitle, _countof(szTitle), pszTitleW);
 
-    // Delete invalid characters
-    SHDOCVW_PathDeleteInvalidChars(szTitle);
-
-    // Build shortcut pathname
-    WCHAR szPath[MAX_PATH];
-    if (!SHGetSpecialFolderPathW(hwnd, szPath, CSIDL_FAVORITES, TRUE))
+    WCHAR szDir[MAX_PATH];
+    if (!SHGetSpecialFolderPathW(hwnd, szDir, CSIDL_FAVORITES, TRUE))
         return E_FAIL;
-    PathAppendW(szPath, szTitle);
-    PathAddExtensionW(szPath, L".lnk");
 
-    return SHDOCVW_CreateShortcut(szPath, pidl, NULL);
+    if (fDisplayUI)
+    {
+        PCWSTR pszText = IsUrl ? pszUrlW : PathFindFileNameW(pszUrlW);
+        if ((hr = AddFavoriteDialog(hwnd, szDir, szTitle, pszText)) == S_FALSE)
+            return hr;
+    }
+    SHDOCVW_PathDeleteInvalidChars(szTitle);
+    
+    WCHAR szLnk[MAX_PATH * 2];
+    if (SUCCEEDED(hr))
+        hr = StringCchPrintfW(szLnk, _countof(szLnk), L"%s\\%s%s", szDir, szTitle, pszExt);
+
+    if (IsUrl && SUCCEEDED(hr))
+    {
+        hr = WritePrivateProfileStringW(L"InternetShortcut", L"URL", pszUrlW, szLnk) ? S_OK : E_FAIL;
+    }
+    else if (SUCCEEDED(hr))
+    {
+        BOOL bMustCopy;
+        if (!fDisplayUI)
+            hr = SHGetNewLinkInfoW(pszUrlW, szDir, szLnk, &bMustCopy, 0) ? S_OK : E_FAIL;
+
+        CComHeapPtr<ITEMIDLIST> pidl;
+        if (!FAILED_UNEXPECTEDLY(hr))
+            hr = SHParseDisplayName(pszUrlW, NULL, &pidl, 0, NULL);
+        if (!FAILED_UNEXPECTEDLY(hr))
+            hr = SHDOCVW_CreateShortcut(szLnk, pidl, NULL);
+    }
+
+    if (FAILED(hr) && fDisplayUI)
+        SHELL_ErrorBox(hwnd, hr);
+    return hr;
 }

--- a/dll/win32/shdocvw/utility.cpp
+++ b/dll/win32/shdocvw/utility.cpp
@@ -205,8 +205,8 @@ static LRESULT AddFavoriteDialogProc(
     if (uMsg == WM_NOTIFY)
         data.IgnoreChanges |= pHdr->code == NM_CLICK || pHdr->code == NM_SETFOCUS; // Ignore changes from the tree
     if (uMsg == WM_COMMAND && HIWORD(wParam) == EN_SETFOCUS)
-        data.IgnoreChanges = FALSE;
-    if (uMsg == WM_COMMAND && HIWORD(wParam) == EN_UPDATE && !data.IgnoreChanges)
+        data.IgnoreChanges = (HWND)lParam != data.hEdit; // Ignore changes in the tree rename edit
+    if (uMsg == WM_COMMAND && HIWORD(wParam) == EN_UPDATE && (HWND)lParam == data.hEdit && !data.IgnoreChanges)
     {
         SendMessageW(data.hEdit, WM_GETTEXT, MAX_PATH, (LPARAM)data.pszName); // Save user input
         BOOL bad = FALSE;

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -841,6 +841,10 @@ BrFolder_OnInitDialog(HWND hWnd, BrFolder *info)
             ILFree(pidl);
         }
     }
+    else
+    {
+        info->pidlRet = ILClone(lpBrowseInfo->pidlRoot);
+    }
 
     BrFolder_Callback(info->lpBrowseInfo, hWnd, BFFM_INITIALIZED, 0);
 

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -288,7 +288,7 @@ SHGetAttributes(_In_ IShellFolder *psf, _In_ LPCITEMIDLIST pidl, _In_ DWORD dwAt
 HRESULT SHELL_GetIDListTarget(_In_ LPCITEMIDLIST pidl, _Out_ PIDLIST_ABSOLUTE *ppidl);
 HRESULT SHCoInitializeAnyApartment(VOID);
 
-HRESULT
+EXTERN_C HRESULT
 SHGetNameAndFlagsW(
     _In_ LPCITEMIDLIST pidl,
     _In_ DWORD dwFlags,

--- a/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
@@ -36,6 +36,16 @@ WINE_DEFAULT_DEBUG_CHANNEL(CMenuToolbars);
 // User-defined timer ID used while hot-tracking around the menu
 #define TIMERID_HOTTRACK 1
 
+static inline SFGAOF GetFolderItemBaseType(UINT sfgao)
+{
+    return (sfgao & SFGAO_STREAM) ? SFGAO_STREAM : (sfgao & SFGAO_FOLDER);
+}
+
+static SFGAOF GetFolderItemBaseType(IShellFolder *psf, LPCITEMIDLIST pidl)
+{
+    return GetFolderItemBaseType(SHELL_GetAttributesOf(psf, pidl, SFGAO_FOLDER | SFGAO_STREAM));
+}
+
 LRESULT CMenuToolbarBase::OnWinEventWrap(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     LRESULT lr;
@@ -1410,20 +1420,13 @@ HRESULT CMenuSFToolbar::FillToolbar(BOOL clearFirst)
             continue;
         }
 
-        INT indexOpen = 0;
-        INT index = SHMapPIDLToSystemImageListIndex(m_shellFolder, item, &indexOpen);
-
-        LPCITEMIDLIST itemc = item;
-
-        SFGAOF attrs = SFGAO_FOLDER;
-        hr = m_shellFolder->GetAttributesOf(1, &itemc, &attrs);
-
-        DWORD_PTR dwData = reinterpret_cast<DWORD_PTR>(item);
+        INT index = SHMapPIDLToSystemImageListIndex(m_shellFolder, item, NULL);
+        BOOL isPureFolder = GetFolderItemBaseType(m_shellFolder, item) == SFGAO_FOLDER; // Don't expand .cab/.zip
 
         // Fetch next item already, so we know if the current one is the last
         i++;
 
-        AddButton(i, MenuString, attrs & SFGAO_FOLDER, index, dwData, i >= DPA_GetPtrCount(dpaSort));
+        AddButton(i, MenuString, isPureFolder, index, reinterpret_cast<DWORD_PTR>(item), i >= DPA_GetPtrCount(dpaSort));
 
         CoTaskMemFree(MenuString);
     }
@@ -1551,13 +1554,7 @@ HRESULT CMenuSFToolbar::InternalPopupItem(INT iItem, INT index, DWORD_PTR dwData
 
 HRESULT CMenuSFToolbar::InternalHasSubMenu(INT iItem, INT index, DWORD_PTR dwData)
 {
-    HRESULT hr;
     LPCITEMIDLIST pidl = reinterpret_cast<LPITEMIDLIST>(dwData);
-
-    SFGAOF attrs = SFGAO_FOLDER;
-    hr = m_shellFolder->GetAttributesOf(1, &pidl, &attrs);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return hr;
-
-    return (attrs & SFGAO_FOLDER) ? S_OK : S_FALSE;
+    BOOL isPureFolder = GetFolderItemBaseType(m_shellFolder, pidl) == SFGAO_FOLDER;
+    return isPureFolder ? S_OK : S_FALSE;
 }

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -547,7 +547,7 @@ HRESULT SHCoInitializeAnyApartment(VOID)
     return hr;
 }
 
-HRESULT
+EXTERN_C HRESULT
 SHGetNameAndFlagsW(
     _In_ LPCITEMIDLIST pidl,
     _In_ DWORD dwFlags,

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -73,6 +73,8 @@ extern INT    WINAPI FindMRUData(HANDLE hList, LPCVOID lpData, DWORD cbData, LPI
 extern INT    WINAPI EnumMRUListA(HANDLE hList, INT nItemPos, LPVOID lpBuffer, DWORD nBufferSize);
 #endif
 
+EXTERN_C HRESULT SHGetNameAndFlagsW(LPCITEMIDLIST pidl, DWORD Shgdn, LPWSTR pszText, UINT cchBuf, DWORD *pSfgao);
+
 /*************************************************************************
  * ParseFieldA					[internal]
  *
@@ -2641,48 +2643,87 @@ BOOL WINAPI SHGetNewLinkInfoA(LPCSTR pszLinkTo, LPCSTR pszDir, LPSTR pszName, BO
 BOOL WINAPI SHGetNewLinkInfoW(LPCWSTR pszLinkTo, LPCWSTR pszDir, LPWSTR pszName, BOOL *pfMustCopy,
                               UINT uFlags)
 {
-    const WCHAR *basename;
-    WCHAR *dst_basename;
+    enum { HANDLEDFLAGS = SHGNLI_PIDL | SHGNLI_NOUNIQUE | SHGNLI_NOLNK | SHGNLI_NOLOCNAME | SHGNLI_USEURLEXT };
+    const WCHAR *basename, *pszDotForExt = L".", *pszExt = (uFlags & SHGNLI_USEURLEXT) ? L"url" : L"lnk";
+    WCHAR *dst_basename, szTarget[MAX_PATH];
     int i=2;
+    LPCITEMIDLIST pidl = (uFlags & SHGNLI_PIDL) ? (LPCITEMIDLIST)pszLinkTo : NULL;
+    SHFILEINFO fi;
+    BOOL UseDisplayName = FALSE;
+    UINT SHGFIPidlFlag = pidl ? SHGFI_PIDL : 0;
 
     TRACE("(%s, %s, %p, %p, 0x%08x)\n", debugstr_w(pszLinkTo), debugstr_w(pszDir),
           pszName, pfMustCopy, uFlags);
 
+    if (uFlags & ~HANDLEDFLAGS)
+        FIXME("ignoring flags: 0x%08x\n", uFlags & ~HANDLEDFLAGS);
+
     *pfMustCopy = FALSE;
+    fi.dwAttributes = SFGAO_FILESYSTEM | SFGAO_LINK;
+    if (SHGetFileInfoW(pszLinkTo, 0, &fi, sizeof(fi), SHGFI_DISPLAYNAME | SHGFI_ATTRIBUTES | SHGFI_ATTR_SPECIFIED | SHGFIPidlFlag))
+        UseDisplayName = TRUE;
 
-    if (uFlags & SHGNLI_PIDL)
+    if (pidl)
     {
-        FIXME("SHGNLI_PIDL flag unsupported\n");
-        return FALSE;
-    }
+        if (!UseDisplayName)
+            return FALSE;
 
-    if (uFlags)
-        FIXME("ignoring flags: 0x%08x\n", uFlags);
+        pszLinkTo = fi.szDisplayName;
+        UINT shgdn = (uFlags & SHGNLI_NOLOCNAME) ? SHGDN_FORPARSING : SHGDN_NORMAL;
+        if ((fi.dwAttributes & SFGAO_LINK) && SUCCEEDED(SHGetNameAndFlagsW(pidl, shgdn | SHGDN_INFOLDER,
+                                                                           szTarget, _countof(szTarget), NULL)))
+        {
+            lstrcpynW(fi.szDisplayName, szTarget, _countof(fi.szDisplayName)); // Including possible .lnk extension
+        }
+
+        if (SUCCEEDED(SHGetNameAndFlagsW(pidl, SHGDN_FORPARSING, szTarget, _countof(szTarget), NULL)))
+            pszLinkTo = szTarget;
+        else
+            fi.dwAttributes &= ~SFGAO_FILESYSTEM; // We can't validate this PIDL as a path
+    }
+    else if (uFlags & SHGNLI_NOLOCNAME)
+    {
+        UseDisplayName = FALSE;
+    }
 
     /* FIXME: should test if the file is a shortcut or DOS program */
-    if (GetFileAttributesW(pszLinkTo) == INVALID_FILE_ATTRIBUTES)
+    if ((fi.dwAttributes & SFGAO_FILESYSTEM) && GetFileAttributesW(pszLinkTo) == INVALID_FILE_ATTRIBUTES)
         return FALSE;
 
-    basename = strrchrW(pszLinkTo, '\\');
-    if (basename)
-        basename = basename+1;
-    else
-        basename = pszLinkTo;
-
-    lstrcpynW(pszName, pszDir, MAX_PATH);
-    if (!PathAddBackslashW(pszName))
-        return FALSE;
-
-    dst_basename = pszName + strlenW(pszName);
-
-    snprintfW(dst_basename, pszName + MAX_PATH - dst_basename, L"%s.lnk", basename);
-
-    while (GetFileAttributesW(pszName) != INVALID_FILE_ATTRIBUTES)
+    if (fi.dwAttributes & SFGAO_LINK)
     {
-        snprintfW(dst_basename, pszName + MAX_PATH - dst_basename, L"%s (%d).lnk", basename, i);
-        i++;
+        *pfMustCopy = TRUE; // The caller is not supposed to create a .lnk pointing to a .lnk
+
+        // Remove the "inputname.lnk" extension so that the "(%d)" handling can add it back correctly
+        uFlags &= ~SHGNLI_NOLNK;
+        pszExt = PathFindExtensionW(pszLinkTo);
+        pszDotForExt = L"";
+        UseDisplayName = TRUE;
+        if (pszLinkTo != fi.szDisplayName)
+            lstrcpynW(fi.szDisplayName, pszLinkTo, _countof(fi.szDisplayName));
+        if (*pszExt)
+            PathRemoveExtension(fi.szDisplayName);
     }
 
+    if (uFlags & SHGNLI_NOLNK)
+        pszDotForExt = pszExt = L""; // The caller does not want us to append an extension
+
+    basename = PathFindFileNameW(UseDisplayName ? fi.szDisplayName : pszLinkTo);
+    *pszName = UNICODE_NULL;
+    if (!(uFlags & SHGNLI_NOUNIQUE)) // SHGNLI_NOUNIQUE does not prefix the directory
+    {
+        lstrcpynW(pszName, pszDir, MAX_PATH);
+        if (!PathAddBackslashW(pszName))
+            return FALSE;
+    }
+    dst_basename = pszName + strlenW(pszName);
+
+    snprintfW(dst_basename, pszName + MAX_PATH - dst_basename, L"%s%s%s", basename, pszDotForExt, pszExt);
+    while (!(uFlags & SHGNLI_NOUNIQUE) && GetFileAttributesW(pszName) != INVALID_FILE_ATTRIBUTES)
+    {
+        snprintfW(dst_basename, pszName + MAX_PATH - dst_basename, L"%s (%d)%s%s", basename, i, pszDotForExt, pszExt);
+        i++;
+    }
     return TRUE;
 }
 

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -34,6 +34,7 @@
 #include <shlwapi.h>
 #include <commdlg.h>
 #include <commoncontrols.h>
+#include <strsafe.h>
 #include "../shellrecyclebin/recyclebin.h"
 
 #include <wine/debug.h>
@@ -2673,7 +2674,7 @@ BOOL WINAPI SHGetNewLinkInfoW(LPCWSTR pszLinkTo, LPCWSTR pszDir, LPWSTR pszName,
         if ((fi.dwAttributes & SFGAO_LINK) && SUCCEEDED(SHGetNameAndFlagsW(pidl, shgdn | SHGDN_INFOLDER,
                                                                            szTarget, _countof(szTarget), NULL)))
         {
-            lstrcpynW(fi.szDisplayName, szTarget, _countof(fi.szDisplayName)); // Including possible .lnk extension
+            StringCchCopyW(fi.szDisplayName, _countof(fi.szDisplayName), szTarget); // Including possible .lnk extension
         }
 
         if (SUCCEEDED(SHGetNameAndFlagsW(pidl, SHGDN_FORPARSING, szTarget, _countof(szTarget), NULL)))
@@ -2700,7 +2701,7 @@ BOOL WINAPI SHGetNewLinkInfoW(LPCWSTR pszLinkTo, LPCWSTR pszDir, LPWSTR pszName,
         pszDotForExt = L"";
         UseDisplayName = TRUE;
         if (pszLinkTo != fi.szDisplayName)
-            lstrcpynW(fi.szDisplayName, pszLinkTo, _countof(fi.szDisplayName));
+            StringCchCopyW(fi.szDisplayName, _countof(fi.szDisplayName), pszLinkTo);
         if (*pszExt)
             PathRemoveExtension(fi.szDisplayName);
     }
@@ -2712,7 +2713,7 @@ BOOL WINAPI SHGetNewLinkInfoW(LPCWSTR pszLinkTo, LPCWSTR pszDir, LPWSTR pszName,
     *pszName = UNICODE_NULL;
     if (!(uFlags & SHGNLI_NOUNIQUE)) // SHGNLI_NOUNIQUE does not prefix the directory
     {
-        lstrcpynW(pszName, pszDir, MAX_PATH);
+        StringCchCopyW(pszName, MAX_PATH, pszDir);
         if (!PathAddBackslashW(pszName))
             return FALSE;
     }

--- a/modules/rostests/apitests/shell32/CShellLink.cpp
+++ b/modules/rostests/apitests/shell32/CShellLink.cpp
@@ -10,6 +10,8 @@
 #define NDEBUG
 #include <debug.h>
 #include <stdio.h>
+#include <shellapi.h>
+#include <versionhelpers.h>
 #include <shellutils.h>
 
 /* Test IShellLink::SetPath with environment-variables, existing, non-existing, ...*/
@@ -473,11 +475,58 @@ TestIconLocation(void)
 
 START_TEST(CShellLink)
 {
-    CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+    CCoInit ComInit;
 
     TestShellLink();
     TestDescription();
     TestIconLocation();
+}
 
-    CoUninitialize();
+START_TEST(SHGetNewLinkInfo)
+{
+    CCoInit ComInit;
+    LPCWSTR DotUrlOn7 = IsReactOS() || GetNTVersion() >= _WIN32_WINNT_WIN7 ? L".url" : L".lnk";
+    WCHAR FullTarget[MAX_PATH], Dir[MAX_PATH];
+
+    SHGetSpecialFolderPathW(NULL, Dir, CSIDL_PROFILE, TRUE);
+
+    GetModuleFileNameW(GetModuleHandleW(L"KERNEL32"), FullTarget, _countof(FullTarget));
+    LPWSTR TargetFile = PathFindFileNameW(FullTarget);
+
+    #define Test_SHGNLI(path, dir, rdir, rfile, rext, flags, ret, mustcopy) do \
+    { \
+        WCHAR Result[MAX_PATH], Buf[MAX_PATH]; \
+        BOOL MustCopy, Success = SHGetNewLinkInfoW((path), (dir), lstrcpyW(Result, L"?"), &MustCopy, (flags)); \
+        ok(Success == (ret), "Return (%#x)\n", UINT(flags)); \
+        ok(MustCopy == (mustcopy), "MustCopy (%#x)\n", UINT(flags)); \
+        lstrcpyW(Buf, (rdir)); \
+        if (*Buf) PathAddBackslashW(Buf); \
+        lstrcatW(Buf, (rfile)); \
+        lstrcatW(Buf, (rext)); \
+        ok((!(ret) && !Success) || !_wcsicmp(Result, Buf), "%ls should be %ls (%#x)\n", Result, Buf, UINT(flags)); \
+    } while(0)
+
+    Test_SHGNLI(FullTarget, Dir, Dir, TargetFile, L".lnk", 0, 1, 0);
+
+    CComHeapPtr<ITEMIDLIST> pidl(SHELL_SimpleIDListFromPath(FullTarget));
+    Test_SHGNLI((LPWSTR)(LPITEMIDLIST)pidl, Dir, Dir, TargetFile, L".lnk", SHGNLI_PIDL, 1, 0);
+
+    Test_SHGNLI(FullTarget, Dir, L"", TargetFile, L".lnk", SHGNLI_NOUNIQUE, 1, 0);
+
+    Test_SHGNLI(FullTarget, Dir, Dir, TargetFile, L"", SHGNLI_NOLNK, 1, 0);
+    Test_SHGNLI(FullTarget, Dir, L"", TargetFile, L"", SHGNLI_NOLNK | SHGNLI_NOUNIQUE, 1, 0);
+    Test_SHGNLI(FullTarget, Dir, Dir, TargetFile, L"", SHGNLI_NOLNK | SHGNLI_USEURLEXT, 1, 0);
+
+    Test_SHGNLI(FullTarget, Dir, Dir, TargetFile, DotUrlOn7, SHGNLI_USEURLEXT, 1, 0);
+
+    PathRemoveExtensionW(FullTarget);
+    Test_SHGNLI(FullTarget, Dir, L"", L"", L"", 0, 0, 0); // Target does not exist
+
+    #define SHGNLIFileName L"ROS_Test_Shell32"
+    PathAppendW(lstrcpyW(FullTarget, Dir), SHGNLIFileName L".lnk");
+    CloseHandle(CreateFileW(FullTarget, 0, 7, NULL, OPEN_ALWAYS, 0, NULL));
+    Test_SHGNLI(FullTarget, Dir, Dir, SHGNLIFileName L" (2)", L".lnk", 0, 1, 1);
+    Test_SHGNLI(FullTarget, Dir, L"", SHGNLIFileName, L".lnk", SHGNLI_NOUNIQUE, 1, 1);
+    Test_SHGNLI(FullTarget, Dir, Dir, SHGNLIFileName L" (2)", L".lnk", SHGNLI_NOLNK, 1, 1); // SFGAO_LINK ignores SHGNLI_NOLNK
+    DeleteFileW(FullTarget);
 }

--- a/modules/rostests/apitests/shell32/shelltest.cpp
+++ b/modules/rostests/apitests/shell32/shelltest.cpp
@@ -79,7 +79,7 @@ CreateFileSysBindCtx(_Outptr_ IBindCtx **ppbc)
     return hr;
 }
 
-VOID
+HRESULT
 PathToIDList(LPCWSTR pszPath, ITEMIDLIST** ppidl)
 {
     CComPtr<IBindCtx> spbc;
@@ -90,6 +90,7 @@ PathToIDList(LPCWSTR pszPath, ITEMIDLIST** ppidl)
         hr = SHParseDisplayName(pszPath, spbc, ppidl, 0, NULL);
         ok(hr == S_OK, "hr = %lx\n", hr);
     }
+    return hr;
 }
 
 // - Adapted from https://devblogs.microsoft.com/oldnewthing/20130503-00/?p=4463

--- a/modules/rostests/apitests/shell32/shelltest.h
+++ b/modules/rostests/apitests/shell32/shelltest.h
@@ -17,6 +17,13 @@
 // Vista's shell32 is buggy so we need to skip some tests there.
 static const BOOL g_bVista = (GetNTVersion() == _WIN32_WINNT_VISTA);
 
-VOID PathToIDList(LPCWSTR pszPath, ITEMIDLIST** ppidl);
+HRESULT PathToIDList(LPCWSTR pszPath, ITEMIDLIST** ppidl);
+
+static inline LPITEMIDLIST SHELL_SimpleIDListFromPath(LPCWSTR pszPath)
+{
+    ITEMIDLIST *pidl = NULL;
+    HRESULT hr = PathToIDList(pszPath, &pidl);
+    return SUCCEEDED(hr) ? pidl : NULL;
+}
 
 #endif /* !_SHELLTEST_H_ */

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -51,6 +51,7 @@ extern void func_ShellState(void);
 extern void func_SHGetAttributesFromDataObject(void);
 extern void func_SHGetComputerDisplayNameW(void);
 extern void func_SHGetFileInfo(void);
+extern void func_SHGetNewLinkInfo(void);
 extern void func_SHGetUnreadMailCountW(void);
 extern void func_SHGetUserDisplayName(void);
 extern void func_SHIsBadInterfacePtr(void);
@@ -113,6 +114,7 @@ const struct test winetest_testlist[] =
     { "SHGetAttributesFromDataObject", func_SHGetAttributesFromDataObject },
     { "SHGetComputerDisplayNameW", func_SHGetComputerDisplayNameW },
     { "SHGetFileInfo", func_SHGetFileInfo },
+    { "SHGetNewLinkInfo", func_SHGetNewLinkInfo },
     { "SHGetUnreadMailCountW", func_SHGetUnreadMailCountW },
     { "SHGetUserDisplayName", func_SHGetUserDisplayName },
     { "SHIsBadInterfacePtr", func_SHIsBadInterfacePtr },

--- a/sdk/include/psdk/shellapi.h
+++ b/sdk/include/psdk/shellapi.h
@@ -414,11 +414,6 @@ typedef struct _SHNAMEMAPPINGW {
  * Links
  */
 
-#define SHGNLI_PIDL        0x01
-#define SHGNLI_PREFIXNAME  0x02
-#define SHGNLI_NOUNIQUE    0x04
-#define SHGNLI_NOLNK       0x08
-
 LPWSTR * WINAPI CommandLineToArgvW(_In_ LPCWSTR, _Out_ int*);
 void WINAPI DragAcceptFiles(_In_ HWND, _In_ BOOL);
 void WINAPI DragFinish(_In_ HDROP);
@@ -602,6 +597,12 @@ SHGetFileInfoW(
   UINT cbFileInfo,
   UINT uFlags);
 
+#define SHGNLI_PIDL        0x01
+#define SHGNLI_PREFIXNAME  0x02
+#define SHGNLI_NOUNIQUE    0x04
+#define SHGNLI_NOLNK       0x08
+#define SHGNLI_NOLOCNAME   0x10 // WinVista+
+#define SHGNLI_USEURLEXT   0x20 // Win7+
 _Success_(return != 0)
 BOOL
 WINAPI

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -723,8 +723,65 @@ static inline PCUIDLIST_RELATIVE HIDA_GetPIDLItem(CIDA const* pida, SIZE_T i)
     return (PCUIDLIST_RELATIVE)(((LPBYTE)pida) + (pida)->aoffset[i + 1]);
 }
 
+static inline SFGAOF SHELL_GetAttributesOf(IShellFolder *psf, LPCITEMIDLIST pidlChild, SFGAOF query)
+{
+    SFGAOF attr = query;
+#ifdef __cplusplus
+    HRESULT hr = psf ? psf->GetAttributesOf(1, &pidlChild, &attr) : E_INVALIDARG;
+#else
+    HRESULT hr = psf ? psf->lpVtbl->GetAttributesOf(psf, 1, &pidlChild, &attr) : E_INVALIDARG;
+#endif
+    return SUCCEEDED(hr) ? (attr & query) : 0;
+}
+
+static inline SFGAOF SHELL_GetAttributesOfAbsolute(PCIDLIST_ABSOLUTE pidl, SFGAOF query)
+{
+    IShellFolder *psf;
+    PCUITEMID_CHILD pidlChild;
+    HRESULT hr = SHBindToParent(pidl, IID_PPV_ARG(IShellFolder, &psf), &pidlChild);
+    if (SUCCEEDED(hr))
+    {
+        SFGAOF attrib = SHELL_GetAttributesOf(psf, pidlChild, query);
+#ifdef __cplusplus
+        psf->Release();
+#else
+        psf->lpVtbl->Release(psf);
+#endif
+        return attrib;
+    }
+    return 0;
+}
+
+#if defined(_INC_SHLWAPI) || defined(_SHLWAPI_)
+static inline HRESULT SHELL_GetDisplayNameOf(IShellFolder *psf, LPCITEMIDLIST pidlChild, SHGDNF Flags, PWSTR *ppStr)
+{
+    STRRET strret;
+#ifdef __cplusplus
+    HRESULT hr = psf->GetDisplayNameOf(pidlChild, Flags, &strret);
+#else
+    HRESULT hr = psf->lpVtbl->GetDisplayNameOf(psf, pidlChild, Flags, &strret);
+#endif
+    *ppStr = NULL;
+    return FAILED_UNEXPECTEDLY(hr) ? hr : StrRetToStrW(&strret, NULL, ppStr);
+}
+
+static inline HRESULT SHELL_GetAbsolutePidl(IShellFolder *psf, LPCITEMIDLIST pidlChild, PIDLIST_ABSOLUTE *ppidl)
+{
+    PWSTR path = NULL;
+    HRESULT hr = SHELL_GetDisplayNameOf(psf, pidlChild, SHGDN_FORPARSING, &path);
+    if (SUCCEEDED(hr))
+        hr = SHParseDisplayName(path, NULL, ppidl, 0, NULL);
+    CoTaskMemFree(path);
+    return hr;
+}
+#endif // _INC_SHLWAPI
 
 #ifdef __cplusplus
+
+static inline SFGAOF SHELL_GetAttributesOf(PCIDLIST_ABSOLUTE pidl, SFGAOF query) // C++ Overload
+{
+    return SHELL_GetAttributesOfAbsolute(pidl, query);
+}
 
 #if defined(CMIC_MASK_UNICODE) && defined(SEE_MASK_UNICODE)
 static inline bool IsUnicode(const CMINVOKECOMMANDINFOEX &ici)


### PR DESCRIPTION
- Browses favorite folders in-place (like Windows)
- Fixes the issue where .cab/.zip are treated as folders ([CORE-20077](https://jira.reactos.org/browse/CORE-20077))
- Added a simple favorite location selection dialog
- Adds support for more `SHGetNewLinkInfo` flags (40 new tests, all passing on ROS, XP, 8 and 10)

The favorite dialog just uses `SHBrowseForFolder` because we lack a real implementation of [`INameSpaceTreeControl`](https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-inamespacetreecontrol) and writing the tree code manually is not worth it just to duplicate the dialog.

Windows:
<img width="424" height="210" alt="XP" src="https://github.com/user-attachments/assets/e5d9c8c9-ca21-4482-9f7c-52fa2d82d58a" />
ROS:
<img width="332" height="376" alt="ROS" src="https://github.com/user-attachments/assets/cd779723-3132-405a-b659-7174c98f6963" />

Notes:
- Our shell32 does not have enough support for "internet PIDLs" for `SHGetNewLinkInfo` to generate names for URLs, the name from the user is used directly for now.
- On Windows, `AddUrlToFavorites` uses `shlwapi::SHGetNewLinkInfoWrapW` which forwards to `shell32::SHGetNewLinkInfoW` but this is just Unicode compatibility for IE4/5 on Win9x and we don't have that function in a public header so I did not replicate this redirection.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: