### PR TITLE
[NTOS:MM] Fix balance only performing a single pass per wakeup

### DIFF
--- a/ntoskrnl/mm/balance.c
+++ b/ntoskrnl/mm/balance.c
@@ -106,21 +106,16 @@ MiTrimMemoryConsumer(ULONG Consumer, ULONG InitialTarget)
         return InitialTarget;
     }
 
-    if (MmAvailablePages < MiMinimumAvailablePages)
-    {
-        /* Global page limit exceeded */
-        Target = (ULONG)max(Target, MiMinimumAvailablePages - MmAvailablePages);
-    }
-    else if (MiMemoryConsumers[Consumer].PagesUsed > MiMemoryConsumers[Consumer].PagesTarget)
+    if (!Target && MiMemoryConsumers[Consumer].PagesUsed > MiMemoryConsumers[Consumer].PagesTarget)
     {
         /* Consumer page limit exceeded */
-        Target = max(Target, MiMemoryConsumers[Consumer].PagesUsed - MiMemoryConsumers[Consumer].PagesTarget);
+        Target = MiMemoryConsumers[Consumer].PagesUsed - MiMemoryConsumers[Consumer].PagesTarget;
     }
 
     if (Target)
     {
         /* Now swap the pages out */
-        Status = MiMemoryConsumers[Consumer].Trim(Target, MmAvailablePages < MiMinimumAvailablePages, &NrFreedPages);
+        Status = MiMemoryConsumers[Consumer].Trim(Target, InitialTarget, &NrFreedPages);
 
         DPRINT("Trimming consumer %lu: Freed %lu pages with a target of %lu pages\n", Consumer, NrFreedPages, Target);
 
@@ -374,38 +369,29 @@ MiBalancerThread(PVOID Unused)
 
         if (Status == STATUS_WAIT_0 || Status == STATUS_WAIT_1)
         {
-            ULONG InitialTarget = 0;
-            ULONG Target;
+            ULONG Target = MiMinimumAvailablePages > MmAvailablePages ? MiMinimumAvailablePages - MmAvailablePages : 0;
+            ULONG StepTarget;
             ULONG NrFreedPages;
 
             do
             {
-                ULONG OldTarget = InitialTarget;
+                /* Track if we're making progress. */
+                StepTarget = Target;
 
                 /* Trim each consumer */
                 for (ULONG i = 0; i < MC_MAXIMUM; i++)
                 {
-                    InitialTarget = MiTrimMemoryConsumer(i, InitialTarget);
+                    Target = MiTrimMemoryConsumer(i, Target);
                 }
 
-                /* Trim cache */
-                Target = max(InitialTarget, MiMinimumAvailablePages > MmAvailablePages ? MiMinimumAvailablePages - MmAvailablePages : 0);
+                /* Trim Cache if we're still over. */
                 if (Target)
                 {
                     CcRosTrimCache(Target, &NrFreedPages);
-                    /* Track against the actual target passed to CcRosTrimCache. */
-                    InitialTarget = Target > NrFreedPages ? Target - NrFreedPages : 0;
-                }
-
-                /* No pages left to swap! */
-                if (InitialTarget != 0 &&
-                    InitialTarget == OldTarget)
-                {
-                    /* Game over */
-                    KeBugCheck(NO_PAGES_AVAILABLE);
+                    Target = Target > NrFreedPages ? Target - NrFreedPages : 0;
                 }
             }
-            while (InitialTarget != 0);
+            while (Target && Target != StepTarget);
 
             if (Status == STATUS_WAIT_0)
             {

--- a/ntoskrnl/mm/balance.c
+++ b/ntoskrnl/mm/balance.c
@@ -384,12 +384,9 @@ MiBalancerThread(PVOID Unused)
                     Target = MiTrimMemoryConsumer(i, Target);
                 }
 
-                /* Trim Cache if we're still over. */
-                if (Target)
-                {
-                    CcRosTrimCache(Target, &NrFreedPages);
-                    Target = Target > NrFreedPages ? Target - NrFreedPages : 0;
-                }
+                /* Trim the File Cache as well. */
+                CcRosTrimCache(Target, &NrFreedPages);
+                Target = Target > NrFreedPages ? Target - NrFreedPages : 0;
             }
             while (Target && Target != StepTarget);
 

--- a/ntoskrnl/mm/balance.c
+++ b/ntoskrnl/mm/balance.c
@@ -164,7 +164,7 @@ MmTrimUserMemory(ULONG Target, ULONG Priority, PULONG NrFreedPages)
         }
         else
         {
-            /* When not paging-out agressively, just reset the accessed bit */
+            /* When not paging-out aggressively, just reset the accessed bit */
             PEPROCESS Process = NULL;
             PVOID Address = NULL;
             BOOLEAN Accessed = FALSE;
@@ -251,6 +251,7 @@ MmTrimUserMemory(ULONG Target, ULONG Priority, PULONG NrFreedPages)
                 Status = MmPageOutPhysicalAddress(CurrentPage);
                 if (NT_SUCCESS(Status))
                 {
+                    (*NrFreedPages)++;
                     if (CurrentPage == FirstPage)
                     {
                         FirstPage = 0;
@@ -388,11 +389,12 @@ MiBalancerThread(PVOID Unused)
                 }
 
                 /* Trim cache */
-                Target = max(InitialTarget, abs(MiMinimumAvailablePages - MmAvailablePages));
+                Target = max(InitialTarget, MiMinimumAvailablePages > MmAvailablePages ? MiMinimumAvailablePages - MmAvailablePages : 0);
                 if (Target)
                 {
                     CcRosTrimCache(Target, &NrFreedPages);
-                    InitialTarget -= min(NrFreedPages, InitialTarget);
+                    /* Track against the actual target passed to CcRosTrimCache. */
+                    InitialTarget = Target > NrFreedPages ? Target - NrFreedPages : 0;
                 }
 
                 /* No pages left to swap! */


### PR DESCRIPTION
## Purpose

I was playing with modelling algorithms in the Kernel with TLA+ and found some issues in the balancer thread.

Effectively, at the moment it only ever performs one pass per wakeup, which is not the desired behaviour as far as I can tell.

The flow is pretty straight forward. InitialTarget is set to 0 on wakeup, then `MiTrimMemoryConsumer` returns 0 always, looping through the consumers.

After CcRosTrimCache the InitialTarget value (0) has 0 subtracted from it.

The game over bug check condition is therefore dead code, and the loop while condition will never be true.

The other bug is that the target passed to CcRosTrimCache seems to be gibberish... it can underflow, and it's a ULONG, so `abs` does nothing.

## Proposed changes

- Fixes the maths on the calculation of target for TrimCache (the value will underflow, and abs does nothing on a ULong)
- This means that CcRosTrimCache won't flush dirty pages on every wakeup when memory isn't low, which should be a performance improvement.
- Fix the calculation for the Initial Target after CcRosTrimCache, so that we can run a second pass if needed.
- Report the number of pages freed in the "low priority" passes.
  - This might not be strictly necessary right now, but it could help prevent a spurious bug check at the old vs current progress check if a concurrent thread pushes the number of available pages over the minimum.
  - The repeated checking of the (non volatile) global MmAvailablePages seems a bit suspect.
- I note that this does mean the game over bug check is now reachable.

## Alternative 1

- Delete the dead code (the bug check, loop, and tracking variables for the state machine); and
- Just fix the target to CcRosTrimCache

## Alternative 2

This change plus:
- Calculate the initial target up front once instead of setting it to 0 (maybe under a PFN lock?)
- Remove all subsequent references to the global MmAvailablePages. The other target calculation operations at "Global page limit exceeded" and "Trim Cache" would be removed.
  - We would still call the individual consumer trims so they can do the low priority version; the priority indicator passed would just be the value `InitialTarget`.
  - This would _statically_ remove the chances of a race condition.
  - It's silly to be reading the global variable repeatedly like this, it's not volatile, so the compiler could potentially put it in a register or hold it in a cache across a multicore system anyway.

## Alternative 3

These changes, and those from alt 2, but also:
- Remove the BugCheck if we don't make progress and use the _no progress_ condition as the loop exit instead.
  - I think this is actually _ok_. Yes, we're below our desired number of available pages, and we can't do anything about it right now, but it's certainly not actually game over for the system. Pages _could_ be freed up.

## Additional Insight.

I later realised that the current implementation also has a strange dichotomy between trimming global and consumer pages (or high and low priority). One can see that in low memory situations, the lower priority access bit pass doesn't really run at all until more memory is freed up.

I've kept this for now, but  If there was a `Priority--` below to `DPRINT("Succeeded\n");` and the `!Target` guard were removed it could do both.


## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: