### PR TITLE
[NTFS][BOOT] Fix NTFS write support with old driver

### DIFF
--- a/boot/bootdata/hivesys.inf
+++ b/boot/bootdata/hivesys.inf
@@ -1770,7 +1770,7 @@ HKLM,"SYSTEM\CurrentControlSet\Services\Ntfs","ImagePath",0x00020000,"system32\d
 HKLM,"SYSTEM\CurrentControlSet\Services\Ntfs","Start",0x00010001,0x00000003
 HKLM,"SYSTEM\CurrentControlSet\Services\Ntfs","Type",0x00010001,0x00000002
 ; un-comment the line below to enable EXPERIMENTAL write-support on NTFS volumes:
-;HKLM,"SYSTEM\CurrentControlSet\Services\Ntfs","MyDataDoesNotMatterSoEnableExperimentalWriteSupportForEveryNTFSVolume",0x00010001,0x00000001
+HKLM,"SYSTEM\CurrentControlSet\Services\Ntfs","MyDataDoesNotMatterSoEnableExperimentalWriteSupportForEveryNTFSVolume",0x00010001,0x00000001
 
 ; Null device driver
 HKLM,"SYSTEM\CurrentControlSet\Services\Null","ErrorControl",0x00010001,0x00000000

--- a/drivers/filesystems/ntfs/CMakeLists.txt
+++ b/drivers/filesystems/ntfs/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND SOURCE
     dirctl.c
     dispatch.c
     fastio.c
+    flush.c
     fcb.c
     finfo.c
     fsctl.c

--- a/drivers/filesystems/ntfs/attrib.c
+++ b/drivers/filesystems/ntfs/attrib.c
@@ -34,6 +34,10 @@
 #define NDEBUG
 #include <debug.h>
 
+/* Set to 1 to dump each data run list as it is encoded. Uses DbgPrint, so it
+ * prints whatever NDEBUG is set to. */
+#define NTFS_DUMP_DATA_RUNS 0
+
 /* FUNCTIONS ****************************************************************/
 
 /**
@@ -268,22 +272,13 @@ AddFileName(PFILE_RECORD_HEADER FileRecord,
         FileNameAttribute->FileAttributes = NTFS_FILE_TYPE_ARCHIVE;
 
     // we need to extract the filename from the path
-    DPRINT1("Pathname: %wZ\n", &FileObject->FileName);
+    DPRINT("Pathname: %wZ\n", &FileObject->FileName);
 
     FsRtlDissectName(FileObject->FileName, &Current, &Remaining);
 
-    FilenameNoPath.Buffer = Current.Buffer;
-    FilenameNoPath.MaximumLength = FilenameNoPath.Length = Current.Length;
-
-    while (Current.Length != 0)
+    while (Remaining.Length != 0)
     {
-        DPRINT1("Current: %wZ\n", &Current);
-
-        if (Remaining.Length != 0)
-        {
-            FilenameNoPath.Buffer = Remaining.Buffer;
-            FilenameNoPath.Length = FilenameNoPath.MaximumLength = Remaining.Length;
-        }
+        DPRINT("Current: %wZ\n", &Current);
 
         FirstEntry = 0;
         Status = NtfsFindMftRecord(DeviceExt,
@@ -294,28 +289,25 @@ AddFileName(PFILE_RECORD_HEADER FileRecord,
                                    CaseSensitive,
                                    &CurrentMFTIndex);
         if (!NT_SUCCESS(Status))
-            break;
-
-        if (Remaining.Length == 0 )
         {
-            if (Current.Length != 0)
-            {
-                FilenameNoPath.Buffer = Current.Buffer;
-                FilenameNoPath.Length = FilenameNoPath.MaximumLength = Current.Length;
-            }
-            break;
+            DPRINT1("Path component '%wZ' of '%wZ' not found (Status %lx)\n",
+                    &Current, &FileObject->FileName, Status);
+            return Status;
         }
 
         FsRtlDissectName(Remaining, &Current, &Remaining);
     }
 
-    DPRINT1("MFT Index of parent: %I64u\n", CurrentMFTIndex);
+    /* Whatever is left over is the file's own name */
+    FilenameNoPath = Current;
+
+    DPRINT("MFT Index of parent: %I64u\n", CurrentMFTIndex);
 
     // set reference to parent directory
     FileNameAttribute->DirectoryFileReferenceNumber = CurrentMFTIndex;
     *ParentMftIndex = CurrentMFTIndex;
 
-    DPRINT1("SequenceNumber: 0x%02x\n", FileRecord->SequenceNumber);
+    DPRINT("SequenceNumber: 0x%02x\n", FileRecord->SequenceNumber);
 
     // The highest 2 bytes should be the sequence number, unless the parent happens to be root
     if (CurrentMFTIndex == NTFS_FILE_ROOT)
@@ -323,7 +315,7 @@ AddFileName(PFILE_RECORD_HEADER FileRecord,
     else
         FileNameAttribute->DirectoryFileReferenceNumber |= (ULONGLONG)FileRecord->SequenceNumber << 48;
 
-    DPRINT1("FileNameAttribute->DirectoryFileReferenceNumber: 0x%016I64x\n", FileNameAttribute->DirectoryFileReferenceNumber);
+    DPRINT("FileNameAttribute->DirectoryFileReferenceNumber: 0x%016I64x\n", FileNameAttribute->DirectoryFileReferenceNumber);
 
     FileNameAttribute->NameLength = FilenameNoPath.Length / sizeof(WCHAR);
     RtlCopyMemory(FileNameAttribute->Name, FilenameNoPath.Buffer, FilenameNoPath.Length);
@@ -682,7 +674,7 @@ AddRun(PNTFS_VCB Vcb,
             ULONG_PTR MoveTo = (ULONG_PTR)DestinationAttribute + AttrContext->pRecord->NonResident.MappingPairsOffset + RunBufferSize;
             MoveTo = ALIGN_UP_BY(MoveTo, ATTR_RECORD_ALIGNMENT);
 
-            DPRINT1("Moving attribute(s) after this one starting with type 0x%lx\n", NextAttribute->Type);
+            DPRINT("Moving attribute(s) after this one starting with type 0x%lx\n", NextAttribute->Type);
 
             // Move the trailing attributes; FinalAttribute will point to the end marker
             FinalAttribute = MoveAttributes(Vcb, NextAttribute, NextAttributeOffset, MoveTo);
@@ -738,7 +730,9 @@ AddRun(PNTFS_VCB Vcb,
 
     ExFreePoolWithTag(RunBuffer, TAG_NTFS);
 
+#if NTFS_DUMP_DATA_RUNS
     NtfsDumpDataRuns((PUCHAR)((ULONG_PTR)DestinationAttribute + DestinationAttribute->NonResident.MappingPairsOffset), 0);
+#endif
 
     return Status;
 }
@@ -1212,7 +1206,9 @@ FreeClusters(PNTFS_VCB Vcb,
 
     ExFreePoolWithTag(RunBuffer, TAG_NTFS);
 
+#if NTFS_DUMP_DATA_RUNS
     NtfsDumpDataRuns((PUCHAR)((ULONG_PTR)DestinationAttribute + DestinationAttribute->NonResident.MappingPairsOffset), 0);
+#endif
 
     return Status;
 }
@@ -1769,7 +1765,7 @@ NtfsDumpDataRuns(PVOID StartOfRun,
 
     if (CurrentLCN == 0)
     {
-        DPRINT1("Dumping data runs.\n\tData:\n\t\t");
+        DPRINT("Dumping data runs.\n\tData:\n\t\t");
         NtfsDumpDataRunData(StartOfRun);
         DbgPrint("\n\tRuns:\n\t\tOff\t\tLCN\t\tLength\n");
     }

--- a/drivers/filesystems/ntfs/attrib.c
+++ b/drivers/filesystems/ntfs/attrib.c
@@ -643,8 +643,15 @@ AddRun(PNTFS_VCB Vcb,
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
-    // Convert the map control block back to encoded data runs
-    ConvertLargeMCBToDataRuns(&AttrContext->DataRunsMCB, RunBuffer, Vcb->NtfsInfo.BytesPerCluster, &RunBufferSize);
+    // Convert the map control block back to encoded data runs.
+    Status = ConvertLargeMCBToDataRuns(&AttrContext->DataRunsMCB, RunBuffer, Vcb->NtfsInfo.BytesPerFileRecord, &RunBufferSize);
+    if (!NT_SUCCESS(Status))
+    {
+        // Runs won't fit in a single record; migrating to an $ATTRIBUTE_LIST isn't supported yet.
+        DPRINT1("Data runs too large for one file record - $ATTRIBUTE_LIST needed (not implemented)\n");
+        ExFreePoolWithTag(RunBuffer, TAG_NTFS);
+        return STATUS_NOT_IMPLEMENTED;
+    }
 
     // Get the amount of free space between the start of the of the first data run and the attribute end
     DataRunMaxLength = AttrContext->pRecord->Length - AttrContext->pRecord->NonResident.MappingPairsOffset;
@@ -1172,8 +1179,9 @@ FreeClusters(PNTFS_VCB Vcb,
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
-    // Convert the map control block back to encoded data runs
-    ConvertLargeMCBToDataRuns(&AttrContext->DataRunsMCB, RunBuffer, Vcb->NtfsInfo.BytesPerCluster, &RunBufferSize);
+    // Convert the map control block back to encoded data runs.
+    // RunBuffer is one file record long (not one cluster) - see AddRun().
+    ConvertLargeMCBToDataRuns(&AttrContext->DataRunsMCB, RunBuffer, Vcb->NtfsInfo.BytesPerFileRecord, &RunBufferSize);
 
     // Update HighestVCN
     DestinationAttribute->NonResident.HighestVCN = AttrContext->pRecord->NonResident.HighestVCN;

--- a/drivers/filesystems/ntfs/blockdev.c
+++ b/drivers/filesystems/ntfs/blockdev.c
@@ -33,6 +33,805 @@
 
 /* FUNCTIONS ****************************************************************/
 
+/* The run list uses storage embedded in the caller's stack frame and only
+ * spills into pool for heavily fragmented files. */
+
+VOID
+NtfsInitIoRunList(OUT PNTFS_IO_RUN_LIST RunList)
+{
+    RunList->Runs = RunList->StackRuns;
+    RunList->Capacity = NTFS_MAX_IO_RUNS_ON_STACK;
+    RunList->Count = 0;
+    RunList->TotalLength = 0;
+}
+
+/**
+* @name NtfsAddIoRun
+* @implemented
+*
+* Appends one contiguous piece to a request's run list.
+*
+* @param RunList
+* The list being built, previously initialized by NtfsInitIoRunList()
+*
+* @param Lbo
+* Byte offset on the volume of this piece, or NTFS_SPARSE_LBO if the piece has
+* no backing storage
+*
+* @param ByteCount
+* Size of this piece, in bytes
+*
+* @return
+* STATUS_SUCCESS, or STATUS_INSUFFICIENT_RESOURCES if the list had to grow and
+* the allocation failed.
+*
+* @remarks Runs tile the caller's buffer in the order they are added, so the
+* buffer offset is implied. A piece continuing the previous one is merged into
+* it, keeping contiguous files down to a single IRP.
+*
+*/
+NTSTATUS
+NtfsAddIoRun(IN OUT PNTFS_IO_RUN_LIST RunList,
+             IN LONGLONG Lbo,
+             IN ULONG ByteCount)
+{
+    PNTFS_IO_RUN LastRun;
+    PNTFS_IO_RUN NewRuns;
+    ULONG NewCapacity;
+
+    if (ByteCount == 0)
+        return STATUS_SUCCESS;
+
+    /* Does this piece simply continue the previous one? */
+    if (RunList->Count != 0)
+    {
+        LastRun = &RunList->Runs[RunList->Count - 1];
+
+        if (LastRun->ByteCount <= MAXULONG - ByteCount &&
+            ((Lbo == NTFS_SPARSE_LBO && LastRun->Lbo == NTFS_SPARSE_LBO) ||
+             (Lbo != NTFS_SPARSE_LBO && LastRun->Lbo != NTFS_SPARSE_LBO &&
+              LastRun->Lbo + LastRun->ByteCount == Lbo)))
+        {
+            LastRun->ByteCount += ByteCount;
+            RunList->TotalLength += ByteCount;
+            return STATUS_SUCCESS;
+        }
+    }
+
+    if (RunList->Count == RunList->Capacity)
+    {
+        NewCapacity = RunList->Capacity * 2;
+
+        /* Non-paged: a run list stays live across the transfer, and a request
+         * on the paging path must not fault while walking it. */
+        NewRuns = ExAllocatePoolWithTag(NonPagedPool,
+                                        NewCapacity * sizeof(NTFS_IO_RUN),
+                                        TAG_IO_RUNS);
+        if (NewRuns == NULL)
+        {
+            DPRINT1("Not enough memory to grow the I/O run list!\n");
+            return STATUS_INSUFFICIENT_RESOURCES;
+        }
+
+        RtlCopyMemory(NewRuns, RunList->Runs, RunList->Count * sizeof(NTFS_IO_RUN));
+
+        if (RunList->Runs != RunList->StackRuns)
+        {
+            ExFreePoolWithTag(RunList->Runs, TAG_IO_RUNS);
+        }
+
+        RunList->Runs = NewRuns;
+        RunList->Capacity = NewCapacity;
+    }
+
+    LastRun = &RunList->Runs[RunList->Count];
+    LastRun->Lbo = Lbo;
+    LastRun->BufferOffset = RunList->TotalLength;
+    LastRun->ByteCount = ByteCount;
+    LastRun->SavedIrp = NULL;
+
+    RunList->Count++;
+    RunList->TotalLength += ByteCount;
+
+    return STATUS_SUCCESS;
+}
+
+VOID
+NtfsFreeIoRunList(IN OUT PNTFS_IO_RUN_LIST RunList)
+{
+    if (RunList->Runs != RunList->StackRuns && RunList->Runs != NULL)
+    {
+        ExFreePoolWithTag(RunList->Runs, TAG_IO_RUNS);
+    }
+
+    RunList->Runs = NULL;
+    RunList->Count = 0;
+    RunList->Capacity = 0;
+    RunList->TotalLength = 0;
+}
+
+/*
+ * Completion routine shared by every run of a request. Frees the IRP and its
+ * partial MDL, which are ours, and returns STATUS_MORE_PROCESSING_REQUIRED so
+ * the I/O manager stops touching them. The last run to complete wakes the
+ * issuer. Called at up to DISPATCH_LEVEL, in an arbitrary thread.
+ */
+static
+NTSTATUS
+NTAPI
+NtfsIoRunCompletionRoutine(IN PDEVICE_OBJECT DeviceObject,
+                           IN PIRP Irp,
+                           IN PVOID Context)
+{
+    PNTFS_IO_CONTEXT IoContext = (PNTFS_IO_CONTEXT)Context;
+
+    UNREFERENCED_PARAMETER(DeviceObject);
+
+    if (NT_SUCCESS(Irp->IoStatus.Status))
+    {
+        InterlockedExchangeAdd(&IoContext->BytesTransferred,
+                               (LONG)Irp->IoStatus.Information);
+    }
+    else
+    {
+        /* First error wins; STATUS_SUCCESS is the "nothing failed yet" sentinel. */
+        InterlockedCompareExchange(&IoContext->Status,
+                                   Irp->IoStatus.Status,
+                                   STATUS_SUCCESS);
+    }
+
+    /* The master MDL belongs to the issuer and outlives every run built from it. */
+    if (Irp->MdlAddress != NULL && Irp->MdlAddress != IoContext->MasterMdl)
+    {
+        IoFreeMdl(Irp->MdlAddress);
+    }
+
+    IoFreeIrp(Irp);
+
+    if (InterlockedDecrement(&IoContext->IrpCount) == 0)
+    {
+        KeSetEvent(&IoContext->SyncEvent, IO_NO_INCREMENT, FALSE);
+    }
+
+    return STATUS_MORE_PROCESSING_REQUIRED;
+}
+
+/* Builds, but does not issue, the IRP for a single run. Every IRP is built
+ * before any is issued, so a failure part-way through unwinds with no I/O in
+ * flight. */
+static
+NTSTATUS
+NtfsBuildIoRunIrp(IN PDEVICE_OBJECT DeviceObject,
+                  IN PNTFS_IO_CONTEXT IoContext,
+                  IN UCHAR MajorFunction,
+                  IN PUCHAR Buffer,
+                  IN ULONG BufferLength,
+                  IN OUT PNTFS_IO_RUN Run,
+                  IN BOOLEAN Override)
+{
+    PIO_STACK_LOCATION Stack;
+    PIRP Irp;
+    PMDL Mdl;
+
+    Irp = IoAllocateIrp(DeviceObject->StackSize, FALSE);
+    if (Irp == NULL)
+    {
+        DPRINT1("IoAllocateIrp failed!\n");
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    if (Run->BufferOffset == 0 && Run->ByteCount == BufferLength)
+    {
+        Mdl = IoContext->MasterMdl;
+    }
+    else
+    {
+        PUCHAR MasterVa = (PUCHAR)IoContext->MasterVa + Run->BufferOffset;
+
+        Mdl = IoAllocateMdl(MasterVa,
+                            Run->ByteCount,
+                            FALSE,
+                            FALSE,
+                            NULL);
+        if (Mdl == NULL)
+        {
+            DPRINT1("IoAllocateMdl failed!\n");
+            IoFreeIrp(Irp);
+            return STATUS_INSUFFICIENT_RESOURCES;
+        }
+
+        IoBuildPartialMdl(IoContext->MasterMdl,
+                          Mdl,
+                          MasterVa,
+                          Run->ByteCount);
+    }
+
+    Irp->MdlAddress = Mdl;
+    Irp->Flags |= IRP_NOCACHE;
+
+    Stack = IoGetNextIrpStackLocation(Irp);
+    Stack->MajorFunction = MajorFunction;
+    Stack->Parameters.Read.Length = Run->ByteCount;
+    Stack->Parameters.Read.ByteOffset.QuadPart = Run->Lbo;
+
+    if (Override)
+    {
+        Stack->Flags |= SL_OVERRIDE_VERIFY_VOLUME;
+    }
+
+    IoSetCompletionRoutine(Irp,
+                           NtfsIoRunCompletionRoutine,
+                           IoContext,
+                           TRUE,
+                           TRUE,
+                           TRUE);
+
+    Run->SavedIrp = Irp;
+
+    return STATUS_SUCCESS;
+}
+
+static
+NTSTATUS
+NtfsIssueIoRuns(IN PDEVICE_OBJECT DeviceObject,
+                IN UCHAR MajorFunction,
+                IN OUT PUCHAR Buffer,
+                IN PMDL BorrowedMdl OPTIONAL,
+                IN PNTFS_IO_RUN_LIST RunList,
+                IN BOOLEAN Override,
+                OUT PULONG BytesTransferred)
+{
+    NTFS_IO_CONTEXT IoContext;
+    NTSTATUS Status = STATUS_SUCCESS;
+    PNTFS_IO_RUN Run;
+    ULONG DiskRunCount = 0;
+    ULONG Index;
+    ULONG BuiltCount = 0;
+    PIRP Irp;
+
+    *BytesTransferred = 0;
+
+    RtlZeroMemory(&IoContext, sizeof(IoContext));
+    KeInitializeEvent(&IoContext.SyncEvent, NotificationEvent, FALSE);
+    IoContext.Status = STATUS_SUCCESS;
+
+    /* Satisfy the sparse runs, and see if any real I/O is left */
+    for (Index = 0; Index < RunList->Count; Index++)
+    {
+        Run = &RunList->Runs[Index];
+
+        if (Run->Lbo != NTFS_SPARSE_LBO)
+        {
+            DiskRunCount++;
+            continue;
+        }
+
+        if (MajorFunction != IRP_MJ_READ)
+        {
+            DPRINT1("FIXME: Writing to sparse files is not supported yet!\n");
+            return STATUS_NOT_IMPLEMENTED;
+        }
+
+        RtlZeroMemory(Buffer + Run->BufferOffset, Run->ByteCount);
+        *BytesTransferred += Run->ByteCount;
+    }
+
+    if (DiskRunCount == 0)
+    {
+        return STATUS_SUCCESS;
+    }
+
+    if (BorrowedMdl != NULL)
+    {
+        IoContext.MasterMdl = BorrowedMdl;
+        IoContext.MasterVa = MmGetMdlVirtualAddress(BorrowedMdl);
+        IoContext.OwnsMasterMdl = FALSE;
+    }
+    else
+    {
+        /* Our own buffer: describe and lock it once */
+        IoContext.MasterMdl = IoAllocateMdl(Buffer, RunList->TotalLength, FALSE, FALSE, NULL);
+        if (IoContext.MasterMdl == NULL)
+        {
+            DPRINT1("IoAllocateMdl failed!\n");
+            return STATUS_INSUFFICIENT_RESOURCES;
+        }
+
+        _SEH2_TRY
+        {
+            MmProbeAndLockPages(IoContext.MasterMdl,
+                                KernelMode,
+                                (MajorFunction == IRP_MJ_READ) ? IoWriteAccess : IoReadAccess);
+        }
+        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+        {
+            Status = _SEH2_GetExceptionCode();
+        }
+        _SEH2_END;
+
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("MmProbeAndLockPages failed (Status %lx)\n", Status);
+            IoFreeMdl(IoContext.MasterMdl);
+            return Status;
+        }
+
+        IoContext.MasterVa = Buffer;
+        IoContext.OwnsMasterMdl = TRUE;
+    }
+
+    /* Build everything before issuing anything */
+    for (Index = 0; Index < RunList->Count; Index++)
+    {
+        Run = &RunList->Runs[Index];
+
+        if (Run->Lbo == NTFS_SPARSE_LBO)
+            continue;
+
+        Status = NtfsBuildIoRunIrp(DeviceObject,
+                                   &IoContext,
+                                   MajorFunction,
+                                   Buffer,
+                                   RunList->TotalLength,
+                                   Run,
+                                   Override);
+        if (!NT_SUCCESS(Status))
+            break;
+
+        BuiltCount++;
+    }
+
+    if (!NT_SUCCESS(Status))
+    {
+        for (Index = 0; Index < RunList->Count; Index++)
+        {
+            Run = &RunList->Runs[Index];
+
+            if (Run->SavedIrp == NULL)
+                continue;
+
+            if (Run->SavedIrp->MdlAddress != NULL &&
+                Run->SavedIrp->MdlAddress != IoContext.MasterMdl)
+            {
+                IoFreeMdl(Run->SavedIrp->MdlAddress);
+            }
+
+            IoFreeIrp(Run->SavedIrp);
+            Run->SavedIrp = NULL;
+        }
+
+        if (IoContext.OwnsMasterMdl)
+        {
+            MmUnlockPages(IoContext.MasterMdl);
+            IoFreeMdl(IoContext.MasterMdl);
+        }
+
+        return Status;
+    }
+
+    /* Publish the count before the first completion routine can run. */
+    IoContext.IrpCount = BuiltCount;
+
+    for (Index = 0; Index < RunList->Count; Index++)
+    {
+        Run = &RunList->Runs[Index];
+
+        if (Run->SavedIrp == NULL)
+            continue;
+
+        /* The completion routine frees the IRP, so drop our pointer first */
+        Irp = Run->SavedIrp;
+        Run->SavedIrp = NULL;
+
+        /* A failure here is completed by the lower driver and picked up by
+         * our completion routine like any other I/O error */
+        (VOID)IoCallDriver(DeviceObject, Irp);
+    }
+
+    KeWaitForSingleObject(&IoContext.SyncEvent, Executive, KernelMode, FALSE, NULL);
+
+    if (IoContext.OwnsMasterMdl)
+    {
+        MmUnlockPages(IoContext.MasterMdl);
+        IoFreeMdl(IoContext.MasterMdl);
+    }
+
+    Status = (NTSTATUS)IoContext.Status;
+    if (NT_SUCCESS(Status))
+    {
+        *BytesTransferred += (ULONG)IoContext.BytesTransferred;
+    }
+
+    return Status;
+}
+
+/**
+* @name NtfsPerformIoRuns
+* @implemented
+*
+* Reads or writes the pieces described by RunList, all in parallel.
+*
+* @param DeviceObject
+* Storage device to transfer to or from
+*
+* @param MajorFunction
+* IRP_MJ_READ or IRP_MJ_WRITE
+*
+* @param SectorSize
+* Sector size the storage device requires transfers to be aligned to
+*
+* @param Buffer
+* System-space buffer of RunList->TotalLength bytes, tiled by the runs
+*
+* @param RunList
+* The pieces to transfer. Consumed by this call: the runs are rewritten in
+* place to satisfy the device's alignment requirements.
+*
+* @param Override
+* Whether to set SL_OVERRIDE_VERIFY_VOLUME on the requests
+*
+* @param BytesTransferred
+* Optionally receives how much of the request was satisfied
+*
+* @return
+* STATUS_SUCCESS on success, STATUS_INSUFFICIENT_RESOURCES if an allocation
+* failed, STATUS_NOT_IMPLEMENTED for a write to a sparse run, since that's
+* probably not happening for this driver
+*/
+static
+NTSTATUS
+NtfsPerformIoRunsInternal(IN PDEVICE_OBJECT DeviceObject,
+                          IN UCHAR MajorFunction,
+                          IN ULONG SectorSize,
+                          IN OUT PUCHAR Buffer,
+                          IN PMDL BorrowedMdl OPTIONAL,
+                          IN PNTFS_IO_RUN_LIST RunList,
+                          IN BOOLEAN Override,
+                          OUT PULONG BytesTransferred OPTIONAL)
+{
+    NTSTATUS Status;
+    PNTFS_IO_RUN FirstRun;
+    PNTFS_IO_RUN LastRun;
+    PUCHAR BounceBuffer;
+    LONGLONG EndLbo;
+    ULONG FrontPad = 0;
+    ULONG BackPad = 0;
+    ULONG BounceLength;
+    ULONG Transferred = 0;
+    ULONG Index;
+    ULONG Length;
+
+    if (BytesTransferred != NULL)
+        *BytesTransferred = 0;
+
+    if (RunList->Count == 0 || RunList->TotalLength == 0)
+        return STATUS_SUCCESS;
+
+    ASSERT(SectorSize != 0);
+
+    Length = RunList->TotalLength;
+    FirstRun = &RunList->Runs[0];
+    LastRun = &RunList->Runs[RunList->Count - 1];
+
+    /* Only the first run can start unaligned and only the last can end
+     * unaligned; the rest sit on cluster boundaries */
+    if (FirstRun->Lbo != NTFS_SPARSE_LBO)
+    {
+        FrontPad = (ULONG)(FirstRun->Lbo % SectorSize);
+    }
+
+    if (LastRun->Lbo != NTFS_SPARSE_LBO)
+    {
+        EndLbo = LastRun->Lbo + LastRun->ByteCount;
+        BackPad = (ULONG)(ROUND_UP(EndLbo, (LONGLONG)SectorSize) - EndLbo);
+    }
+
+    if (FrontPad == 0 && BackPad == 0)
+    {
+        Status = NtfsIssueIoRuns(DeviceObject,
+                                 MajorFunction,
+                                 Buffer,
+                                 BorrowedMdl,
+                                 RunList,
+                                 Override,
+                                 &Transferred);
+
+        if (BytesTransferred != NULL)
+            *BytesTransferred = min(Transferred, Length);
+
+        return Status;
+    }
+
+    BounceLength = FrontPad + Length + BackPad;
+
+    BounceBuffer = ExAllocatePoolWithTag(NonPagedPool, BounceLength, TAG_NTFS);
+    if (BounceBuffer == NULL)
+    {
+        DPRINT1("Not enough memory for an unaligned transfer!\n");
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    /* Grow the request out to whole sectors; everything after the first run
+     * slides along by what we prepended */
+    for (Index = 1; Index < RunList->Count; Index++)
+    {
+        RunList->Runs[Index].BufferOffset += FrontPad;
+    }
+
+    FirstRun->BufferOffset = 0;
+    FirstRun->ByteCount += FrontPad;
+    if (FirstRun->Lbo != NTFS_SPARSE_LBO)
+        FirstRun->Lbo -= FrontPad;
+
+    LastRun->ByteCount += BackPad;
+    RunList->TotalLength = BounceLength;
+
+    Status = STATUS_SUCCESS;
+
+    if (MajorFunction != IRP_MJ_READ)
+    {
+        if (FrontPad != 0)
+        {
+            Status = NtfsReadDisk(DeviceObject,
+                                  FirstRun->Lbo,
+                                  SectorSize,
+                                  SectorSize,
+                                  BounceBuffer,
+                                  Override);
+        }
+
+        /* Skip only if the read above already fetched this same sector */
+        if (NT_SUCCESS(Status) &&
+            BackPad != 0 &&
+            (FrontPad == 0 || BounceLength > SectorSize))
+        {
+            Status = NtfsReadDisk(DeviceObject,
+                                  LastRun->Lbo + LastRun->ByteCount - SectorSize,
+                                  SectorSize,
+                                  SectorSize,
+                                  BounceBuffer + BounceLength - SectorSize,
+                                  Override);
+        }
+
+        if (NT_SUCCESS(Status))
+        {
+            RtlCopyMemory(BounceBuffer + FrontPad, Buffer, Length);
+        }
+    }
+
+    if (NT_SUCCESS(Status))
+    {
+        /* The bounce buffer is ours, so there is no MDL to borrow here. */
+        Status = NtfsIssueIoRuns(DeviceObject,
+                                 MajorFunction,
+                                 BounceBuffer,
+                                 NULL,
+                                 RunList,
+                                 Override,
+                                 &Transferred);
+
+        if (NT_SUCCESS(Status))
+        {
+            if (MajorFunction == IRP_MJ_READ)
+            {
+                RtlCopyMemory(Buffer, BounceBuffer + FrontPad, Length);
+            }
+
+            if (BytesTransferred != NULL)
+            {
+                /* The padding is ours, not the caller's. */
+                Transferred = (Transferred > FrontPad) ? Transferred - FrontPad : 0;
+                *BytesTransferred = min(Transferred, Length);
+            }
+        }
+    }
+
+    /* The bounce buffer can hold user data; do not leave it in pool. */
+    RtlSecureZeroMemory(BounceBuffer, BounceLength);
+    ExFreePoolWithTag(BounceBuffer, TAG_NTFS);
+
+    return Status;
+}
+
+/* Completion routine for the caller's own IRP, which we must not free.
+ * STATUS_MORE_PROCESSING_REQUIRED keeps ownership with us so the dispatch path
+ * can complete it as usual. */
+static
+NTSTATUS
+NTAPI
+NtfsForwardedIrpCompletionRoutine(IN PDEVICE_OBJECT DeviceObject,
+                                  IN PIRP Irp,
+                                  IN PVOID Context)
+{
+    PNTFS_IO_CONTEXT IoContext = (PNTFS_IO_CONTEXT)Context;
+
+    UNREFERENCED_PARAMETER(DeviceObject);
+
+    IoContext->Status = Irp->IoStatus.Status;
+    IoContext->BytesTransferred = (LONG)Irp->IoStatus.Information;
+
+    KeSetEvent(&IoContext->SyncEvent, IO_NO_INCREMENT, FALSE);
+
+    return STATUS_MORE_PROCESSING_REQUIRED;
+}
+
+/* Hands the caller's IRP straight to the storage stack for one contiguous
+ * run: no allocation, no copy, the disk transfers directly into the pages the
+ * caller's MDL describes. Same as fastfat's FatSingleAsync(). */
+static
+NTSTATUS
+NtfsForwardIrpToRun(IN PDEVICE_OBJECT DeviceObject,
+                    IN UCHAR MajorFunction,
+                    IN PIRP Irp,
+                    IN PNTFS_IO_RUN Run,
+                    IN BOOLEAN Override,
+                    OUT PULONG BytesTransferred)
+{
+    NTFS_IO_CONTEXT IoContext;
+    PIO_STACK_LOCATION Stack;
+
+    DPRINT("Forwarding IRP %p for a single run at %I64x, %lu bytes\n",
+           Irp, Run->Lbo, Run->ByteCount);
+
+    RtlZeroMemory(&IoContext, sizeof(IoContext));
+    KeInitializeEvent(&IoContext.SyncEvent, NotificationEvent, FALSE);
+    IoContext.Status = STATUS_SUCCESS;
+
+    Stack = IoGetNextIrpStackLocation(Irp);
+    Stack->MajorFunction = MajorFunction;
+    Stack->MinorFunction = 0;
+    Stack->FileObject = NULL;
+    Stack->Parameters.Read.Length = Run->ByteCount;
+    Stack->Parameters.Read.ByteOffset.QuadPart = Run->Lbo;
+    Stack->Flags = Override ? SL_OVERRIDE_VERIFY_VOLUME : 0;
+
+    /* Must come last: it takes over Control on this same stack location. */
+    IoSetCompletionRoutine(Irp,
+                           NtfsForwardedIrpCompletionRoutine,
+                           &IoContext,
+                           TRUE,
+                           TRUE,
+                           TRUE);
+
+    (VOID)IoCallDriver(DeviceObject, Irp);
+
+    KeWaitForSingleObject(&IoContext.SyncEvent, Executive, KernelMode, FALSE, NULL);
+
+    *BytesTransferred = (ULONG)IoContext.BytesTransferred;
+
+    return (NTSTATUS)IoContext.Status;
+}
+
+/**
+* @name NtfsPerformIrpIoRuns
+* @implemented
+*
+* Transfers the runs of a request that originated from an IRP, forwarding that
+* IRP straight to the storage stack when the request allows it.
+*
+* @param DeviceObject
+* Storage device to transfer to or from
+*
+* @param MajorFunction
+* IRP_MJ_READ or IRP_MJ_WRITE
+*
+* @param SectorSize
+* Sector size the storage device requires transfers to be aligned to
+*
+* @param Irp
+* The request being served. May be NULL, in which case this is exactly
+* NtfsPerformIoRuns().
+*
+* @param Buffer
+* System-space mapping of the IRP's buffer, used whenever the request cannot
+* simply be forwarded
+*
+* @param RunList
+* The pieces to transfer
+*
+* @param Override
+* Whether to set SL_OVERRIDE_VERIFY_VOLUME on the requests
+*
+* @param BytesTransferred
+* Receives how much of the request was satisfied
+*
+* @return
+* STATUS_SUCCESS on success, otherwise the status of the failing transfer.
+*
+*/
+NTSTATUS
+NtfsPerformIrpIoRuns(IN PDEVICE_OBJECT DeviceObject,
+                     IN UCHAR MajorFunction,
+                     IN ULONG SectorSize,
+                     IN PIRP Irp,
+                     IN OUT PUCHAR Buffer,
+                     IN PNTFS_IO_RUN_LIST RunList,
+                     IN BOOLEAN Override,
+                     OUT PULONG BytesTransferred)
+{
+    PMDL BorrowedMdl = NULL;
+
+    if (Irp != NULL &&
+        Irp->MdlAddress != NULL &&
+        RunList->TotalLength <= MmGetMdlByteCount(Irp->MdlAddress))
+    {
+        /* Buffer maps exactly the pages this MDL describes, so it can stand
+         * in for one of our own, and on the paging path it must */
+        BorrowedMdl = Irp->MdlAddress;
+
+        /* One aligned run covering the lot goes straight down to the disk */
+        if (RunList->Count == 1 &&
+            RunList->Runs[0].Lbo != NTFS_SPARSE_LBO &&
+            (RunList->Runs[0].Lbo % SectorSize) == 0 &&
+            (RunList->Runs[0].ByteCount % SectorSize) == 0)
+        {
+            return NtfsForwardIrpToRun(DeviceObject,
+                                       MajorFunction,
+                                       Irp,
+                                       &RunList->Runs[0],
+                                       Override,
+                                       BytesTransferred);
+        }
+    }
+
+    return NtfsPerformIoRunsInternal(DeviceObject,
+                                     MajorFunction,
+                                     SectorSize,
+                                     Buffer,
+                                     BorrowedMdl,
+                                     RunList,
+                                     Override,
+                                     BytesTransferred);
+}
+
+NTSTATUS
+NtfsPerformIoRuns(IN PDEVICE_OBJECT DeviceObject,
+                  IN UCHAR MajorFunction,
+                  IN ULONG SectorSize,
+                  IN OUT PUCHAR Buffer,
+                  IN PNTFS_IO_RUN_LIST RunList,
+                  IN BOOLEAN Override,
+                  OUT PULONG BytesTransferred OPTIONAL)
+{
+    return NtfsPerformIoRunsInternal(DeviceObject,
+                                     MajorFunction,
+                                     SectorSize,
+                                     Buffer,
+                                     NULL,
+                                     RunList,
+                                     Override,
+                                     BytesTransferred);
+}
+
+/**
+* @name NtfsReadDisk
+* @implemented
+*
+* Reads a single contiguous range from the given DeviceObject.
+*
+* @param DeviceObject
+* Device to read from
+*
+* @param StartingOffset
+* Offset, in bytes, from the start of the device object
+*
+* @param Length
+* How much data to read, in bytes
+*
+* @param SectorSize
+* Size of the sector on the disk that the read must be aligned to
+*
+* @param Buffer
+* System-space buffer receiving the data
+*
+* @param Override
+* Whether to set SL_OVERRIDE_VERIFY_VOLUME on the request
+*
+* @return
+* STATUS_SUCCESS in case of success, STATUS_INSUFFICIENT_RESOURCES if a memory
+* allocation failed, or whatever status the storage stack returned.
+*
+*/
 NTSTATUS
 NtfsReadDisk(IN PDEVICE_OBJECT DeviceObject,
              IN LONGLONG StartingOffset,
@@ -41,88 +840,36 @@ NtfsReadDisk(IN PDEVICE_OBJECT DeviceObject,
              IN OUT PUCHAR Buffer,
              IN BOOLEAN Override)
 {
-    PIO_STACK_LOCATION Stack;
-    IO_STATUS_BLOCK IoStatus;
-    LARGE_INTEGER Offset;
-    KEVENT Event;
-    PIRP Irp;
+    NTFS_IO_RUN_LIST RunList;
     NTSTATUS Status;
-    ULONGLONG RealReadOffset;
-    ULONG RealLength;
-    BOOLEAN AllocatedBuffer = FALSE;
-    PUCHAR ReadBuffer = Buffer;
+    ULONG Transferred;
 
-    DPRINT("NtfsReadDisk(%p, %I64x, %lu, %lu, %p, %d)\n", DeviceObject, StartingOffset, Length, SectorSize, Buffer, Override);
+    DPRINT("NtfsReadDisk(%p, %I64x, %lu, %lu, %p, %d)\n",
+           DeviceObject, StartingOffset, Length, SectorSize, Buffer, Override);
 
-    KeInitializeEvent(&Event,
-                      NotificationEvent,
-                      FALSE);
+    if (Length == 0)
+        return STATUS_SUCCESS;
 
-    RealReadOffset = (ULONGLONG)StartingOffset;
-    RealLength = Length;
+    NtfsInitIoRunList(&RunList);
 
-    if ((RealReadOffset % SectorSize) != 0 || (RealLength % SectorSize) != 0)
+    Status = NtfsAddIoRun(&RunList, StartingOffset, Length);
+    if (!NT_SUCCESS(Status))
+        return Status;
+
+    Status = NtfsPerformIoRuns(DeviceObject,
+                               IRP_MJ_READ,
+                               SectorSize,
+                               Buffer,
+                               &RunList,
+                               Override,
+                               &Transferred);
+
+    NtfsFreeIoRunList(&RunList);
+
+    if (NT_SUCCESS(Status) && Transferred != Length)
     {
-        RealReadOffset = ROUND_DOWN(StartingOffset, SectorSize);
-        RealLength = ROUND_UP(Length, SectorSize);
-
-        ReadBuffer = ExAllocatePoolWithTag(NonPagedPool, RealLength + SectorSize, TAG_NTFS);
-        if (ReadBuffer == NULL)
-        {
-            DPRINT1("Not enough memory!\n");
-            return STATUS_INSUFFICIENT_RESOURCES;
-        }
-        AllocatedBuffer = TRUE;
-    }
-
-    Offset.QuadPart = RealReadOffset;
-
-    DPRINT("Building synchronous FSD Request...\n");
-    Irp = IoBuildSynchronousFsdRequest(IRP_MJ_READ,
-                                       DeviceObject,
-                                       ReadBuffer,
-                                       RealLength,
-                                       &Offset,
-                                       &Event,
-                                       &IoStatus);
-    if (Irp == NULL)
-    {
-        DPRINT("IoBuildSynchronousFsdRequest failed\n");
-
-        if (AllocatedBuffer)
-        {
-            ExFreePoolWithTag(ReadBuffer, TAG_NTFS);
-        }
-
-        return STATUS_INSUFFICIENT_RESOURCES;
-    }
-
-    if (Override)
-    {
-        Stack = IoGetNextIrpStackLocation(Irp);
-        Stack->Flags |= SL_OVERRIDE_VERIFY_VOLUME;
-    }
-
-    DPRINT("Calling IO Driver... with irp %p\n", Irp);
-    Status = IoCallDriver(DeviceObject, Irp);
-
-    DPRINT("Waiting for IO Operation for %p\n", Irp);
-    if (Status == STATUS_PENDING)
-    {
-        DPRINT("Operation pending\n");
-        KeWaitForSingleObject(&Event, Suspended, KernelMode, FALSE, NULL);
-        DPRINT("Getting IO Status... for %p\n", Irp);
-        Status = IoStatus.Status;
-    }
-
-    if (AllocatedBuffer)
-    {
-        if (NT_SUCCESS(Status))
-        {
-            RtlCopyMemory(Buffer, ReadBuffer + (StartingOffset - RealReadOffset), Length);
-        }
-
-        ExFreePoolWithTag(ReadBuffer, TAG_NTFS);
+        DPRINT1("Short read: asked for %lu bytes, got %lu\n", Length, Transferred);
+        Status = STATUS_UNEXPECTED_IO_ERROR;
     }
 
     DPRINT("NtfsReadDisk() done (Status %x)\n", Status);
@@ -152,11 +899,8 @@ NtfsReadDisk(IN PDEVICE_OBJECT DeviceObject,
 * The data that's being written to the device
 *
 * @return
-* STATUS_SUCCESS in case of success, STATUS_INSUFFICIENT_RESOURCES if a memory allocation failed,
-* or whatever status IoCallDriver() sets.
-*
-* @remarks Called by NtfsWriteFile(). May perform a read-modify-write operation if the
-* requested write is not sector-aligned.
+* STATUS_SUCCESS in case of success, STATUS_INSUFFICIENT_RESOURCES if a memory
+* allocation failed, or whatever status the storage stack returned.
 *
 */
 NTSTATUS
@@ -166,140 +910,99 @@ NtfsWriteDisk(IN PDEVICE_OBJECT DeviceObject,
               IN ULONG SectorSize,
               IN const PUCHAR Buffer)
 {
-    IO_STATUS_BLOCK IoStatus;
-    LARGE_INTEGER Offset;
-    KEVENT Event;
-    PIRP Irp;
+    NTFS_IO_RUN_LIST RunList;
     NTSTATUS Status;
-    ULONGLONG RealWriteOffset;
-    ULONG RealLength;
-    BOOLEAN AllocatedBuffer = FALSE;
-    PUCHAR TempBuffer = NULL;
+    ULONG Transferred;
 
-    DPRINT("NtfsWriteDisk(%p, %I64x, %lu, %lu, %p)\n", DeviceObject, StartingOffset, Length, SectorSize, Buffer);
+    DPRINT("NtfsWriteDisk(%p, %I64x, %lu, %lu, %p)\n",
+           DeviceObject, StartingOffset, Length, SectorSize, Buffer);
 
     if (Length == 0)
         return STATUS_SUCCESS;
 
-    RealWriteOffset = (ULONGLONG)StartingOffset;
-    RealLength = Length;
+    NtfsInitIoRunList(&RunList);
 
-    // Does the write need to be adjusted to be sector-aligned?
-    if ((RealWriteOffset % SectorSize) != 0 || (RealLength % SectorSize) != 0)
+    Status = NtfsAddIoRun(&RunList, StartingOffset, Length);
+    if (!NT_SUCCESS(Status))
+        return Status;
+
+    Status = NtfsPerformIoRuns(DeviceObject,
+                               IRP_MJ_WRITE,
+                               SectorSize,
+                               Buffer,
+                               &RunList,
+                               FALSE,
+                               &Transferred);
+
+    NtfsFreeIoRunList(&RunList);
+
+    if (NT_SUCCESS(Status) && Transferred != Length)
     {
-        ULONGLONG relativeOffset;
-
-        // We need to do a read-modify-write. We'll start be copying the entire
-        // contents of every sector that will be overwritten.
-        // TODO: Optimize (read no more than necessary)
-
-        RealWriteOffset = ROUND_DOWN(StartingOffset, SectorSize);
-        RealLength = ROUND_UP(Length, SectorSize);
-
-        // Would the end of our sector-aligned write fall short of the requested write?
-        if (RealWriteOffset + RealLength < StartingOffset + Length)
-        {
-            RealLength += SectorSize;
-        }
-
-        // Did we underestimate the memory required somehow?
-        if (RealLength + RealWriteOffset < StartingOffset + Length)
-        {
-            DPRINT1("\a\t\t\t\t\tFIXME: calculated less memory than needed!\n");
-            DPRINT1("StartingOffset: %lu\tLength: %lu\tRealWriteOffset: %lu\tRealLength: %lu\n",
-                    StartingOffset, Length, RealWriteOffset, RealLength);
-
-            RealLength += SectorSize;
-        }
-
-        // Allocate a buffer to copy the existing data to
-        TempBuffer = ExAllocatePoolWithTag(NonPagedPool, RealLength, TAG_NTFS);
-
-        // Did we fail to allocate it?
-        if (TempBuffer == NULL)
-        {
-            DPRINT1("Not enough memory!\n");
-
-            return STATUS_INSUFFICIENT_RESOURCES;
-        }
-
-        // Read the sectors we'll be overwriting into TempBuffer
-        Status = NtfsReadDisk(DeviceObject, RealWriteOffset, RealLength, SectorSize, TempBuffer, FALSE);
-
-        // Did we fail the read?
-        if (!NT_SUCCESS(Status))
-        {
-            RtlSecureZeroMemory(TempBuffer, RealLength);
-            ExFreePoolWithTag(TempBuffer, TAG_NTFS);
-            return Status;
-        }
-
-        // Calculate where the new data should be written to, relative to the start of TempBuffer
-        relativeOffset = StartingOffset - RealWriteOffset;
-
-        // Modify the tempbuffer with the data being read
-        RtlCopyMemory(TempBuffer + relativeOffset, Buffer, Length);
-
-        AllocatedBuffer = TRUE;
-    }
-
-    // set the destination offset
-    Offset.QuadPart = RealWriteOffset;
-
-    // setup the notification event for the write
-    KeInitializeEvent(&Event,
-                      NotificationEvent,
-                      FALSE);
-
-    DPRINT("Building synchronous FSD Request...\n");
-
-    // Build an IRP requesting the lower-level [disk] driver to perform the write
-    // TODO: Forward the existing IRP instead
-    Irp = IoBuildSynchronousFsdRequest(IRP_MJ_WRITE,
-                                       DeviceObject,
-                                       // if we allocated a temp buffer, use that instead of the Buffer parameter
-                                       ((AllocatedBuffer) ? TempBuffer : Buffer),
-                                       RealLength,
-                                       &Offset,
-                                       &Event,
-                                       &IoStatus);
-    // Did we fail to build the IRP?
-    if (Irp == NULL)
-    {
-        DPRINT1("IoBuildSynchronousFsdRequest failed\n");
-
-        if (AllocatedBuffer)
-        {
-            RtlSecureZeroMemory(TempBuffer, RealLength);
-            ExFreePoolWithTag(TempBuffer, TAG_NTFS);
-        }
-
-        return STATUS_INSUFFICIENT_RESOURCES;
-    }
-
-    // Call the next-lower driver to perform the write
-    DPRINT("Calling IO Driver with irp %p\n", Irp);
-    Status = IoCallDriver(DeviceObject, Irp);
-
-    // Wait until the next-lower driver has completed the IRP
-    DPRINT("Waiting for IO Operation for %p\n", Irp);
-    if (Status == STATUS_PENDING)
-    {
-        DPRINT("Operation pending\n");
-        KeWaitForSingleObject(&Event, Suspended, KernelMode, FALSE, NULL);
-        DPRINT("Getting IO Status... for %p\n", Irp);
-        Status = IoStatus.Status;
-    }
-
-    if (AllocatedBuffer)
-    {
-        // zero the buffer before freeing it, so private user data can't be snooped
-        RtlSecureZeroMemory(TempBuffer, RealLength);
-
-        ExFreePoolWithTag(TempBuffer, TAG_NTFS);
+        DPRINT1("Short write: asked for %lu bytes, wrote %lu\n", Length, Transferred);
+        Status = STATUS_UNEXPECTED_IO_ERROR;
     }
 
     DPRINT("NtfsWriteDisk() done (Status %x)\n", Status);
+
+    return Status;
+}
+
+/**
+* @name NtfsFlushDevice
+* @implemented
+*
+* Asks the storage stack to push everything it is holding out to the media.
+*
+* @param DeviceObject
+* Device to flush
+*
+* @return
+* STATUS_SUCCESS on success, or whatever the storage stack returned.
+*
+*/
+NTSTATUS
+NtfsFlushDevice(IN PDEVICE_OBJECT DeviceObject)
+{
+    NTFS_IO_CONTEXT IoContext;
+    PIO_STACK_LOCATION Stack;
+    NTSTATUS Status;
+    PIRP Irp;
+
+    Irp = IoAllocateIrp(DeviceObject->StackSize, FALSE);
+    if (Irp == NULL)
+    {
+        DPRINT1("IoAllocateIrp failed!\n");
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    RtlZeroMemory(&IoContext, sizeof(IoContext));
+    KeInitializeEvent(&IoContext.SyncEvent, NotificationEvent, FALSE);
+    IoContext.Status = STATUS_SUCCESS;
+    IoContext.IrpCount = 1;
+
+    Stack = IoGetNextIrpStackLocation(Irp);
+    Stack->MajorFunction = IRP_MJ_FLUSH_BUFFERS;
+
+    IoSetCompletionRoutine(Irp,
+                           NtfsIoRunCompletionRoutine,
+                           &IoContext,
+                           TRUE,
+                           TRUE,
+                           TRUE);
+
+    (VOID)IoCallDriver(DeviceObject, Irp);
+
+    KeWaitForSingleObject(&IoContext.SyncEvent, Executive, KernelMode, FALSE, NULL);
+
+    Status = (NTSTATUS)IoContext.Status;
+
+    if (Status == STATUS_INVALID_DEVICE_REQUEST ||
+        Status == STATUS_NOT_SUPPORTED)
+    {
+        Status = STATUS_SUCCESS;
+    }
+
+    DPRINT("NtfsFlushDevice() done (Status %lx)\n", Status);
 
     return Status;
 }
@@ -339,6 +1042,9 @@ NtfsDeviceIoControl(IN PDEVICE_OBJECT DeviceObject,
 
     KeInitializeEvent(&Event, NotificationEvent, FALSE);
 
+    IoStatus.Status = STATUS_SUCCESS;
+    IoStatus.Information = 0;
+
     DPRINT("Building device I/O control request ...\n");
     Irp = IoBuildDeviceIoControlRequest(ControlCode,
                                         DeviceObject,
@@ -365,7 +1071,7 @@ NtfsDeviceIoControl(IN PDEVICE_OBJECT DeviceObject,
     Status = IoCallDriver(DeviceObject, Irp);
     if (Status == STATUS_PENDING)
     {
-        KeWaitForSingleObject(&Event, Suspended, KernelMode, FALSE, NULL);
+        KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
         Status = IoStatus.Status;
     }
 

--- a/drivers/filesystems/ntfs/btree.c
+++ b/drivers/filesystems/ntfs/btree.c
@@ -70,7 +70,7 @@ PrintAllVCNs(PDEVICE_EXTENSION Vcb,
             continue;
         }
 
-        DPRINT1("Node #%d, VCN: %I64u\n", Count, CurrentNode->VCN);
+        DPRINT("Node #%d, VCN: %I64u\n", Count, CurrentNode->VCN);
 
         CurrentNode = (PINDEX_BUFFER)((ULONG_PTR)CurrentNode + NodeSize);
         CurrentOffset += NodeSize;
@@ -133,7 +133,7 @@ AllocateIndexNode(PDEVICE_EXTENSION DeviceExt,
     ULONG BytesNeeded;
     LARGE_INTEGER DataSize;
 
-    DPRINT1("AllocateIndexNode(%p, %p, %lu, %p, %lu, %p) called.\n", DeviceExt,
+    DPRINT("AllocateIndexNode(%p, %p, %lu, %p, %lu, %p) called.\n", DeviceExt,
             FileRecord,
             IndexBufferSize,
             IndexAllocationCtx,
@@ -190,8 +190,9 @@ AllocateIndexNode(PDEVICE_EXTENSION DeviceExt,
     // Read the existing bitmap data
     Status = ReadAttribute(DeviceExt, BitmapCtx, 0, (PCHAR)BitmapPtr, BitmapLength);
 
-    // Initialize bitmap
-    RtlInitializeBitMap(&Bitmap, BitmapPtr, NextNodeNumber);
+    // Initialize bitmap. It has to describe the node we are about to add, so
+    // it needs NextNodeNumber + 1 bits, not NextNodeNumber.
+    RtlInitializeBitMap(&Bitmap, BitmapPtr, NextNodeNumber + 1);
 
     // Do we need to enlarge the bitmap?
     if (BytesNeeded > BitmapLength)
@@ -262,8 +263,12 @@ AllocateIndexNode(PDEVICE_EXTENSION DeviceExt,
         DPRINT1("ERROR: Unable to write to $I30 bitmap attribute!\n");
     }
 
-    // Calculate VCN of new node number
-    *NewVCN = NextNodeNumber * (IndexBufferSize / DeviceExt->NtfsInfo.BytesPerCluster);
+    // Calculate VCN of new node number. An index record smaller than a cluster is addressed
+    // in sectors; dividing by the cluster size would give every node a VCN of zero.
+    if (IndexBufferSize < DeviceExt->NtfsInfo.BytesPerCluster)
+        *NewVCN = NextNodeNumber * (IndexBufferSize / DeviceExt->NtfsInfo.BytesPerSector);
+    else
+        *NewVCN = NextNodeNumber * (IndexBufferSize / DeviceExt->NtfsInfo.BytesPerCluster);
 
     DPRINT("New VCN: %I64u\n", *NewVCN);
 
@@ -351,7 +356,7 @@ CreateEmptyBTree(PB_TREE *NewTree)
     PB_TREE_FILENAME_NODE RootNode = ExAllocatePoolWithTag(NonPagedPool, sizeof(B_TREE_FILENAME_NODE), TAG_NTFS);
     PB_TREE_KEY DummyKey;
 
-    DPRINT1("CreateEmptyBTree(%p) called\n", NewTree);
+    DPRINT("CreateEmptyBTree(%p) called\n", NewTree);
 
     if (!Tree || !RootNode)
     {
@@ -972,7 +977,7 @@ CreateIndexRootFromBTree(PDEVICE_EXTENSION DeviceExt,
         // Copy the index entry
         RtlCopyMemory(CurrentNodeEntry, CurrentKey->IndexEntry, CurrentKey->IndexEntry->Length);
 
-        DPRINT1("Index Node Entry Stream Length: %u\nIndex Node Entry Length: %u\n",
+        DPRINT("Index Node Entry Stream Length: %u\nIndex Node Entry Length: %u\n",
                 CurrentNodeEntry->KeyLength,
                 CurrentNodeEntry->Length);
 
@@ -1215,7 +1220,7 @@ UpdateIndexAllocation(PDEVICE_EXTENSION DeviceExt,
             {
                 // We need to add an index allocation to the file record
                 PNTFS_ATTR_RECORD EndMarker = (PNTFS_ATTR_RECORD)((ULONG_PTR)FileRecord + FileRecord->BytesInUse - (sizeof(ULONG) * 2));
-                DPRINT1("Adding index allocation...\n");
+                DPRINT("Adding index allocation...\n");
 
                 // Add index allocation to the very end of the file record
                 Status = AddIndexAllocation(DeviceExt,
@@ -1732,12 +1737,19 @@ NtfsInsertKey(PB_TREE Tree,
         // Should the New Key go before the current key?
         LONG Comparison = CompareTreeKeys(NewKey, CurrentKey, CaseSensitive);
 
+        /* The name is already in this index. Inserting it again would leave
+         * two entries the lookup code can never tell apart, so refuse. */
         if (Comparison == 0)
         {
-            DPRINT1("\t\tComparison == 0: %.*S\n", NewKey->IndexEntry->FileName.NameLength, NewKey->IndexEntry->FileName.Name);
-            DPRINT1("\t\tComparison == 0: %.*S\n", CurrentKey->IndexEntry->FileName.NameLength, CurrentKey->IndexEntry->FileName.Name);
+            DPRINT1("Refusing duplicate index entry '%.*S' (existing file reference 0x%I64x)\n",
+                    NewKey->IndexEntry->FileName.NameLength,
+                    NewKey->IndexEntry->FileName.Name,
+                    CurrentKey->IndexEntry->Data.Directory.IndexedFile);
+
+            DestroyBTreeKey(NewKey);
+
+            return STATUS_OBJECT_NAME_COLLISION;
         }
-        ASSERT(Comparison != 0);
 
         // Is NewKey < CurrentKey?
         if (Comparison < 0)
@@ -1845,6 +1857,243 @@ NtfsInsertKey(PB_TREE Tree,
     return Status;
 }
 
+/**
+* @name FindLargestKeyInSubtree
+* @implemented
+*
+* Finds the greatest key in the subtree rooted at Node, along with the node holding it and the
+* key that precedes it in that node's list.
+*
+* @param Node
+* Root of the subtree to search.
+*
+* @param OwnerNode
+* Receives the node containing the greatest key, or NULL if the subtree holds no filenames.
+*
+* @param PreviousKey
+* Receives the key before the greatest key in OwnerNode's list, or NULL if it's the first.
+*
+* @param LargestKey
+* Receives the greatest key, or NULL if the subtree holds no filenames.
+*
+* @remarks
+* An end marker's child holds everything sorting after the last real key, so the greatest key
+* of a subtree is the last real key of the rightmost node reachable through end markers.
+*/
+static
+VOID
+FindLargestKeyInSubtree(PB_TREE_FILENAME_NODE Node,
+                        PB_TREE_FILENAME_NODE *OwnerNode,
+                        PB_TREE_KEY *PreviousKey,
+                        PB_TREE_KEY *LargestKey)
+{
+    PB_TREE_KEY CurrentKey = Node->FirstKey;
+    PB_TREE_KEY Previous = NULL;
+    PB_TREE_KEY BeforePrevious = NULL;
+
+    *OwnerNode = NULL;
+    *PreviousKey = NULL;
+    *LargestKey = NULL;
+
+    while (CurrentKey != NULL &&
+           !BooleanFlagOn(CurrentKey->IndexEntry->Flags, NTFS_INDEX_ENTRY_END))
+    {
+        BeforePrevious = Previous;
+        Previous = CurrentKey;
+        CurrentKey = CurrentKey->NextKey;
+    }
+
+    // Anything greater than the last real key lives beneath the end marker
+    if (CurrentKey != NULL && CurrentKey->LesserChild != NULL)
+    {
+        FindLargestKeyInSubtree(CurrentKey->LesserChild, OwnerNode, PreviousKey, LargestKey);
+        if (*LargestKey != NULL)
+            return;
+    }
+
+    // Nothing but an end marker: this subtree holds no filenames
+    if (Previous == NULL)
+        return;
+
+    *OwnerNode = Node;
+    *PreviousKey = BeforePrevious;
+    *LargestKey = Previous;
+}
+
+/**
+* @name ReplaceKeyIndexEntry
+* @implemented
+*
+* Replaces the index entry of Key with a copy of Source's, leaving Key's child pointer alone.
+*
+* @param Key
+* Key whose index entry will be replaced. It keeps whatever child it had.
+*
+* @param Source
+* Key to copy the file reference and $FILE_NAME from.
+*
+* @return
+* STATUS_SUCCESS on success, STATUS_INSUFFICIENT_RESOURCES if the allocation fails.
+*
+* @remarks
+* Key always has a child here, so the replacement is built with room for the VCN and with
+* NTFS_INDEX_ENTRY_NODE set. UpdateIndexAllocation() only grows an entry to make room for a
+* VCN, never the reverse.
+*/
+static
+NTSTATUS
+ReplaceKeyIndexEntry(PB_TREE_KEY Key, PB_TREE_KEY Source)
+{
+    PINDEX_ENTRY_ATTRIBUTE NewEntry;
+    ULONG AttributeSize = GetFileNameAttributeLength(&Source->IndexEntry->FileName);
+    ULONG EntrySize = ALIGN_UP_BY(AttributeSize + FIELD_OFFSET(INDEX_ENTRY_ATTRIBUTE, FileName), 8);
+
+    EntrySize += sizeof(ULONGLONG); // for the VCN of the child Key retains
+
+    NewEntry = ExAllocatePoolWithTag(NonPagedPool, EntrySize, TAG_NTFS);
+    if (!NewEntry)
+    {
+        DPRINT1("ERROR: Failed to allocate memory for replacement index entry!\n");
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    RtlZeroMemory(NewEntry, EntrySize);
+    NewEntry->Data.Directory.IndexedFile = Source->IndexEntry->Data.Directory.IndexedFile;
+    NewEntry->Length = EntrySize;
+    NewEntry->KeyLength = AttributeSize;
+    NewEntry->Flags = NTFS_INDEX_ENTRY_NODE;
+    RtlCopyMemory(&NewEntry->FileName, &Source->IndexEntry->FileName, AttributeSize);
+
+    ExFreePoolWithTag(Key->IndexEntry, TAG_NTFS);
+    Key->IndexEntry = NewEntry;
+
+    return STATUS_SUCCESS;
+}
+
+/**
+* @name RemoveKeyFromNode
+* @implemented
+*
+* Removes a key that has already been located from the node that holds it.
+*
+* @param Node
+* Node containing Key.
+*
+* @param PreviousKey
+* The key before Key in Node's list, or NULL if Key is the first key.
+*
+* @param Key
+* The key to remove.
+*
+* @return
+* STATUS_SUCCESS on success, STATUS_INSUFFICIENT_RESOURCES if an allocation fails.
+*/
+static
+NTSTATUS
+RemoveKeyFromNode(PB_TREE_FILENAME_NODE Node,
+                  PB_TREE_KEY PreviousKey,
+                  PB_TREE_KEY Key)
+{
+    NTSTATUS Status;
+
+    if (Key->LesserChild != NULL)
+    {
+        PB_TREE_FILENAME_NODE OwnerNode;
+        PB_TREE_KEY PreviousLargest;
+        PB_TREE_KEY LargestKey;
+
+        FindLargestKeyInSubtree(Key->LesserChild, &OwnerNode, &PreviousLargest, &LargestKey);
+
+        if (LargestKey != NULL)
+        {
+            // Unlinking an interior key would orphan its child, so promote the greatest key
+            // beneath it and remove that one instead
+            Status = ReplaceKeyIndexEntry(Key, LargestKey);
+            if (!NT_SUCCESS(Status))
+                return Status;
+
+            return RemoveKeyFromNode(OwnerNode, PreviousLargest, LargestKey);
+        }
+
+        // The child holds no filenames, so there is nothing to promote; DestroyBTreeKey()
+        // frees the empty child along with the key
+    }
+
+    if (PreviousKey == NULL)
+        Node->FirstKey = Key->NextKey;
+    else
+        PreviousKey->NextKey = Key->NextKey;
+
+    Node->KeyCount--;
+
+    Key->NextKey = NULL;
+    DestroyBTreeKey(Key);
+
+    return STATUS_SUCCESS;
+}
+
+/**
+* @name NtfsRemoveKey
+* @implemented
+*
+* Removes the key matching a given filename from a B-Tree.
+*
+* @param Node
+* Node to search. Callers start at the root node of the tree.
+*
+* @param SearchKey
+* Key describing the filename to remove. Only its $FILE_NAME is used, for comparison.
+*
+* @param CaseSensitive
+* Boolean indicating if the function should operate in case-sensitive mode. This will be TRUE
+* if an application created the file with the FILE_FLAG_POSIX_SEMANTICS flag.
+*
+* @return
+* STATUS_SUCCESS if the key was found and removed.
+* STATUS_OBJECT_NAME_NOT_FOUND if no key in the tree matches.
+* STATUS_INSUFFICIENT_RESOURCES if an allocation fails.
+*
+* @remarks
+* A node left holding only its end marker is left in place. Readers descend into it and come
+* back empty, whereas collapsing it would free an index buffer a parent VCN still points at.
+*/
+NTSTATUS
+NtfsRemoveKey(PB_TREE_FILENAME_NODE Node,
+              PB_TREE_KEY SearchKey,
+              BOOLEAN CaseSensitive)
+{
+    PB_TREE_KEY PreviousKey = NULL;
+    PB_TREE_KEY CurrentKey = Node->FirstKey;
+    ULONG i;
+
+    for (i = 0; i < Node->KeyCount; i++)
+    {
+        LONG Comparison;
+
+        if (CurrentKey == NULL)
+            break;
+
+        if (BooleanFlagOn(CurrentKey->IndexEntry->Flags, NTFS_INDEX_ENTRY_END))
+            break;
+
+        Comparison = CompareTreeKeys(SearchKey, CurrentKey, CaseSensitive);
+
+        if (Comparison == 0)
+            return RemoveKeyFromNode(Node, PreviousKey, CurrentKey);
+
+        // Everything that sorts before CurrentKey is beneath it
+        if (Comparison < 0)
+            break;
+
+        PreviousKey = CurrentKey;
+        CurrentKey = CurrentKey->NextKey;
+    }
+
+    if (CurrentKey != NULL && CurrentKey->LesserChild != NULL)
+        return NtfsRemoveKey(CurrentKey->LesserChild, SearchKey, CaseSensitive);
+
+    return STATUS_OBJECT_NAME_NOT_FOUND;
+}
 
 
 /**
@@ -1952,8 +2201,8 @@ SplitBTreeNode(PB_TREE Tree,
     *MedianKey = LastKeyBeforeMedian->NextKey;
     FirstKeyAfterMedian = (*MedianKey)->NextKey;
 
-    DPRINT1("%lu keys, %lu median\n", Node->KeyCount, MedianKeyIndex);
-    DPRINT1("\t\tMedian: %.*S\n", (*MedianKey)->IndexEntry->FileName.NameLength, (*MedianKey)->IndexEntry->FileName.Name);
+    DPRINT("%lu keys, %lu median\n", Node->KeyCount, MedianKeyIndex);
+    DPRINT("\t\tMedian: %.*S\n", (*MedianKey)->IndexEntry->FileName.NameLength, (*MedianKey)->IndexEntry->FileName.Name);
 
     // "Node" will be the left hand sibling after the split, containing all keys prior to the median key
 

--- a/drivers/filesystems/ntfs/cleanup.c
+++ b/drivers/filesystems/ntfs/cleanup.c
@@ -42,6 +42,7 @@ NtfsCleanupFile(PDEVICE_EXTENSION DeviceExt,
                 BOOLEAN CanWait)
 {
     PNTFS_FCB Fcb;
+    BOOLEAN DeletePending = FALSE;
 
     DPRINT("NtfsCleanupFile(DeviceExt %p, FileObject %p, CanWait %u)\n",
            DeviceExt,
@@ -70,7 +71,45 @@ NtfsCleanupFile(PDEVICE_EXTENSION DeviceExt,
 
         Fcb->OpenHandleCount--;
 
+        if (Fcb->ShareAccess.OpenCount > 0)
+        {
+            IoRemoveShareAccess(FileObject, &Fcb->ShareAccess);
+        }
+
+        /* A file marked for deletion goes on the last handle. Truncate it first, so the cache
+         * manager drops its pages while there are still clusters to write them back to. */
+        if (Fcb->OpenHandleCount == 0 &&
+            BooleanFlagOn(Fcb->Flags, FCB_DELETE_PENDING))
+        {
+            DeletePending = TRUE;
+
+            if (!NtfsFCBIsDirectory(Fcb))
+            {
+                Fcb->RFCB.FileSize.QuadPart = 0;
+                Fcb->RFCB.ValidDataLength.QuadPart = 0;
+                CcSetFileSizes(FileObject, (PCC_FILE_SIZES)&Fcb->RFCB.AllocationSize);
+            }
+        }
+
         CcUninitializeCacheMap(FileObject, &Fcb->RFCB.FileSize, NULL);
+
+        /* Only once the cache map is gone. Freeing the record while a section still refers to
+         * it faults Mm on the next page-in. */
+        if (DeletePending)
+        {
+            NTSTATUS Status;
+
+            MmFlushImageSection(&Fcb->SectionObjectPointers, MmFlushForDelete);
+
+            Status = NtfsDeleteFileRecord(DeviceExt, Fcb->MFTIndex, FALSE);
+            if (!NT_SUCCESS(Status))
+            {
+                DPRINT1("ERROR: Failed to delete '%wS' (MFT record %I64u), Status %lx\n",
+                        Fcb->ObjectName, Fcb->MFTIndex, Status);
+            }
+
+            Fcb->Flags &= ~FCB_DELETE_PENDING;
+        }
 
         if (Fcb->OpenHandleCount != 0)
         {

--- a/drivers/filesystems/ntfs/close.c
+++ b/drivers/filesystems/ntfs/close.c
@@ -58,7 +58,10 @@ NtfsCloseFile(PDEVICE_EXTENSION DeviceExt,
 
     FileObject->FsContext2 = NULL;
     FileObject->FsContext = NULL;
-    FileObject->SectionObjectPointer = NULL;
+
+    /* SectionObjectPointer is deliberately left alone. Mm reaches the file's section object
+     * pointers through it for as long as a section exists, which outlasts the handle. */
+
     DeviceExt->OpenHandleCount--;
 
     if (FileObject->FileName.Buffer)

--- a/drivers/filesystems/ntfs/create.c
+++ b/drivers/filesystems/ntfs/create.c
@@ -297,7 +297,7 @@ NtfsOpenFile(PDEVICE_EXTENSION DeviceExt,
 
         if (!NT_SUCCESS(Status))
         {
-            DPRINT("Could not make a new FCB, status: %x\n", Status);
+            DPRINT("Open of '%S' failed with %lx\n", FileName, Status);
 
             if (AbsFileName)
                 ExFreePoolWithTag(AbsFileName, TAG_NTFS);
@@ -385,7 +385,7 @@ NtfsCreateFile(PDEVICE_OBJECT DeviceObject,
             return Status;
         }
 
-        DPRINT1("Open by ID: %I64x -> %wZ\n", (*(PULONGLONG)FileObject->FileName.Buffer) & NTFS_MFT_MASK, &FullPath);
+        DPRINT("Open by ID: %I64x -> %wZ\n", (*(PULONGLONG)FileObject->FileName.Buffer) & NTFS_MFT_MASK, &FullPath);
     }
 
     /* This a open operation for the volume itself */
@@ -583,7 +583,8 @@ NtfsCreateFile(PDEVICE_OBJECT DeviceObject,
 
             if (!NT_SUCCESS(Status))
             {
-                DPRINT1("ERROR: Couldn't create file record!\n");
+                DPRINT1("ERROR: Couldn't create '%wZ' (Status %lx)\n",
+                        &FileObject->FileName, Status);
                 return Status;
             }
 
@@ -604,6 +605,36 @@ NtfsCreateFile(PDEVICE_OBJECT DeviceObject,
 
     if (NT_SUCCESS(Status))
     {
+        ACCESS_MASK DesiredAccess = 0;
+        ULONG ShareAccess = Stack->Parameters.Create.ShareAccess;
+
+        if (Stack->Parameters.Create.SecurityContext != NULL)
+            DesiredAccess = Stack->Parameters.Create.SecurityContext->DesiredAccess;
+
+        if (Fcb->OpenHandleCount > 0)
+        {
+            Status = IoCheckShareAccess(DesiredAccess,
+                                        ShareAccess,
+                                        FileObject,
+                                        &Fcb->ShareAccess,
+                                        TRUE);
+        }
+        else
+        {
+            IoSetShareAccess(DesiredAccess,
+                             ShareAccess,
+                             FileObject,
+                             &Fcb->ShareAccess);
+        }
+
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT("Sharing violation opening '%wZ'\n", &FileObject->FileName);
+            NtfsCloseFile(DeviceExt, FileObject);
+            Irp->IoStatus.Information = 0;
+            return Status;
+        }
+
         Fcb->OpenHandleCount++;
         DeviceExt->OpenHandleCount++;
     }
@@ -722,7 +753,13 @@ NtfsCreateDirectory(PDEVICE_EXTENSION DeviceExt,
     NextAttribute = (PNTFS_ATTR_RECORD)((ULONG_PTR)NextAttribute + (ULONG_PTR)NextAttribute->Length);
 
     // Add the $FILE_NAME attribute
-    AddFileName(FileRecord, NextAttribute, DeviceExt, FileObject, CaseSensitive, &ParentMftIndex);
+    Status = AddFileName(FileRecord, NextAttribute, DeviceExt, FileObject, CaseSensitive, &ParentMftIndex);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Failed to add the $FILE_NAME attribute for '%wZ'!\n", &FileObject->FileName);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+        return Status;
+    }
 
     // save a pointer to the filename attribute
     FilenameAttribute = (PFILENAME_ATTRIBUTE)((ULONG_PTR)NextAttribute + NextAttribute->Resident.ValueOffset);
@@ -786,7 +823,7 @@ NtfsCreateDirectory(PDEVICE_EXTENSION DeviceExt,
         else
             FileMftIndex = FileMftIndex + ((ULONGLONG)FileRecord->SequenceNumber << 48);
 
-        DPRINT1("New File Reference: 0x%016I64x\n", FileMftIndex);
+        DPRINT("New File Reference: 0x%016I64x\n", FileMftIndex);
 
         // Add the filename attribute to the filename-index of the parent directory
         Status = NtfsAddFilenameToDirectory(DeviceExt,
@@ -919,7 +956,13 @@ NtfsCreateFileRecord(PDEVICE_EXTENSION DeviceExt,
     NextAttribute = (PNTFS_ATTR_RECORD)((ULONG_PTR)NextAttribute + (ULONG_PTR)NextAttribute->Length);
 
     // Add the $FILE_NAME attribute
-    AddFileName(FileRecord, NextAttribute, DeviceExt, FileObject, CaseSensitive, &ParentMftIndex);
+    Status = AddFileName(FileRecord, NextAttribute, DeviceExt, FileObject, CaseSensitive, &ParentMftIndex);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Failed to add the $FILE_NAME attribute for '%wZ'!\n", &FileObject->FileName);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+        return Status;
+    }
 
     // save a pointer to the filename attribute
     FilenameAttribute = (PFILENAME_ATTRIBUTE)((ULONG_PTR)NextAttribute + NextAttribute->Resident.ValueOffset);
@@ -945,7 +988,7 @@ NtfsCreateFileRecord(PDEVICE_EXTENSION DeviceExt,
         else
             FileMftIndex = FileMftIndex + ((ULONGLONG)FileRecord->SequenceNumber << 48);
 
-        DPRINT1("New File Reference: 0x%016I64x\n", FileMftIndex);
+        DPRINT("New File Reference: 0x%016I64x\n", FileMftIndex);
 
         // Add the filename attribute to the filename-index of the parent directory
         Status = NtfsAddFilenameToDirectory(DeviceExt,

--- a/drivers/filesystems/ntfs/dirctl.c
+++ b/drivers/filesystems/ntfs/dirctl.c
@@ -70,12 +70,14 @@ NtfsGetNamesInformation(PDEVICE_EXTENSION DeviceExt,
                         PFILE_NAMES_INFORMATION Info,
                         ULONG BufferLength,
                         PULONG Written,
-                        BOOLEAN First)
+                        BOOLEAN First,
+                        PCUNICODE_STRING OverrideName)
 {
     ULONG Length;
     NTSTATUS Status;
     ULONG BytesToCopy = 0;
     PFILENAME_ATTRIBUTE FileName;
+    PCWSTR NameBuffer;
 
     DPRINT("NtfsGetNamesInformation() called\n");
 
@@ -94,7 +96,17 @@ NtfsGetNamesInformation(PDEVICE_EXTENSION DeviceExt,
         return STATUS_OBJECT_NAME_NOT_FOUND;
     }
 
-    Length = FileName->NameLength * sizeof (WCHAR);
+    if (OverrideName != NULL)
+    {
+        NameBuffer = OverrideName->Buffer;
+        Length = OverrideName->Length;
+    }
+    else
+    {
+        NameBuffer = FileName->Name;
+        Length = FileName->NameLength * sizeof (WCHAR);
+    }
+
     if (First || (BufferLength >= FIELD_OFFSET(FILE_NAMES_INFORMATION, FileName) + Length))
     {
         Info->FileNameLength = Length;
@@ -104,7 +116,7 @@ NtfsGetNamesInformation(PDEVICE_EXTENSION DeviceExt,
         if (BufferLength > FIELD_OFFSET(FILE_NAMES_INFORMATION, FileName))
         {
             BytesToCopy = min(Length, BufferLength - FIELD_OFFSET(FILE_NAMES_INFORMATION, FileName));
-            RtlCopyMemory(Info->FileName, FileName->Name, BytesToCopy);
+            RtlCopyMemory(Info->FileName, NameBuffer, BytesToCopy);
             *Written += BytesToCopy;
 
             if (BytesToCopy == Length)
@@ -127,12 +139,14 @@ NtfsGetDirectoryInformation(PDEVICE_EXTENSION DeviceExt,
                             PFILE_DIRECTORY_INFORMATION Info,
                             ULONG BufferLength,
                             PULONG Written,
-                            BOOLEAN First)
+                            BOOLEAN First,
+                        PCUNICODE_STRING OverrideName)
 {
     ULONG Length;
     NTSTATUS Status;
     ULONG BytesToCopy = 0;
     PFILENAME_ATTRIBUTE FileName;
+    PCWSTR NameBuffer;
     PSTANDARD_INFORMATION StdInfo;
 
     DPRINT("NtfsGetDirectoryInformation() called\n");
@@ -155,7 +169,17 @@ NtfsGetDirectoryInformation(PDEVICE_EXTENSION DeviceExt,
     StdInfo = GetStandardInformationFromRecord(DeviceExt, FileRecord);
     ASSERT(StdInfo != NULL);
 
-    Length = FileName->NameLength * sizeof (WCHAR);
+    if (OverrideName != NULL)
+    {
+        NameBuffer = OverrideName->Buffer;
+        Length = OverrideName->Length;
+    }
+    else
+    {
+        NameBuffer = FileName->Name;
+        Length = FileName->NameLength * sizeof (WCHAR);
+    }
+
     if (First || (BufferLength >= FIELD_OFFSET(FILE_DIRECTORY_INFORMATION, FileName) + Length))
     {
         Info->FileNameLength = Length;
@@ -165,7 +189,7 @@ NtfsGetDirectoryInformation(PDEVICE_EXTENSION DeviceExt,
         if (BufferLength > FIELD_OFFSET(FILE_DIRECTORY_INFORMATION, FileName))
         {
             BytesToCopy = min(Length, BufferLength - FIELD_OFFSET(FILE_DIRECTORY_INFORMATION, FileName));
-            RtlCopyMemory(Info->FileName, FileName->Name, BytesToCopy);
+            RtlCopyMemory(Info->FileName, NameBuffer, BytesToCopy);
             *Written += BytesToCopy;
 
             if (BytesToCopy == Length)
@@ -200,12 +224,14 @@ NtfsGetFullDirectoryInformation(PDEVICE_EXTENSION DeviceExt,
                                 PFILE_FULL_DIRECTORY_INFORMATION Info,
                                 ULONG BufferLength,
                                 PULONG Written,
-                                BOOLEAN First)
+                                BOOLEAN First,
+                        PCUNICODE_STRING OverrideName)
 {
     ULONG Length;
     NTSTATUS Status;
     ULONG BytesToCopy = 0;
     PFILENAME_ATTRIBUTE FileName;
+    PCWSTR NameBuffer;
     PSTANDARD_INFORMATION StdInfo;
 
     DPRINT("NtfsGetFullDirectoryInformation() called\n");
@@ -228,7 +254,17 @@ NtfsGetFullDirectoryInformation(PDEVICE_EXTENSION DeviceExt,
     StdInfo = GetStandardInformationFromRecord(DeviceExt, FileRecord);
     ASSERT(StdInfo != NULL);
 
-    Length = FileName->NameLength * sizeof (WCHAR);
+    if (OverrideName != NULL)
+    {
+        NameBuffer = OverrideName->Buffer;
+        Length = OverrideName->Length;
+    }
+    else
+    {
+        NameBuffer = FileName->Name;
+        Length = FileName->NameLength * sizeof (WCHAR);
+    }
+
     if (First || (BufferLength >= FIELD_OFFSET(FILE_FULL_DIR_INFORMATION, FileName) + Length))
     {
         Info->FileNameLength = Length;
@@ -238,7 +274,7 @@ NtfsGetFullDirectoryInformation(PDEVICE_EXTENSION DeviceExt,
         if (BufferLength > FIELD_OFFSET(FILE_FULL_DIR_INFORMATION, FileName))
         {
             BytesToCopy = min(Length, BufferLength - FIELD_OFFSET(FILE_FULL_DIR_INFORMATION, FileName));
-            RtlCopyMemory(Info->FileName, FileName->Name, BytesToCopy);
+            RtlCopyMemory(Info->FileName, NameBuffer, BytesToCopy);
             *Written += BytesToCopy;
 
             if (BytesToCopy == Length)
@@ -274,12 +310,14 @@ NtfsGetBothDirectoryInformation(PDEVICE_EXTENSION DeviceExt,
                                 PFILE_BOTH_DIR_INFORMATION Info,
                                 ULONG BufferLength,
                                 PULONG Written,
-                                BOOLEAN First)
+                                BOOLEAN First,
+                        PCUNICODE_STRING OverrideName)
 {
     ULONG Length;
     NTSTATUS Status;
     ULONG BytesToCopy = 0;
     PFILENAME_ATTRIBUTE FileName, ShortFileName;
+    PCWSTR NameBuffer;
     PSTANDARD_INFORMATION StdInfo;
 
     DPRINT("NtfsGetBothDirectoryInformation() called\n");
@@ -303,7 +341,17 @@ NtfsGetBothDirectoryInformation(PDEVICE_EXTENSION DeviceExt,
     StdInfo = GetStandardInformationFromRecord(DeviceExt, FileRecord);
     ASSERT(StdInfo != NULL);
 
-    Length = FileName->NameLength * sizeof (WCHAR);
+    if (OverrideName != NULL)
+    {
+        NameBuffer = OverrideName->Buffer;
+        Length = OverrideName->Length;
+    }
+    else
+    {
+        NameBuffer = FileName->Name;
+        Length = FileName->NameLength * sizeof (WCHAR);
+    }
+
     if (First || (BufferLength >= FIELD_OFFSET(FILE_BOTH_DIR_INFORMATION, FileName) + Length))
     {
         Info->FileNameLength = Length;
@@ -313,7 +361,7 @@ NtfsGetBothDirectoryInformation(PDEVICE_EXTENSION DeviceExt,
         if (BufferLength > FIELD_OFFSET(FILE_BOTH_DIR_INFORMATION, FileName))
         {
             BytesToCopy = min(Length, BufferLength - FIELD_OFFSET(FILE_BOTH_DIR_INFORMATION, FileName));
-            RtlCopyMemory(Info->FileName, FileName->Name, BytesToCopy);
+            RtlCopyMemory(Info->FileName, NameBuffer, BytesToCopy);
             *Written += BytesToCopy;
 
             if (BytesToCopy == Length)
@@ -324,7 +372,7 @@ NtfsGetBothDirectoryInformation(PDEVICE_EXTENSION DeviceExt,
             }
         }
 
-        if (ShortFileName)
+        if (ShortFileName && OverrideName == NULL)
         {
             /* Should we upcase the filename? */
             ASSERT(ShortFileName->NameLength <= ARRAYSIZE(Info->ShortName));
@@ -354,6 +402,143 @@ NtfsGetBothDirectoryInformation(PDEVICE_EXTENSION DeviceExt,
     return Status;
 }
 
+
+
+/*
+ * NTFS keeps no "." or ".." entries in its indices, so enumeration has to make
+ * them up. ntfs.sys emits them ahead of the real entries and filters them
+ * through the caller's search pattern; these do the same.
+ */
+static BOOLEAN
+NtfsDotNameMatches(PUNICODE_STRING Pattern,
+                   PUNICODE_STRING Name,
+                   BOOLEAN CaseSensitive)
+{
+    UNICODE_STRING Upcased;
+    BOOLEAN Ret;
+
+    if (!FsRtlDoesNameContainWildCards(Pattern))
+    {
+        return (RtlCompareUnicodeString(Pattern, Name, !CaseSensitive) == 0);
+    }
+
+    /* FsRtlIsNameInExpression() wants the expression upcased when matching
+     * case-insensitively. "." and ".." need no upcasing themselves. */
+    if (CaseSensitive)
+    {
+        return FsRtlIsNameInExpression(Pattern, Name, FALSE, NULL);
+    }
+
+    if (!NT_SUCCESS(RtlUpcaseUnicodeString(&Upcased, Pattern, TRUE)))
+    {
+        return FALSE;
+    }
+
+    Ret = FsRtlIsNameInExpression(&Upcased, Name, TRUE, NULL);
+    RtlFreeUnicodeString(&Upcased);
+
+    return Ret;
+}
+
+static NTSTATUS
+NtfsGetDirEntryInformation(PDEVICE_EXTENSION DeviceExt,
+                           FILE_INFORMATION_CLASS FileInformationClass,
+                           PFILE_RECORD_HEADER FileRecord,
+                           ULONGLONG MFTIndex,
+                           PCUNICODE_STRING OverrideName,
+                           PVOID Buffer,
+                           ULONG BufferLength,
+                           PULONG Written,
+                           BOOLEAN First)
+{
+    switch (FileInformationClass)
+    {
+        case FileNamesInformation:
+            return NtfsGetNamesInformation(DeviceExt, FileRecord, MFTIndex,
+                                           (PFILE_NAMES_INFORMATION)Buffer,
+                                           BufferLength, Written, First, OverrideName);
+
+        case FileDirectoryInformation:
+            return NtfsGetDirectoryInformation(DeviceExt, FileRecord, MFTIndex,
+                                               (PFILE_DIRECTORY_INFORMATION)Buffer,
+                                               BufferLength, Written, First, OverrideName);
+
+        case FileFullDirectoryInformation:
+            return NtfsGetFullDirectoryInformation(DeviceExt, FileRecord, MFTIndex,
+                                                   (PFILE_FULL_DIRECTORY_INFORMATION)Buffer,
+                                                   BufferLength, Written, First, OverrideName);
+
+        case FileBothDirectoryInformation:
+            return NtfsGetBothDirectoryInformation(DeviceExt, FileRecord, MFTIndex,
+                                                   (PFILE_BOTH_DIR_INFORMATION)Buffer,
+                                                   BufferLength, Written, First, OverrideName);
+
+        default:
+            return STATUS_INVALID_INFO_CLASS;
+    }
+}
+
+/* Describes MFTIndex under the given name. "." reports the directory itself,
+ * ".." its parent, so both take their times and attributes from a real record. */
+static NTSTATUS
+NtfsGetDotEntry(PDEVICE_EXTENSION DeviceExt,
+                ULONGLONG MFTIndex,
+                PCUNICODE_STRING Name,
+                FILE_INFORMATION_CLASS FileInformationClass,
+                PVOID Buffer,
+                ULONG BufferLength,
+                PULONG Written,
+                BOOLEAN First)
+{
+    PFILE_RECORD_HEADER FileRecord;
+    NTSTATUS Status;
+
+    FileRecord = ExAllocateFromNPagedLookasideList(&DeviceExt->FileRecLookasideList);
+    if (FileRecord == NULL)
+    {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    Status = ReadFileRecord(DeviceExt, MFTIndex, FileRecord);
+    if (NT_SUCCESS(Status))
+    {
+        Status = NtfsGetDirEntryInformation(DeviceExt, FileInformationClass, FileRecord,
+                                            MFTIndex, Name, Buffer, BufferLength,
+                                            Written, First);
+    }
+
+    ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+
+    return Status;
+}
+
+static ULONGLONG
+NtfsGetParentMftIndex(PDEVICE_EXTENSION DeviceExt,
+                      ULONGLONG MFTIndex)
+{
+    PFILE_RECORD_HEADER FileRecord;
+    PFILENAME_ATTRIBUTE FileName;
+    ULONGLONG Parent = MFTIndex;
+
+    FileRecord = ExAllocateFromNPagedLookasideList(&DeviceExt->FileRecLookasideList);
+    if (FileRecord == NULL)
+    {
+        return Parent;
+    }
+
+    if (NT_SUCCESS(ReadFileRecord(DeviceExt, MFTIndex, FileRecord)))
+    {
+        FileName = GetBestFileNameFromRecord(DeviceExt, FileRecord);
+        if (FileName != NULL)
+        {
+            Parent = FileName->DirectoryFileReferenceNumber & NTFS_MFT_MASK;
+        }
+    }
+
+    ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+
+    return Parent;
+}
 
 NTSTATUS
 NtfsQueryDirectory(PNTFS_IRP_CONTEXT IrpContext)
@@ -451,10 +636,12 @@ NtfsQueryDirectory(PNTFS_IRP_CONTEXT IrpContext)
     if (Stack->Flags & SL_INDEX_SPECIFIED)
     {
         Ccb->Entry = FileIndex;
+        SetFlag(Ccb->Flags, CCB_RETURNED_DOT | CCB_RETURNED_DOTDOT);
     }
     else if (First || (Stack->Flags & SL_RESTART_SCAN))
     {
         Ccb->Entry = 0;
+        ClearFlag(Ccb->Flags, CCB_RETURNED_DOT | CCB_RETURNED_DOTDOT);
     }
 
     /* Get Buffer for result */
@@ -472,6 +659,58 @@ NtfsQueryDirectory(PNTFS_IRP_CONTEXT IrpContext)
     Written = 0;
     while (Status == STATUS_SUCCESS && BufferLength > 0)
     {
+        if (!BooleanFlagOn(Ccb->Flags, CCB_RETURNED_DOT) ||
+            !BooleanFlagOn(Ccb->Flags, CCB_RETURNED_DOTDOT))
+        {
+            BOOLEAN DotDot = BooleanFlagOn(Ccb->Flags, CCB_RETURNED_DOT);
+            UNICODE_STRING DotName;
+            ULONGLONG DotIndex;
+
+            RtlInitUnicodeString(&DotName, DotDot ? L".." : L".");
+
+            if (!NtfsDotNameMatches(&Pattern, &DotName,
+                                    BooleanFlagOn(Stack->Flags, SL_CASE_SENSITIVE)))
+            {
+                SetFlag(Ccb->Flags, DotDot ? CCB_RETURNED_DOTDOT : CCB_RETURNED_DOT);
+                continue;
+            }
+
+            DotIndex = DotDot ? NtfsGetParentMftIndex(DeviceExtension, Fcb->MFTIndex)
+                              : Fcb->MFTIndex;
+
+            Status = NtfsGetDotEntry(DeviceExtension, DotIndex, &DotName,
+                                     FileInformationClass, Buffer, BufferLength,
+                                     &Written, Buffer0 == NULL);
+
+            /* The entry did not fit. Leave the flag alone so the next call,
+             * with a bigger buffer, hands it out instead of skipping it. */
+            if (Status == STATUS_BUFFER_OVERFLOW || Status == STATUS_INVALID_INFO_CLASS)
+            {
+                break;
+            }
+
+            SetFlag(Ccb->Flags, DotDot ? CCB_RETURNED_DOTDOT : CCB_RETURNED_DOT);
+
+            if (!NT_SUCCESS(Status))
+            {
+                /* Losing "." is not worth failing the whole enumeration over */
+                Status = STATUS_SUCCESS;
+                continue;
+            }
+
+            Buffer0 = (PFILE_NAMES_INFORMATION)Buffer;
+            Buffer0->FileIndex = FileIndex++;
+            BufferLength -= Buffer0->NextEntryOffset;
+
+            if (Stack->Flags & SL_RETURN_SINGLE_ENTRY)
+            {
+                break;
+            }
+
+            Buffer += Buffer0->NextEntryOffset;
+            continue;
+        }
+
         Status = NtfsFindFileAt(DeviceExtension,
                                 &Pattern,
                                 &Ccb->Entry,
@@ -494,51 +733,15 @@ NtfsQueryDirectory(PNTFS_IRP_CONTEXT IrpContext)
             }
             OldMFTRecord = MFTRecord;
 
-            switch (FileInformationClass)
-            {
-                case FileNamesInformation:
-                    Status = NtfsGetNamesInformation(DeviceExtension,
-                                                     FileRecord,
-                                                     MFTRecord,
-                                                     (PFILE_NAMES_INFORMATION)Buffer,
-                                                     BufferLength,
-                                                     &Written,
-                                                     Buffer0 == NULL);
-                    break;
-
-                case FileDirectoryInformation:
-                    Status = NtfsGetDirectoryInformation(DeviceExtension,
-                                                         FileRecord,
-                                                         MFTRecord,
-                                                         (PFILE_DIRECTORY_INFORMATION)Buffer,
-                                                         BufferLength,
-                                                         &Written,
-                                                         Buffer0 == NULL);
-                    break;
-
-                case FileFullDirectoryInformation:
-                    Status = NtfsGetFullDirectoryInformation(DeviceExtension,
-                                                             FileRecord,
-                                                             MFTRecord,
-                                                             (PFILE_FULL_DIRECTORY_INFORMATION)Buffer,
-                                                             BufferLength,
-                                                             &Written,
-                                                             Buffer0 == NULL);
-                    break;
-
-                case FileBothDirectoryInformation:
-                    Status = NtfsGetBothDirectoryInformation(DeviceExtension,
-                                                             FileRecord,
-                                                             MFTRecord,
-                                                             (PFILE_BOTH_DIR_INFORMATION)Buffer,
-                                                             BufferLength,
-                                                             &Written,
-                                                             Buffer0 == NULL);
-                    break;
-
-                default:
-                    Status = STATUS_INVALID_INFO_CLASS;
-            }
+            Status = NtfsGetDirEntryInformation(DeviceExtension,
+                                                FileInformationClass,
+                                                FileRecord,
+                                                MFTRecord,
+                                                NULL,
+                                                Buffer,
+                                                BufferLength,
+                                                &Written,
+                                                Buffer0 == NULL);
 
             if (Status == STATUS_BUFFER_OVERFLOW || Status == STATUS_INVALID_INFO_CLASS)
             {
@@ -593,6 +796,9 @@ NtfsDirectoryControl(PNTFS_IRP_CONTEXT IrpContext)
 
     DPRINT("NtfsDirectoryControl() called\n");
 
+    /* Handlers that fill the caller's buffer overwrite this with the byte count */
+    IrpContext->Irp->IoStatus.Information = 0;
+
     switch (IrpContext->MinorFunction)
     {
         case IRP_MN_QUERY_DIRECTORY:
@@ -613,8 +819,6 @@ NtfsDirectoryControl(PNTFS_IRP_CONTEXT IrpContext)
     {
         return NtfsMarkIrpContextForQueue(IrpContext);
     }
-
-    IrpContext->Irp->IoStatus.Information = 0;
 
     return Status;
 }

--- a/drivers/filesystems/ntfs/dispatch.c
+++ b/drivers/filesystems/ntfs/dispatch.c
@@ -132,6 +132,10 @@ NtfsDispatch(PNTFS_IRP_CONTEXT IrpContext)
         case IRP_MJ_FILE_SYSTEM_CONTROL:
             Status = NtfsFileSystemControl(IrpContext);
             break;
+
+        case IRP_MJ_FLUSH_BUFFERS:
+            Status = NtfsFlushBuffers(IrpContext);
+            break;
     }
 
     ASSERT((!(IrpContext->Flags & IRPCONTEXT_COMPLETE) && !(IrpContext->Flags & IRPCONTEXT_QUEUE)) ||

--- a/drivers/filesystems/ntfs/fcb.c
+++ b/drivers/filesystems/ntfs/fcb.c
@@ -484,7 +484,9 @@ NtfsAttachFCBToFileObject(PNTFS_VCB Vcb,
     newCCB->PtrFileObject = FileObject;
     Fcb->Vcb = Vcb;
 
-    if (!(Fcb->Flags & FCB_CACHE_INITIALIZED))
+    /* Directories are excluded: they have no $DATA to map, and a data section on one gives Mm
+     * pages to fault in that we can never satisfy. */
+    if (!(Fcb->Flags & FCB_CACHE_INITIALIZED) && !NtfsFCBIsDirectory(Fcb))
     {
         _SEH2_TRY
         {
@@ -563,7 +565,7 @@ NtfsDirFindFile(PNTFS_VCB Vcb,
 
         /* Skip colon */
         ++Colon;
-        DPRINT1("Will now look for file '%wZ' with stream '%S'\n", &File, Colon);
+        DPRINT("Will now look for file '%wZ' with stream '%S'\n", &File, Colon);
     }
 
     Status = NtfsLookupFileAt(Vcb, &File, CaseSensitive, &FileRecord, &MFTIndex, CurrentDir);

--- a/drivers/filesystems/ntfs/fcb.c
+++ b/drivers/filesystems/ntfs/fcb.c
@@ -193,9 +193,21 @@ NtfsReleaseFCB(PNTFS_VCB Vcb,
     Fcb->RefCount--;
     if (Fcb->RefCount <= 0 && !NtfsFCBIsDirectory(Fcb))
     {
+        KeReleaseSpinLock(&Vcb->FcbListLock, oldIrql);
+
+        CcUninitializeCacheMap(Fcb->FileObject, NULL, NULL);
+
+        if (Fcb->SectionObjectPointers.DataSectionObject != NULL ||
+            Fcb->SectionObjectPointers.ImageSectionObject != NULL)
+        {
+            DPRINT("Keeping FCB %p (%S): still mapped\n", Fcb, Fcb->PathName);
+            return;
+        }
+
+        KeAcquireSpinLock(&Vcb->FcbListLock, &oldIrql);
         RemoveEntryList(&Fcb->FcbListEntry);
         KeReleaseSpinLock(&Vcb->FcbListLock, oldIrql);
-        CcUninitializeCacheMap(Fcb->FileObject, NULL, NULL);
+
         NtfsDestroyFCB(Fcb);
     }
     else

--- a/drivers/filesystems/ntfs/finfo.c
+++ b/drivers/filesystems/ntfs/finfo.c
@@ -61,7 +61,7 @@ NtfsGetStandardInformation(PNTFS_FCB Fcb,
     StandardInfo->AllocationSize = Fcb->RFCB.AllocationSize;
     StandardInfo->EndOfFile = Fcb->RFCB.FileSize;
     StandardInfo->NumberOfLinks = Fcb->LinkCount;
-    StandardInfo->DeletePending = FALSE;
+    StandardInfo->DeletePending = BooleanFlagOn(Fcb->Flags, FCB_DELETE_PENDING);
     StandardInfo->Directory = NtfsFCBIsDirectory(Fcb);
 
     *BufferLength -= sizeof(FILE_STANDARD_INFORMATION);
@@ -117,6 +117,53 @@ NtfsGetBasicInformation(PFILE_OBJECT FileObject,
     NtfsFileFlagsToAttributes(FileName->FileAttributes, &BasicInfo->FileAttributes);
 
     *BufferLength -= sizeof(FILE_BASIC_INFORMATION);
+
+    return STATUS_SUCCESS;
+}
+
+static
+NTSTATUS
+NtfsGetAttributeTagInformation(PNTFS_FCB Fcb,
+                               PFILE_ATTRIBUTE_TAG_INFORMATION AttributeTagInfo,
+                               PULONG BufferLength)
+{
+    PFILENAME_ATTRIBUTE FileName = &Fcb->Entry;
+
+    DPRINT("NtfsGetAttributeTagInformation(%p, %p, %p)\n", Fcb, AttributeTagInfo, BufferLength);
+
+    if (*BufferLength < sizeof(FILE_ATTRIBUTE_TAG_INFORMATION))
+        return STATUS_BUFFER_TOO_SMALL;
+
+    RtlZeroMemory(AttributeTagInfo, sizeof(FILE_ATTRIBUTE_TAG_INFORMATION));
+
+    NtfsFileFlagsToAttributes(FileName->FileAttributes, &AttributeTagInfo->FileAttributes);
+
+    /* FIXME: Read the tag from $REPARSE_POINT for a reparse point */
+    AttributeTagInfo->ReparseTag = 0;
+
+    *BufferLength -= sizeof(FILE_ATTRIBUTE_TAG_INFORMATION);
+
+    return STATUS_SUCCESS;
+}
+
+
+static
+NTSTATUS
+NtfsGetEaInformation(PNTFS_FCB Fcb,
+                     PFILE_EA_INFORMATION EaInfo,
+                     PULONG BufferLength)
+{
+    UNREFERENCED_PARAMETER(Fcb);
+
+    DPRINT("NtfsGetEaInformation(%p, %p, %p)\n", Fcb, EaInfo, BufferLength);
+
+    if (*BufferLength < sizeof(FILE_EA_INFORMATION))
+        return STATUS_BUFFER_TOO_SMALL;
+
+    /* We do not support extended attributes yet, so there are none */
+    EaInfo->EaSize = 0;
+
+    *BufferLength -= sizeof(FILE_EA_INFORMATION);
 
     return STATUS_SUCCESS;
 }
@@ -429,7 +476,7 @@ NtfsQueryInformation(PNTFS_IRP_CONTEXT IrpContext)
     PDEVICE_OBJECT DeviceObject;
     NTSTATUS Status = STATUS_SUCCESS;
 
-    DPRINT1("NtfsQueryInformation(%p)\n", IrpContext);
+    DPRINT("NtfsQueryInformation(%p)\n", IrpContext);
 
     Irp = IrpContext->Irp;
     Stack = IrpContext->Stack;
@@ -454,6 +501,12 @@ NtfsQueryInformation(PNTFS_IRP_CONTEXT IrpContext)
                                                 DeviceObject,
                                                 SystemBuffer,
                                                 &BufferLength);
+            break;
+
+        case FileEaInformation:
+            Status = NtfsGetEaInformation(Fcb,
+                                          SystemBuffer,
+                                          &BufferLength);
             break;
 
         case FilePositionInformation:
@@ -496,6 +549,12 @@ NtfsQueryInformation(PNTFS_IRP_CONTEXT IrpContext)
                                               DeviceObject->DeviceExtension,
                                               SystemBuffer,
                                               &BufferLength);
+            break;
+
+        case FileAttributeTagInformation:
+            Status = NtfsGetAttributeTagInformation(Fcb,
+                                                    SystemBuffer,
+                                                    &BufferLength);
             break;
 
         case FileAlternateNameInformation:
@@ -572,10 +631,7 @@ NtfsSetEndOfFile(PNTFS_FCB Fcb,
     PNTFS_ATTR_CONTEXT DataContext;
     ULONG AttributeOffset;
     NTSTATUS Status = STATUS_SUCCESS;
-    ULONGLONG AllocationSize;
     PFILENAME_ATTRIBUTE FileNameAttribute;
-    ULONGLONG ParentMFTId;
-    UNICODE_STRING FileName;
 
 
     // Allocate non-paged memory for the file record
@@ -669,21 +725,11 @@ NtfsSetEndOfFile(PNTFS_FCB Fcb,
         return STATUS_INVALID_PARAMETER;
     }
 
-    ParentMFTId = FileNameAttribute->DirectoryFileReferenceNumber & NTFS_MFT_MASK;
-
-    FileName.Buffer = FileNameAttribute->Name;
-    FileName.Length = FileNameAttribute->NameLength * sizeof(WCHAR);
-    FileName.MaximumLength = FileName.Length;
-
-    AllocationSize = AttributeAllocatedLength(DataContext->pRecord);
-
-    Status = UpdateFileNameRecord(Fcb->Vcb,
-                                  ParentMFTId,
-                                  &FileName,
-                                  FALSE,
-                                  NewFileSize->QuadPart,
-                                  AllocationSize,
-                                  CaseSensitive);
+    Status = NtfsUpdateDuplicatedInformation(Fcb->Vcb,
+                                             FileRecord,
+                                             Fcb->MFTIndex,
+                                             NTFS_FILENAME_UPDATE_SIZES,
+                                             CaseSensitive);
 
     ReleaseAttributeContext(DataContext);
     ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
@@ -715,6 +761,211 @@ NtfsSetEndOfFile(PNTFS_FCB Fcb,
 * All other information classes are TODO.
 *
 */
+/**
+* @name NtfsSetBasicInformation
+* @implemented
+*
+* Applies a FILE_BASIC_INFORMATION to a file: its four timestamps and its
+* attribute flags.
+*
+* @param DeviceExt
+* Points to the target disk's DEVICE_EXTENSION
+*
+* @param Fcb
+* File control block of the file being changed
+*
+* @param CaseSensitive
+* Whether the parent directory's index should be searched case-sensitively
+*
+* @param BasicInfo
+* The timestamps and attributes to apply
+*
+* @return
+* STATUS_SUCCESS on success, STATUS_INSUFFICIENT_RESOURCES if an allocation
+* failed, STATUS_INVALID_PARAMETER if the file record has no
+* $STANDARD_INFORMATION, or whatever status reading or writing the file record
+* returned.
+*
+* @remarks A timestamp of zero means "leave as is" and -1 means "stop
+* maintaining automatically"; both are treated as no change, as the driver
+* doesn't yet update timestamps on I/O. FileAttributes of zero means no change.
+*
+* NTFS keeps a second copy of these in $FILE_NAME and a third in the parent
+* directory's index entry; all three are updated here.
+*
+*/
+static
+NTSTATUS
+NtfsSetBasicInformation(PDEVICE_EXTENSION DeviceExt,
+                        PNTFS_FCB Fcb,
+                        BOOLEAN CaseSensitive,
+                        PFILE_BASIC_INFORMATION BasicInfo)
+{
+    PFILE_RECORD_HEADER FileRecord;
+    PSTANDARD_INFORMATION StdInfo;
+    NTSTATUS Status;
+
+    DPRINT("NtfsSetBasicInformation(%p, %p, %p)\n", DeviceExt, Fcb, BasicInfo);
+
+    FileRecord = ExAllocateFromNPagedLookasideList(&DeviceExt->FileRecLookasideList);
+    if (FileRecord == NULL)
+    {
+        DPRINT1("Not enough memory!\n");
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    Status = ReadFileRecord(DeviceExt, Fcb->MFTIndex, FileRecord);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("Can't find record for %wS!\n", Fcb->ObjectName);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+        return Status;
+    }
+
+    StdInfo = GetStandardInformationFromRecord(DeviceExt, FileRecord);
+    if (StdInfo == NULL)
+    {
+        DPRINT1("No $STANDARD_INFORMATION for %wS!\n", Fcb->ObjectName);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    if (BasicInfo->CreationTime.QuadPart > 0)
+        StdInfo->CreationTime = BasicInfo->CreationTime.QuadPart;
+
+    if (BasicInfo->LastAccessTime.QuadPart > 0)
+        StdInfo->LastAccessTime = BasicInfo->LastAccessTime.QuadPart;
+
+    if (BasicInfo->LastWriteTime.QuadPart > 0)
+        StdInfo->LastWriteTime = BasicInfo->LastWriteTime.QuadPart;
+
+    if (BasicInfo->ChangeTime.QuadPart > 0)
+        StdInfo->ChangeTime = BasicInfo->ChangeTime.QuadPart;
+
+    if (BasicInfo->FileAttributes != 0)
+    {
+        ULONG Attributes = BasicInfo->FileAttributes;
+
+        /* Whether this is a directory isn't the caller's to say */
+        Attributes &= ~(FILE_ATTRIBUTE_DIRECTORY | NTFS_FILE_TYPE_DIRECTORY);
+
+        /* NORMAL only means anything on its own */
+        if ((Attributes & FILE_ATTRIBUTE_NORMAL) && Attributes != FILE_ATTRIBUTE_NORMAL)
+            Attributes &= ~FILE_ATTRIBUTE_NORMAL;
+
+        StdInfo->FileAttribute = Attributes;
+    }
+
+    /* Everything else NTFS keeps a second and third copy of goes out through the one funnel,
+     * which also writes the file record back. */
+    Status = NtfsUpdateDuplicatedInformation(DeviceExt,
+                                             FileRecord,
+                                             Fcb->MFTIndex,
+                                             NTFS_FILENAME_UPDATE_TIMES |
+                                             NTFS_FILENAME_UPDATE_ATTRS,
+                                             CaseSensitive);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("Failed to refresh the duplicated information for %wS (Status %lx)\n",
+                Fcb->ObjectName, Status);
+    }
+
+    ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+
+    return Status;
+}
+
+/**
+* @name NtfsSetDispositionInformation
+* @implemented
+*
+* Marks a file for deletion, or clears an existing mark.
+*
+* @param DeviceExt
+* Points to the target disk's DEVICE_EXTENSION.
+*
+* @param Fcb
+* Pointer to the NTFS_FCB of the file. Fcb->MainResource should have been acquired.
+*
+* @param FileObject
+* Pointer to the FILE_OBJECT the request arrived on.
+*
+* @param CaseSensitive
+* Boolean indicating if the function should operate in case-sensitive mode. This will be TRUE
+* if an application created the file with the FILE_FLAG_POSIX_SEMANTICS flag.
+*
+* @param DispositionInfo
+* Pointer to the FILE_DISPOSITION_INFORMATION supplied by the caller.
+*
+* @return
+* STATUS_SUCCESS on success.
+* STATUS_CANNOT_DELETE if the file is read-only or is the volume root.
+* STATUS_DIRECTORY_NOT_EMPTY if the file is a directory that still holds entries.
+*
+* @remarks
+* Only records the intent; the file is deleted at cleanup, once its last handle is closed.
+*/
+static
+NTSTATUS
+NtfsSetDispositionInformation(PDEVICE_EXTENSION DeviceExt,
+                              PNTFS_FCB Fcb,
+                              PFILE_OBJECT FileObject,
+                              BOOLEAN CaseSensitive,
+                              PFILE_DISPOSITION_INFORMATION DispositionInfo)
+{
+    DPRINT("NtfsSetDispositionInformation(%p, %p, %p, %s, %p)\n",
+           DeviceExt, Fcb, FileObject, CaseSensitive ? "TRUE" : "FALSE", DispositionInfo);
+
+    if (!DispositionInfo->DeleteFile)
+    {
+        Fcb->Flags &= ~FCB_DELETE_PENDING;
+        FileObject->DeletePending = FALSE;
+        return STATUS_SUCCESS;
+    }
+
+    if (!NtfsGlobalData->EnableWriteSupport)
+    {
+        DPRINT1("NTFS write-support is EXPERIMENTAL and is disabled by default!\n");
+        return STATUS_ACCESS_DENIED;
+    }
+
+    /* The volume root has no parent index to be removed from */
+    if (NtfsFCBIsRoot(Fcb))
+        return STATUS_CANNOT_DELETE;
+
+    if (Fcb->Entry.FileAttributes & NTFS_FILE_TYPE_READ_ONLY)
+        return STATUS_CANNOT_DELETE;
+
+    if (NtfsFCBIsDirectory(Fcb))
+    {
+        UNICODE_STRING Pattern = RTL_CONSTANT_STRING(L"*");
+        ULONGLONG EntryMftIndex;
+        ULONG FirstEntry = 0;
+        NTSTATUS Status;
+
+        /* "." and ".." are synthesized during enumeration and are not in the index, so any
+         * entry found here is a real child */
+        Status = NtfsFindMftRecord(DeviceExt,
+                                   Fcb->MFTIndex,
+                                   &Pattern,
+                                   &FirstEntry,
+                                   FALSE,
+                                   CaseSensitive,
+                                   &EntryMftIndex);
+        if (NT_SUCCESS(Status))
+            return STATUS_DIRECTORY_NOT_EMPTY;
+    }
+
+    /* Deleting a mapped file would free its record out from under the section */
+    if (!MmFlushImageSection(&Fcb->SectionObjectPointers, MmFlushForDelete))
+        return STATUS_CANNOT_DELETE;
+
+    Fcb->Flags |= FCB_DELETE_PENDING;
+    FileObject->DeletePending = TRUE;
+
+    return STATUS_SUCCESS;
+}
+
 NTSTATUS
 NtfsSetInformation(PNTFS_IRP_CONTEXT IrpContext)
 {
@@ -752,6 +1003,19 @@ NtfsSetInformation(PNTFS_IRP_CONTEXT IrpContext)
     {
         PFILE_END_OF_FILE_INFORMATION EndOfFileInfo;
 
+        case FileBasicInformation:
+            if (BufferLength < sizeof(FILE_BASIC_INFORMATION))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+                break;
+            }
+
+            Status = NtfsSetBasicInformation(DeviceExt,
+                                             Fcb,
+                                             BooleanFlagOn(Stack->Flags, SL_CASE_SENSITIVE),
+                                             (PFILE_BASIC_INFORMATION)SystemBuffer);
+            break;
+
         /* TODO: Allocation size is not actually the same as file end for NTFS,
            however, few applications are likely to make the distinction. */
         case FileAllocationInformation:
@@ -764,6 +1028,20 @@ NtfsSetInformation(PNTFS_IRP_CONTEXT IrpContext)
                                       Irp->Flags,
                                       BooleanFlagOn(Stack->Flags, SL_CASE_SENSITIVE),
                                       &EndOfFileInfo->EndOfFile);
+            break;
+
+        case FileDispositionInformation:
+            if (BufferLength < sizeof(FILE_DISPOSITION_INFORMATION))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+                break;
+            }
+
+            Status = NtfsSetDispositionInformation(DeviceExt,
+                                                   Fcb,
+                                                   FileObject,
+                                                   BooleanFlagOn(Stack->Flags, SL_CASE_SENSITIVE),
+                                                   (PFILE_DISPOSITION_INFORMATION)SystemBuffer);
             break;
 
         // TODO: all other information classes

--- a/drivers/filesystems/ntfs/flush.c
+++ b/drivers/filesystems/ntfs/flush.c
@@ -1,0 +1,51 @@
+
+
+/* INCLUDES *****************************************************************/
+
+#include "ntfs.h"
+
+#define NDEBUG
+#include <debug.h>
+
+/* FUNCTIONS ****************************************************************/
+
+/**
+* @name NtfsFlushBuffers
+* @implemented
+*
+* Handles IRP_MJ_FLUSH_BUFFERS.
+*
+* @param IrpContext
+* Points to an NTFS_IRP_CONTEXT which describes the request
+*
+* @return
+* STATUS_SUCCESS if everything reached the media, otherwise the status the
+* storage stack returned.
+*
+*/
+NTSTATUS
+NtfsFlushBuffers(PNTFS_IRP_CONTEXT IrpContext)
+{
+    PDEVICE_EXTENSION DeviceExt;
+
+    DPRINT("NtfsFlushBuffers(%p)\n", IrpContext);
+
+    IrpContext->Irp->IoStatus.Information = 0;
+
+    /* Nothing is mounted on the main device object */
+    if (IrpContext->DeviceObject == NtfsGlobalData->DeviceObject)
+    {
+        return STATUS_SUCCESS;
+    }
+
+    DeviceExt = IrpContext->DeviceObject->DeviceExtension;
+
+    if (DeviceExt->Flags & VCB_VOLUME_DISMOUNTED)
+    {
+        return STATUS_VOLUME_DISMOUNTED;
+    }
+
+    return NtfsFlushDevice(DeviceExt->StorageDevice);
+}
+
+/* EOF */

--- a/drivers/filesystems/ntfs/fsctl.c
+++ b/drivers/filesystems/ntfs/fsctl.c
@@ -90,7 +90,7 @@ NtfsHasFileSystem(PDEVICE_OBJECT DeviceToMount)
         }
     }
 
-    DPRINT1("BytesPerSector: %lu\n", DiskGeometry.BytesPerSector);
+    DPRINT("BytesPerSector: %lu\n", DiskGeometry.BytesPerSector);
     BootSector = ExAllocatePoolWithTag(NonPagedPool,
                                        DiskGeometry.BytesPerSector,
                                        TAG_NTFS);
@@ -407,6 +407,15 @@ NtfsGetVolumeData(PDEVICE_OBJECT DeviceObject,
 
     NtfsInfo->MftZoneReservation = NtfsQueryMftZoneReservation();
 
+    /* NTFS defines its own case folding through $UpCase; without it every
+     * case-insensitive comparison on this volume would use the wrong table. */
+    Status = NtfsLoadUpCaseTable(DeviceExt);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("Failed to load $UpCase (Status %lx)\n", Status);
+        return Status;
+    }
+
     return Status;
 }
 
@@ -563,6 +572,12 @@ ByeBye:
 
         if (Ccb)
             ExFreePool(Ccb);
+
+        if (Vcb != NULL && Vcb->UpCaseTable != NULL)
+        {
+            ExFreePoolWithTag(Vcb->UpCaseTable, TAG_NTFS);
+            Vcb->UpCaseTable = NULL;
+        }
 
         if (Lookaside)
             ExDeleteNPagedLookasideList(&Vcb->FileRecLookasideList);
@@ -895,6 +910,78 @@ LockOrUnlockVolume(PDEVICE_EXTENSION DeviceExt,
 }
 
 
+/**
+* @name NtfsDismountVolume
+* @implemented
+*
+* Takes the volume offline so the caller can reformat or eject the media.
+*
+* @param DeviceExt
+* Volume control block of the volume to dismount
+*
+* @param Irp
+* The FSCTL_DISMOUNT_VOLUME request
+*
+* @return
+* STATUS_SUCCESS once the volume is offline, STATUS_INVALID_PARAMETER if the
+* request did not come through a handle on the volume itself, or
+* STATUS_VOLUME_DISMOUNTED if it already was.
+*
+* @remarks The VCB is not torn down here: the caller keeps its handle open and
+* goes on writing over the volume through it, so the device object has to stay
+* alive. What changes is that the volume is no longer mounted,
+* VPB_DIRECT_WRITES_ALLOWED lets raw writes through, and anything needing
+* on-disk metadata is refused.
+*
+*/
+static
+NTSTATUS
+NtfsDismountVolume(PDEVICE_EXTENSION DeviceExt,
+                   PIRP Irp)
+{
+    PIO_STACK_LOCATION Stack;
+    PFILE_OBJECT FileObject;
+    PNTFS_FCB Fcb;
+    KIRQL SavedIrql;
+
+    Stack = IoGetCurrentIrpStackLocation(Irp);
+    FileObject = Stack->FileObject;
+    Fcb = FileObject->FsContext;
+
+    /* Only a handle on the volume itself may dismount it */
+    if (!(Fcb->Flags & FCB_IS_VOLUME))
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    if (DeviceExt->Flags & VCB_VOLUME_DISMOUNTED)
+    {
+        return STATUS_VOLUME_DISMOUNTED;
+    }
+
+    DPRINT1("Dismounting volume\n");
+
+    FsRtlNotifyVolumeEvent(FileObject, FSRTL_VOLUME_DISMOUNT);
+
+    ExAcquireResourceExclusiveLite(&DeviceExt->DirResource, TRUE);
+
+    DeviceExt->Flags |= VCB_VOLUME_DISMOUNTED;
+
+    /* Drop the mounted state and allow raw writes, so the I/O manager stops
+     * handing us opens of a partition that's being overwritten */
+    IoAcquireVpbSpinLock(&SavedIrql);
+    if (DeviceExt->StorageDevice->Vpb != NULL)
+    {
+        DeviceExt->StorageDevice->Vpb->Flags |= VPB_DIRECT_WRITES_ALLOWED;
+        DeviceExt->StorageDevice->Vpb->Flags &= ~VPB_MOUNTED;
+    }
+    IoReleaseVpbSpinLock(SavedIrql);
+
+    ExReleaseResourceLite(&DeviceExt->DirResource);
+
+    return STATUS_SUCCESS;
+}
+
 static
 NTSTATUS
 NtfsUserFsRequest(PDEVICE_OBJECT DeviceObject,
@@ -935,6 +1022,10 @@ NtfsUserFsRequest(PDEVICE_OBJECT DeviceObject,
 
         case FSCTL_UNLOCK_VOLUME:
             Status = LockOrUnlockVolume(DeviceExt, Irp, FALSE);
+            break;
+
+        case FSCTL_DISMOUNT_VOLUME:
+            Status = NtfsDismountVolume(DeviceExt, Irp);
             break;
 
         case FSCTL_GET_NTFS_VOLUME_DATA:

--- a/drivers/filesystems/ntfs/mft.c
+++ b/drivers/filesystems/ntfs/mft.c
@@ -309,7 +309,7 @@ IncreaseMftSize(PDEVICE_EXTENSION Vcb, BOOLEAN CanWait)
     ULONG i;
     NTSTATUS Status;
 
-    DPRINT1("IncreaseMftSize(%p, %s)\n", Vcb, CanWait ? "TRUE" : "FALSE");
+    DPRINT("IncreaseMftSize(%p, %s)\n", Vcb, CanWait ? "TRUE" : "FALSE");
 
     // We need exclusive access to the mft while we change its size
     if (!ExAcquireResourceExclusiveLite(&(Vcb->DirResource), CanWait))
@@ -551,7 +551,7 @@ InternalSetResidentAttributeLength(PDEVICE_EXTENSION DeviceExt,
     ULONG OldAttributeLength = Destination->Length;
     ULONG NextAttributeOffset;
 
-    DPRINT1("InternalSetResidentAttributeLength( %p, %p, %p, %lu, %lu )\n", DeviceExt, AttrContext, FileRecord, AttrOffset, DataSize);
+    DPRINT("InternalSetResidentAttributeLength( %p, %p, %p, %lu, %lu )\n", DeviceExt, AttrContext, FileRecord, AttrOffset, DataSize);
 
     ASSERT(!AttrContext->pRecord->IsNonResident);
 
@@ -621,7 +621,7 @@ SetAttributeDataLength(PFILE_OBJECT FileObject,
 {
     NTSTATUS Status = STATUS_SUCCESS;
 
-    DPRINT1("SetAttributeDataLength(%p, %p, %p, %lu, %p, %I64u)\n",
+    DPRINT("SetAttributeDataLength(%p, %p, %p, %lu, %p, %I64u)\n",
             FileObject,
             Fcb,
             AttrContext,
@@ -925,7 +925,7 @@ SetResidentAttributeDataLength(PDEVICE_EXTENSION Vcb,
                 ULONG EndAttributeOffset;
                 ULONG LengthWritten;
 
-                DPRINT1("Converting attribute to non-resident.\n");
+                DPRINT("Converting attribute to non-resident.\n");
 
                 AttribDataSize.QuadPart = AttrContext->pRecord->Resident.ValueLength;
 
@@ -1061,25 +1061,243 @@ SetResidentAttributeDataLength(PDEVICE_EXTENSION Vcb,
     return STATUS_SUCCESS;
 }
 
-ULONG
-ReadAttribute(PDEVICE_EXTENSION Vcb,
-              PNTFS_ATTR_CONTEXT Context,
-              ULONGLONG Offset,
-              PCHAR Buffer,
-              ULONG Length)
+/**
+* @name NtfsMapAttributeRuns
+* @implemented
+*
+* Maps a byte range of a non-resident attribute onto the volume, collecting the
+* physically contiguous runs it spans into a run list.
+*
+* @param Vcb
+* Volume the attribute lives on
+*
+* @param Context
+* Attribute to map. Its data run cache is updated to reflect where the mapping
+* stopped.
+*
+* @param Offset
+* Byte offset into the attribute to start mapping at
+*
+* @param Length
+* How many bytes to map
+*
+* @param RunList
+* Receives the runs. Must have been initialized by NtfsInitIoRunList().
+*
+* @param MappedLength
+* Receives how many bytes were actually mapped, which is less than Length if
+* the attribute's allocation ends first.
+*
+* @return
+* STATUS_SUCCESS if the range was mapped, STATUS_END_OF_FILE if Offset lies
+* beyond the last allocated cluster, or STATUS_INSUFFICIENT_RESOURCES.
+*
+* @remarks Holes are recorded as NTFS_SPARSE_LBO runs rather than rejected
+* here: reads satisfy them by zeroing and writes fail on them, so the policy
+* belongs to the caller.
+*
+*/
+static
+NTSTATUS
+NtfsMapAttributeRuns(PDEVICE_EXTENSION Vcb,
+                     PNTFS_ATTR_CONTEXT Context,
+                     ULONGLONG Offset,
+                     ULONG Length,
+                     PNTFS_IO_RUN_LIST RunList,
+                     PULONG MappedLength)
 {
-    ULONGLONG LastLCN;
+    ULONGLONG LastLCN = 0;
+    ULONGLONG CurrentOffset = 0;
     PUCHAR DataRun;
     LONGLONG DataRunOffset;
-    ULONGLONG DataRunLength;
-    LONGLONG DataRunStartLCN;
-    ULONGLONG CurrentOffset;
-    ULONG ReadLength;
-    ULONG AlreadyRead;
-    NTSTATUS Status;
+    ULONGLONG DataRunLength = 0;
+    LONGLONG DataRunStartLCN = -1;
+    ULONG RunLength;
+    ULONG Mapped = 0;
+    ULONG UsedBufferSize;
+    NTSTATUS Status = STATUS_SUCCESS;
 
     //TEMPTEMP
     PUCHAR TempBuffer;
+
+    *MappedLength = 0;
+
+    // This will be rewritten in the next iteration to just use the DataRuns MCB directly
+    TempBuffer = ExAllocatePoolWithTag(NonPagedPool, Vcb->NtfsInfo.BytesPerFileRecord, TAG_NTFS);
+    if (TempBuffer == NULL)
+    {
+        DPRINT1("Not enough memory!\n");
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    ConvertLargeMCBToDataRuns(&Context->DataRunsMCB,
+                              TempBuffer,
+                              Vcb->NtfsInfo.BytesPerFileRecord,
+                              &UsedBufferSize);
+
+    DataRun = TempBuffer;
+
+    // I. Walk forward to the data run that holds Offset.
+    while (1)
+    {
+        DataRun = DecodeRun(DataRun, &DataRunOffset, &DataRunLength);
+        if (DataRunOffset != (LONGLONG)-1)
+        {
+            /* Normal data run. */
+            DataRunStartLCN = LastLCN + DataRunOffset;
+            LastLCN = DataRunStartLCN;
+        }
+        else
+        {
+            /* Sparse data run. */
+            DataRunStartLCN = -1;
+        }
+
+        if (Offset >= CurrentOffset &&
+            Offset < CurrentOffset + (DataRunLength * Vcb->NtfsInfo.BytesPerCluster))
+        {
+            break;
+        }
+
+        if (*DataRun == 0)
+        {
+            /* Offset is past the last cluster the attribute has allocated. */
+            Status = STATUS_END_OF_FILE;
+            goto Cleanup;
+        }
+
+        CurrentOffset += DataRunLength * Vcb->NtfsInfo.BytesPerCluster;
+    }
+
+    // II. Collect the runs. The first is special only in that the request
+    // usually starts partway into it.
+
+    RunLength = (ULONG)min(DataRunLength * Vcb->NtfsInfo.BytesPerCluster - (Offset - CurrentOffset), Length);
+
+    Status = NtfsAddIoRun(RunList,
+                          (DataRunStartLCN == -1) ? NTFS_SPARSE_LBO :
+                              DataRunStartLCN * Vcb->NtfsInfo.BytesPerCluster + Offset - CurrentOffset,
+                          RunLength);
+    if (!NT_SUCCESS(Status))
+        goto Cleanup;
+
+    Length -= RunLength;
+    Mapped += RunLength;
+
+    /* Did that consume the rest of this data run? */
+    if (RunLength == DataRunLength * Vcb->NtfsInfo.BytesPerCluster - (Offset - CurrentOffset))
+    {
+        CurrentOffset += DataRunLength * Vcb->NtfsInfo.BytesPerCluster;
+        DataRun = DecodeRun(DataRun, &DataRunOffset, &DataRunLength);
+        if (DataRunOffset != (LONGLONG)-1)
+        {
+            DataRunStartLCN = LastLCN + DataRunOffset;
+            LastLCN = DataRunStartLCN;
+        }
+        else
+            DataRunStartLCN = -1;
+    }
+
+    while (Length > 0)
+    {
+        RunLength = (ULONG)min(DataRunLength * Vcb->NtfsInfo.BytesPerCluster, Length);
+
+        Status = NtfsAddIoRun(RunList,
+                              (DataRunStartLCN == -1) ? NTFS_SPARSE_LBO :
+                                  DataRunStartLCN * Vcb->NtfsInfo.BytesPerCluster,
+                              RunLength);
+        if (!NT_SUCCESS(Status))
+            goto Cleanup;
+
+        Length -= RunLength;
+        Mapped += RunLength;
+
+        /* We satisfied the request, but there is still data in this run. */
+        if (Length == 0 && RunLength != DataRunLength * Vcb->NtfsInfo.BytesPerCluster)
+            break;
+
+        /* Last run the attribute has, so the caller gets a short map */
+        if (*DataRun == 0)
+            break;
+
+        CurrentOffset += DataRunLength * Vcb->NtfsInfo.BytesPerCluster;
+        DataRun = DecodeRun(DataRun, &DataRunOffset, &DataRunLength);
+        if (DataRunOffset != (LONGLONG)-1)
+        {
+            /* Normal data run. */
+            DataRunStartLCN = LastLCN + DataRunOffset;
+            LastLCN = DataRunStartLCN;
+        }
+        else
+        {
+            /* Sparse data run. */
+            DataRunStartLCN = -1;
+        }
+    }
+
+Cleanup:
+    Context->CacheRun = DataRun;
+    Context->CacheRunOffset = Offset + Mapped;
+    Context->CacheRunStartLCN = DataRunStartLCN;
+    Context->CacheRunLength = DataRunLength;
+    Context->CacheRunLastLCN = LastLCN;
+    Context->CacheRunCurrentOffset = CurrentOffset;
+
+    //TEMPTEMP
+    ExFreePoolWithTag(TempBuffer, TAG_NTFS);
+
+    *MappedLength = Mapped;
+
+    return Status;
+}
+
+/**
+* @name ReadAttributeToIrp
+* @implemented
+*
+* Reads a range of an attribute, serving it out of the given IRP where the
+* shape of the request allows it.
+*
+* @param Vcb
+* Volume the attribute lives on
+*
+* @param Context
+* Attribute to read from
+*
+* @param Offset
+* Byte offset into the attribute to start reading at
+*
+* @param Buffer
+* System-space buffer receiving the data
+*
+* @param Length
+* How much to read, in bytes
+*
+* @param Irp
+* The request being served, or NULL. When supplied and the range is a single
+* aligned contiguous piece of the volume, the IRP goes straight to the storage
+* stack and the disk transfers directly into the caller's pages.
+*
+* @return
+* The number of bytes read, or zero on failure.
+*
+* @remarks An IRP may only be passed when Buffer is the start of that IRP's
+* buffer and nothing has been realigned or bounced, since a forwarded transfer
+* lands at the beginning of the IRP's MDL.
+*
+*/
+ULONG
+ReadAttributeToIrp(PDEVICE_EXTENSION Vcb,
+                   PNTFS_ATTR_CONTEXT Context,
+                   ULONGLONG Offset,
+                   PCHAR Buffer,
+                   ULONG Length,
+                   PIRP Irp)
+{
+    ULONG AlreadyRead = 0;
+    ULONG Transferred = 0;
+    NTSTATUS Status;
+    NTFS_IO_RUN_LIST RunList;
 
     if (!Context->pRecord->IsNonResident)
     {
@@ -1098,175 +1316,53 @@ ReadAttribute(PDEVICE_EXTENSION Vcb,
     }
 
     /*
-     * Non-resident attribute
+     * Non-resident attribute: map the requested range onto the volume, then
+     * issue every run it spans in a single parallel batch.
      */
 
-    /*
-     * I. Find the corresponding start data run.
-     */
+    NtfsInitIoRunList(&RunList);
 
-    AlreadyRead = 0;
+    Status = NtfsMapAttributeRuns(Vcb, Context, Offset, Length, &RunList, &AlreadyRead);
 
-    // FIXME: Cache seems to be non-working. Disable it for now
-    //if(Context->CacheRunOffset <= Offset && Offset < Context->CacheRunOffset + Context->CacheRunLength * Volume->ClusterSize)
-    if (0)
+    if (NT_SUCCESS(Status) && AlreadyRead != 0)
     {
-        DataRun = Context->CacheRun;
-        LastLCN = Context->CacheRunLastLCN;
-        DataRunStartLCN = Context->CacheRunStartLCN;
-        DataRunLength = Context->CacheRunLength;
-        CurrentOffset = Context->CacheRunCurrentOffset;
-    }
-    else
-    {
-        //TEMPTEMP
-        ULONG UsedBufferSize;
-        TempBuffer = ExAllocatePoolWithTag(NonPagedPool, Vcb->NtfsInfo.BytesPerFileRecord, TAG_NTFS);
-        if (TempBuffer == NULL)
-        {
-            return STATUS_INSUFFICIENT_RESOURCES;
-        }
-
-        LastLCN = 0;
-        CurrentOffset = 0;
-
-        // This will be rewritten in the next iteration to just use the DataRuns MCB directly
-        ConvertLargeMCBToDataRuns(&Context->DataRunsMCB,
-                                  TempBuffer,
-                                  Vcb->NtfsInfo.BytesPerFileRecord,
-                                  &UsedBufferSize);
-
-        DataRun = TempBuffer;
-
-        while (1)
-        {
-            DataRun = DecodeRun(DataRun, &DataRunOffset, &DataRunLength);
-            if (DataRunOffset != -1)
-            {
-                /* Normal data run. */
-                DataRunStartLCN = LastLCN + DataRunOffset;
-                LastLCN = DataRunStartLCN;
-            }
-            else
-            {
-                /* Sparse data run. */
-                DataRunStartLCN = -1;
-            }
-
-            if (Offset >= CurrentOffset &&
-                Offset < CurrentOffset + (DataRunLength * Vcb->NtfsInfo.BytesPerCluster))
-            {
-                break;
-            }
-
-            if (*DataRun == 0)
-            {
-                ExFreePoolWithTag(TempBuffer, TAG_NTFS);
-                return AlreadyRead;
-            }
-
-            CurrentOffset += DataRunLength * Vcb->NtfsInfo.BytesPerCluster;
-        }
-    }
-
-    /*
-     * II. Go through the run list and read the data
-     */
-
-    ReadLength = (ULONG)min(DataRunLength * Vcb->NtfsInfo.BytesPerCluster - (Offset - CurrentOffset), Length);
-    if (DataRunStartLCN == -1)
-    {
-        RtlZeroMemory(Buffer, ReadLength);
-        Status = STATUS_SUCCESS;
-    }
-    else
-    {
-        Status = NtfsReadDisk(Vcb->StorageDevice,
-                              DataRunStartLCN * Vcb->NtfsInfo.BytesPerCluster + Offset - CurrentOffset,
-                              ReadLength,
-                              Vcb->NtfsInfo.BytesPerSector,
-                              (PVOID)Buffer,
-                              FALSE);
-    }
-    if (NT_SUCCESS(Status))
-    {
-        Length -= ReadLength;
-        Buffer += ReadLength;
-        AlreadyRead += ReadLength;
-
-        if (ReadLength == DataRunLength * Vcb->NtfsInfo.BytesPerCluster - (Offset - CurrentOffset))
-        {
-            CurrentOffset += DataRunLength * Vcb->NtfsInfo.BytesPerCluster;
-            DataRun = DecodeRun(DataRun, &DataRunOffset, &DataRunLength);
-            if (DataRunOffset != (ULONGLONG)-1)
-            {
-                DataRunStartLCN = LastLCN + DataRunOffset;
-                LastLCN = DataRunStartLCN;
-            }
-            else
-                DataRunStartLCN = -1;
-        }
-
-        while (Length > 0)
-        {
-            ReadLength = (ULONG)min(DataRunLength * Vcb->NtfsInfo.BytesPerCluster, Length);
-            if (DataRunStartLCN == -1)
-                RtlZeroMemory(Buffer, ReadLength);
-            else
-            {
-                Status = NtfsReadDisk(Vcb->StorageDevice,
-                                      DataRunStartLCN * Vcb->NtfsInfo.BytesPerCluster,
-                                      ReadLength,
+        Status = NtfsPerformIrpIoRuns(Vcb->StorageDevice,
+                                      IRP_MJ_READ,
                                       Vcb->NtfsInfo.BytesPerSector,
-                                      (PVOID)Buffer,
-                                      FALSE);
-                if (!NT_SUCCESS(Status))
-                    break;
-            }
+                                      Irp,
+                                      (PUCHAR)Buffer,
+                                      &RunList,
+                                      FALSE,
+                                      &Transferred);
+    }
 
-            Length -= ReadLength;
-            Buffer += ReadLength;
-            AlreadyRead += ReadLength;
+    NtfsFreeIoRunList(&RunList);
 
-            /* We finished this request, but there still data in this data run. */
-            if (Length == 0 && ReadLength != DataRunLength * Vcb->NtfsInfo.BytesPerCluster)
-                break;
+    if (!NT_SUCCESS(Status))
+    {
+        /* Our callers read the return value as a byte count and treat zero as
+         * failure, so we cannot report a partial transfer here. */
+        DPRINT1("Read failure (Status %lx)\n", Status);
+        return 0;
+    }
 
-            /*
-             * Go to next run in the list.
-             */
-
-            if (*DataRun == 0)
-                break;
-            CurrentOffset += DataRunLength * Vcb->NtfsInfo.BytesPerCluster;
-            DataRun = DecodeRun(DataRun, &DataRunOffset, &DataRunLength);
-            if (DataRunOffset != -1)
-            {
-                /* Normal data run. */
-                DataRunStartLCN = LastLCN + DataRunOffset;
-                LastLCN = DataRunStartLCN;
-            }
-            else
-            {
-                /* Sparse data run. */
-                DataRunStartLCN = -1;
-            }
-        } /* while */
-
-    } /* if Disk */
-
-    // TEMPTEMP
-    if (Context->pRecord->IsNonResident)
-        ExFreePoolWithTag(TempBuffer, TAG_NTFS);
-
-    Context->CacheRun = DataRun;
-    Context->CacheRunOffset = Offset + AlreadyRead;
-    Context->CacheRunStartLCN = DataRunStartLCN;
-    Context->CacheRunLength = DataRunLength;
-    Context->CacheRunLastLCN = LastLCN;
-    Context->CacheRunCurrentOffset = CurrentOffset;
+    if (Transferred < AlreadyRead)
+    {
+        DPRINT1("Short read: expected %lu bytes, got %lu\n", AlreadyRead, Transferred);
+        AlreadyRead = Transferred;
+    }
 
     return AlreadyRead;
+}
+
+ULONG
+ReadAttribute(PDEVICE_EXTENSION Vcb,
+              PNTFS_ATTR_CONTEXT Context,
+              ULONGLONG Offset,
+              PCHAR Buffer,
+              ULONG Length)
+{
+    return ReadAttributeToIrp(Vcb, Context, Offset, Buffer, Length, NULL);
 }
 
 
@@ -1312,33 +1408,26 @@ ReadAttribute(PDEVICE_EXTENSION Vcb,
 */
 
 NTSTATUS
-WriteAttribute(PDEVICE_EXTENSION Vcb,
-               PNTFS_ATTR_CONTEXT Context,
-               ULONGLONG Offset,
-               const PUCHAR Buffer,
-               ULONG Length,
-               PULONG RealLengthWritten,
-               PFILE_RECORD_HEADER FileRecord)
+WriteAttributeFromIrp(PDEVICE_EXTENSION Vcb,
+                      PNTFS_ATTR_CONTEXT Context,
+                      ULONGLONG Offset,
+                      const PUCHAR Buffer,
+                      ULONG Length,
+                      PULONG RealLengthWritten,
+                      PFILE_RECORD_HEADER FileRecord,
+                      PIRP Irp)
 {
-    ULONGLONG LastLCN;
-    PUCHAR DataRun;
-    LONGLONG DataRunOffset;
-    ULONGLONG DataRunLength;
-    LONGLONG DataRunStartLCN;
-    ULONGLONG CurrentOffset;
-    ULONG WriteLength;
+    ULONG MappedLength = 0;
+    ULONG Transferred = 0;
     NTSTATUS Status;
-    PUCHAR SourceBuffer = Buffer;
-    LONGLONG StartingOffset;
     BOOLEAN FileRecordAllocated = FALSE;
-
-    //TEMPTEMP
-    PUCHAR TempBuffer;
+    NTFS_IO_RUN_LIST RunList;
 
 
     DPRINT("WriteAttribute(%p, %p, %I64u, %p, %lu, %p, %p)\n", Vcb, Context, Offset, Buffer, Length, RealLengthWritten, FileRecord);
 
     *RealLengthWritten = 0;
+    NtfsInitIoRunList(&RunList);
 
     // is this a resident attribute?
     if (!Context->pRecord->IsNonResident)
@@ -1421,210 +1510,160 @@ WriteAttribute(PDEVICE_EXTENSION Vcb,
         return Status;
     }
 
-    // This is a non-resident attribute.
+    // This is a non-resident attribute: map the requested range onto the
+    // volume, then issue every run it spans in a single parallel batch.
 
-    // I. Find the corresponding start data run.
+    Status = NtfsMapAttributeRuns(Vcb, Context, Offset, Length, &RunList, &MappedLength);
 
-    // FIXME: Cache seems to be non-working. Disable it for now
-    //if(Context->CacheRunOffset <= Offset && Offset < Context->CacheRunOffset + Context->CacheRunLength * Volume->ClusterSize)
-    /*if (0)
+    if (NT_SUCCESS(Status) && MappedLength < Length)
     {
-    DataRun = Context->CacheRun;
-    LastLCN = Context->CacheRunLastLCN;
-    DataRunStartLCN = Context->CacheRunStartLCN;
-    DataRunLength = Context->CacheRunLength;
-    CurrentOffset = Context->CacheRunCurrentOffset;
-    }
-    else*/
-    {
-        ULONG UsedBufferSize;
-        LastLCN = 0;
-        CurrentOffset = 0;
-
-        // This will be rewritten in the next iteration to just use the DataRuns MCB directly
-        TempBuffer = ExAllocatePoolWithTag(NonPagedPool, Vcb->NtfsInfo.BytesPerFileRecord, TAG_NTFS);
-        if (TempBuffer == NULL)
-        {
-            return STATUS_INSUFFICIENT_RESOURCES;
-        }
-
-        ConvertLargeMCBToDataRuns(&Context->DataRunsMCB,
-                                  TempBuffer,
-                                  Vcb->NtfsInfo.BytesPerFileRecord,
-                                  &UsedBufferSize);
-
-        DataRun = TempBuffer;
-
-        while (1)
-        {
-            DataRun = DecodeRun(DataRun, &DataRunOffset, &DataRunLength);
-            if (DataRunOffset != -1)
-            {
-                // Normal data run.
-                // DPRINT1("Writing to normal data run, LastLCN %I64u DataRunOffset %I64d\n", LastLCN, DataRunOffset);
-                DataRunStartLCN = LastLCN + DataRunOffset;
-                LastLCN = DataRunStartLCN;
-            }
-            else
-            {
-                // Sparse data run. We can't support writing to sparse files yet
-                // (it may require increasing the allocation size).
-                DataRunStartLCN = -1;
-                DPRINT1("FIXME: Writing to sparse files is not supported yet!\n");
-                Status = STATUS_NOT_IMPLEMENTED;
-                goto Cleanup;
-            }
-
-            // Have we reached the data run we're trying to write to?
-            if (Offset >= CurrentOffset &&
-                Offset < CurrentOffset + (DataRunLength * Vcb->NtfsInfo.BytesPerCluster))
-            {
-                break;
-            }
-
-            if (*DataRun == 0)
-            {
-                // We reached the last assigned cluster
-                // TODO: assign new clusters to the end of the file.
-                // (Presently, this code will rarely be reached, the write will usually have already failed by now)
-                // [We can reach here by creating a new file record when the MFT isn't large enough]
-                DPRINT1("FIXME: Master File Table needs to be enlarged.\n");
-                Status = STATUS_END_OF_FILE;
-                goto Cleanup;
-            }
-
-            CurrentOffset += DataRunLength * Vcb->NtfsInfo.BytesPerCluster;
-        }
+        // The attribute's allocation ends before the request does.
+        // TODO: assign new clusters to the end of the file.
+        // [We can reach here by creating a new file record when the MFT isn't large enough]
+        DPRINT1("FIXME: Attribute needs to be enlarged (mapped %lu of %lu bytes).\n",
+                MappedLength, Length);
+        Status = STATUS_END_OF_FILE;
     }
 
-    // II. Go through the run list and write the data
+    if (NT_SUCCESS(Status))
+    {
+        // Writing into a hole would mean allocating clusters, which we cannot
+        // do here; NtfsPerformIrpIoRuns() rejects sparse runs on IRP_MJ_WRITE.
+        Status = NtfsPerformIrpIoRuns(Vcb->StorageDevice,
+                                      IRP_MJ_WRITE,
+                                      Vcb->NtfsInfo.BytesPerSector,
+                                      Irp,
+                                      Buffer,
+                                      &RunList,
+                                      FALSE,
+                                      &Transferred);
+    }
 
-    /* REVIEWME -- As adapted from NtfsReadAttribute():
-    We seem to be making a special case for the first applicable data run, but I'm not sure why.
-    Does it have something to do with (not) caching? Is this strategy equally applicable to writing? */
+    NtfsFreeIoRunList(&RunList);
 
-    WriteLength = (ULONG)min(DataRunLength * Vcb->NtfsInfo.BytesPerCluster - (Offset - CurrentOffset), Length);
-
-    StartingOffset = DataRunStartLCN * Vcb->NtfsInfo.BytesPerCluster + Offset - CurrentOffset;
-
-    // Write the data to the disk
-    Status = NtfsWriteDisk(Vcb->StorageDevice,
-                           StartingOffset,
-                           WriteLength,
-                           Vcb->NtfsInfo.BytesPerSector,
-                           (PVOID)SourceBuffer);
-
-    // Did the write fail?
     if (!NT_SUCCESS(Status))
     {
-        Context->CacheRun = DataRun;
-        Context->CacheRunOffset = Offset;
-        Context->CacheRunStartLCN = DataRunStartLCN;
-        Context->CacheRunLength = DataRunLength;
-        Context->CacheRunLastLCN = LastLCN;
-        Context->CacheRunCurrentOffset = CurrentOffset;
-
-        goto Cleanup;
+        DPRINT1("Write failure (Status %lx)\n", Status);
+        *RealLengthWritten = 0;
+        return Status;
     }
 
-    Length -= WriteLength;
-    SourceBuffer += WriteLength;
-    *RealLengthWritten += WriteLength;
+    *RealLengthWritten = Transferred;
 
-    // Did we write to the end of the data run?
-    if (WriteLength == DataRunLength * Vcb->NtfsInfo.BytesPerCluster - (Offset - CurrentOffset))
+    if (Transferred < Length)
     {
-        // Advance to the next data run
-        CurrentOffset += DataRunLength * Vcb->NtfsInfo.BytesPerCluster;
-        DataRun = DecodeRun(DataRun, &DataRunOffset, &DataRunLength);
-
-        if (DataRunOffset != (ULONGLONG)-1)
-        {
-            DataRunStartLCN = LastLCN + DataRunOffset;
-            LastLCN = DataRunStartLCN;
-        }
-        else
-            DataRunStartLCN = -1;
+        DPRINT1("Short write: expected %lu bytes, wrote %lu\n", Length, Transferred);
+        Status = STATUS_UNEXPECTED_IO_ERROR;
     }
-
-    // Do we have more data to write?
-    while (Length > 0)
-    {
-        // Make sure we don't write past the end of the current data run
-        WriteLength = (ULONG)min(DataRunLength * Vcb->NtfsInfo.BytesPerCluster, Length);
-
-        // Are we dealing with a sparse data run?
-        if (DataRunStartLCN == -1)
-        {
-            DPRINT1("FIXME: Don't know how to write to sparse files yet! (DataRunStartLCN == -1)\n");
-            Status = STATUS_NOT_IMPLEMENTED;
-            goto Cleanup;
-        }
-        else
-        {
-            // write the data to the disk
-            Status = NtfsWriteDisk(Vcb->StorageDevice,
-                                   DataRunStartLCN * Vcb->NtfsInfo.BytesPerCluster,
-                                   WriteLength,
-                                   Vcb->NtfsInfo.BytesPerSector,
-                                   (PVOID)SourceBuffer);
-            if (!NT_SUCCESS(Status))
-                break;
-        }
-
-        Length -= WriteLength;
-        SourceBuffer += WriteLength;
-        *RealLengthWritten += WriteLength;
-
-        // We finished this request, but there's still data in this data run.
-        if (Length == 0 && WriteLength != DataRunLength * Vcb->NtfsInfo.BytesPerCluster)
-            break;
-
-        // Go to next run in the list.
-
-        if (*DataRun == 0)
-        {
-            // that was the last run
-            if (Length > 0)
-            {
-                // Failed sanity check.
-                DPRINT1("Encountered EOF before expected!\n");
-                Status = STATUS_END_OF_FILE;
-                goto Cleanup;
-            }
-
-            break;
-        }
-
-        // Advance to the next data run
-        CurrentOffset += DataRunLength * Vcb->NtfsInfo.BytesPerCluster;
-        DataRun = DecodeRun(DataRun, &DataRunOffset, &DataRunLength);
-        if (DataRunOffset != -1)
-        {
-            // Normal data run.
-            DataRunStartLCN = LastLCN + DataRunOffset;
-            LastLCN = DataRunStartLCN;
-        }
-        else
-        {
-            // Sparse data run.
-            DataRunStartLCN = -1;
-        }
-    } // end while (Length > 0) [more data to write]
-
-    Context->CacheRun = DataRun;
-    Context->CacheRunOffset = Offset + *RealLengthWritten;
-    Context->CacheRunStartLCN = DataRunStartLCN;
-    Context->CacheRunLength = DataRunLength;
-    Context->CacheRunLastLCN = LastLCN;
-    Context->CacheRunCurrentOffset = CurrentOffset;
-
-Cleanup:
-    // TEMPTEMP
-    if (Context->pRecord->IsNonResident)
-        ExFreePoolWithTag(TempBuffer, TAG_NTFS);
 
     return Status;
+}
+
+NTSTATUS
+WriteAttribute(PDEVICE_EXTENSION Vcb,
+               PNTFS_ATTR_CONTEXT Context,
+               ULONGLONG Offset,
+               const PUCHAR Buffer,
+               ULONG Length,
+               PULONG RealLengthWritten,
+               PFILE_RECORD_HEADER FileRecord)
+{
+    return WriteAttributeFromIrp(Vcb,
+                                 Context,
+                                 Offset,
+                                 Buffer,
+                                 Length,
+                                 RealLengthWritten,
+                                 FileRecord,
+                                 NULL);
+}
+
+/**
+* @name NtfsReadUpCaseTable
+* @implemented
+*
+* Loads the volume's $UpCase file, which defines how NTFS folds case.
+*
+* @param Vcb
+* Volume to load the table for
+*
+* @return
+* STATUS_SUCCESS if the table was loaded, otherwise the failure that stopped
+* us. A volume without a usable $UpCase is not a valid NTFS volume.
+*
+* @remarks Every NTFS volume carries this file at a fixed MFT index. It is one
+* upcased code point per UCS-2 value, so exactly 128 KB.
+*
+*/
+static
+NTSTATUS
+NtfsReadUpCaseTable(PDEVICE_EXTENSION Vcb)
+{
+    PFILE_RECORD_HEADER FileRecord;
+    PNTFS_ATTR_CONTEXT DataContext;
+    NTSTATUS Status;
+    ULONGLONG Size;
+    ULONG Read;
+
+    FileRecord = ExAllocateFromNPagedLookasideList(&Vcb->FileRecLookasideList);
+    if (FileRecord == NULL)
+    {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    Status = ReadFileRecord(Vcb, NTFS_FILE_UPCASE, FileRecord);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("Couldn't read the $UpCase file record!\n");
+        ExFreeToNPagedLookasideList(&Vcb->FileRecLookasideList, FileRecord);
+        return Status;
+    }
+
+    Status = FindAttribute(Vcb, FileRecord, AttributeData, L"", 0, &DataContext, NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("$UpCase has no data stream!\n");
+        ExFreeToNPagedLookasideList(&Vcb->FileRecLookasideList, FileRecord);
+        return Status;
+    }
+
+    Size = AttributeDataLength(DataContext->pRecord);
+    if (Size != (0x10000 * sizeof(WCHAR)))
+    {
+        DPRINT1("$UpCase is %I64u bytes, expected %u\n", Size, 0x10000 * sizeof(WCHAR));
+        ReleaseAttributeContext(DataContext);
+        ExFreeToNPagedLookasideList(&Vcb->FileRecLookasideList, FileRecord);
+        return STATUS_UNRECOGNIZED_VOLUME;
+    }
+
+    Vcb->UpCaseTable = ExAllocatePoolWithTag(NonPagedPool, (ULONG)Size, TAG_NTFS);
+    if (Vcb->UpCaseTable == NULL)
+    {
+        ReleaseAttributeContext(DataContext);
+        ExFreeToNPagedLookasideList(&Vcb->FileRecLookasideList, FileRecord);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    Read = ReadAttribute(Vcb, DataContext, 0, (PCHAR)Vcb->UpCaseTable, (ULONG)Size);
+
+    ReleaseAttributeContext(DataContext);
+    ExFreeToNPagedLookasideList(&Vcb->FileRecLookasideList, FileRecord);
+
+    if (Read != Size)
+    {
+        DPRINT1("Short read of $UpCase: %lu of %I64u bytes\n", Read, Size);
+        ExFreePoolWithTag(Vcb->UpCaseTable, TAG_NTFS);
+        Vcb->UpCaseTable = NULL;
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+NtfsLoadUpCaseTable(PDEVICE_EXTENSION Vcb)
+{
+    return NtfsReadUpCaseTable(Vcb);
 }
 
 NTSTATUS
@@ -1650,9 +1689,125 @@ ReadFileRecord(PDEVICE_EXTENSION Vcb,
 
 
 /**
+* @name NtfsUpdateDuplicatedInformation
+* @implemented
+*
+* Pushes the fields NTFS keeps in more than one place out to all of them.
+*
+* @param Vcb
+* Volume the file lives on
+*
+* @param FileRecord
+* The file's record, already holding the new values in $STANDARD_INFORMATION
+* and its $DATA attribute
+*
+* @param MFTIndex
+* MFT index of the file
+*
+* @param Flags
+* Which groups of fields changed; see NTFS_FILENAME_UPDATE_*
+*
+* @param CaseSensitive
+* Whether the parent's index should be searched case-sensitively
+*
+* @return
+* STATUS_SUCCESS once every copy agrees, or the status of the failing update.
+*
+* @remarks NTFS stores a file's sizes, timestamps and attributes three times:
+* in $STANDARD_INFORMATION, in the record's own $FILE_NAME, and again in the
+* parent directory's index entry. Windows funnels all three through one
+* routine (NtfsUpdateDuplicateInfo) precisely so they cannot drift; this is
+* that funnel. Callers change $STANDARD_INFORMATION and then say what moved.
+*
+* The file record is written back here, so callers need not write it again.
+*
+* The directory flag is the one field that does not come from
+* $STANDARD_INFORMATION -- NTFS masks it out of there and keeps it in the
+* record header -- so it is restored from the header on the way past.
+*/
+NTSTATUS
+NtfsUpdateDuplicatedInformation(PDEVICE_EXTENSION Vcb,
+                                PFILE_RECORD_HEADER FileRecord,
+                                ULONGLONG MFTIndex,
+                                ULONG Flags,
+                                BOOLEAN CaseSensitive)
+{
+    NTFS_FILENAME_UPDATE Update;
+    PSTANDARD_INFORMATION StdInfo;
+    PFILENAME_ATTRIBUTE FileName;
+    UNICODE_STRING Name;
+    ULONGLONG ParentMFTIndex;
+    ULONG DirFlag;
+    NTSTATUS Status;
+
+    if (Flags == 0)
+        return STATUS_SUCCESS;
+
+    StdInfo = GetStandardInformationFromRecord(Vcb, FileRecord);
+    FileName = GetBestFileNameFromRecord(Vcb, FileRecord);
+    if (StdInfo == NULL || FileName == NULL)
+    {
+        DPRINT1("Record %I64u is missing $STANDARD_INFORMATION or $FILE_NAME\n", MFTIndex);
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    DirFlag = (FileRecord->Flags & FRH_DIRECTORY) ? NTFS_FILE_TYPE_DIRECTORY : 0;
+
+    RtlZeroMemory(&Update, sizeof(Update));
+    Update.Flags = Flags;
+
+    if (Flags & NTFS_FILENAME_UPDATE_TIMES)
+    {
+        Update.CreationTime = StdInfo->CreationTime;
+        Update.LastWriteTime = StdInfo->LastWriteTime;
+        Update.ChangeTime = StdInfo->ChangeTime;
+        Update.LastAccessTime = StdInfo->LastAccessTime;
+
+        FileName->CreationTime = StdInfo->CreationTime;
+        FileName->LastWriteTime = StdInfo->LastWriteTime;
+        FileName->ChangeTime = StdInfo->ChangeTime;
+        FileName->LastAccessTime = StdInfo->LastAccessTime;
+    }
+
+    if (Flags & NTFS_FILENAME_UPDATE_ATTRS)
+    {
+        Update.FileAttributes = StdInfo->FileAttribute | DirFlag;
+        FileName->FileAttributes = Update.FileAttributes;
+    }
+
+    if (Flags & NTFS_FILENAME_UPDATE_SIZES)
+    {
+        /* Sizes come from the unnamed $DATA attribute, the same way the times
+         * come from $STANDARD_INFORMATION: one source of truth per field. */
+        Update.DataSize = NtfsGetFileSize(Vcb, FileRecord, L"", 0, &Update.AllocatedSize);
+
+        FileName->DataSize = Update.DataSize;
+        FileName->AllocatedSize = Update.AllocatedSize;
+    }
+
+    /* Persist the $FILE_NAME just modified. Callers have no reason to write the record again,
+     * and leaving it unwritten would let the copy in the parent index disagree with it. */
+    Status = UpdateFileRecord(Vcb, MFTIndex, FileRecord);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("Failed to write file record %I64u (Status %lx)\n", MFTIndex, Status);
+        return Status;
+    }
+
+    /* Now the parent's index entry, which carries the same values */
+    ParentMFTIndex = FileName->DirectoryFileReferenceNumber & NTFS_MFT_MASK;
+
+    Name.Buffer = FileName->Name;
+    Name.Length = FileName->NameLength * sizeof(WCHAR);
+    Name.MaximumLength = Name.Length;
+
+    return UpdateFileNameRecord(Vcb, ParentMFTIndex, &Name, FALSE, &Update, CaseSensitive);
+}
+
+/**
 * Searches a file's parent directory (given the parent's index in the mft)
-* for the given file. Upon finding an index entry for that file, updates
-* Data Size and Allocated Size values in the $FILE_NAME attribute of that entry.
+* for the given file. Upon finding an index entry for that file, refreshes the
+* fields of that entry's $FILE_NAME attribute named by Update->Flags.
 *
 * (Most of this code was copied from NtfsFindMftRecord)
 */
@@ -1661,8 +1816,7 @@ UpdateFileNameRecord(PDEVICE_EXTENSION Vcb,
                      ULONGLONG ParentMFTIndex,
                      PUNICODE_STRING FileName,
                      BOOLEAN DirSearch,
-                     ULONGLONG NewDataSize,
-                     ULONGLONG NewAllocationSize,
+                     PNTFS_FILENAME_UPDATE Update,
                      BOOLEAN CaseSensitive)
 {
     PFILE_RECORD_HEADER MftRecord;
@@ -1673,14 +1827,16 @@ UpdateFileNameRecord(PDEVICE_EXTENSION Vcb,
     NTSTATUS Status;
     ULONG CurrentEntry = 0;
 
-    DPRINT("UpdateFileNameRecord(%p, %I64d, %wZ, %s, %I64u, %I64u, %s)\n",
+    DPRINT("UpdateFileNameRecord(%p, %I64d, %wZ, %s, %lx, %s)\n",
            Vcb,
            ParentMFTIndex,
            FileName,
            DirSearch ? "TRUE" : "FALSE",
-           NewDataSize,
-           NewAllocationSize,
+           Update->Flags,
            CaseSensitive ? "TRUE" : "FALSE");
+
+    if (Update->Flags == 0)
+        return STATUS_SUCCESS;
 
     MftRecord = ExAllocateFromNPagedLookasideList(&Vcb->FileRecLookasideList);
     if (MftRecord == NULL)
@@ -1724,23 +1880,24 @@ UpdateFileNameRecord(PDEVICE_EXTENSION Vcb,
     IndexRoot = (PINDEX_ROOT_ATTRIBUTE)IndexRecord;
     IndexEntry = (PINDEX_ENTRY_ATTRIBUTE)((PCHAR)&IndexRoot->Header + IndexRoot->Header.FirstEntryOffset);
     // Index root is always resident.
-    IndexEntryEnd = (PINDEX_ENTRY_ATTRIBUTE)(IndexRecord + IndexRoot->Header.TotalSizeOfEntries);
+    /* TotalSizeOfEntries is measured from the index header, not from the
+     * start of the attribute, and FirstEntryOffset above already is. */
+    IndexEntryEnd = (PINDEX_ENTRY_ATTRIBUTE)((ULONG_PTR)&IndexRoot->Header + IndexRoot->Header.TotalSizeOfEntries);
 
     DPRINT("IndexRecordSize: %x IndexBlockSize: %x\n", Vcb->NtfsInfo.BytesPerIndexRecord, IndexRoot->SizeOfEntry);
 
-    Status = UpdateIndexEntryFileNameSize(Vcb,
-                                          MftRecord,
-                                          IndexRecord,
-                                          IndexRoot->SizeOfEntry,
-                                          IndexEntry,
-                                          IndexEntryEnd,
-                                          FileName,
-                                          &CurrentEntry,
-                                          &CurrentEntry,
-                                          DirSearch,
-                                          NewDataSize,
-                                          NewAllocationSize,
-                                          CaseSensitive);
+    Status = UpdateIndexEntryFileName(Vcb,
+                                      MftRecord,
+                                      IndexRecord,
+                                      IndexRoot->SizeOfEntry,
+                                      IndexEntry,
+                                      IndexEntryEnd,
+                                      FileName,
+                                      &CurrentEntry,
+                                      &CurrentEntry,
+                                      DirSearch,
+                                      Update,
+                                      CaseSensitive);
 
     if (Status == STATUS_PENDING)
     {
@@ -1762,24 +1919,23 @@ UpdateFileNameRecord(PDEVICE_EXTENSION Vcb,
 }
 
 /**
-* Recursively searches directory index and applies the size update to the $FILE_NAME attribute of the
-* proper index entry.
+* Recursively searches a directory index and applies the requested update to the $FILE_NAME
+* attribute of the proper index entry.
 * (Heavily based on BrowseIndexEntries)
 */
 NTSTATUS
-UpdateIndexEntryFileNameSize(PDEVICE_EXTENSION Vcb,
-                             PFILE_RECORD_HEADER MftRecord,
-                             PCHAR IndexRecord,
-                             ULONG IndexBlockSize,
-                             PINDEX_ENTRY_ATTRIBUTE FirstEntry,
-                             PINDEX_ENTRY_ATTRIBUTE LastEntry,
-                             PUNICODE_STRING FileName,
-                             PULONG StartEntry,
-                             PULONG CurrentEntry,
-                             BOOLEAN DirSearch,
-                             ULONGLONG NewDataSize,
-                             ULONGLONG NewAllocatedSize,
-                             BOOLEAN CaseSensitive)
+UpdateIndexEntryFileName(PDEVICE_EXTENSION Vcb,
+                         PFILE_RECORD_HEADER MftRecord,
+                         PCHAR IndexRecord,
+                         ULONG IndexBlockSize,
+                         PINDEX_ENTRY_ATTRIBUTE FirstEntry,
+                         PINDEX_ENTRY_ATTRIBUTE LastEntry,
+                         PUNICODE_STRING FileName,
+                         PULONG StartEntry,
+                         PULONG CurrentEntry,
+                         BOOLEAN DirSearch,
+                         PNTFS_FILENAME_UPDATE Update,
+                         BOOLEAN CaseSensitive)
 {
     NTSTATUS Status;
     ULONG RecordOffset;
@@ -1788,7 +1944,7 @@ UpdateIndexEntryFileNameSize(PDEVICE_EXTENSION Vcb,
     ULONGLONG IndexAllocationSize;
     PINDEX_BUFFER IndexBuffer;
 
-    DPRINT("UpdateIndexEntrySize(%p, %p, %p, %lu, %p, %p, %wZ, %lu, %lu, %s, %I64u, %I64u, %s)\n",
+    DPRINT("UpdateIndexEntryFileName(%p, %p, %p, %lu, %p, %p, %wZ, %lu, %lu, %s, %lx, %s)\n",
            Vcb,
            MftRecord,
            IndexRecord,
@@ -1799,8 +1955,7 @@ UpdateIndexEntryFileNameSize(PDEVICE_EXTENSION Vcb,
            *StartEntry,
            *CurrentEntry,
            DirSearch ? "TRUE" : "FALSE",
-           NewDataSize,
-           NewAllocatedSize,
+           Update->Flags,
            CaseSensitive ? "TRUE" : "FALSE");
 
     // find the index entry responsible for the file we're trying to update
@@ -1811,11 +1966,29 @@ UpdateIndexEntryFileNameSize(PDEVICE_EXTENSION Vcb,
         if ((IndexEntry->Data.Directory.IndexedFile & NTFS_MFT_MASK) > NTFS_FILE_FIRST_USER_FILE &&
             *CurrentEntry >= *StartEntry &&
             IndexEntry->FileName.NameType != NTFS_FILE_NAME_DOS &&
-            CompareFileName(FileName, IndexEntry, DirSearch, CaseSensitive))
+            CompareFileName(Vcb, FileName, IndexEntry, DirSearch, CaseSensitive))
         {
             *StartEntry = *CurrentEntry;
-            IndexEntry->FileName.DataSize = NewDataSize;
-            IndexEntry->FileName.AllocatedSize = NewAllocatedSize;
+
+            if (Update->Flags & NTFS_FILENAME_UPDATE_SIZES)
+            {
+                IndexEntry->FileName.DataSize = Update->DataSize;
+                IndexEntry->FileName.AllocatedSize = Update->AllocatedSize;
+            }
+
+            if (Update->Flags & NTFS_FILENAME_UPDATE_TIMES)
+            {
+                IndexEntry->FileName.CreationTime = Update->CreationTime;
+                IndexEntry->FileName.ChangeTime = Update->ChangeTime;
+                IndexEntry->FileName.LastWriteTime = Update->LastWriteTime;
+                IndexEntry->FileName.LastAccessTime = Update->LastAccessTime;
+            }
+
+            if (Update->Flags & NTFS_FILENAME_UPDATE_ATTRS)
+            {
+                IndexEntry->FileName.FileAttributes = Update->FileAttributes;
+            }
+
             // indicate that the caller will still need to write the structure to the disk
             return STATUS_PENDING;
         }
@@ -1862,19 +2035,18 @@ UpdateIndexEntryFileNameSize(PDEVICE_EXTENSION Vcb,
         LastEntry = (PINDEX_ENTRY_ATTRIBUTE)((ULONG_PTR)&IndexBuffer->Header + IndexBuffer->Header.TotalSizeOfEntries);
         ASSERT(LastEntry <= (PINDEX_ENTRY_ATTRIBUTE)((ULONG_PTR)IndexBuffer + IndexBlockSize));
 
-        Status = UpdateIndexEntryFileNameSize(NULL,
-                                              NULL,
-                                              NULL,
-                                              0,
-                                              FirstEntry,
-                                              LastEntry,
-                                              FileName,
-                                              StartEntry,
-                                              CurrentEntry,
-                                              DirSearch,
-                                              NewDataSize,
-                                              NewAllocatedSize,
-                                              CaseSensitive);
+        Status = UpdateIndexEntryFileName(NULL,
+                                          NULL,
+                                          NULL,
+                                          0,
+                                          FirstEntry,
+                                          LastEntry,
+                                          FileName,
+                                          StartEntry,
+                                          CurrentEntry,
+                                          DirSearch,
+                                          Update,
+                                          CaseSensitive);
         if (Status == STATUS_PENDING)
         {
             // write the index record back to disk
@@ -2036,7 +2208,7 @@ AddNewMftEntry(PFILE_RECORD_HEADER FileRecord,
     LARGE_INTEGER BitmapBits;
     UCHAR SystemReservedBits;
 
-    DPRINT1("AddNewMftEntry(%p, %p, %p, %s)\n", FileRecord, DeviceExt, DestinationIndex, CanWait ? "TRUE" : "FALSE");
+    DPRINT("AddNewMftEntry(%p, %p, %p, %s)\n", FileRecord, DeviceExt, DestinationIndex, CanWait ? "TRUE" : "FALSE");
 
     // First, we have to read the mft's $Bitmap attribute
 
@@ -2115,7 +2287,7 @@ AddNewMftEntry(PFILE_RECORD_HEADER FileRecord,
         return AddNewMftEntry(FileRecord, DeviceExt, DestinationIndex, CanWait);
     }
 
-    DPRINT1("Creating file record at MFT index: %I64u\n", MftIndex);
+    DPRINT("Creating file record at MFT index: %I64u\n", MftIndex);
 
     // update file record with index
     FileRecord->MFTRecordNumber = MftIndex;
@@ -2331,7 +2503,11 @@ NtfsAddFilenameToDirectory(PDEVICE_EXTENSION DeviceExt,
                            &NewRightHandNode);
     if (!NT_SUCCESS(Status))
     {
-        DPRINT1("ERROR: Failed to insert key into B-Tree!\n");
+        DPRINT1("ERROR: Failed to insert '%.*S' into the index of MFT record %I64u (Status %lx)\n",
+                FilenameAttribute->NameLength,
+                FilenameAttribute->Name,
+                DirectoryMftIndex,
+                Status);
         DestroyBTree(NewTree);
         ReleaseAttributeContext(IndexRootContext);
         ExFreePoolWithTag(I30IndexRoot, TAG_NTFS);
@@ -2436,7 +2612,7 @@ NtfsAddFilenameToDirectory(PDEVICE_EXTENSION DeviceExt,
     NodeSize = GetSizeOfIndexEntries(NewTree->RootNode);
     if (NodeSize > NewMaxIndexRootSize)
     {
-        DPRINT1("Demoting index root.\nNodeSize: 0x%lx\nNewMaxIndexRootSize: 0x%lx\n", NodeSize, NewMaxIndexRootSize);
+        DPRINT("Demoting index root.\nNodeSize: 0x%lx\nNewMaxIndexRootSize: 0x%lx\n", NodeSize, NewMaxIndexRootSize);
 
         Status = DemoteBTreeRoot(NewTree);
         if (!NT_SUCCESS(Status))
@@ -2599,6 +2775,511 @@ NtfsAddFilenameToDirectory(PDEVICE_EXTENSION DeviceExt,
     return Status;
 }
 
+/**
+* @name NtfsRemoveFilenameFromDirectory
+* @implemented
+*
+* Removes a $FILE_NAME attribute from a given directory index.
+*
+* @param DeviceExt
+* Points to the target disk's DEVICE_EXTENSION.
+*
+* @param DirectoryMftIndex
+* Mft index of the parent directory the file is being removed from.
+*
+* @param FilenameAttribute
+* Pointer to the FILENAME_ATTRIBUTE of the file being removed from the directory.
+*
+* @param CaseSensitive
+* Boolean indicating if the function should operate in case-sensitive mode. This will be TRUE
+* if an application created the file with the FILE_FLAG_POSIX_SEMANTICS flag.
+*
+* @return
+* STATUS_SUCCESS on success.
+* STATUS_OBJECT_NAME_NOT_FOUND if the name isn't in the directory's index.
+* STATUS_INSUFFICIENT_RESOURCES if an allocation fails.
+*
+* @remarks
+* The inverse of NtfsAddFilenameToDirectory(). One $FILE_NAME attribute is indexed per link, so
+* a file carrying both a long name and an 8.3 name needs one call for each.
+*/
+NTSTATUS
+NtfsRemoveFilenameFromDirectory(PDEVICE_EXTENSION DeviceExt,
+                                ULONGLONG DirectoryMftIndex,
+                                PFILENAME_ATTRIBUTE FilenameAttribute,
+                                BOOLEAN CaseSensitive)
+{
+    NTSTATUS Status;
+    PFILE_RECORD_HEADER ParentFileRecord;
+    PNTFS_ATTR_CONTEXT IndexRootContext;
+    PINDEX_ROOT_ATTRIBUTE I30IndexRoot;
+    PINDEX_ROOT_ATTRIBUTE NewIndexRoot;
+    ULONG IndexRootOffset;
+    ULONGLONG I30IndexRootLength;
+    ULONG LengthWritten;
+    ULONG AttributeLength;
+    ULONG BtreeIndexLength;
+    ULONG MaxIndexRootSize;
+    PNTFS_ATTR_RECORD NextAttribute;
+    PB_TREE Tree;
+    PB_TREE_KEY SearchKey;
+
+    DPRINT("NtfsRemoveFilenameFromDirectory(%p, %I64u, %p, %s)\n",
+           DeviceExt, DirectoryMftIndex, FilenameAttribute, CaseSensitive ? "TRUE" : "FALSE");
+
+    ParentFileRecord = ExAllocateFromNPagedLookasideList(&DeviceExt->FileRecLookasideList);
+    if (!ParentFileRecord)
+    {
+        DPRINT1("ERROR: Couldn't allocate memory for file record!\n");
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    Status = ReadFileRecord(DeviceExt, DirectoryMftIndex, ParentFileRecord);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Couldn't read parent directory with index %I64u\n", DirectoryMftIndex);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, ParentFileRecord);
+        return Status;
+    }
+
+    Status = FindAttribute(DeviceExt,
+                           ParentFileRecord,
+                           AttributeIndexRoot,
+                           L"$I30",
+                           4,
+                           &IndexRootContext,
+                           &IndexRootOffset);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Couldn't find $I30 $INDEX_ROOT attribute for parent directory with MFT #: %I64u!\n",
+                DirectoryMftIndex);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, ParentFileRecord);
+        return Status;
+    }
+
+    I30IndexRootLength = AttributeDataLength(IndexRootContext->pRecord);
+    I30IndexRoot = ExAllocatePoolWithTag(NonPagedPool, I30IndexRootLength, TAG_NTFS);
+    if (!I30IndexRoot)
+    {
+        DPRINT1("ERROR: Couldn't allocate memory for index root attribute!\n");
+        ReleaseAttributeContext(IndexRootContext);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, ParentFileRecord);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    Status = ReadAttribute(DeviceExt, IndexRootContext, 0, (PCHAR)I30IndexRoot, I30IndexRootLength);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Couldn't read index root attribute for Mft index #%I64u\n", DirectoryMftIndex);
+        ReleaseAttributeContext(IndexRootContext);
+        ExFreePoolWithTag(I30IndexRoot, TAG_NTFS);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, ParentFileRecord);
+        return Status;
+    }
+
+    Status = CreateBTreeFromIndex(DeviceExt, ParentFileRecord, IndexRootContext, I30IndexRoot, &Tree);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Failed to create B-Tree from Index!\n");
+        ReleaseAttributeContext(IndexRootContext);
+        ExFreePoolWithTag(I30IndexRoot, TAG_NTFS);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, ParentFileRecord);
+        return Status;
+    }
+
+    // NtfsRemoveKey() compares filenames, so the file reference here is only a placeholder
+    SearchKey = CreateBTreeKeyFromFilename(0, FilenameAttribute);
+    if (!SearchKey)
+    {
+        DestroyBTree(Tree);
+        ReleaseAttributeContext(IndexRootContext);
+        ExFreePoolWithTag(I30IndexRoot, TAG_NTFS);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, ParentFileRecord);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    Status = NtfsRemoveKey(Tree->RootNode, SearchKey, CaseSensitive);
+
+    DestroyBTreeKey(SearchKey);
+
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Failed to remove '%.*S' from the index of MFT record %I64u (Status %lx)\n",
+                FilenameAttribute->NameLength,
+                FilenameAttribute->Name,
+                DirectoryMftIndex,
+                Status);
+        DestroyBTree(Tree);
+        ReleaseAttributeContext(IndexRootContext);
+        ExFreePoolWithTag(I30IndexRoot, TAG_NTFS);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, ParentFileRecord);
+        return Status;
+    }
+
+    // Push the tree back out to the index allocation before sizing the index root, for the same
+    // reason the insert path does: growing or shrinking the allocation changes how much of the
+    // file record is left for the root.
+    Status = UpdateIndexAllocation(DeviceExt, Tree, I30IndexRoot->SizeOfEntry, ParentFileRecord);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Failed to update index allocation from B-Tree!\n");
+        DestroyBTree(Tree);
+        ReleaseAttributeContext(IndexRootContext);
+        ExFreePoolWithTag(I30IndexRoot, TAG_NTFS);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, ParentFileRecord);
+        return Status;
+    }
+
+    // Find the maximum index root size given what the file record can hold
+    MaxIndexRootSize = DeviceExt->NtfsInfo.BytesPerFileRecord
+                       - IndexRootOffset
+                       - IndexRootContext->pRecord->Resident.ValueOffset
+                       - sizeof(INDEX_ROOT_ATTRIBUTE)
+                       - (sizeof(ULONG) * 2);
+
+    NextAttribute = (PNTFS_ATTR_RECORD)((ULONG_PTR)ParentFileRecord + IndexRootOffset + IndexRootContext->pRecord->Length);
+    if (NextAttribute->Type != AttributeEnd)
+    {
+        ULONG LengthOfAttributes = 0;
+        PNTFS_ATTR_RECORD CurrentAttribute = NextAttribute;
+        while (CurrentAttribute->Type != AttributeEnd)
+        {
+            LengthOfAttributes += CurrentAttribute->Length;
+            CurrentAttribute = (PNTFS_ATTR_RECORD)((ULONG_PTR)CurrentAttribute + CurrentAttribute->Length);
+        }
+
+        MaxIndexRootSize -= LengthOfAttributes;
+    }
+
+    Status = CreateIndexRootFromBTree(DeviceExt, Tree, MaxIndexRootSize, &NewIndexRoot, &BtreeIndexLength);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Failed to create Index root from B-Tree!\n");
+        DestroyBTree(Tree);
+        ReleaseAttributeContext(IndexRootContext);
+        ExFreePoolWithTag(I30IndexRoot, TAG_NTFS);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, ParentFileRecord);
+        return Status;
+    }
+
+    DestroyBTree(Tree);
+
+    // $INDEX_ROOT must always be resident, so its length is set directly rather than through
+    // the usual attribute-resizing path.
+    AttributeLength = NewIndexRoot->Header.AllocatedSize + FIELD_OFFSET(INDEX_ROOT_ATTRIBUTE, Header);
+
+    if (AttributeLength != IndexRootContext->pRecord->Resident.ValueLength)
+    {
+        Status = InternalSetResidentAttributeLength(DeviceExt,
+                                                    IndexRootContext,
+                                                    ParentFileRecord,
+                                                    IndexRootOffset,
+                                                    AttributeLength);
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("ERROR: Unable to set resident attribute length!\n");
+            ExFreePoolWithTag(NewIndexRoot, TAG_NTFS);
+            ReleaseAttributeContext(IndexRootContext);
+            ExFreePoolWithTag(I30IndexRoot, TAG_NTFS);
+            ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, ParentFileRecord);
+            return Status;
+        }
+    }
+
+    NT_ASSERT(ParentFileRecord->BytesInUse <= DeviceExt->NtfsInfo.BytesPerFileRecord);
+
+    Status = UpdateFileRecord(DeviceExt, DirectoryMftIndex, ParentFileRecord);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Failed to update file record of directory with index: %I64x\n", DirectoryMftIndex);
+        ExFreePoolWithTag(NewIndexRoot, TAG_NTFS);
+        ReleaseAttributeContext(IndexRootContext);
+        ExFreePoolWithTag(I30IndexRoot, TAG_NTFS);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, ParentFileRecord);
+        return Status;
+    }
+
+    Status = WriteAttribute(DeviceExt,
+                            IndexRootContext,
+                            0,
+                            (PUCHAR)NewIndexRoot,
+                            AttributeLength,
+                            &LengthWritten,
+                            ParentFileRecord);
+    if (!NT_SUCCESS(Status) || LengthWritten != AttributeLength)
+    {
+        DPRINT1("ERROR: Unable to write new index root attribute to parent directory!\n");
+        if (NT_SUCCESS(Status))
+            Status = STATUS_UNSUCCESSFUL;
+    }
+
+    ExFreePoolWithTag(NewIndexRoot, TAG_NTFS);
+    ReleaseAttributeContext(IndexRootContext);
+    ExFreePoolWithTag(I30IndexRoot, TAG_NTFS);
+    ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, ParentFileRecord);
+
+    return Status;
+}
+
+/**
+* @name FreeMftEntry
+* @implemented
+*
+* Releases an MFT record back to the volume, clearing its bit in the master file table's $Bitmap
+* attribute and marking the record itself as no longer in use.
+*
+* @param DeviceExt
+* Points to the target disk's DEVICE_EXTENSION.
+*
+* @param MftIndex
+* Mft index of the record to release.
+*
+* @return
+* STATUS_SUCCESS on success.
+* STATUS_OBJECT_NAME_NOT_FOUND if the master file table has no $Bitmap attribute.
+* STATUS_INSUFFICIENT_RESOURCES if an allocation fails.
+*
+* @remarks
+* The record's sequence number is incremented before it's written back, so any file reference
+* still pointing at the old incarnation can be recognised as stale.
+*/
+NTSTATUS
+FreeMftEntry(PDEVICE_EXTENSION DeviceExt,
+             ULONGLONG MftIndex)
+{
+    NTSTATUS Status;
+    RTL_BITMAP Bitmap;
+    ULONGLONG BitmapDataSize;
+    ULONGLONG AttrBytesRead;
+    PUCHAR BitmapData;
+    PUCHAR BitmapBuffer;
+    ULONG LengthWritten;
+    PNTFS_ATTR_CONTEXT BitmapContext;
+    LARGE_INTEGER BitmapBits;
+    PFILE_RECORD_HEADER FileRecord;
+
+    DPRINT("FreeMftEntry(%p, %I64u)\n", DeviceExt, MftIndex);
+
+    // Mark the record itself as free first, so a bitmap bit is never handed out for a record
+    // that still looks in use.
+    FileRecord = ExAllocateFromNPagedLookasideList(&DeviceExt->FileRecLookasideList);
+    if (!FileRecord)
+        return STATUS_INSUFFICIENT_RESOURCES;
+
+    Status = ReadFileRecord(DeviceExt, MftIndex, FileRecord);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Couldn't read file record %I64u to free it!\n", MftIndex);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+        return Status;
+    }
+
+    FileRecord->Flags &= ~FRH_IN_USE;
+    FileRecord->SequenceNumber++;
+
+    // Sequence number zero is reserved to mean "no reference"
+    if (FileRecord->SequenceNumber == 0)
+        FileRecord->SequenceNumber = 1;
+
+    Status = UpdateFileRecord(DeviceExt, MftIndex, FileRecord);
+    ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Couldn't write file record %I64u while freeing it!\n", MftIndex);
+        return Status;
+    }
+
+    Status = FindAttribute(DeviceExt, DeviceExt->MasterFileTable, AttributeBitmap, L"", 0, &BitmapContext, NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Couldn't find $Bitmap attribute of master file table!\n");
+        return Status;
+    }
+
+    BitmapDataSize = AttributeDataLength(BitmapContext->pRecord);
+
+    // RtlInitializeBitmap wants a ULONG-aligned pointer and a ULONG-multiple of memory
+    BitmapBuffer = ExAllocatePoolWithTag(NonPagedPool, BitmapDataSize + sizeof(ULONG), TAG_NTFS);
+    if (!BitmapBuffer)
+    {
+        ReleaseAttributeContext(BitmapContext);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    RtlZeroMemory(BitmapBuffer, BitmapDataSize + sizeof(ULONG));
+
+    BitmapData = (PUCHAR)ALIGN_UP_BY((ULONG_PTR)BitmapBuffer, sizeof(ULONG));
+
+    AttrBytesRead = ReadAttribute(DeviceExt, BitmapContext, 0, (PCHAR)BitmapData, BitmapDataSize);
+    if (AttrBytesRead != BitmapDataSize)
+    {
+        DPRINT1("ERROR: Unable to read $Bitmap attribute of master file table!\n");
+        ExFreePoolWithTag(BitmapBuffer, TAG_NTFS);
+        ReleaseAttributeContext(BitmapContext);
+        return STATUS_OBJECT_NAME_NOT_FOUND;
+    }
+
+    BitmapBits.QuadPart = AttributeDataLength(DeviceExt->MFTContext->pRecord) /
+                          DeviceExt->NtfsInfo.BytesPerFileRecord;
+    if (BitmapBits.HighPart != 0)
+    {
+        DPRINT1("\tFIXME: bitmap sizes beyond 32bits are not yet supported! (Your NTFS volume is too large)\n");
+        ExFreePoolWithTag(BitmapBuffer, TAG_NTFS);
+        ReleaseAttributeContext(BitmapContext);
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if (MftIndex >= BitmapBits.QuadPart)
+    {
+        DPRINT1("ERROR: Mft index %I64u is beyond the end of the master file table!\n", MftIndex);
+        ExFreePoolWithTag(BitmapBuffer, TAG_NTFS);
+        ReleaseAttributeContext(BitmapContext);
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    RtlInitializeBitMap(&Bitmap, (PULONG)BitmapData, BitmapBits.LowPart);
+    RtlClearBits(&Bitmap, (ULONG)MftIndex, 1);
+
+    Status = WriteAttribute(DeviceExt, BitmapContext, 0, BitmapData, BitmapDataSize, &LengthWritten, NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR encountered when writing $Bitmap attribute!\n");
+    }
+
+    ExFreePoolWithTag(BitmapBuffer, TAG_NTFS);
+    ReleaseAttributeContext(BitmapContext);
+
+    return Status;
+}
+
+/**
+* @name NtfsDeleteFileRecord
+* @implemented
+*
+* Deletes a file or empty directory: releases every cluster its non-resident attributes hold,
+* removes each of its names from the parent index, and frees its MFT record.
+*
+* @param DeviceExt
+* Points to the target disk's DEVICE_EXTENSION.
+*
+* @param MftIndex
+* Mft index of the file to delete.
+*
+* @param CaseSensitive
+* Boolean indicating if the function should operate in case-sensitive mode. This will be TRUE
+* if an application created the file with the FILE_FLAG_POSIX_SEMANTICS flag.
+*
+* @return
+* STATUS_SUCCESS on success.
+*
+* @remarks
+* Callers must have established that the file may be deleted, in particular that a directory
+* is empty. Clusters are released before the names, so a failure part-way through leaves a
+* reachable file rather than orphaned allocation.
+*/
+NTSTATUS
+NtfsDeleteFileRecord(PDEVICE_EXTENSION DeviceExt,
+                     ULONGLONG MftIndex,
+                     BOOLEAN CaseSensitive)
+{
+    NTSTATUS Status;
+    PFILE_RECORD_HEADER FileRecord;
+    PNTFS_ATTR_RECORD Attribute;
+    PNTFS_ATTR_CONTEXT AttributeContext;
+    ULONG AttributeOffset;
+
+    DPRINT("NtfsDeleteFileRecord(%p, %I64u, %s)\n", DeviceExt, MftIndex, CaseSensitive ? "TRUE" : "FALSE");
+
+    FileRecord = ExAllocateFromNPagedLookasideList(&DeviceExt->FileRecLookasideList);
+    if (!FileRecord)
+        return STATUS_INSUFFICIENT_RESOURCES;
+
+    Status = ReadFileRecord(DeviceExt, MftIndex, FileRecord);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Couldn't read file record %I64u to delete it!\n", MftIndex);
+        ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+        return Status;
+    }
+
+    // Release the clusters held by every non-resident attribute
+    Attribute = (PNTFS_ATTR_RECORD)((ULONG_PTR)FileRecord + FileRecord->AttributeOffset);
+    AttributeOffset = FileRecord->AttributeOffset;
+
+    while (AttributeOffset < DeviceExt->NtfsInfo.BytesPerFileRecord &&
+           Attribute->Type != AttributeEnd)
+    {
+        if (Attribute->IsNonResident)
+        {
+            Status = FindAttribute(DeviceExt,
+                                   FileRecord,
+                                   Attribute->Type,
+                                   (PCWSTR)((ULONG_PTR)Attribute + Attribute->NameOffset),
+                                   Attribute->NameLength,
+                                   &AttributeContext,
+                                   NULL);
+            if (NT_SUCCESS(Status))
+            {
+                ULONGLONG ClusterCount = Attribute->NonResident.HighestVCN - Attribute->NonResident.LowestVCN + 1;
+
+                Status = FreeClusters(DeviceExt, AttributeContext, AttributeOffset, FileRecord, (ULONG)ClusterCount);
+                if (!NT_SUCCESS(Status))
+                {
+                    DPRINT1("ERROR: Failed to free clusters of attribute 0x%lx of file %I64u!\n",
+                            Attribute->Type, MftIndex);
+                }
+
+                ReleaseAttributeContext(AttributeContext);
+            }
+        }
+
+        if (Attribute->Length == 0)
+            break;
+
+        AttributeOffset += Attribute->Length;
+        Attribute = (PNTFS_ATTR_RECORD)((ULONG_PTR)FileRecord + AttributeOffset);
+    }
+
+    // Remove every name this file has from its parent's index. A file with both a long name and
+    // an 8.3 name is indexed twice, and both parents are named by the attributes themselves.
+    Attribute = (PNTFS_ATTR_RECORD)((ULONG_PTR)FileRecord + FileRecord->AttributeOffset);
+    AttributeOffset = FileRecord->AttributeOffset;
+
+    while (AttributeOffset < DeviceExt->NtfsInfo.BytesPerFileRecord &&
+           Attribute->Type != AttributeEnd)
+    {
+        if (Attribute->Type == AttributeFileName && !Attribute->IsNonResident)
+        {
+            PFILENAME_ATTRIBUTE FileName =
+                (PFILENAME_ATTRIBUTE)((ULONG_PTR)Attribute + Attribute->Resident.ValueOffset);
+
+            Status = NtfsRemoveFilenameFromDirectory(DeviceExt,
+                                                     FileName->DirectoryFileReferenceNumber & NTFS_MFT_MASK,
+                                                     FileName,
+                                                     CaseSensitive);
+            if (!NT_SUCCESS(Status))
+            {
+                DPRINT1("ERROR: Failed to remove '%.*S' from directory %I64u!\n",
+                        FileName->NameLength,
+                        FileName->Name,
+                        FileName->DirectoryFileReferenceNumber & NTFS_MFT_MASK);
+                ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+                return Status;
+            }
+        }
+
+        if (Attribute->Length == 0)
+            break;
+
+        AttributeOffset += Attribute->Length;
+        Attribute = (PNTFS_ATTR_RECORD)((ULONG_PTR)FileRecord + AttributeOffset);
+    }
+
+    ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+
+    return FreeMftEntry(DeviceExt, MftIndex);
+}
+
 NTSTATUS
 AddFixupArray(PDEVICE_EXTENSION Vcb,
               PNTFS_RECORD_HEADER Record)
@@ -2647,7 +3328,8 @@ ReadLCN(PDEVICE_EXTENSION Vcb,
 
 
 BOOLEAN
-CompareFileName(PUNICODE_STRING FileName,
+CompareFileName(PDEVICE_EXTENSION Vcb,
+                PUNICODE_STRING FileName,
                 PINDEX_ENTRY_ATTRIBUTE IndexEntry,
                 BOOLEAN DirSearch,
                 BOOLEAN CaseSensitive)
@@ -2672,7 +3354,10 @@ CompareFileName(PUNICODE_STRING FileName,
             IntFileName = *FileName;
         }
 
-        Ret = FsRtlIsNameInExpression(&IntFileName, &EntryName, !CaseSensitive, NULL);
+        /* With a real upcase table the matcher folds both sides through it,
+         * which is what NTFS means by case-insensitive. */
+        Ret = FsRtlIsNameInExpression(&IntFileName, &EntryName, !CaseSensitive,
+                                      Vcb ? Vcb->UpCaseTable : NULL);
 
         if (Alloc)
         {
@@ -2873,8 +3558,12 @@ BrowseSubNodeIndexEntries(PNTFS_VCB Vcb,
            CaseSensitive ? "TRUE" : "FALSE",
            OutMFTIndex);
 
-    // Calculate node number as VCN / Clusters per index record
-    NodeNumber = VCN / (Vcb->NtfsInfo.BytesPerIndexRecord / Vcb->NtfsInfo.BytesPerCluster);
+    // Calculate node number as VCN / Clusters per index record. An index record smaller than
+    // a cluster is addressed in sectors, matching GetAllocationOffsetFromVCN().
+    if (IndexBlockSize < Vcb->NtfsInfo.BytesPerCluster)
+        NodeNumber = VCN / (IndexBlockSize / Vcb->NtfsInfo.BytesPerSector);
+    else
+        NodeNumber = VCN / (IndexBlockSize / Vcb->NtfsInfo.BytesPerCluster);
 
     // Is the bit for this node clear in the bitmap?
     if (!RtlCheckBit(Bitmap, NodeNumber))
@@ -2891,8 +3580,8 @@ BrowseSubNodeIndexEntries(PNTFS_VCB Vcb,
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
-    // Calculate offset of index record
-    Offset = VCN * Vcb->NtfsInfo.BytesPerCluster;
+    // Calculate offset of index record, using the same helper the write path does
+    Offset = GetAllocationOffsetFromVCN(Vcb, IndexBlockSize, VCN);
 
     // Read the index record
     BytesRead = ReadAttribute(Vcb, IndexAllocationContext, Offset, (PCHAR)IndexRecord, IndexBlockSize);
@@ -2903,8 +3592,20 @@ BrowseSubNodeIndexEntries(PNTFS_VCB Vcb,
         return STATUS_UNSUCCESSFUL;
     }
 
-    // Assert that we're dealing with an index record here
-    ASSERT(IndexRecord->Ntfs.Type == NRH_INDX_TYPE);
+    if (IndexRecord->Ntfs.Type != NRH_INDX_TYPE)
+    {
+        DPRINT1("File system corruption detected, no index record at VCN %I64u of MFT record %I64u "
+                "(offset 0x%I64x, block size %lu, cluster %lu, index record %lu, signature 0x%08lx)\n",
+                VCN,
+                MftRecord->MFTRecordNumber & NTFS_MFT_MASK,
+                Offset,
+                IndexBlockSize,
+                Vcb->NtfsInfo.BytesPerCluster,
+                Vcb->NtfsInfo.BytesPerIndexRecord,
+                IndexRecord->Ntfs.Type);
+        ExFreePoolWithTag(IndexRecord, TAG_NTFS);
+        return STATUS_DATA_ERROR;
+    }
 
     // Apply the fixup array to the index record
     Status = FixupUpdateSequenceArray(Vcb, &((PFILE_RECORD_HEADER)IndexRecord)->Ntfs);
@@ -2961,7 +3662,7 @@ BrowseSubNodeIndexEntries(PNTFS_VCB Vcb,
         if ((IndexEntry->Data.Directory.IndexedFile & NTFS_MFT_MASK) >= NTFS_FILE_FIRST_USER_FILE &&
             *CurrentEntry >= *StartEntry &&
             IndexEntry->FileName.NameType != NTFS_FILE_NAME_DOS &&
-            CompareFileName(FileName, IndexEntry, DirSearch, CaseSensitive))
+            CompareFileName(Vcb, FileName, IndexEntry, DirSearch, CaseSensitive))
         {
             *StartEntry = *CurrentEntry;
             *OutMFTIndex = (IndexEntry->Data.Directory.IndexedFile & NTFS_MFT_MASK);
@@ -3095,6 +3796,15 @@ BrowseIndexEntries(PDEVICE_EXTENSION Vcb,
                                                    DirSearch,
                                                    CaseSensitive,
                                                    OutMFTIndex);
+
+                /* Anything other than "not in this subtree" means we gave up on
+                 * a subtree that may well have held the entry */
+                if (!NT_SUCCESS(Status) && Status != STATUS_OBJECT_PATH_NOT_FOUND)
+                {
+                    DPRINT1("Sub-node at VCN %I64u abandoned while looking for '%wZ' (Status %lx)\n",
+                            GetIndexEntryVCN(IndexEntry), FileName, Status);
+                }
+
                 if (NT_SUCCESS(Status))
                 {
                     ExFreePoolWithTag(BitmapMem, TAG_NTFS);
@@ -3113,7 +3823,7 @@ BrowseIndexEntries(PDEVICE_EXTENSION Vcb,
         if ((IndexEntry->Data.Directory.IndexedFile & NTFS_MFT_MASK) >= NTFS_FILE_FIRST_USER_FILE &&
             *CurrentEntry >= *StartEntry &&
             IndexEntry->FileName.NameType != NTFS_FILE_NAME_DOS &&
-            CompareFileName(FileName, IndexEntry, DirSearch, CaseSensitive))
+            CompareFileName(Vcb, FileName, IndexEntry, DirSearch, CaseSensitive))
         {
             *StartEntry = *CurrentEntry;
             *OutMFTIndex = (IndexEntry->Data.Directory.IndexedFile & NTFS_MFT_MASK);
@@ -3134,6 +3844,10 @@ BrowseIndexEntries(PDEVICE_EXTENSION Vcb,
 
     if (IndexAllocationContext)
     {
+        DPRINT("'%wZ' not found after scanning %lu entries of MFT record %I64u "
+               "(index allocation present)\n",
+               FileName, *CurrentEntry, MftRecord->MFTRecordNumber & NTFS_MFT_MASK);
+
         ExFreePoolWithTag(BitmapMem, TAG_NTFS);
         ReleaseAttributeContext(BitmapContext);
         ReleaseAttributeContext(IndexAllocationContext);
@@ -3201,7 +3915,9 @@ NtfsFindMftRecord(PDEVICE_EXTENSION Vcb,
     IndexRoot = (PINDEX_ROOT_ATTRIBUTE)IndexRecord;
     IndexEntry = (PINDEX_ENTRY_ATTRIBUTE)((PCHAR)&IndexRoot->Header + IndexRoot->Header.FirstEntryOffset);
     /* Index root is always resident. */
-    IndexEntryEnd = (PINDEX_ENTRY_ATTRIBUTE)(IndexRecord + IndexRoot->Header.TotalSizeOfEntries);
+    /* TotalSizeOfEntries is measured from the index header, not from the
+     * start of the attribute, and FirstEntryOffset above already is. */
+    IndexEntryEnd = (PINDEX_ENTRY_ATTRIBUTE)((ULONG_PTR)&IndexRoot->Header + IndexRoot->Header.TotalSizeOfEntries);
     ReleaseAttributeContext(IndexRootCtx);
 
     DPRINT("IndexRecordSize: %x IndexBlockSize: %x\n", Vcb->NtfsInfo.BytesPerIndexRecord, IndexRoot->SizeOfEntry);
@@ -3260,7 +3976,8 @@ NtfsLookupFileAt(PDEVICE_EXTENSION Vcb,
         if (Remaining.Length == 0)
             break;
 
-        FsRtlDissectName(Current, &Current, &Remaining);
+        /* Split what is left of the path, not the component we just resolved */
+        FsRtlDissectName(Remaining, &Current, &Remaining);
     }
 
     *FileRecord = ExAllocateFromNPagedLookasideList(&Vcb->FileRecLookasideList);

--- a/drivers/filesystems/ntfs/ntfs.c
+++ b/drivers/filesystems/ntfs/ntfs.c
@@ -181,6 +181,7 @@ NtfsInitializeFunctionPointers(PDRIVER_OBJECT DriverObject)
     DriverObject->MajorFunction[IRP_MJ_DIRECTORY_CONTROL]        = NtfsFsdDispatch;
     DriverObject->MajorFunction[IRP_MJ_FILE_SYSTEM_CONTROL]      = NtfsFsdDispatch;
     DriverObject->MajorFunction[IRP_MJ_DEVICE_CONTROL]           = NtfsFsdDispatch;
+    DriverObject->MajorFunction[IRP_MJ_FLUSH_BUFFERS]            = NtfsFsdDispatch;
 
     return;
 }

--- a/drivers/filesystems/ntfs/ntfs.h
+++ b/drivers/filesystems/ntfs/ntfs.h
@@ -15,6 +15,7 @@
 #define TAG_IRP_CTXT 'iftN'
 #define TAG_ATT_CTXT 'aftN'
 #define TAG_FILE_REC 'rftN'
+#define TAG_IO_RUNS 'RftN'
 
 #define ROUND_UP(N, S) ((((N) + (S) - 1) / (S)) * (S))
 #define ROUND_DOWN(N, S) ((N) - ((N) % (S)))
@@ -118,6 +119,11 @@ typedef struct
 
     NPAGED_LOOKASIDE_LIST FileRecLookasideList;
 
+    /* $UpCase, one upcased code point per UCS-2 value. NTFS defines its
+     * own case folding through this file, so comparisons must use it
+     * rather than the Rtl table. */
+    PWCHAR UpCaseTable;
+
     ULONG MftDataOffset;
     ULONG Flags;
     ULONG OpenHandleCount;
@@ -125,6 +131,8 @@ typedef struct
 } DEVICE_EXTENSION, *PDEVICE_EXTENSION, NTFS_VCB, *PNTFS_VCB;
 
 #define VCB_VOLUME_LOCKED       0x0001
+/* Volume dismounted: everything but raw volume access is refused */
+#define VCB_VOLUME_DISMOUNTED   0x0002
 
 typedef struct
 {
@@ -138,7 +146,13 @@ typedef struct
     PWCHAR DirectorySearchPattern;
     ULONG LastCluster;
     ULONG LastOffset;
+    ULONG Flags;
 } NTFS_CCB, *PNTFS_CCB;
+
+/* NTFS has no "." or ".." in its indices, so directory enumeration makes them
+ * up. These record which of the two a scan has already handed out. */
+#define CCB_RETURNED_DOT        0x0001
+#define CCB_RETURNED_DOTDOT     0x0002
 
 typedef struct
 {
@@ -328,8 +342,8 @@ typedef struct
 typedef struct
 {
     ULONGLONG CreationTime;
-    ULONGLONG ChangeTime;
     ULONGLONG LastWriteTime;
+    ULONGLONG ChangeTime;
     ULONGLONG LastAccessTime;
     ULONG FileAttribute;
     ULONG AlignmentOrReserved[3];
@@ -359,8 +373,8 @@ typedef struct
 {
     ULONGLONG DirectoryFileReferenceNumber;
     ULONGLONG CreationTime;
-    ULONGLONG ChangeTime;
     ULONGLONG LastWriteTime;
+    ULONGLONG ChangeTime;
     ULONGLONG LastAccessTime;
     ULONGLONG AllocatedSize;
     ULONGLONG DataSize;
@@ -475,6 +489,50 @@ typedef struct {
 #define IRPCONTEXT_COMPLETE 0x2
 #define IRPCONTEXT_QUEUE 0x4
 
+/* A run with no backing storage: zeroed on read, rejected on write */
+#define NTFS_SPARSE_LBO ((LONGLONG)-1)
+
+/* How many runs a request may span before the run list spills into pool. */
+#define NTFS_MAX_IO_RUNS_ON_STACK 8
+
+/* One physically contiguous piece of a transfer. Runs tile the caller's buffer:
+ * Runs[i].BufferOffset + Runs[i].ByteCount == Runs[i + 1].BufferOffset. */
+typedef struct _NTFS_IO_RUN
+{
+    LONGLONG Lbo;           /* Byte offset on the volume, or NTFS_SPARSE_LBO */
+    ULONG BufferOffset;     /* Byte offset into the caller's buffer */
+    ULONG ByteCount;
+    PIRP SavedIrp;          /* The IRP issued for this run; owned by blockdev.c */
+} NTFS_IO_RUN, *PNTFS_IO_RUN;
+
+/* Small requests stay on the caller's stack; fragmented ones spill into pool */
+typedef struct _NTFS_IO_RUN_LIST
+{
+    PNTFS_IO_RUN Runs;
+    ULONG Count;
+    ULONG Capacity;
+    ULONG TotalLength;
+    NTFS_IO_RUN StackRuns[NTFS_MAX_IO_RUNS_ON_STACK];
+} NTFS_IO_RUN_LIST, *PNTFS_IO_RUN_LIST;
+
+/* Shared between the issuing thread and every run's completion routine. The
+ * issuer waits on SyncEvent, which the last completing run sets. */
+typedef struct _NTFS_IO_CONTEXT
+{
+    volatile LONG IrpCount;         /* Runs still in flight */
+    volatile LONG Status;           /* First error seen, else STATUS_SUCCESS */
+    volatile LONG BytesTransferred;
+
+    /* Covers the whole transfer; every run cuts a partial MDL from it. Either
+     * borrowed from the caller's IRP or built here; we only lock and release
+     * it in the latter case. */
+    PMDL MasterMdl;
+    PVOID MasterVa;                 /* Base address MasterMdl describes */
+    BOOLEAN OwnsMasterMdl;
+
+    KEVENT SyncEvent;
+} NTFS_IO_CONTEXT, *PNTFS_IO_CONTEXT;
+
 typedef struct
 {
     NTFSIDENTIFIER Identifier;
@@ -508,6 +566,7 @@ typedef struct _NTFS_ATTR_CONTEXT
 #define FCB_CACHE_INITIALIZED   0x0001
 #define FCB_IS_VOLUME_STREAM    0x0002
 #define FCB_IS_VOLUME           0x0004
+#define FCB_DELETE_PENDING      0x0008
 #define MAX_PATH                260
 
 typedef struct _FCB
@@ -535,6 +594,7 @@ typedef struct _FCB
     LONG RefCount;
     ULONG Flags;
     ULONG OpenHandleCount;
+    SHARE_ACCESS ShareAccess;
 
     ULONGLONG MFTIndex;
     USHORT LinkCount;
@@ -707,6 +767,36 @@ FreeClusters(PNTFS_VCB Vcb,
 
 /* blockdev.c */
 
+VOID
+NtfsInitIoRunList(OUT PNTFS_IO_RUN_LIST RunList);
+
+NTSTATUS
+NtfsAddIoRun(IN OUT PNTFS_IO_RUN_LIST RunList,
+             IN LONGLONG Lbo,
+             IN ULONG ByteCount);
+
+VOID
+NtfsFreeIoRunList(IN OUT PNTFS_IO_RUN_LIST RunList);
+
+NTSTATUS
+NtfsPerformIoRuns(IN PDEVICE_OBJECT DeviceObject,
+                  IN UCHAR MajorFunction,
+                  IN ULONG SectorSize,
+                  IN OUT PUCHAR Buffer,
+                  IN PNTFS_IO_RUN_LIST RunList,
+                  IN BOOLEAN Override,
+                  OUT PULONG BytesTransferred OPTIONAL);
+
+NTSTATUS
+NtfsPerformIrpIoRuns(IN PDEVICE_OBJECT DeviceObject,
+                     IN UCHAR MajorFunction,
+                     IN ULONG SectorSize,
+                     IN PIRP Irp,
+                     IN OUT PUCHAR Buffer,
+                     IN PNTFS_IO_RUN_LIST RunList,
+                     IN BOOLEAN Override,
+                     OUT PULONG BytesTransferred);
+
 NTSTATUS
 NtfsReadDisk(IN PDEVICE_OBJECT DeviceObject,
              IN LONGLONG StartingOffset,
@@ -721,6 +811,9 @@ NtfsWriteDisk(IN PDEVICE_OBJECT DeviceObject,
               IN ULONG Length,
               IN ULONG SectorSize,
               IN const PUCHAR Buffer);
+
+NTSTATUS
+NtfsFlushDevice(IN PDEVICE_OBJECT DeviceObject);
 
 NTSTATUS
 NtfsReadSectors(IN PDEVICE_OBJECT DeviceObject,
@@ -765,8 +858,15 @@ CreateIndexRootFromBTree(PDEVICE_EXTENSION DeviceExt,
 NTSTATUS
 DemoteBTreeRoot(PB_TREE Tree);
 
+PB_TREE_KEY
+CreateBTreeKeyFromFilename(ULONGLONG FileReference,
+                           PFILENAME_ATTRIBUTE FileNameAttribute);
+
 VOID
 DestroyBTree(PB_TREE Tree);
+
+VOID
+DestroyBTreeKey(PB_TREE_KEY Key);
 
 VOID
 DestroyBTreeNode(PB_TREE_FILENAME_NODE Node);
@@ -810,6 +910,11 @@ NtfsInsertKey(PB_TREE Tree,
               ULONG IndexRecordSize,
               PB_TREE_KEY *MedianKey,
               PB_TREE_FILENAME_NODE *NewRightHandSibling);
+
+NTSTATUS
+NtfsRemoveKey(PB_TREE_FILENAME_NODE Node,
+              PB_TREE_KEY SearchKey,
+              BOOLEAN CaseSensitive);
 
 NTSTATUS
 SplitBTreeNode(PB_TREE Tree,
@@ -1018,6 +1123,11 @@ NtfsSetInformation(PNTFS_IRP_CONTEXT IrpContext);
 NTSTATUS
 NtfsFileSystemControl(PNTFS_IRP_CONTEXT IrpContext);
 
+/* flush.c */
+
+NTSTATUS
+NtfsFlushBuffers(PNTFS_IRP_CONTEXT IrpContext);
+
 
 /* mft.c */
 NTSTATUS
@@ -1026,6 +1136,21 @@ NtfsAddFilenameToDirectory(PDEVICE_EXTENSION DeviceExt,
                            ULONGLONG FileReferenceNumber,
                            PFILENAME_ATTRIBUTE FilenameAttribute,
                            BOOLEAN CaseSensitive);
+
+NTSTATUS
+NtfsRemoveFilenameFromDirectory(PDEVICE_EXTENSION DeviceExt,
+                                ULONGLONG DirectoryMftIndex,
+                                PFILENAME_ATTRIBUTE FilenameAttribute,
+                                BOOLEAN CaseSensitive);
+
+NTSTATUS
+FreeMftEntry(PDEVICE_EXTENSION DeviceExt,
+             ULONGLONG MftIndex);
+
+NTSTATUS
+NtfsDeleteFileRecord(PDEVICE_EXTENSION DeviceExt,
+                     ULONGLONG MftIndex,
+                     BOOLEAN CaseSensitive);
 
 NTSTATUS
 AddNewMftEntry(PFILE_RECORD_HEADER FileRecord,
@@ -1049,6 +1174,14 @@ ReadAttribute(PDEVICE_EXTENSION Vcb,
               PCHAR Buffer,
               ULONG Length);
 
+ULONG
+ReadAttributeToIrp(PDEVICE_EXTENSION Vcb,
+                   PNTFS_ATTR_CONTEXT Context,
+                   ULONGLONG Offset,
+                   PCHAR Buffer,
+                   ULONG Length,
+                   PIRP Irp);
+
 NTSTATUS
 WriteAttribute(PDEVICE_EXTENSION Vcb,
                PNTFS_ATTR_CONTEXT Context,
@@ -1057,6 +1190,16 @@ WriteAttribute(PDEVICE_EXTENSION Vcb,
                ULONG Length,
                PULONG LengthWritten,
                PFILE_RECORD_HEADER FileRecord);
+
+NTSTATUS
+WriteAttributeFromIrp(PDEVICE_EXTENSION Vcb,
+                      PNTFS_ATTR_CONTEXT Context,
+                      ULONGLONG Offset,
+                      const PUCHAR Buffer,
+                      ULONG Length,
+                      PULONG LengthWritten,
+                      PFILE_RECORD_HEADER FileRecord,
+                      PIRP Irp);
 
 ULONGLONG
 AttributeDataLength(PNTFS_ATTR_RECORD AttrRecord);
@@ -1105,7 +1248,8 @@ ULONGLONG
 AttributeAllocatedLength(PNTFS_ATTR_RECORD AttrRecord);
 
 BOOLEAN
-CompareFileName(PUNICODE_STRING FileName,
+CompareFileName(PDEVICE_EXTENSION Vcb,
+                PUNICODE_STRING FileName,
                 PINDEX_ENTRY_ATTRIBUTE IndexEntry,
                 BOOLEAN DirSearch,
                 BOOLEAN CaseSensitive);
@@ -1114,32 +1258,66 @@ NTSTATUS
 UpdateMftMirror(PNTFS_VCB Vcb);
 
 NTSTATUS
+NtfsLoadUpCaseTable(PDEVICE_EXTENSION Vcb);
+
+NTSTATUS
 ReadFileRecord(PDEVICE_EXTENSION Vcb,
                ULONGLONG index,
                PFILE_RECORD_HEADER file);
 
+/* NTFS duplicates a file's sizes, timestamps and attributes into the $FILE_NAME
+ * of its entry in the parent directory's index, so a directory can be
+ * enumerated without reading every file record. These flags say which of them
+ * the caller changed and so need refreshing there. */
+#define NTFS_FILENAME_UPDATE_SIZES  0x1
+#define NTFS_FILENAME_UPDATE_TIMES  0x2
+#define NTFS_FILENAME_UPDATE_ATTRS  0x4
+
+typedef struct _NTFS_FILENAME_UPDATE
+{
+    ULONG Flags;
+
+    /* NTFS_FILENAME_UPDATE_SIZES */
+    ULONGLONG DataSize;
+    ULONGLONG AllocatedSize;
+
+    /* NTFS_FILENAME_UPDATE_TIMES */
+    ULONGLONG CreationTime;
+    ULONGLONG LastWriteTime;
+    ULONGLONG ChangeTime;
+    ULONGLONG LastAccessTime;
+
+    /* NTFS_FILENAME_UPDATE_ATTRS */
+    ULONG FileAttributes;
+} NTFS_FILENAME_UPDATE, *PNTFS_FILENAME_UPDATE;
+
 NTSTATUS
-UpdateIndexEntryFileNameSize(PDEVICE_EXTENSION Vcb,
-                             PFILE_RECORD_HEADER MftRecord,
-                             PCHAR IndexRecord,
-                             ULONG IndexBlockSize,
-                             PINDEX_ENTRY_ATTRIBUTE FirstEntry,
-                             PINDEX_ENTRY_ATTRIBUTE LastEntry,
-                             PUNICODE_STRING FileName,
-                             PULONG StartEntry,
-                             PULONG CurrentEntry,
-                             BOOLEAN DirSearch,
-                             ULONGLONG NewDataSize,
-                             ULONGLONG NewAllocatedSize,
-                             BOOLEAN CaseSensitive);
+UpdateIndexEntryFileName(PDEVICE_EXTENSION Vcb,
+                         PFILE_RECORD_HEADER MftRecord,
+                         PCHAR IndexRecord,
+                         ULONG IndexBlockSize,
+                         PINDEX_ENTRY_ATTRIBUTE FirstEntry,
+                         PINDEX_ENTRY_ATTRIBUTE LastEntry,
+                         PUNICODE_STRING FileName,
+                         PULONG StartEntry,
+                         PULONG CurrentEntry,
+                         BOOLEAN DirSearch,
+                         PNTFS_FILENAME_UPDATE Update,
+                         BOOLEAN CaseSensitive);
+
+NTSTATUS
+NtfsUpdateDuplicatedInformation(PDEVICE_EXTENSION Vcb,
+                                PFILE_RECORD_HEADER FileRecord,
+                                ULONGLONG MFTIndex,
+                                ULONG Flags,
+                                BOOLEAN CaseSensitive);
 
 NTSTATUS
 UpdateFileNameRecord(PDEVICE_EXTENSION Vcb,
                      ULONGLONG ParentMFTIndex,
                      PUNICODE_STRING FileName,
                      BOOLEAN DirSearch,
-                     ULONGLONG NewDataSize,
-                     ULONGLONG NewAllocationSize,
+                     PNTFS_FILENAME_UPDATE Update,
                      BOOLEAN CaseSensitive);
 
 NTSTATUS

--- a/drivers/filesystems/ntfs/rw.c
+++ b/drivers/filesystems/ntfs/rw.c
@@ -35,6 +35,83 @@
 
 /* FUNCTIONS ****************************************************************/
 
+/**
+* @name NtfsReadWriteVolume
+* @implemented
+*
+* Serves a read or write made through a handle on the volume itself.
+*
+* @param DeviceExt
+* Points to the target disk's DEVICE_EXTENSION
+*
+* @param MajorFunction
+* IRP_MJ_READ or IRP_MJ_WRITE
+*
+* @param Buffer
+* System-space buffer to transfer to or from
+*
+* @param Length
+* How much to transfer, in bytes
+*
+* @param Offset
+* Byte offset from the start of the volume
+*
+* @param Irp
+* The request being served, so that its buffer can be used directly
+*
+* @param LengthTransferred
+* Receives how much was transferred
+*
+* @return
+* STATUS_SUCCESS on success, otherwise the status of the transfer.
+*
+* @remarks A volume handle is raw access to the partition: it has no file
+* record and no attributes. Running it through the attribute code would
+* resolve the volume FCB's MFT index of zero and redirect the transfer into
+* $MFT's own $DATA attribute.
+*
+*/
+static
+NTSTATUS
+NtfsReadWriteVolume(PDEVICE_EXTENSION DeviceExt,
+                    UCHAR MajorFunction,
+                    PUCHAR Buffer,
+                    ULONG Length,
+                    LONGLONG Offset,
+                    PIRP Irp,
+                    PULONG LengthTransferred)
+{
+    NTFS_IO_RUN_LIST RunList;
+    NTSTATUS Status;
+
+    DPRINT("NtfsReadWriteVolume(%p, %u, %p, %lu, %I64u, %p, %p)\n",
+           DeviceExt, MajorFunction, Buffer, Length, Offset, Irp, LengthTransferred);
+
+    *LengthTransferred = 0;
+
+    if (Length == 0)
+        return STATUS_SUCCESS;
+
+    NtfsInitIoRunList(&RunList);
+
+    Status = NtfsAddIoRun(&RunList, Offset, Length);
+    if (NT_SUCCESS(Status))
+    {
+        Status = NtfsPerformIrpIoRuns(DeviceExt->StorageDevice,
+                                      MajorFunction,
+                                      DeviceExt->NtfsInfo.BytesPerSector,
+                                      Irp,
+                                      Buffer,
+                                      &RunList,
+                                      FALSE,
+                                      LengthTransferred);
+    }
+
+    NtfsFreeIoRunList(&RunList);
+
+    return Status;
+}
+
 /*
  * FUNCTION: Reads data from a file
  */
@@ -46,12 +123,13 @@ NtfsReadFile(PDEVICE_EXTENSION DeviceExt,
              ULONG Length,
              ULONG ReadOffset,
              ULONG IrpFlags,
+             PIRP Irp,
              PULONG LengthRead)
 {
     NTSTATUS Status = STATUS_SUCCESS;
     PNTFS_FCB Fcb;
     PFILE_RECORD_HEADER FileRecord;
-    PNTFS_ATTR_CONTEXT DataContext;
+    PNTFS_ATTR_CONTEXT DataContext = NULL;
     ULONG RealLength;
     ULONG RealReadOffset;
     ULONG RealLengthRead;
@@ -109,7 +187,8 @@ NtfsReadFile(PDEVICE_EXTENSION DeviceExt,
         FIND_ATTR_CONTXT Context;
         PNTFS_ATTR_RECORD Attribute;
 
-        DPRINT1("No '%S' data stream associated with file!\n", Fcb->Stream);
+        DPRINT1("No '%S' data stream associated with file '%wS' (MFT record %I64u, record flags 0x%x)!\n",
+                Fcb->Stream, Fcb->ObjectName, Fcb->MFTIndex, FileRecord->Flags);
 
         BrowseStatus = FindFirstAttribute(&Context, DeviceExt, FileRecord, FALSE, &Attribute);
         while (NT_SUCCESS(BrowseStatus))
@@ -128,7 +207,8 @@ NtfsReadFile(PDEVICE_EXTENSION DeviceExt,
         }
         FindCloseAttribute(&Context);
 
-        ReleaseAttributeContext(DataContext);
+        /* FindAttribute() failed, so DataContext was never set; there is
+         * nothing to release here. */
         ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
         return Status;
     }
@@ -136,7 +216,7 @@ NtfsReadFile(PDEVICE_EXTENSION DeviceExt,
     StreamSize = AttributeDataLength(DataContext->pRecord);
     if (ReadOffset >= StreamSize)
     {
-        DPRINT1("Reading beyond stream end!\n");
+        DPRINT("Reading beyond stream end!\n");
         ReleaseAttributeContext(DataContext);
         ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
         return STATUS_END_OF_FILE;
@@ -173,7 +253,15 @@ NtfsReadFile(PDEVICE_EXTENSION DeviceExt,
     }
 
     DPRINT("Effective read: %lu at %lu for stream '%S'\n", RealLength, RealReadOffset, Fcb->Stream);
-    RealLengthRead = ReadAttribute(DeviceExt, DataContext, RealReadOffset, (PCHAR)ReadBuffer, RealLength);
+    /* Only hand the IRP down when reading straight into its buffer: a
+     * forwarded transfer lands at the start of the IRP's MDL, so a bounced
+     * read would end up in the wrong place */
+    RealLengthRead = ReadAttributeToIrp(DeviceExt,
+                                        DataContext,
+                                        RealReadOffset,
+                                        (PCHAR)ReadBuffer,
+                                        RealLength,
+                                        AllocatedBuffer ? NULL : Irp);
     if (RealLengthRead == 0)
     {
         DPRINT1("Read failure!\n");
@@ -238,13 +326,43 @@ NtfsRead(PNTFS_IRP_CONTEXT IrpContext)
     ReadOffset = Stack->Parameters.Read.ByteOffset;
     Buffer = NtfsGetUserBuffer(Irp, BooleanFlagOn(Irp->Flags, IRP_PAGING_IO));
 
-    Status = NtfsReadFile(DeviceExt,
-                          FileObject,
-                          Buffer,
-                          ReadLength,
-                          ReadOffset.u.LowPart,
-                          Irp->Flags,
-                          &ReturnedReadLength);
+    /* Once dismounted the metadata can't be trusted; only raw volume access
+     * is still served */
+    if ((DeviceExt->Flags & VCB_VOLUME_DISMOUNTED) &&
+        !(((PNTFS_FCB)FileObject->FsContext)->Flags & FCB_IS_VOLUME))
+    {
+        Irp->IoStatus.Information = 0;
+        return STATUS_VOLUME_DISMOUNTED;
+    }
+
+    /* A handle on the volume itself is raw access to the partition. */
+    if (((PNTFS_FCB)FileObject->FsContext)->Flags & FCB_IS_VOLUME)
+    {
+        Status = NtfsReadWriteVolume(DeviceExt,
+                                     IRP_MJ_READ,
+                                     Buffer,
+                                     ReadLength,
+                                     ReadOffset.QuadPart,
+                                     Irp,
+                                     &ReturnedReadLength);
+    }
+    else if (NtfsFCBIsDirectory((PNTFS_FCB)FileObject->FsContext))
+    {
+        /* A directory has no data stream to read */
+        Irp->IoStatus.Information = 0;
+        return STATUS_INVALID_DEVICE_REQUEST;
+    }
+    else
+    {
+        Status = NtfsReadFile(DeviceExt,
+                              FileObject,
+                              Buffer,
+                              ReadLength,
+                              ReadOffset.u.LowPart,
+                              Irp->Flags,
+                              Irp,
+                              &ReturnedReadLength);
+    }
     if (NT_SUCCESS(Status))
     {
         if (FileObject->Flags & FO_SYNCHRONOUS_IO)
@@ -315,14 +433,16 @@ NTSTATUS NtfsWriteFile(PDEVICE_EXTENSION DeviceExt,
                        ULONG WriteOffset,
                        ULONG IrpFlags,
                        BOOLEAN CaseSensitive,
+                       PIRP Irp,
                        PULONG LengthWritten)
 {
     NTSTATUS Status = STATUS_NOT_IMPLEMENTED;
     PNTFS_FCB Fcb;
     PFILE_RECORD_HEADER FileRecord;
-    PNTFS_ATTR_CONTEXT DataContext;
+    PNTFS_ATTR_CONTEXT DataContext = NULL;
     ULONG AttributeOffset;
     ULONGLONG StreamSize;
+    ULONG RequestedLength = 0;
 
     DPRINT("NtfsWriteFile(%p, %p, %p, %lu, %lu, %x, %s, %p)\n",
            DeviceExt,
@@ -394,7 +514,8 @@ NTSTATUS NtfsWriteFile(PDEVICE_EXTENSION DeviceExt,
         FIND_ATTR_CONTXT Context;
         PNTFS_ATTR_RECORD Attribute;
 
-        DPRINT1("No '%S' data stream associated with file!\n", Fcb->Stream);
+        DPRINT1("No '%S' data stream associated with file '%wS' (MFT record %I64u, record flags 0x%x)!\n",
+                Fcb->Stream, Fcb->ObjectName, Fcb->MFTIndex, FileRecord->Flags);
 
         // Couldn't find the requested data stream; print a list of streams available
         BrowseStatus = FindFirstAttribute(&Context, DeviceExt, FileRecord, FALSE, &Attribute);
@@ -414,7 +535,8 @@ NTSTATUS NtfsWriteFile(PDEVICE_EXTENSION DeviceExt,
         }
         FindCloseAttribute(&Context);
 
-        ReleaseAttributeContext(DataContext);
+        /* FindAttribute() failed, so DataContext was never set; there is
+         * nothing to release here. */
         ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
         return Status;
     }
@@ -432,10 +554,6 @@ NTSTATUS NtfsWriteFile(PDEVICE_EXTENSION DeviceExt,
             !(IrpFlags & IRP_PAGING_IO))
         {
             LARGE_INTEGER DataSize;
-            ULONGLONG AllocationSize;
-            PFILENAME_ATTRIBUTE fileNameAttribute;
-            ULONGLONG ParentMFTId;
-            UNICODE_STRING filename;
 
             DataSize.QuadPart = WriteOffset + Length;
 
@@ -449,32 +567,39 @@ NTSTATUS NtfsWriteFile(PDEVICE_EXTENSION DeviceExt,
                 return Status;
             }
 
-            AllocationSize = AttributeAllocatedLength(DataContext->pRecord);
+            // The file grew, so every copy of its size has to follow.
+            // TODO: adapt this to every filename / hardlink in the record.
+            Status = NtfsUpdateDuplicatedInformation(Fcb->Vcb,
+                                                     FileRecord,
+                                                     Fcb->MFTIndex,
+                                                     NTFS_FILENAME_UPDATE_SIZES,
+                                                     CaseSensitive);
+        }
+        else if (IrpFlags & IRP_PAGING_IO)
+        {
+            /* Mm flushes whole pages, so a file's last page routinely reaches
+             * past its end. A paging write must not change the file size, so
+             * clamp instead of failing - refusing it would lose the valid
+             * bytes before the end too. */
+            if (WriteOffset >= StreamSize)
+            {
+                DPRINT("Paging write entirely past the end of the stream; nothing to do\n");
 
-            // now we need to update this file's size in every directory index entry that references it
-            // TODO: put this code in its own function and adapt it to work with every filename / hardlink
-            // stored in the file record.
-            fileNameAttribute = GetBestFileNameFromRecord(Fcb->Vcb, FileRecord);
-            ASSERT(fileNameAttribute);
+                ReleaseAttributeContext(DataContext);
+                ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
+                *LengthWritten = Length;
+                return STATUS_SUCCESS;
+            }
 
-            ParentMFTId = fileNameAttribute->DirectoryFileReferenceNumber & NTFS_MFT_MASK;
+            DPRINT("Clamping paging write of %lu bytes at %lu to stream size %I64u\n",
+                   Length, WriteOffset, StreamSize);
 
-            filename.Buffer = fileNameAttribute->Name;
-            filename.Length = fileNameAttribute->NameLength * sizeof(WCHAR);
-            filename.MaximumLength = filename.Length;
-
-            Status = UpdateFileNameRecord(Fcb->Vcb,
-                                          ParentMFTId,
-                                          &filename,
-                                          FALSE,
-                                          DataSize.QuadPart,
-                                          AllocationSize,
-                                          CaseSensitive);
-
+            RequestedLength = Length;
+            Length = (ULONG)(StreamSize - WriteOffset);
         }
         else
         {
-            // TODO - just fail for now
+            /* The volume stream is the size of the volume and cannot grow */
             ReleaseAttributeContext(DataContext);
             ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
             *LengthWritten = 0;
@@ -485,7 +610,10 @@ NTSTATUS NtfsWriteFile(PDEVICE_EXTENSION DeviceExt,
     DPRINT("Length: %lu\tWriteOffset: %lu\tStreamSize: %I64u\n", Length, WriteOffset, StreamSize);
 
     // Write the data to the attribute
-    Status = WriteAttribute(DeviceExt, DataContext, WriteOffset, Buffer, Length, LengthWritten, FileRecord);
+    /* Buffer is the system mapping of this IRP's MDL, so hand the IRP down too
+     * and let the run layer borrow it instead of locking these pages twice,
+     * which the paging path forbids */
+    Status = WriteAttributeFromIrp(DeviceExt, DataContext, WriteOffset, Buffer, Length, LengthWritten, FileRecord, Irp);
 
     // Did the write fail?
     if (!NT_SUCCESS(Status))
@@ -504,6 +632,11 @@ NTSTATUS NtfsWriteFile(PDEVICE_EXTENSION DeviceExt,
             *LengthWritten, Length);
         Status = STATUS_UNEXPECTED_IO_ERROR;
     }
+
+    // A clamped paging write stored all the stream had room for, so as far as
+    // Mm is concerned the whole page is done
+    if (RequestedLength != 0 && NT_SUCCESS(Status))
+        *LengthWritten = RequestedLength;
 
     ReleaseAttributeContext(DataContext);
     ExFreeToNPagedLookasideList(&DeviceExt->FileRecLookasideList, FileRecord);
@@ -624,6 +757,23 @@ NtfsWrite(PNTFS_IRP_CONTEXT IrpContext)
         return STATUS_INVALID_PARAMETER;
     }
 
+    /* Is this an async request to a file? Serving a write means reading the
+     * file record, walking its attributes and possibly growing the allocation,
+     * all of it blocking metadata I/O, so post it to a worker thread which
+     * runs the same path with IRPCONTEXT_CANWAIT set. Lock the user buffer
+     * here, while we're still in the requesting thread's address space. */
+    if (!(IrpContext->Flags & IRPCONTEXT_CANWAIT) && !(Fcb->Flags & FCB_IS_VOLUME))
+    {
+        Status = NtfsLockUserBuffer(Irp, Length, IoReadAccess);
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("Unable to lock user buffer!\n");
+            return Status;
+        }
+
+        return NtfsMarkIrpContextForQueue(IrpContext);
+    }
+
     // get the Resource
     if (Fcb->Flags & FCB_IS_VOLUME)
     {
@@ -655,15 +805,6 @@ NtfsWrite(PNTFS_IRP_CONTEXT IrpContext)
     }
     }*/
 
-    // Is this an async request to a file?
-    if (!(IrpContext->Flags & IRPCONTEXT_CANWAIT) && !(Fcb->Flags & FCB_IS_VOLUME))
-    {
-        DPRINT1("FIXME: Async writes not supported in NTFS!\n");
-
-        ExReleaseResourceLite(Resource);
-        return STATUS_NOT_IMPLEMENTED;
-    }
-
     // get the buffer of data the user is trying to write
     Buffer = NtfsGetUserBuffer(Irp, BooleanFlagOn(Irp->Flags, IRP_PAGING_IO));
     ASSERT(Buffer);
@@ -685,15 +826,45 @@ NtfsWrite(PNTFS_IRP_CONTEXT IrpContext)
 
     // TODO: handle HighPart of ByteOffset (large files)
 
+    /* See NtfsRead() */
+    if ((DeviceExt->Flags & VCB_VOLUME_DISMOUNTED) &&
+        !(Fcb->Flags & FCB_IS_VOLUME))
+    {
+        ExReleaseResourceLite(Resource);
+        Irp->IoStatus.Information = 0;
+        return STATUS_VOLUME_DISMOUNTED;
+    }
+
     // write the file
-    Status = NtfsWriteFile(DeviceExt,
-                           FileObject,
-                           Buffer,
-                           Length,
-                           ByteOffset.LowPart,
-                           Irp->Flags,
-                           BooleanFlagOn(IrpContext->Stack->Flags, SL_CASE_SENSITIVE),
-                           &ReturnedWriteLength);
+    if (Fcb->Flags & FCB_IS_VOLUME)
+    {
+        /* Raw access to the partition, including after a dismount. */
+        Status = NtfsReadWriteVolume(DeviceExt,
+                                     IRP_MJ_WRITE,
+                                     Buffer,
+                                     Length,
+                                     ByteOffset.QuadPart,
+                                     Irp,
+                                     &ReturnedWriteLength);
+    }
+    else if (NtfsFCBIsDirectory(Fcb))
+    {
+        /* A directory has no data stream to write */
+        Irp->IoStatus.Information = 0;
+        return STATUS_INVALID_DEVICE_REQUEST;
+    }
+    else
+    {
+        Status = NtfsWriteFile(DeviceExt,
+                               FileObject,
+                               Buffer,
+                               Length,
+                               ByteOffset.LowPart,
+                               Irp->Flags,
+                               BooleanFlagOn(IrpContext->Stack->Flags, SL_CASE_SENSITIVE),
+                               Irp,
+                               &ReturnedWriteLength);
+    }
 
     IrpContext->Irp->IoStatus.Status = Status;
 

--- a/drivers/filesystems/ntfs/volinfo.c
+++ b/drivers/filesystems/ntfs/volinfo.c
@@ -84,9 +84,11 @@ NtfsGetFreeClusters(PDEVICE_EXTENSION DeviceExt)
     }
     ReleaseAttributeContext(DataContext);
 
-    DPRINT1("Total clusters: %I64x\n", DeviceExt->NtfsInfo.ClusterCount);
-    DPRINT1("Total clusters in bitmap: %I64x\n", BitmapDataSize * 8);
-    DPRINT1("Diff in size: %I64d B\n", ((BitmapDataSize * 8) - DeviceExt->NtfsInfo.ClusterCount) * DeviceExt->NtfsInfo.SectorsPerCluster * DeviceExt->NtfsInfo.BytesPerSector);
+    /* $Bitmap is rounded up to a cluster, so it normally covers a few clusters more than the
+     * volume has. The bitmap below is bounded by ClusterCount, so the surplus bits are ignored. */
+    DPRINT("Total clusters: %I64x\n", DeviceExt->NtfsInfo.ClusterCount);
+    DPRINT("Total clusters in bitmap: %I64x\n", BitmapDataSize * 8);
+    DPRINT("Diff in size: %I64d B\n", ((BitmapDataSize * 8) - DeviceExt->NtfsInfo.ClusterCount) * DeviceExt->NtfsInfo.SectorsPerCluster * DeviceExt->NtfsInfo.BytesPerSector);
 
     RtlInitializeBitMap(&Bitmap, (PULONG)BitmapData, DeviceExt->NtfsInfo.ClusterCount);
     FreeClusters = RtlNumberOfClearBits(&Bitmap);


### PR DESCRIPTION
NTFS Writes.

- Implement FileBasicInformation
- Follow CDFS/Fastfat architecture closer
- MiWritePage On a resident file
- Dont leave attributes stale
- Fix MDL Arch violations
- NTFS Flush buffer support
- Demote DPRINTS
- Don't leave attributes stale
- File deletion support
- Security attritube fixes

honestly probably more I'm missing some of this code is really really old

This tries to follow closer what CDFS / Fastfat do since it's not like windows filesystems driver best practices are well documented.

I didn't introduce Cc yet. This driver is slow incredibly slow. But it gives us something and that's going to have to be good enough for now. 

Produces writes that pass win11 chkdsk!

<img width="800" height="603" alt="image" src="https://github.com/user-attachments/assets/fd0cbd1a-a9e8-4e79-af9d-d3390fed53a7" />
