### PR TITLE
[NPFS] Implement FSCTL_PIPE_GET_CONNECTION_ATTRIBUTE

### DIFF
--- a/drivers/filesystems/npfs/fsctrl.c
+++ b/drivers/filesystems/npfs/fsctrl.c
@@ -752,6 +752,91 @@ Quickie:
 
 NTSTATUS
 NTAPI
+NpGetConnectionAttribute(_In_ PDEVICE_OBJECT DeviceObject,
+                         _In_ PIRP Irp)
+{
+    NTSTATUS Status = STATUS_SUCCESS;
+    PIO_STACK_LOCATION IoStackLocation;
+    NODE_TYPE_CODE NodeTypeCode;
+    PNP_CCB Ccb;
+    PCSTR SystemBuffer;
+    ULONG InputBufferLength, OutputBufferLength;
+    PAGED_CODE();
+
+    /* Get the current stack location */
+    IoStackLocation = IoGetCurrentIrpStackLocation(Irp);
+
+    /* Decode the file object and check the node type */
+    NodeTypeCode = NpDecodeFileObject(IoStackLocation->FileObject, 0, &Ccb, 0);
+    if (NodeTypeCode != NPFS_NTC_CCB)
+    {
+        return STATUS_PIPE_DISCONNECTED;
+    }
+
+    SystemBuffer = Irp->AssociatedIrp.SystemBuffer;
+    InputBufferLength = IoStackLocation->Parameters.FileSystemControl.InputBufferLength;
+    OutputBufferLength = IoStackLocation->Parameters.FileSystemControl.OutputBufferLength;
+
+    if (InputBufferLength == 0 || OutputBufferLength == 0 || SystemBuffer == NULL)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    /* Lock the Ccb */
+    ExAcquireResourceExclusiveLite(&Ccb->NonPagedCcb->Lock, TRUE);
+
+    /* TODO: implement "extended attributes" support */
+
+    /* HACK: This should be set as an extended attribute by NpCreateClientEnd,
+     * and we should query the EA instead of returning PID directly. */
+
+    if (Ccb->Process == NULL)
+    {
+        Status = STATUS_NOT_FOUND;
+        goto Cleanup;
+    }
+    else if (OutputBufferLength < sizeof(ULONG))
+    {
+        Status = STATUS_BUFFER_TOO_SMALL;
+        goto Cleanup;
+    }
+
+    if (strcmp(SystemBuffer, "ClientProcessId") == 0)
+    {
+        *(PULONG)SystemBuffer = (ULONG)(ULONG_PTR)PsGetProcessId(Ccb->Process);
+        Irp->IoStatus.Information = sizeof(ULONG);
+    }
+    else if (strcmp(SystemBuffer, "ClientSessionId") == 0)
+    {
+        *(PULONG)SystemBuffer = (ULONG)(ULONG_PTR)PsGetProcessSessionId(Ccb->Process);
+        Irp->IoStatus.Information = sizeof(ULONG);
+    }
+    /* These are set by SMB when a pipe is opened on a remote computer.
+     * In this case ClientProcessId is set to 4. */
+    /*
+    else if (strcmp(SystemBuffer, "ServerProcessId"))
+    {
+
+    }
+    else if (strcmp(SystemBuffer, "ServerSessionId"))
+    {
+
+    }
+    */
+    else
+    {
+        Status = STATUS_NOT_FOUND;
+    }
+
+Cleanup:
+    /* Unlock the Ccb */
+    ExReleaseResourceLite(&Ccb->NonPagedCcb->Lock);
+
+    return Status;
+}
+
+NTSTATUS
+NTAPI
 NpCommonFileSystemControl(IN PDEVICE_OBJECT DeviceObject,
                           IN PIRP Irp)
 {
@@ -840,6 +925,11 @@ NpCommonFileSystemControl(IN PDEVICE_OBJECT DeviceObject,
         case FSCTL_PIPE_SET_CLIENT_PROCESS:
             NpAcquireExclusiveVcb();
             Status = NpSetClientProcess(DeviceObject, Irp);
+            break;
+
+        case FSCTL_PIPE_GET_CONNECTION_ATTRIBUTE:
+            NpAcquireSharedVcb();
+            Status = NpGetConnectionAttribute(DeviceObject, Irp);
             break;
 
         default:

--- a/drivers/filesystems/npfs/npfs.h
+++ b/drivers/filesystems/npfs/npfs.h
@@ -14,6 +14,7 @@
 /* System Headers */
 #include <ntifs.h>
 #include <ndk/obfuncs.h>
+#include <ndk/psfuncs.h>
 #include <pseh/pseh2.h>
 //#define UNIMPLEMENTED
 //#define DPRINT1 DbgPrint


### PR DESCRIPTION
## Purpose

This PR imports part of Simone Lombardo's [patch](https://jira.reactos.org/secure/attachment/72285/72285_nvda_partial.patch) to fix NVDA's compatibility issues.

It implements support for querying `ClientProcessId` using `FSCTL_PIPE_GET_CONNECTION_ATTRIBUTE` without actually implementing "[extended attribute](https://projectzero.google/2019/09/windows-exploitation-tricks-spoofing.html)" feature available on NPFS driver on Windows.

I lack confidence and knowledge to fully implement the feature as it needs making some design decisions about NPFS implementation in ReactOS so I'll leave it to more experienced developers here.

**Test result:**
* Before patch:
<img width="696" height="466" alt="image" src="https://github.com/user-attachments/assets/33922eb4-181d-4eea-80ac-05429e298d16" />

* After patch:
<img width="692" height="472" alt="image" src="https://github.com/user-attachments/assets/becdbb5f-e498-48fc-b0a8-99ae6b7caa89" />


JIRA issue: [CORE-17834](https://jira.reactos.org/browse/CORE-17834)

## Proposed changes

* Return PID or session ID when a caller queries `ClientProcessId` or `ClientSessionId`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: