### PR TITLE
[PARTMGR][NTOS:PNP] Fix partition PDO lifetime during re-enumeration

### DIFF
--- a/drivers/storage/partmgr/partmgr.c
+++ b/drivers/storage/partmgr/partmgr.c
@@ -699,6 +699,7 @@ FdoIoctlDiskSetDriveLayout(
     if (FdoExtension->IsSuperFloppy && (layoutEx->PartitionCount > 1))
     {
         PartMgrReleaseLayoutLock(FdoExtension);
+        ExFreePoolWithTag(layoutEx, TAG_PARTMGR);
         return STATUS_INVALID_DEVICE_REQUEST;
     }
 
@@ -730,6 +731,7 @@ FdoIoctlDiskSetDriveLayout(
     else
     {
         FdoExtension->LayoutValid = FALSE;
+        ExFreePoolWithTag(layoutEx, TAG_PARTMGR);
     }
 
     PartMgrReleaseLayoutLock(FdoExtension);
@@ -750,8 +752,8 @@ FdoIoctlDiskSetDriveLayout(
                                            NULL,
                                            NULL);
 
-    Irp->IoStatus.Information = layoutSize;
-    return STATUS_SUCCESS;
+    Irp->IoStatus.Information = NT_SUCCESS(status) ? layoutSize : 0;
+    return status;
 }
 
 static
@@ -798,6 +800,7 @@ FdoIoctlDiskSetDriveLayoutEx(
          (layoutEx->PartitionCount > 1)))
     {
         PartMgrReleaseLayoutLock(FdoExtension);
+        ExFreePoolWithTag(layoutEx, TAG_PARTMGR);
         return STATUS_INVALID_DEVICE_REQUEST;
     }
 
@@ -851,6 +854,7 @@ FdoIoctlDiskSetDriveLayoutEx(
     else
     {
         FdoExtension->LayoutValid = FALSE;
+        ExFreePoolWithTag(layoutEx, TAG_PARTMGR);
     }
 
     PartMgrReleaseLayoutLock(FdoExtension);
@@ -871,8 +875,8 @@ FdoIoctlDiskSetDriveLayoutEx(
                                            NULL,
                                            NULL);
 
-    Irp->IoStatus.Information = layoutSize;
-    return STATUS_SUCCESS;
+    Irp->IoStatus.Information = NT_SUCCESS(status) ? layoutSize : 0;
+    return status;
 }
 
 static
@@ -1068,11 +1072,10 @@ FdoHandleDeviceRelations(
         // now fill the DeviceRelations structure
         TRACE("Reporting %u partitions\n", FdoExtension->EnumeratedPartitionsTotal);
 
+        /* EnumeratedPartitionsTotal can be zero, so it must not be decremented or the size underflows */
         PDEVICE_RELATIONS deviceRelations =
             ExAllocatePoolWithTag(PagedPool,
-                                  sizeof(DEVICE_RELATIONS)
-                                  + sizeof(PDEVICE_OBJECT)
-                                  * (FdoExtension->EnumeratedPartitionsTotal - 1),
+                                  FIELD_OFFSET(DEVICE_RELATIONS, Objects) + sizeof(PDEVICE_OBJECT) * FdoExtension->EnumeratedPartitionsTotal,
                                   TAG_PARTMGR);
 
         if (!deviceRelations)

--- a/ntoskrnl/io/iomgr/volume.c
+++ b/ntoskrnl/io/iomgr/volume.c
@@ -696,6 +696,7 @@ IopMountVolume(IN PDEVICE_OBJECT DeviceObject,
                             (Status == STATUS_USER_APC))
                         {
                             /* Don't mount if we were interrupted */
+                            IopInterlockedDecrementUlong(LockQueueIoDatabaseLock, (PULONG)&DeviceObject->ReferenceCount);
                             ObDereferenceObject(AttachedDeviceObject);
                             return Status;
                         }
@@ -704,6 +705,8 @@ IopMountVolume(IN PDEVICE_OBJECT DeviceObject,
                     /* Reacquire the lock */
                     KeEnterCriticalRegion();
                     ExAcquireResourceSharedLite(&IopDatabaseResource, TRUE);
+
+                    IopInterlockedDecrementUlong(LockQueueIoDatabaseLock, (PULONG)&DeviceObject->ReferenceCount);
 
                     /* When we released the lock, make sure nobody beat us */
                     if (DeviceObject->Vpb->Flags & VPB_MOUNTED)

--- a/ntoskrnl/io/pnpmgr/devaction.c
+++ b/ntoskrnl/io/pnpmgr/devaction.c
@@ -1223,15 +1223,22 @@ PiInitializeDevNode(
     {
         PDEVICE_NODE OldDeviceNode = IopGetDeviceNode(OldDeviceObject);
 
-        DPRINT1("Duplicate device instance '%wZ'\n", &InstancePathU);
-        DPRINT1("Current instance parent: '%wZ'\n", &DeviceNode->Parent->InstancePath);
-        DPRINT1("Old instance parent: '%wZ'\n", &OldDeviceNode->Parent->InstancePath);
+        if (OldDeviceNode->State == DeviceNodeRemoved &&
+            OldDeviceNode->Child == NULL &&
+            IsListEmpty(&OldDeviceNode->TargetDeviceNotify))
+        {
+            /* PDO deletion reclaims the devnode after its references drain. */
+            OldDeviceNode->InstancePath.Length = 0;
+            ObDereferenceObject(OldDeviceObject);
+        }
+        else
+        {
+            DPRINT1("Duplicate device instance '%wZ'\n", &InstancePathU);
+            DPRINT1("Current instance parent: '%wZ'\n", &DeviceNode->Parent->InstancePath);
+            DPRINT1("Old instance parent: '%wZ'\n", &OldDeviceNode->Parent->InstancePath);
 
-        KeBugCheckEx(PNP_DETECTED_FATAL_ERROR,
-                     0x01,
-                     (ULONG_PTR)DeviceNode->PhysicalDeviceObject,
-                     (ULONG_PTR)OldDeviceObject,
-                     0);
+            KeBugCheckEx(PNP_DETECTED_FATAL_ERROR, 0x01, (ULONG_PTR)DeviceNode->PhysicalDeviceObject, (ULONG_PTR)OldDeviceObject, 0);
+        }
     }
 
     DeviceNode->InstancePath = InstancePathU;
@@ -2118,8 +2125,7 @@ PiEnumerateDevice(
         // treat as if there are no child objects
     }
 
-    PDEVICE_RELATIONS DeviceRelations = DeviceNode->OverUsed1.PendingDeviceRelations;
-    DeviceNode->OverUsed1.PendingDeviceRelations = NULL;
+    PDEVICE_RELATIONS DeviceRelations = InterlockedExchangePointer((PVOID volatile *)&DeviceNode->OverUsed1.PendingDeviceRelations, NULL);
 
     // it's acceptable not to have PDOs
     if (!DeviceRelations)

--- a/ntoskrnl/io/pnpmgr/pnpirp.c
+++ b/ntoskrnl/io/pnpmgr/pnpirp.c
@@ -189,9 +189,19 @@ PiIrpQueryDeviceRelations(
     };
 
     // Vista+ does an asynchronous call
-    NTSTATUS status = IopSynchronousCall(DeviceNode->PhysicalDeviceObject,
-                                         &stack,
-                                         (PVOID)&DeviceNode->OverUsed1.PendingDeviceRelations);
+    PVOID newRelations = NULL;
+    NTSTATUS status = IopSynchronousCall(DeviceNode->PhysicalDeviceObject, &stack, &newRelations);
+
+    PDEVICE_RELATIONS oldRelations = InterlockedExchangePointer((PVOID volatile *)&DeviceNode->OverUsed1.PendingDeviceRelations, newRelations);
+    if (oldRelations != NULL)
+    {
+        for (ULONG i = 0; i < oldRelations->Count; i++)
+        {
+            ObDereferenceObject(oldRelations->Objects[i]);
+        }
+        ExFreePool(oldRelations);
+    }
+
     DeviceNode->CompletionStatus = status;
     return status;
 }


### PR DESCRIPTION
Deleting and recreating a partition can leave the removed PDO referenced long enough for a new PDO with the same instance path to arrive. The new device then hits the duplicate-instance bugcheck instead of being initialized.

This fixes the related ownership boundaries:

- release temporary layouts on rejected or failed updates, preserve partition-table write failures, and size zero-partition device relations without underflow;
- balance the device reference held while IopMountVolume drops its locks to load a file-system driver;
- atomically replace and consume pending bus relations, releasing the PDO references owned by a superseded result;
- detach a removed same-identity PDO from instance-path lookup without freeing its devnode. Normal PDO deletion reclaims the devnode after outstanding references drain.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
