### PR TITLE
[NTOS:FSTUB] Avoid overwriting the MBR without an extended partition

### DIFF
--- a/ntoskrnl/fstub/disksup.c
+++ b/ntoskrnl/fstub/disksup.c
@@ -2548,6 +2548,7 @@ xHalIoWritePartitionTable(IN PDEVICE_OBJECT DeviceObject,
         /* Update the partition offset and set the extended offset if needed */
         Offset = NextOffset;
         if (IsMbr) ExtendedOffset = NextOffset;
+        if (!Offset.QuadPart) break;
     }
 
     /* If we had a buffer, free it, then return status */


### PR DESCRIPTION
Deleting an empty extended partition can leave a stale logical-table count in the drive layout. xHalIoWritePartitionTable then advances to another table even though no container entry supplied an EBR offset, so it reads and writes the next table at sector 0 and can replace the MBR entries with empty logical entries.

Stop the table loop when there is no next EBR offset. This preserves the primary partition table instead of treating the MBR as a phantom EBR.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
