### PR TITLE
[EXPLORER] Improve DPI scaling for Show Desktop button

### DIFF
--- a/base/shell/explorer/traydeskbtn.cpp
+++ b/base/shell/explorer/traydeskbtn.cpp
@@ -38,8 +38,9 @@ INT CTrayShowDesktopButton::WidthOrHeight() const
         {
             if (GetSystemMetrics(SM_TABLETPC))
             {
-                //TODO: DPI scaling - return logical-to-physical conversion of 24, not fixed value
-                return 24;
+                return MulDiv(24,
+                              m_hWnd ? GetDpiForWindow(m_hWnd) : GetDpiForSystem(),
+                              USER_DEFAULT_SCREEN_DPI);
             }
             else
                 return 15;


### PR DESCRIPTION
## Summary
This patch improves DPI scaling for the Show Desktop button by replacing the fixed size with DPI-aware sizing.

## Motivation
The previous implementation used a fixed value, which could result in inconsistent sizing on high-DPI displays.

## Testing
- Project builds successfully.
- Verified the Show Desktop button renders correctly.