### PR TITLE
[DEVMGR] Fix spelling of "occurred" in comments

### DIFF
--- a/dll/win32/devmgr/api.cpp
+++ b/dll/win32/devmgr/api.cpp
@@ -183,7 +183,7 @@ Cleanup:
 *                  the advanced device property dialog
 *
 * RETURN VALUE
-*   1:  if bShowDevMgr is non-zero and no error occured
+*   1:  if bShowDevMgr is non-zero and no error occurred
 *   -1: a call to GetLastError returns 0 if successful
 *
 * @implemented
@@ -262,7 +262,7 @@ Cleanup:
 *                  the advanced device property dialog
 *
 * RETURN VALUE
-*   1:  if bShowDevMgr is non-zero and no error occured
+*   1:  if bShowDevMgr is non-zero and no error occurred
 *   -1: a call to GetLastError returns 0 if successful
 *
 * @implemented
@@ -354,8 +354,8 @@ DevicePropertiesExW(IN HWND hWndParent  OPTIONAL,
 *                  the device property dialog
 *
 * RETURN VALUE
-*   >=0: if no errors occured
-*   -1:  if errors occured
+*   >=0: if no errors occurred
+*   -1:  if errors occurred
 *
 * REVISIONS
 *
@@ -391,8 +391,8 @@ DevicePropertiesA(HWND hWndParent,
 *                  the device property dialog
 *
 * RETURN VALUE
-*   >=0: if no errors occured
-*   -1:  if errors occured
+*   >=0: if no errors occurred
+*   -1:  if errors occurred
 *
 * REVISIONS
 *
@@ -534,7 +534,7 @@ DeviceProperties_RunDLLW(HWND hWndParent,
 *   nCmdShow:      Specifies how the window should be shown
 *
 * RETURN VALUE
-*   TRUE:  if no errors occured
+*   TRUE:  if no errors occurred
 *   FALSE: if the device manager could not be executed
 *
 * REVISIONS
@@ -595,7 +595,7 @@ DeviceManager_ExecuteA(HWND hWndParent,
 *   nCmdShow:      Specifies how the window should be shown
 *
 * RETURN VALUE
-*   TRUE:  if no errors occured
+*   TRUE:  if no errors occurred
 *   FALSE: if the device manager could not be executed
 *
 * REVISIONS
@@ -718,8 +718,8 @@ DeviceProblemWizard_RunDLLW(HWND hWndParent,
 *                   nPrintMode is DEV_PRINT_SELECTED
 *
 * RETURN VALUE
-*   TRUE:  if no errors occured
-*   FALSE: if errors occured
+*   TRUE:  if no errors occurred
+*   FALSE: if errors occurred
 *
 * REVISIONS
 *
@@ -762,8 +762,8 @@ DeviceManagerPrintA(LPCSTR lpMachineName,
 *                   nPrintMode is DEV_PRINT_SELECTED
 *
 * RETURN VALUE
-*   TRUE:  if no errors occured
-*   FALSE: if errors occured
+*   TRUE:  if no errors occurred
+*   FALSE: if errors occurred
 *
 * REVISIONS
 *

--- a/dll/win32/devmgr/properties/devprblm.cpp
+++ b/dll/win32/devmgr/properties/devprblm.cpp
@@ -203,8 +203,8 @@ ShowDeviceProblemWizard(IN HWND hWndParent  OPTIONAL,
  *   lpDeviceID:    Specifies the device, also see NOTEs
  *
  * RETURN VALUE
- *   TRUE:  if no errors occured
- *   FALSE: if errors occured
+ *   TRUE:  if no errors occurred
+ *   FALSE: if errors occurred
  *
  * @implemented
  */
@@ -270,8 +270,8 @@ Cleanup:
  *   lpDeviceID:    Specifies the device, also see NOTEs
  *
  * RETURN VALUE
- *   TRUE:  if no errors occured
- *   FALSE: if errors occured
+ *   TRUE:  if no errors occurred
+ *   FALSE: if errors occurred
  *
  * @unimplemented
  */
@@ -408,7 +408,7 @@ static const UINT ProblemStringId[NUM_CM_PROB] =
  *
  * RETURN VALUE
  *   The return value is the length of the string in characters.
- *   It returns 0 if an error occured.
+ *   It returns 0 if an error occurred.
  *
  * @implemented
  */
@@ -482,7 +482,7 @@ DeviceProblemTextA(IN HMACHINE hMachine  OPTIONAL,
  *
  * RETURN VALUE
  *   The return value is the length of the string in characters.
- *   It returns 0 if an error occured.
+ *   It returns 0 if an error occurred.
  *
  * @implemented
  */


### PR DESCRIPTION
Fixed several instances where "occurred" was misspelled as "occured" in the API and Properties documentation blocks.

## Purpose

_Do a quick recap of your work here._

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- 
- 

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: