### PR TITLE
[NTOS:KE] Implement KeIsWaitListEmpty

### DIFF
--- a/ntoskrnl/ke/wait.c
+++ b/ntoskrnl/ke/wait.c
@@ -290,7 +290,7 @@ KeIsWaitListEmpty(_In_ PVOID Object)
     /* Check if the object's wait list is empty */
     ListEmpty = IsListEmpty(&Header->WaitListHead);
 
-    /* Release the lock and release the result */
+    /* Release the lock and return the result */
     KiReleaseDispatcherLock(OldIrql);
     return ListEmpty;
 }

--- a/ntoskrnl/ke/wait.c
+++ b/ntoskrnl/ke/wait.c
@@ -267,15 +267,17 @@ Quickie:
 
 /* PUBLIC FUNCTIONS **********************************************************/
 
-/*************************************************************************
- *                KeIsWaitListEmpty
+/**
+ * @brief
+ * Determines whether there are waiters waiting on the specified
+ * dispatcher object.
  *
  * @param[in] Object
  * Pointer to a dispatcher object.
  *
  * @return
  * TRUE if no thread is currently waiting on the object, FALSE otherwise.
- */
+ **/
 BOOLEAN
 NTAPI
 KeIsWaitListEmpty(

--- a/ntoskrnl/ke/wait.c
+++ b/ntoskrnl/ke/wait.c
@@ -267,12 +267,32 @@ Quickie:
 
 /* PUBLIC FUNCTIONS **********************************************************/
 
+/*************************************************************************
+ *                KeIsWaitListEmpty
+ *
+ * @param[in] Object
+ * Pointer to a dispatcher object.
+ *
+ * @return
+ * TRUE if no thread is currently waiting on the object, FALSE otherwise.
+ */
 BOOLEAN
 NTAPI
-KeIsWaitListEmpty(IN PVOID Object)
+KeIsWaitListEmpty(_In_ PVOID Object)
 {
-    UNIMPLEMENTED;
-    return FALSE;
+    KIRQL OldIrql;
+    BOOLEAN ListEmpty;
+    PDISPATCHER_HEADER Header = Object;
+
+    /* Lock the dispatcher database */
+    OldIrql = KiAcquireDispatcherLock();
+
+    /* Check if the object's wait list is empty */
+    ListEmpty = IsListEmpty(&Header->WaitListHead);
+
+    /* Release the lock and release the result */
+    KiReleaseDispatcherLock(OldIrql);
+    return ListEmpty;
 }
 
 /*

--- a/ntoskrnl/ke/wait.c
+++ b/ntoskrnl/ke/wait.c
@@ -278,7 +278,8 @@ Quickie:
  */
 BOOLEAN
 NTAPI
-KeIsWaitListEmpty(_In_ PVOID Object)
+KeIsWaitListEmpty(
+    _In_ PVOID Object)
 {
     KIRQL OldIrql;
     BOOLEAN ListEmpty;


### PR DESCRIPTION
## Purpose

Implement KeIsWaitListEmpty.

NOTE: I didn't do a test intentionally. I think this function is small enough that it doesn't need one. Tell me if you want me to make a test for it.

JIRA issue: None

## Proposed changes
- Implement `KeIsWaitListEmpty` in `wait.c`
- Add Doxygen documentation for it
- Change its annotation to SAL2.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: