### PR TITLE
[NTOS:IO] Do not free the active VPB

### DIFF
--- a/ntoskrnl/io/iomgr/volume.c
+++ b/ntoskrnl/io/iomgr/volume.c
@@ -192,7 +192,7 @@ IopDereferenceVpbAndFree(IN PVPB Vpb)
     Vpb->ReferenceCount--;
 
     /* Check if we're out of references */
-    if (!Vpb->ReferenceCount && Vpb->RealDevice->Vpb == Vpb &&
+    if (!Vpb->ReferenceCount && Vpb->RealDevice->Vpb != Vpb &&
         !(Vpb->Flags & VPB_PERSISTENT))
     {
         /* Release VPB lock */


### PR DESCRIPTION
IopDereferenceVpbAndFree frees a zero-reference VPB only while it is still installed in RealDevice->Vpb. This can leave the device with a dangling VPB pointer while detached VPBs are retained.

Reverse the identity test so only a detached, nonpersistent VPB is released after its reference count reaches zero.

Reference:
- https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/ns-wdm-_vpb

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109121,109126,109148
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109132,109133,109149
