### PR TITLE
[NTOS][NDK] Switch Ob callbacks to NT6 style

### DIFF
--- a/drivers/filters/fltmgr/Messaging.c
+++ b/drivers/filters/fltmgr/Messaging.c
@@ -289,8 +289,8 @@ NTAPI
 FltpServerPortClose(_In_opt_ PEPROCESS Process,
                     _In_ PVOID Object,
                     _In_ ACCESS_MASK GrantedAccess,
-                    _In_ ULONG ProcessHandleCount,
-                    _In_ ULONG SystemHandleCount)
+                    _In_ ULONG_PTR ProcessHandleCount,
+                    _In_ ULONG_PTR SystemHandleCount)
 {
     PFLT_SERVER_PORT_OBJECT PortObject;
     PFAST_MUTEX Lock;
@@ -327,8 +327,8 @@ NTAPI
 FltpClientPortClose(_In_opt_ PEPROCESS Process,
                     _In_ PVOID Object,
                     _In_ ACCESS_MASK GrantedAccess,
-                    _In_ ULONG ProcessHandleCount,
-                    _In_ ULONG SystemHandleCount)
+                    _In_ ULONG_PTR ProcessHandleCount,
+                    _In_ ULONG_PTR SystemHandleCount)
 {
     PFLT_PORT_OBJECT PortObject = (PFLT_PORT_OBJECT)Object;
 

--- a/modules/rostests/kmtests/ntos_ob/ObType.cpp
+++ b/modules/rostests/kmtests/ntos_ob/ObType.cpp
@@ -203,7 +203,7 @@ ObtCreateObjectTypes(VOID)
     OBJECT_ATTRIBUTES ObjectAttributes;
     HANDLE ObjectTypeHandle;
     UNICODE_STRING ObjectPath;
-    BOOLEAN UseNT6Callbacks = (GetNTVersion() >= _WIN32_WINNT_VISTA);
+    BOOLEAN UseNT6Callbacks = is_reactos() || (GetNTVersion() >= _WIN32_WINNT_VISTA);
 
     RtlCopyMemory(&Name.DirectoryName, L"\\ObjectTypes\\", sizeof Name.DirectoryName);
 

--- a/modules/rostests/kmtests/ntos_ob/ObType.cpp
+++ b/modules/rostests/kmtests/ntos_ob/ObType.cpp
@@ -110,8 +110,8 @@ CloseProc(
     IN PEPROCESS Process,
     IN PVOID Object,
     IN ACCESS_MASK GrantedAccess,
-    IN ULONG ProcessHandleCount,
-    IN ULONG SystemHandleCount)
+    IN ULONG_PTR ProcessHandleCount,
+    IN ULONG_PTR SystemHandleCount)
 {
     DPRINT("CloseProc() 0x%p, ProcessHandleCount %lu, SystemHandleCount %lu, AccessMask 0x%lX\n",
         Object, ProcessHandleCount, SystemHandleCount, GrantedAccess);

--- a/ntoskrnl/config/cmse.c
+++ b/ntoskrnl/config/cmse.c
@@ -265,7 +265,8 @@ CmpSecurityMethod(IN PVOID ObjectBody,
                   IN OUT PULONG BufferLength,
                   IN OUT PSECURITY_DESCRIPTOR *OldSecurityDescriptor,
                   IN POOL_TYPE PoolType,
-                  IN PGENERIC_MAPPING GenericMapping)
+                  IN PGENERIC_MAPPING GenericMapping,
+                  IN KPROCESSOR_MODE AccessMode)
 {
     PCM_KEY_CONTROL_BLOCK Kcb;
     NTSTATUS Status = STATUS_SUCCESS;

--- a/ntoskrnl/config/cmsysini.c
+++ b/ntoskrnl/config/cmsysini.c
@@ -162,8 +162,8 @@ NTAPI
 CmpCloseKeyObject(IN PEPROCESS Process OPTIONAL,
                   IN PVOID Object,
                   IN ACCESS_MASK GrantedAccess,
-                  IN ULONG ProcessHandleCount,
-                  IN ULONG SystemHandleCount)
+                  IN ULONG_PTR ProcessHandleCount,
+                  IN ULONG_PTR SystemHandleCount)
 {
     PCM_KEY_BODY KeyBody = (PCM_KEY_BODY)Object;
     PAGED_CODE();

--- a/ntoskrnl/dbgk/dbgkobj.c
+++ b/ntoskrnl/dbgk/dbgkobj.c
@@ -1111,8 +1111,8 @@ NTAPI
 DbgkpCloseObject(IN PEPROCESS OwnerProcess OPTIONAL,
                  IN PVOID ObjectBody,
                  IN ACCESS_MASK GrantedAccess,
-                 IN ULONG HandleCount,
-                 IN ULONG SystemHandleCount)
+                 IN ULONG_PTR HandleCount,
+                 IN ULONG_PTR SystemHandleCount)
 {
     PDEBUG_OBJECT DebugObject = ObjectBody;
     PEPROCESS Process = NULL;

--- a/ntoskrnl/ex/win32k.c
+++ b/ntoskrnl/ex/win32k.c
@@ -237,8 +237,8 @@ NTAPI
 ExpDesktopClose(IN PEPROCESS Process OPTIONAL,
                 IN PVOID Object,
                 IN ACCESS_MASK GrantedAccess,
-                IN ULONG ProcessHandleCount,
-                IN ULONG SystemHandleCount)
+                IN ULONG_PTR ProcessHandleCount,
+                IN ULONG_PTR SystemHandleCount)
 {
     WIN32_CLOSEMETHOD_PARAMETERS Parameters;
 

--- a/ntoskrnl/ex/win32k.c
+++ b/ntoskrnl/ex/win32k.c
@@ -47,6 +47,7 @@ PKWIN32_SESSION_CALLOUT ExpDesktopObjectClose = NULL;
 
 /* FUNCTIONS ****************************************************************/
 
+static
 NTSTATUS
 NTAPI
 ExpWin32SessionCallout(
@@ -108,6 +109,7 @@ ExpWin32SessionCallout(
     return Status;
 }
 
+static
 BOOLEAN
 NTAPI
 ExpDesktopOkToClose( IN PEPROCESS Process OPTIONAL,
@@ -130,6 +132,7 @@ ExpDesktopOkToClose( IN PEPROCESS Process OPTIONAL,
     return NT_SUCCESS(Status);
 }
 
+static
 BOOLEAN
 NTAPI
 ExpWindowStationOkToClose( IN PEPROCESS Process OPTIONAL,
@@ -152,6 +155,7 @@ ExpWindowStationOkToClose( IN PEPROCESS Process OPTIONAL,
     return NT_SUCCESS(Status);
 }
 
+static
 VOID
 NTAPI
 ExpWinStaObjectDelete(PVOID DeletedObject)
@@ -166,6 +170,7 @@ ExpWinStaObjectDelete(PVOID DeletedObject)
                            &Parameters);
 }
 
+static
 NTSTATUS
 NTAPI
 ExpWinStaObjectParse(IN PVOID ParseObject,
@@ -197,6 +202,8 @@ ExpWinStaObjectParse(IN PVOID ParseObject,
                                   ExpWindowStationObjectParse,
                                   &Parameters);
 }
+
+static
 VOID
 NTAPI
 ExpDesktopDelete(PVOID DeletedObject)
@@ -211,12 +218,14 @@ ExpDesktopDelete(PVOID DeletedObject)
                            &Parameters);
 }
 
+static
 NTSTATUS
 NTAPI
 ExpDesktopOpen(IN OB_OPEN_REASON Reason,
+               IN KPROCESSOR_MODE AccessMode,
                IN PEPROCESS Process OPTIONAL,
                IN PVOID ObjectBody,
-               IN ACCESS_MASK GrantedAccess,
+               IN PACCESS_MASK GrantedAccess,
                IN ULONG HandleCount)
 {
     WIN32_OPENMETHOD_PARAMETERS Parameters;
@@ -224,7 +233,7 @@ ExpDesktopOpen(IN OB_OPEN_REASON Reason,
     Parameters.OpenReason = Reason;
     Parameters.Process = Process;
     Parameters.Object = ObjectBody;
-    Parameters.GrantedAccess = GrantedAccess;
+    Parameters.GrantedAccess = *GrantedAccess;
     Parameters.HandleCount = HandleCount;
 
     return ExpWin32SessionCallout(ObjectBody,
@@ -232,6 +241,7 @@ ExpDesktopOpen(IN OB_OPEN_REASON Reason,
                                   &Parameters);
 }
 
+static
 VOID
 NTAPI
 ExpDesktopClose(IN PEPROCESS Process OPTIONAL,

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -730,7 +730,8 @@ CmpSecurityMethod(
     IN OUT PULONG CapturedLength,
     IN OUT PSECURITY_DESCRIPTOR *ObjectSecurityDescriptor,
     IN POOL_TYPE PoolType,
-    IN PGENERIC_MAPPING GenericMapping
+    IN PGENERIC_MAPPING GenericMapping,
+    IN KPROCESSOR_MODE AccessMode
 );
 
 NTSTATUS

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -695,8 +695,8 @@ CmpCloseKeyObject(
     IN PEPROCESS Process OPTIONAL,
     IN PVOID Object,
     IN ACCESS_MASK GrantedAccess,
-    IN ULONG ProcessHandleCount,
-    IN ULONG SystemHandleCount
+    IN ULONG_PTR ProcessHandleCount,
+    IN ULONG_PTR SystemHandleCount
 );
 
 VOID

--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -1225,8 +1225,8 @@ IopCloseFile(
     IN PEPROCESS Process OPTIONAL,
     IN PVOID Object,
     IN ACCESS_MASK GrantedAccess,
-    IN ULONG ProcessHandleCount,
-    IN ULONG SystemHandleCount
+    IN ULONG_PTR ProcessHandleCount,
+    IN ULONG_PTR SystemHandleCount
 );
 
 NTSTATUS

--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -1193,7 +1193,8 @@ IopGetSetSecurityObject(
     IN OUT PULONG BufferLength,
     OUT PSECURITY_DESCRIPTOR *OldSecurityDescriptor,
     IN POOL_TYPE PoolType,
-    IN OUT PGENERIC_MAPPING GenericMapping
+    IN OUT PGENERIC_MAPPING GenericMapping,
+    IN KPROCESSOR_MODE AccessMode
 );
 
 NTSTATUS

--- a/ntoskrnl/include/internal/lpc.h
+++ b/ntoskrnl/include/internal/lpc.h
@@ -84,8 +84,8 @@ LpcpClosePort(
     IN PEPROCESS Process OPTIONAL,
     IN PVOID Object,
     IN ACCESS_MASK GrantedAccess,
-    IN ULONG ProcessHandleCount,
-    IN ULONG SystemHandleCount
+    IN ULONG_PTR ProcessHandleCount,
+    IN ULONG_PTR SystemHandleCount
 );
 
 VOID

--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -517,7 +517,8 @@ SeDefaultObjectMethod(
     _Inout_opt_ PULONG ReturnLength,
     _Inout_opt_ PSECURITY_DESCRIPTOR *OldSecurityDescriptor,
     _In_ POOL_TYPE PoolType,
-    _In_ PGENERIC_MAPPING GenericMapping);
+    _In_ PGENERIC_MAPPING GenericMapping,
+    _In_ KPROCESSOR_MODE AccessMode);
 
 VOID
 NTAPI

--- a/ntoskrnl/io/iomgr/file.c
+++ b/ntoskrnl/io/iomgr/file.c
@@ -2176,8 +2176,8 @@ NTAPI
 IopCloseFile(IN PEPROCESS Process OPTIONAL,
              IN PVOID ObjectBody,
              IN ACCESS_MASK GrantedAccess,
-             IN ULONG HandleCount,
-             IN ULONG SystemHandleCount)
+             IN ULONG_PTR HandleCount,
+             IN ULONG_PTR SystemHandleCount)
 {
     PFILE_OBJECT FileObject = (PFILE_OBJECT)ObjectBody;
     KEVENT Event;

--- a/ntoskrnl/io/iomgr/file.c
+++ b/ntoskrnl/io/iomgr/file.c
@@ -1655,7 +1655,8 @@ IopGetSetSecurityObject(IN PVOID ObjectBody,
                         IN OUT PULONG BufferLength,
                         IN OUT PSECURITY_DESCRIPTOR *OldSecurityDescriptor,
                         IN POOL_TYPE PoolType,
-                        IN OUT PGENERIC_MAPPING GenericMapping)
+                        IN OUT PGENERIC_MAPPING GenericMapping,
+                        IN KPROCESSOR_MODE AccessMode)
 {
     IO_STATUS_BLOCK IoStatusBlock;
     PIO_STACK_LOCATION StackPtr;

--- a/ntoskrnl/lpc/close.c
+++ b/ntoskrnl/lpc/close.c
@@ -244,8 +244,8 @@ NTAPI
 LpcpClosePort(IN PEPROCESS Process OPTIONAL,
               IN PVOID Object,
               IN ACCESS_MASK GrantedAccess,
-              IN ULONG ProcessHandleCount,
-              IN ULONG SystemHandleCount)
+              IN ULONG_PTR ProcessHandleCount,
+              IN ULONG_PTR SystemHandleCount)
 {
     PLPCP_PORT_OBJECT Port = (PLPCP_PORT_OBJECT)Object;
 

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -2227,8 +2227,8 @@ VOID NTAPI
 MmpCloseSection(IN PEPROCESS Process OPTIONAL,
                 IN PVOID Object,
                 IN ACCESS_MASK GrantedAccess,
-                IN ULONG ProcessHandleCount,
-                IN ULONG SystemHandleCount)
+                IN ULONG_PTR ProcessHandleCount,
+                IN ULONG_PTR SystemHandleCount)
 {
     DPRINT("MmpCloseSection(OB %p, HC %lu)\n", Object, ProcessHandleCount);
 }

--- a/ntoskrnl/ob/obhandle.c
+++ b/ntoskrnl/ob/obhandle.c
@@ -995,13 +995,12 @@ ObpIncrementHandleCount(IN PVOID Object,
     {
         /* Call it */
         ObpCalloutStart(&CalloutIrql);
+        ACCESS_MASK GrantedAccess = AccessState ? AccessState->PreviouslyGrantedAccess : 0;
         Status = ObjectType->TypeInfo.OpenProcedure(OpenReason,
+                                                    ProbeMode,
                                                     Process,
                                                     Object,
-                                                    AccessState ?
-                                                    AccessState->
-                                                    PreviouslyGrantedAccess :
-                                                    0,
+                                                    &GrantedAccess,
                                                     ProcessHandleCount);
         ObpCalloutEnd(CalloutIrql, "Open", ObjectType, Object);
 
@@ -1223,9 +1222,10 @@ ObpIncrementUnnamedHandleCount(IN PVOID Object,
         /* Call it */
         ObpCalloutStart(&CalloutIrql);
         Status = ObjectType->TypeInfo.OpenProcedure(ObCreateHandle,
+                                                    AccessMode,
                                                     Process,
                                                     Object,
-                                                    *DesiredAccess,
+                                                    DesiredAccess,
                                                     ProcessHandleCount);
         ObpCalloutEnd(CalloutIrql, "Open", ObjectType, Object);
 

--- a/ntoskrnl/ob/oblife.c
+++ b/ntoskrnl/ob/oblife.c
@@ -195,7 +195,8 @@ ObpDeleteObject(IN PVOID Object,
                                                NULL,
                                                &Header->SecurityDescriptor,
                                                0,
-                                               NULL);
+                                               NULL,
+                                               ExGetPreviousMode());
         ObpCalloutEnd(CalloutIrql, "Security", ObjectType, Object);
     }
 
@@ -1706,7 +1707,8 @@ NtQueryObject(IN HANDLE ObjectHandle,
                                                            &BasicInfo->SecurityDescriptorSize,
                                                            &ObjectHeader->SecurityDescriptor,
                                                            ObjectType->TypeInfo.PoolType,
-                                                           &ObjectType->TypeInfo.GenericMapping);
+                                                           &ObjectType->TypeInfo.GenericMapping,
+                                                           ExGetPreviousMode());
                 }
 
                 /* Break out with success */

--- a/ntoskrnl/ob/obsecure.c
+++ b/ntoskrnl/ob/obsecure.c
@@ -576,7 +576,8 @@ ObAssignSecurity(IN PACCESS_STATE AccessState,
                                               NULL,
                                               NULL,
                                               PagedPool,
-                                              &Type->TypeInfo.GenericMapping);
+                                              &Type->TypeInfo.GenericMapping,
+                                              ExGetPreviousMode());
     ObpCalloutEnd(CalloutIrql, "Security", Type, Object);
 
     /* Check for failure and deassign security if so */
@@ -650,7 +651,8 @@ ObGetObjectSecurity(IN PVOID Object,
                                               &Length,
                                               &Header->SecurityDescriptor,
                                               Type->TypeInfo.PoolType,
-                                              &Type->TypeInfo.GenericMapping);
+                                              &Type->TypeInfo.GenericMapping,
+                                              ExGetPreviousMode());
     ObpCalloutEnd(CalloutIrql, "Security", Type, Object);
 
     /* Check for failure */
@@ -672,7 +674,8 @@ ObGetObjectSecurity(IN PVOID Object,
                                               &Length,
                                               &Header->SecurityDescriptor,
                                               Type->TypeInfo.PoolType,
-                                              &Type->TypeInfo.GenericMapping);
+                                              &Type->TypeInfo.GenericMapping,
+                                              ExGetPreviousMode());
     ObpCalloutEnd(CalloutIrql, "Security", Type, Object);
 
     /* Check for failure */
@@ -769,7 +772,8 @@ ObSetSecurityObjectByPointer(IN PVOID Object,
                                             NULL,
                                             &Header->SecurityDescriptor,
                                             Type->TypeInfo.PoolType,
-                                            &Type->TypeInfo.GenericMapping);
+                                            &Type->TypeInfo.GenericMapping,
+                                            ExGetPreviousMode());
 }
 
 /*++
@@ -856,7 +860,8 @@ NtQuerySecurityObject(IN HANDLE Handle,
                                               &Length,
                                               &Header->SecurityDescriptor,
                                               Type->TypeInfo.PoolType,
-                                              &Type->TypeInfo.GenericMapping);
+                                              &Type->TypeInfo.GenericMapping,
+                                              ExGetPreviousMode());
 
     /* Dereference the object */
     ObDereferenceObject(Object);

--- a/ntoskrnl/se/semgr.c
+++ b/ntoskrnl/se/semgr.c
@@ -356,7 +356,8 @@ SeDefaultObjectMethod(
     _Inout_opt_ PULONG ReturnLength,
     _Inout_ PSECURITY_DESCRIPTOR *OldSecurityDescriptor,
     _In_ POOL_TYPE PoolType,
-    _In_ PGENERIC_MAPPING GenericMapping)
+    _In_ PGENERIC_MAPPING GenericMapping,
+    _In_ KPROCESSOR_MODE AccessMode)
 {
     PAGED_CODE();
 

--- a/ntoskrnl/wmi/guidobj.c
+++ b/ntoskrnl/wmi/guidobj.c
@@ -102,8 +102,8 @@ WmipCloseMethod(
     _In_opt_ PEPROCESS Process,
     _In_ PVOID Object,
     _In_ ACCESS_MASK GrantedAccess,
-    _In_ ULONG ProcessHandleCount,
-    _In_ ULONG SystemHandleCount)
+    _In_ ULONG_PTR ProcessHandleCount,
+    _In_ ULONG_PTR SystemHandleCount)
 {
     /* For now nothing */
 }

--- a/ntoskrnl/wmi/guidobj.c
+++ b/ntoskrnl/wmi/guidobj.c
@@ -40,7 +40,8 @@ WmipSecurityMethod(
     _Inout_ PULONG CapturedLength,
     _Inout_ PSECURITY_DESCRIPTOR *ObjectSecurityDescriptor,
     _In_ POOL_TYPE PoolType,
-    _In_ PGENERIC_MAPPING GenericMapping)
+    _In_ PGENERIC_MAPPING GenericMapping,
+    _In_ KPROCESSOR_MODE AccessMode)
 {
     PAGED_CODE();
 

--- a/sdk/include/ndk/obtypes.h
+++ b/sdk/include/ndk/obtypes.h
@@ -202,8 +202,8 @@ typedef VOID
     _In_opt_ PEPROCESS Process,
     _In_ PVOID Object,
     _In_ ACCESS_MASK GrantedAccess,
-    _In_ ULONG ProcessHandleCount,
-    _In_ ULONG SystemHandleCount
+    _In_ ULONG_PTR ProcessHandleCount,
+    _In_ ULONG_PTR SystemHandleCount
 );
 
 typedef VOID

--- a/sdk/include/ndk/obtypes.h
+++ b/sdk/include/ndk/obtypes.h
@@ -191,9 +191,10 @@ typedef VOID
 typedef NTSTATUS
 (NTAPI *OB_OPEN_METHOD)(
     _In_ OB_OPEN_REASON Reason,
+    _In_ KPROCESSOR_MODE AccessMode,
     _In_opt_ PEPROCESS Process,
     _In_ PVOID ObjectBody,
-    _In_ ACCESS_MASK GrantedAccess,
+    _In_ PACCESS_MASK GrantedAccess,
     _In_ ULONG HandleCount
 );
 
@@ -234,7 +235,8 @@ typedef NTSTATUS
     _Inout_ PULONG CapturedLength,
     _Inout_ PSECURITY_DESCRIPTOR *ObjectSecurityDescriptor,
     _In_ POOL_TYPE PoolType,
-    _In_ PGENERIC_MAPPING GenericMapping
+    _In_ PGENERIC_MAPPING GenericMapping,
+    _In_ KPROCESSOR_MODE AccessMode
 );
 
 typedef NTSTATUS


### PR DESCRIPTION
## Purpose

Switches the Ob object callbacks to NT6 style. This is required to support the NT6 access flags THREAD_QUERY_LIMITED_INFORMATION and THREAD_SET_LIMITED_INFORMATION.

Preparation for PR #9004 

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109180,109182,109190
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109179,109181,109189
