### PR TITLE
[NTOS] Export the UTF-8 conversion routines

### DIFF
--- a/ntoskrnl/ntoskrnl.spec
+++ b/ntoskrnl/ntoskrnl.spec
@@ -1305,6 +1305,7 @@
 @ stdcall RtlTraceDatabaseLock(ptr)
 @ stdcall RtlTraceDatabaseUnlock(ptr)
 @ stdcall RtlTraceDatabaseValidate(ptr)
+@ stdcall -version=0x601+ RtlUTF8ToUnicodeN(ptr long ptr str long)
 @ fastcall -arch=i386,arm RtlUlongByteSwap(long)
 @ fastcall -arch=i386,arm RtlUlonglongByteSwap(long long)
 @ stdcall RtlUnicodeStringToAnsiSize(ptr) RtlxUnicodeStringToAnsiSize
@@ -1317,6 +1318,7 @@
 @ stdcall RtlUnicodeToMultiByteN(ptr long ptr wstr long)
 @ stdcall RtlUnicodeToMultiByteSize(ptr wstr long)
 @ stdcall RtlUnicodeToOemN(ptr long ptr wstr long)
+@ stdcall -version=0x601+ RtlUnicodeToUTF8N(ptr long ptr wstr long)
 @ stdcall RtlUnlockBootStatusData(ptr)
 @ stdcall RtlUnwind(ptr ptr ptr ptr)
 @ stdcall -arch=x86_64,arm RtlUnwindEx(ptr ptr ptr ptr ptr ptr)


### PR DESCRIPTION
RtlUTF8ToUnicodeN and RtlUnicodeToUTF8N are documented kernel APIs since Windows 7, but they are missing from the ntoskrnl export table.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: