### PR TITLE
[NTOS:KE][KMTEST] Implement *ForDpc SpinLock functions

### DIFF
--- a/modules/rostests/kmtests/ntos_ke/KeSpinLock.c
+++ b/modules/rostests/kmtests/ntos_ke/KeSpinLock.c
@@ -236,10 +236,9 @@ BOOLEAN TryNoRaise(PKSPIN_LOCK SpinLock, PCHECK_DATA CheckData) {
                                                                                     \
     if ((CheckData)->IsAcquired)                                                    \
     {                                                                               \
-        if ((CheckData)->SelfRaisingIrql)                                           \
-            ExpectedIrql = (CheckData)->SelfRaisingIrql                             \
-            ? max((CheckData)->OriginalIrql, DISPATCH_LEVEL)                        \
-            : (CheckData)->IrqlWhenAcquired;                                        \
+        ExpectedIrql = (CheckData)->SelfRaisingIrql                                 \
+                        ? max((CheckData)->OriginalIrql, DISPATCH_LEVEL)            \
+                        : (CheckData)->IrqlWhenAcquired;                            \
         else                                                                        \
             ExpectedIrql = (CheckData)->IrqlWhenAcquired;                           \
     }                                                                               \

--- a/modules/rostests/kmtests/ntos_ke/KeSpinLock.c
+++ b/modules/rostests/kmtests/ntos_ke/KeSpinLock.c
@@ -239,8 +239,10 @@ BOOLEAN TryNoRaise(PKSPIN_LOCK SpinLock, PCHECK_DATA CheckData) {
         ExpectedIrql = (CheckData)->SelfRaisingIrql                                 \
                         ? max((CheckData)->OriginalIrql, DISPATCH_LEVEL)            \
                         : (CheckData)->IrqlWhenAcquired;                            \
-        else                                                                        \
-            ExpectedIrql = (CheckData)->IrqlWhenAcquired;                           \
+    }                                                                               \
+    else                                                                            \
+    {                                                                               \
+        ExpectedIrql = (CheckData)->IrqlWhenAcquired;                               \
     }                                                                               \
     if (GetNTVersion() < _WIN32_WINNT_WIN8)                                         \
         ok_irql(ExpectedIrql);                                                      \

--- a/modules/rostests/kmtests/ntos_ke/KeSpinLock.c
+++ b/modules/rostests/kmtests/ntos_ke/KeSpinLock.c
@@ -235,15 +235,9 @@ BOOLEAN TryNoRaise(PKSPIN_LOCK SpinLock, PCHECK_DATA CheckData) {
     }                                                                               \
                                                                                     \
     if ((CheckData)->IsAcquired)                                                    \
-    {                                                                               \
         ExpectedIrql = (CheckData)->SelfRaisingIrql                                 \
                         ? max((CheckData)->OriginalIrql, DISPATCH_LEVEL)            \
                         : (CheckData)->IrqlWhenAcquired;                            \
-    }                                                                               \
-    else                                                                            \
-    {                                                                               \
-        ExpectedIrql = (CheckData)->IrqlWhenAcquired;                               \
-    }                                                                               \
     if (GetNTVersion() < _WIN32_WINNT_WIN8)                                         \
         ok_irql(ExpectedIrql);                                                      \
     if (GetNTVersion() == _WIN32_WINNT_WS03)                                        \

--- a/modules/rostests/kmtests/ntos_ke/KeSpinLock.c
+++ b/modules/rostests/kmtests/ntos_ke/KeSpinLock.c
@@ -87,6 +87,7 @@ struct _CHECK_DATA
         KIRQL Irql;
     } DUMMYUNIONNAME;
     PVOID UntouchedValue;
+    BOOLEAN SelfRaisingIrql;
 };
 
 #define DEFINE_ACQUIRE(LocalName, SetIsAcquired, DoCall)            \
@@ -131,11 +132,8 @@ DEFINE_RELEASE(ReleaseExpNoLower,     FALSE, (KeReleaseSpinLockFromDpcLevel)(Spi
 DEFINE_ACQUIRE(AcquireInStackNoRaise, FALSE, KeAcquireInStackQueuedSpinLockAtDpcLevel(SpinLock, &CheckData->QueueHandle))
 DEFINE_RELEASE(ReleaseInStackNoRaise, FALSE, KeReleaseInStackQueuedSpinLockFromDpcLevel(&CheckData->QueueHandle))
 
-/* TODO: test these functions. They behave weirdly, though */
-#if 0
 DEFINE_ACQUIRE(AcquireForDpc,         TRUE,  CheckData->Irql = KeAcquireSpinLockForDpc(SpinLock))
 DEFINE_RELEASE(ReleaseForDpc,         TRUE,  KeReleaseSpinLockForDpc(SpinLock, CheckData->Irql))
-#endif
 
 DEFINE_ACQUIRE(AcquireInStackForDpc,  FALSE, pKeAcquireInStackQueuedSpinLockForDpc(SpinLock, &CheckData->QueueHandle))
 DEFINE_RELEASE(ReleaseInStackForDpc,  FALSE, pKeReleaseInStackQueuedSpinLockForDpc(&CheckData->QueueHandle))
@@ -237,7 +235,14 @@ BOOLEAN TryNoRaise(PKSPIN_LOCK SpinLock, PCHECK_DATA CheckData) {
     }                                                                               \
                                                                                     \
     if ((CheckData)->IsAcquired)                                                    \
-        ExpectedIrql = (CheckData)->IrqlWhenAcquired;                               \
+    {                                                                               \
+        if ((CheckData)->SelfRaisingIrql)                                           \
+            ExpectedIrql = (CheckData)->SelfRaisingIrql                             \
+            ? max((CheckData)->OriginalIrql, DISPATCH_LEVEL)                        \
+            : (CheckData)->IrqlWhenAcquired;                                        \
+        else                                                                        \
+            ExpectedIrql = (CheckData)->IrqlWhenAcquired;                           \
+    }                                                                               \
     if (GetNTVersion() < _WIN32_WINNT_WIN8)                                         \
         ok_irql(ExpectedIrql);                                                      \
     if (GetNTVersion() == _WIN32_WINNT_WS03)                                        \
@@ -373,8 +378,7 @@ START_TEST(KeSpinLock)
     {
         { CheckLock,        DISPATCH_LEVEL, AcquireNormal,        ReleaseNormal,        NULL,           AcquireNoRaise,        ReleaseNoLower,        TryNoRaise },
         { CheckLock,        DISPATCH_LEVEL, AcquireExp,           ReleaseExp,           NULL,           AcquireExpNoRaise,     ReleaseExpNoLower,     NULL },
-        /* TODO: this one is just weird!
-        { CheckLock,        DISPATCH_LEVEL, AcquireNormal,        ReleaseNormal,        NULL,           AcquireForDpc,         ReleaseForDpc,         NULL },*/
+        { CheckLock,        DISPATCH_LEVEL, AcquireNormal,        ReleaseNormal,        NULL,           AcquireForDpc,         ReleaseForDpc,         NULL, .SelfRaisingIrql = TRUE },
         { CheckLock,        DISPATCH_LEVEL, AcquireNormal,        ReleaseNormal,        NULL,           AcquireInt,            ReleaseInt,            NULL },
         { CheckLock,        SynchIrql,      AcquireSynch,         ReleaseNormal,        NULL,           NULL,                  NULL,                  NULL },
         { CheckQueueHandle, DISPATCH_LEVEL, AcquireInStackQueued, ReleaseInStackQueued, NULL,           AcquireInStackNoRaise, ReleaseInStackNoRaise, NULL },
@@ -387,6 +391,7 @@ START_TEST(KeSpinLock)
     {
         { CheckLock,        DISPATCH_LEVEL, AcquireNormal,        ReleaseNormal,        NULL,           AcquireNoRaise,        ReleaseNoLower,        TryNoRaise },
         { CheckLock,        DISPATCH_LEVEL, AcquireExp,           ReleaseExp,           NULL,           AcquireExpNoRaise,     ReleaseExpNoLower,     NULL },
+        { CheckLock,        DISPATCH_LEVEL, AcquireNormal,        ReleaseNormal,        NULL,           AcquireForDpc,         ReleaseForDpc,         NULL, .SelfRaisingIrql = TRUE },
         { CheckLock,        DISPATCH_LEVEL, AcquireNormal,        ReleaseNormal,        NULL,           AcquireInt,            ReleaseInt,            NULL },
         { CheckLock,        SynchIrql,      AcquireSynch,         ReleaseNormal,        NULL,           NULL,                  NULL,                  NULL },
         { CheckQueueHandle, DISPATCH_LEVEL, AcquireInStackQueued, ReleaseInStackQueued, NULL,           AcquireInStackNoRaise, ReleaseInStackNoRaise, NULL },

--- a/ntoskrnl/ke/spinlock.c
+++ b/ntoskrnl/ke/spinlock.c
@@ -463,8 +463,9 @@ KeAcquireSpinLockForDpc(
  **/
 VOID
 FASTCALL
-KeReleaseSpinLockForDpc(_Inout_ PKSPIN_LOCK SpinLock,
-                        _In_ _IRQL_restores_ KIRQL OldIrql)
+KeReleaseSpinLockForDpc(
+    _Inout_ PKSPIN_LOCK SpinLock,
+    _In_ _IRQL_restores_ KIRQL OldIrql)
 {
     KxReleaseSpinLock(SpinLock);
 

--- a/ntoskrnl/ke/spinlock.c
+++ b/ntoskrnl/ke/spinlock.c
@@ -446,18 +446,20 @@ KeAcquireSpinLockForDpc(_Inout_ PKSPIN_LOCK SpinLock)
     return OldIrql;
 }
 
-/*************************************************************************
- *                KeReleaseSpinLockForDpc
+/**
+ * @brief
+ * Releases a spin lock previously acquired at DPC level,
+ * and restores the original IRQL.
  *
  * @param[in,out] SpinLock
- * Pointer to the spin lock acquired by KeAcquireSpinLockForDpc
+ * Pointer to the spin lock acquired by KeAcquireSpinLockForDpc().
  *
  * @param[in] OldIrql
- * The IRQL value returned by KeAcquireSpinLockForDpc
+ * The IRQL value returned by KeAcquireSpinLockForDpc().
  *
  * @return
  * None
- */
+ **/
 VOID
 FASTCALL
 KeReleaseSpinLockForDpc(_Inout_ PKSPIN_LOCK SpinLock,

--- a/ntoskrnl/ke/spinlock.c
+++ b/ntoskrnl/ke/spinlock.c
@@ -443,7 +443,6 @@ KeAcquireSpinLockForDpc(
     }
 
     KxAcquireSpinLock(SpinLock);
-
     return OldIrql;
 }
 

--- a/ntoskrnl/ke/spinlock.c
+++ b/ntoskrnl/ke/spinlock.c
@@ -416,26 +416,63 @@ KeReleaseInStackQueuedSpinLockFromDpcLevel(IN PKLOCK_QUEUE_HANDLE LockHandle)
     KxReleaseSpinLock(LockHandle->LockQueue.Lock); // HACK
 }
 
-/*
- * @unimplemented
+/*************************************************************************
+ *                KeAcquireSpinLockForDpc
+ *
+ * @param[in,out] SpinLock
+ * Pointer to an initialized spin lock
+ *
+ * @return
+ * The IRQL at the time this routine was called, to be restored via
+ * KeReleaseSpinLockForDpc
  */
 KIRQL
 FASTCALL
-KeAcquireSpinLockForDpc(IN PKSPIN_LOCK SpinLock)
+KeAcquireSpinLockForDpc(_Inout_ PKSPIN_LOCK SpinLock)
 {
-    UNIMPLEMENTED;
-    return 0;
+    KIRQL OldIrql;
+
+    OldIrql = KeGetCurrentIrql();
+
+    if (OldIrql < DISPATCH_LEVEL)
+    {
+        /* Raise to DPC level and acquire normally */
+        KeRaiseIrql(DISPATCH_LEVEL, &OldIrql);
+        KxAcquireSpinLock(SpinLock);
+    }
+    else
+    {
+        /* Already at DPC level or above, just grab the lock */
+        KxAcquireSpinLock(SpinLock);
+    }
+
+    return OldIrql;
 }
 
-/*
- * @unimplemented
+/*************************************************************************
+ *                KeReleaseSpinLockForDpc
+ *
+ * @param[in,out] SpinLock
+ * Pointer to the spin lock acquired by KeAcquireSpinLockForDpc
+ *
+ * @param[in] OldIrql
+ * The IRQL value returned by KeAcquireSpinLockForDpc
+ *
+ * @return
+ * None
  */
 VOID
 FASTCALL
-KeReleaseSpinLockForDpc(IN PKSPIN_LOCK SpinLock,
-                        IN KIRQL OldIrql)
+KeReleaseSpinLockForDpc(_Inout_ PKSPIN_LOCK SpinLock,
+                        _In_ _IRQL_restores_ KIRQL OldIrql)
 {
-    UNIMPLEMENTED;
+    KxReleaseSpinLock(SpinLock);
+
+    if (OldIrql < DISPATCH_LEVEL)
+    {
+        /* We had raised IRQL, lower it back down */
+        KeLowerIrql(OldIrql);
+    }
 }
 
 /*

--- a/ntoskrnl/ke/spinlock.c
+++ b/ntoskrnl/ke/spinlock.c
@@ -429,7 +429,8 @@ KeReleaseInStackQueuedSpinLockFromDpcLevel(IN PKLOCK_QUEUE_HANDLE LockHandle)
  **/
 KIRQL
 FASTCALL
-KeAcquireSpinLockForDpc(_Inout_ PKSPIN_LOCK SpinLock)
+KeAcquireSpinLockForDpc(
+    _Inout_ PKSPIN_LOCK SpinLock)
 {
     KIRQL OldIrql;
 

--- a/ntoskrnl/ke/spinlock.c
+++ b/ntoskrnl/ke/spinlock.c
@@ -434,17 +434,13 @@ KeAcquireSpinLockForDpc(_Inout_ PKSPIN_LOCK SpinLock)
 
     OldIrql = KeGetCurrentIrql();
 
+    /* Only raise if we're not already at DPC level or above */
     if (OldIrql < DISPATCH_LEVEL)
     {
-        /* Raise to DPC level and acquire normally */
         KeRaiseIrql(DISPATCH_LEVEL, &OldIrql);
-        KxAcquireSpinLock(SpinLock);
     }
-    else
-    {
-        /* Already at DPC level or above, just grab the lock */
-        KxAcquireSpinLock(SpinLock);
-    }
+
+    KxAcquireSpinLock(SpinLock);
 
     return OldIrql;
 }

--- a/ntoskrnl/ke/spinlock.c
+++ b/ntoskrnl/ke/spinlock.c
@@ -416,16 +416,17 @@ KeReleaseInStackQueuedSpinLockFromDpcLevel(IN PKLOCK_QUEUE_HANDLE LockHandle)
     KxReleaseSpinLock(LockHandle->LockQueue.Lock); // HACK
 }
 
-/*************************************************************************
- *                KeAcquireSpinLockForDpc
+/**
+ * @brief
+ * Acquires the specified spin lock at DPC level.
  *
  * @param[in,out] SpinLock
- * Pointer to an initialized spin lock
+ * Pointer to an initialized spin lock.
  *
  * @return
  * The IRQL at the time this routine was called, to be restored via
- * KeReleaseSpinLockForDpc
- */
+ * KeReleaseSpinLockForDpc().
+ **/
 KIRQL
 FASTCALL
 KeAcquireSpinLockForDpc(_Inout_ PKSPIN_LOCK SpinLock)

--- a/sdk/lib/3rdparty/freetype/CMakeLists.txt
+++ b/sdk/lib/3rdparty/freetype/CMakeLists.txt
@@ -54,5 +54,5 @@ if(CMAKE_C_COMPILER_ID STREQUAL "MSVC" AND (ARCH STREQUAL "amd64" OR ARCH STREQU
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(freetype PRIVATE -fno-builtin-malloc)
+    target_compile_options(freetype PRIVATE -fno-builtin-malloc -Wno-array-parameter)
 endif()

--- a/sdk/lib/3rdparty/freetype/CMakeLists.txt
+++ b/sdk/lib/3rdparty/freetype/CMakeLists.txt
@@ -54,5 +54,5 @@ if(CMAKE_C_COMPILER_ID STREQUAL "MSVC" AND (ARCH STREQUAL "amd64" OR ARCH STREQU
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(freetype PRIVATE -fno-builtin-malloc -Wno-array-parameter)
+    target_compile_options(freetype PRIVATE -fno-builtin-malloc)
 endif()


### PR DESCRIPTION
## Purpose

Implement both `KeAcquireSpinLockForDpc` and `KeReleaseSpinLockForDpc`. Also uncomment their entries so they're testable.

JIRA issue: None

## Proposed changes
- Implement `KeAcquireSpinLockForDpc` and `KeReleaseSpinLockForDpc` in `spinlock.c`
- Add Doxygen documentation for them.
- Add a new field to the test's `_CHECK_DATA`
- Uncomment their DEFINEs in the test, and update `IsAcquired` check in `CheckSpinLock` to account for the new field (`SelfRaisingIrql`)
- Add their entries for the WS03 and the Win7 test data

AcquireForDpc and ReleaseForDpc are runs 8-11.
<img width="637" height="391" alt="image" src="https://github.com/user-attachments/assets/9abfe8ac-abd2-4c1d-9429-a6cbee54d3ab" />


## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: