### PR TITLE
[RAPPS] Implement Help action to open official wiki

### DIFF
--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -624,7 +624,7 @@ CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam)
             }
 
             case ID_HELP:
-                MessageBoxW(L"Help not implemented yet", NULL, MB_OK);
+                ShellExecuteW(m_hWnd, L"open", L"https://reactos.org/wiki/ReactOS_Applications_Manager", NULL, NULL, SW_SHOWNORMAL);
                 break;
 
             case ID_ABOUT:


### PR DESCRIPTION
Replaced the "Not implemented yet" messagebox with a ShellExecute call to open the ReactOS Applications Manager wiki page in the user's browser.

## Purpose

_Do a quick recap of your work here._

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- 
- 

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: