### PR TITLE
[E100] Add driver for Intel PRO/100 PCI ethernet controller family

### DIFF
--- a/drivers/network/dd/CMakeLists.txt
+++ b/drivers/network/dd/CMakeLists.txt
@@ -1,9 +1,11 @@
 
 add_subdirectory(dc21x4)
+add_subdirectory(e100)
 add_subdirectory(e1000)
 add_subdirectory(ne2000)
 add_subdirectory(netkvm)
 if(ARCH STREQUAL "i386" OR ARCH STREQUAL "amd64")
+    # Integrated into x86 chipsets
     add_subdirectory(nvnet)
 endif()
 add_subdirectory(pcnet)

--- a/drivers/network/dd/e100/CMakeLists.txt
+++ b/drivers/network/dd/e100/CMakeLists.txt
@@ -1,0 +1,26 @@
+
+add_definitions(
+    -DNDIS51_MINIPORT
+    -DNDIS_MINIPORT_DRIVER)
+
+list(APPEND SOURCE
+    debug.h
+    e100.c
+    e100.h
+    e100hw.h
+    eeprom.c
+    hardware.c
+    init.c
+    interrupt.c
+    phy.c
+    power.c
+    requests.c
+    send.c)
+
+add_library(e100 MODULE ${SOURCE} e100.rc)
+target_link_libraries(e100 memcmp)
+add_pch(e100 e100.h SOURCE)
+set_module_type(e100 kernelmodedriver)
+add_importlibs(e100 ndis ntoskrnl hal)
+add_cd_file(TARGET e100 DESTINATION reactos/system32/drivers FOR all)
+add_driver_inf(e100 nete100.inf)

--- a/drivers/network/dd/e100/CMakeLists.txt
+++ b/drivers/network/dd/e100/CMakeLists.txt
@@ -1,0 +1,25 @@
+
+add_definitions(
+    -DNDIS51_MINIPORT
+    -DNDIS_MINIPORT_DRIVER)
+
+list(APPEND SOURCE
+    debug.h
+    e100.c
+    e100.h
+    e100hw.h
+    eeprom.c
+    hardware.c
+    init.c
+    interrupt.c
+    phy.c
+    power.c
+    requests.c
+    send.c)
+
+add_library(e100 MODULE ${SOURCE} e100.rc)
+add_pch(e100 e100.h SOURCE)
+set_module_type(e100 kernelmodedriver)
+add_importlibs(e100 ndis ntoskrnl hal)
+add_cd_file(TARGET e100 DESTINATION reactos/system32/drivers FOR all)
+add_driver_inf(e100 nete100.inf)

--- a/drivers/network/dd/e100/debug.h
+++ b/drivers/network/dd/e100/debug.h
@@ -1,0 +1,93 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Debug support header file
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+#pragma once
+
+#ifndef __RELFILE__
+#define __RELFILE__ __FILE__
+#endif
+
+#if DBG
+
+// #define DEBUG_TRACE
+// #define DEBUG_INFO
+#define DEBUG_INFO_VERB
+#define DEBUG_WARN
+#define DEBUG_ERR
+
+#ifdef DEBUG_TRACE
+#define TRACE(fmt, ...) \
+    do { \
+      if (DbgPrint("(%s:%d) %s " fmt, __RELFILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__)) \
+          DbgPrint("(%s:%d) DbgPrint() failed!\n", __RELFILE__, __LINE__); \
+    } while (0)
+
+#else
+#define TRACE
+#endif
+
+#ifdef DEBUG_INFO
+#define INFO(fmt, ...) \
+    do { \
+      if (DbgPrint("(%s:%d) %s " fmt, __RELFILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__)) \
+          DbgPrint("(%s:%d) DbgPrint() failed!\n", __RELFILE__, __LINE__); \
+    } while (0)
+
+#else
+#define INFO
+#endif
+
+#ifdef DEBUG_INFO_VERB
+#define INFO_VERB(fmt, ...) \
+    do { \
+      if (DbgPrint("(%s:%d) %s " fmt, __RELFILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__)) \
+          DbgPrint("(%s:%d) DbgPrint() failed!\n", __RELFILE__, __LINE__); \
+    } while (0)
+
+#else
+#define INFO_VERB
+#endif
+
+#ifdef DEBUG_WARN
+#define WARN(fmt, ...) \
+    do { \
+      if (DbgPrint("(%s:%d) %s " fmt, __RELFILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__)) \
+          DbgPrint("(%s:%d) DbgPrint() failed!\n", __RELFILE__, __LINE__); \
+    } while (0)
+
+#else
+#define WARN
+#endif
+
+#ifdef DEBUG_ERR
+#define ERR(fmt, ...) \
+    do { \
+      if (DbgPrint("(%s:%d) %s " fmt, __RELFILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__)) \
+          DbgPrint("(%s:%d) DbgPrint() failed!\n", __RELFILE__, __LINE__); \
+    } while (0)
+
+#else
+#define ERR
+#endif
+
+#else
+
+#if defined(_MSC_VER)
+#define TRACE     __noop
+#define INFO      __noop
+#define INFO_VERB __noop
+#define WARN      __noop
+#define ERR       __noop
+#else
+#define TRACE(...)     do { if(0) { DbgPrint(__VA_ARGS__); } } while(0)
+#define INFO(...)      do { if(0) { DbgPrint(__VA_ARGS__); } } while(0)
+#define INFO_VERB(...) do { if(0) { DbgPrint(__VA_ARGS__); } } while(0)
+#define WARN(...)      do { if(0) { DbgPrint(__VA_ARGS__); } } while(0)
+#define ERR(...)       do { if(0) { DbgPrint(__VA_ARGS__); } } while(0)
+#endif
+
+#endif

--- a/drivers/network/dd/e100/e100.c
+++ b/drivers/network/dd/e100/e100.c
@@ -1,0 +1,171 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Miniport driver entry
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* FUNCTIONS ******************************************************************/
+
+static
+VOID
+EeFlushTransmitQueue(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PE100_TX_CONTEXT TxContext;
+    LIST_ENTRY DoneList;
+    PLIST_ENTRY Entry;
+
+    InitializeListHead(&DoneList);
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    /* Remove pending transmissions from the transmit ring */
+    for (TxContext = Adapter->TxFirst; Adapter->TxPending > 0; TxContext = TxContext->Next)
+    {
+        PNDIS_PACKET Packet = TxContext->Packet;
+
+        ASSERT(Packet);
+
+        InsertTailList(&DoneList, E100_LIST_ENTRY_FROM_PACKET(Packet));
+
+        E100_RELEASE_TX_CONTEXT(Adapter, TxContext, TxContext->Tcb);
+    }
+
+    Adapter->TxFirst = TxContext;
+
+    /* Remove pending transmissions from the internal queue */
+    while (!IsListEmpty(&Adapter->SendQueueList))
+    {
+        Entry = RemoveHeadList(&Adapter->SendQueueList);
+
+        InsertTailList(&DoneList, Entry);
+    }
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+
+    while (!IsListEmpty(&DoneList))
+    {
+        Entry = RemoveHeadList(&DoneList);
+
+        NdisMSendComplete(Adapter->AdapterHandle,
+                          E100_PACKET_FROM_LIST_ENTRY(Entry),
+                          NDIS_STATUS_FAILURE);
+    }
+}
+
+static
+DECLSPEC_NOINLINE_FROM_NOT_PAGED
+VOID
+EeStopAdapter(
+    _In_ PE100_ADAPTER Adapter)
+{
+    /* Prevent DPCs from executing and stop accepting incoming packets */
+    Adapter->AdapterActive = FALSE;
+
+    /* Wait for any DPCs to complete */
+    KeFlushQueuedDpcs();
+
+    EeFlushTransmitQueue(Adapter);
+}
+
+static
+NDIS_STATUS
+NTAPI
+MiniportReset(
+    _Out_ PBOOLEAN AddressingReset,
+    _In_ NDIS_HANDLE MiniportAdapterContext)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+
+    WARN("Called\n");
+
+    if (_InterlockedCompareExchange(&Adapter->ResetLock, 1, 0))
+    {
+        return NDIS_STATUS_RESET_IN_PROGRESS;
+    }
+
+    EeSoftReset(Adapter);
+
+    // TODO: Not implemented
+    return STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+NTAPI
+MiniportHalt(
+    _In_ NDIS_HANDLE MiniportAdapterContext)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+
+    PAGED_CODE();
+
+    INFO("Called\n");
+
+    EeSoftReset(Adapter);
+
+    EeStopAdapter(Adapter);
+
+    EeFreeAdapter(Adapter);
+}
+
+static
+VOID
+NTAPI
+MiniportShutdown(
+    _In_ NDIS_HANDLE MiniportAdapterContext)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+
+    INFO("Called\n");
+
+    EeSoftReset(Adapter);
+}
+
+CODE_SEG("INIT")
+NTSTATUS
+NTAPI
+DriverEntry(
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_ PUNICODE_STRING RegistryPath)
+{
+    NDIS_HANDLE WrapperHandle;
+    NDIS_STATUS Status;
+    NDIS_MINIPORT_CHARACTERISTICS Characteristics = { 0 };
+
+    NdisMInitializeWrapper(&WrapperHandle, DriverObject, RegistryPath, NULL);
+    if (!WrapperHandle)
+        return NDIS_STATUS_FAILURE;
+
+    Characteristics.MajorNdisVersion = NDIS_MINIPORT_MAJOR_VERSION;
+    Characteristics.MinorNdisVersion = NDIS_MINIPORT_MINOR_VERSION;
+    Characteristics.CheckForHangHandler = MiniportCheckForHang;
+    Characteristics.HaltHandler = MiniportHalt;
+    Characteristics.HandleInterruptHandler = MiniportHandleInterrupt;
+    Characteristics.InitializeHandler = MiniportInitialize;
+    Characteristics.ISRHandler = MiniportIsr;
+    Characteristics.QueryInformationHandler = MiniportQueryInformation;
+    Characteristics.ResetHandler = MiniportReset;
+    Characteristics.SetInformationHandler = MiniportSetInformation;
+    Characteristics.ReturnPacketHandler = MiniportReturnPacket;
+    Characteristics.SendPacketsHandler = MiniportSendPackets;
+    Characteristics.CancelSendPacketsHandler = MiniportCancelSendPackets;
+    Characteristics.AdapterShutdownHandler = MiniportShutdown;
+
+    Status = NdisMRegisterMiniport(WrapperHandle, &Characteristics, sizeof(Characteristics));
+    if (Status != NDIS_STATUS_SUCCESS)
+    {
+        NdisTerminateWrapper(WrapperHandle, NULL);
+        return Status;
+    }
+
+    return NDIS_STATUS_SUCCESS;
+}

--- a/drivers/network/dd/e100/e100.c
+++ b/drivers/network/dd/e100/e100.c
@@ -1,0 +1,264 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Miniport driver entry
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* FUNCTIONS ******************************************************************/
+
+DECLSPEC_NOINLINE_FROM_PAGED
+VOID
+EeFlushTransmitQueue(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PE100_TX_CONTEXT TxContext;
+    LIST_ENTRY DoneList;
+    PLIST_ENTRY Entry;
+
+    InitializeListHead(&DoneList);
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    /* Remove pending transmissions from the transmit ring */
+    for (TxContext = Adapter->TxFirst; Adapter->TxPending > 0; TxContext = TxContext->Next)
+    {
+        PNDIS_PACKET Packet = TxContext->Packet;
+
+        ASSERT(Packet);
+
+        InsertTailList(&DoneList, E100_LIST_ENTRY_FROM_PACKET(Packet));
+
+        E100_RELEASE_TX_CONTEXT(Adapter, TxContext, TxContext->Tcb);
+    }
+
+    Adapter->TxFirst = TxContext;
+
+    /* Remove pending transmissions from the internal queue */
+    while (!IsListEmpty(&Adapter->SendQueueList))
+    {
+        Entry = RemoveHeadList(&Adapter->SendQueueList);
+
+        InsertTailList(&DoneList, Entry);
+    }
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+
+    while (!IsListEmpty(&DoneList))
+    {
+        Entry = RemoveHeadList(&DoneList);
+
+        NdisMSendComplete(Adapter->AdapterHandle,
+                          E100_PACKET_FROM_LIST_ENTRY(Entry),
+                          NDIS_STATUS_FAILURE);
+    }
+}
+
+static
+DECLSPEC_NOINLINE_FROM_PAGED
+VOID
+EeWaitForReceiveIndications(
+    _In_ PE100_ADAPTER Adapter)
+{
+    BOOLEAN RxStopped;
+
+    ASSERT(KeGetCurrentIrql() < DISPATCH_LEVEL);
+
+    while (TRUE)
+    {
+        NdisAcquireSpinLock(&Adapter->ReceiveLock);
+
+        RxStopped = (Adapter->RxPending == 0);
+
+        NdisReleaseSpinLock(&Adapter->ReceiveLock);
+
+        if (RxStopped)
+            break;
+
+        NdisMSleep(10);
+    }
+}
+
+CODE_SEG("PAGE")
+VOID
+EeStopAdapter(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PAGED_CODE();
+
+    /* Attempt to disable interrupts to complete more quickly */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_INTRCNTL, FXP_SCB_INTR_DISABLE);
+
+    /* Prevent DPCs from executing and stop accepting incoming packets */
+    Adapter->AdapterActive = FALSE;
+
+    /* Wait for any DPCs to complete */
+    KeFlushQueuedDpcs();
+}
+
+CODE_SEG("PAGE")
+VOID
+NTAPI
+EeResetWorker(
+    _In_ PNDIS_WORK_ITEM WorkItem,
+    _In_opt_ PVOID Context)
+{
+    PE100_ADAPTER Adapter = Context;
+    NDIS_STATUS Status;
+
+    UNREFERENCED_PARAMETER(WorkItem);
+
+    PAGED_CODE();
+
+    EeStopAdapter(Adapter);
+    EeSoftReset(Adapter, TRUE);
+
+    if (Adapter->CurrentMedia != E100_MEDIA_NONE)
+    {
+        Adapter->CurrentMedia = E100_MEDIA_NONE;
+
+        NdisMIndicateStatus(Adapter->AdapterHandle,
+                            NDIS_STATUS_MEDIA_DISCONNECT,
+                            NULL,
+                            0);
+        NdisMIndicateStatusComplete(Adapter->AdapterHandle);
+    }
+
+    EeFlushTransmitQueue(Adapter);
+
+    /* Check if the device is present */
+    if (CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK) == 0xFF)
+    {
+        ERR("Hardware is gone...\n");
+
+        /* Remove this adapter */
+        NdisMRemoveMiniport(Adapter->AdapterHandle);
+
+        Status = NDIS_STATUS_HARD_ERRORS;
+        goto Done;
+    }
+
+    Status = EeSetupAdapter(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+    {
+        ERR("Failed to setup adapter\n");
+        goto Done;
+    }
+
+    /* Restore the RX filter */
+    EeApplyPacketFilter(Adapter);
+
+    EeStartAdapter(Adapter);
+
+Done:
+    _InterlockedExchange(&Adapter->ResetLock, 0);
+
+    NdisMResetComplete(Adapter->AdapterHandle, Status, FALSE);
+}
+
+static
+NDIS_STATUS
+NTAPI
+MiniportReset(
+    _Out_ PBOOLEAN AddressingReset,
+    _In_ NDIS_HANDLE MiniportAdapterContext)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+
+    WARN("Reset called %02X %02X %02X\n",
+         CSR_READ_8(Adapter, FXP_CSR_SCB_COMMAND),
+         CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK),
+         CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS));
+
+    if (_InterlockedCompareExchange(&Adapter->ResetLock, 1, 0))
+    {
+        return NDIS_STATUS_RESET_IN_PROGRESS;
+    }
+
+    NdisScheduleWorkItem(&Adapter->ResetWorkItem);
+
+    return NDIS_STATUS_PENDING;
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+NTAPI
+MiniportHalt(
+    _In_ NDIS_HANDLE MiniportAdapterContext)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+
+    PAGED_CODE();
+
+    INFO("Called\n");
+
+    EeStopAdapter(Adapter);
+    EeSoftReset(Adapter, FALSE);
+    EePhySetPower(Adapter, FALSE);
+
+    EeFlushTransmitQueue(Adapter);
+    EeWaitForReceiveIndications(Adapter);
+
+    EeFreeAdapter(Adapter);
+}
+
+static
+VOID
+NTAPI
+MiniportShutdown(
+    _In_ NDIS_HANDLE MiniportAdapterContext)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+
+    INFO("Called\n");
+
+    EeSoftReset(Adapter, FALSE);
+    EePhySetPower(Adapter, FALSE);
+}
+
+CODE_SEG("INIT")
+NTSTATUS
+NTAPI
+DriverEntry(
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_ PUNICODE_STRING RegistryPath)
+{
+    NDIS_HANDLE WrapperHandle;
+    NDIS_STATUS Status;
+    NDIS_MINIPORT_CHARACTERISTICS Characteristics = { 0 };
+
+    NdisMInitializeWrapper(&WrapperHandle, DriverObject, RegistryPath, NULL);
+    if (!WrapperHandle)
+        return NDIS_STATUS_FAILURE;
+
+    Characteristics.MajorNdisVersion = NDIS_MINIPORT_MAJOR_VERSION;
+    Characteristics.MinorNdisVersion = NDIS_MINIPORT_MINOR_VERSION;
+    Characteristics.CheckForHangHandler = MiniportCheckForHang;
+    Characteristics.HaltHandler = MiniportHalt;
+    Characteristics.HandleInterruptHandler = MiniportHandleInterrupt;
+    Characteristics.InitializeHandler = MiniportInitialize;
+    Characteristics.ISRHandler = MiniportIsr;
+    Characteristics.QueryInformationHandler = MiniportQueryInformation;
+    Characteristics.ResetHandler = MiniportReset;
+    Characteristics.SetInformationHandler = MiniportSetInformation;
+    Characteristics.ReturnPacketHandler = MiniportReturnPacket;
+    Characteristics.SendPacketsHandler = MiniportSendPackets;
+    Characteristics.CancelSendPacketsHandler = MiniportCancelSendPackets;
+    Characteristics.AdapterShutdownHandler = MiniportShutdown;
+
+    Status = NdisMRegisterMiniport(WrapperHandle, &Characteristics, sizeof(Characteristics));
+    if (Status != NDIS_STATUS_SUCCESS)
+    {
+        NdisTerminateWrapper(WrapperHandle, NULL);
+        return Status;
+    }
+
+    return NDIS_STATUS_SUCCESS;
+}

--- a/drivers/network/dd/e100/e100.h
+++ b/drivers/network/dd/e100/e100.h
@@ -1,0 +1,464 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Main header file
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+#pragma once
+
+#if !DBG
+#define NO_KERNEL_LIST_ENTRY_CHECKS
+#endif
+#include <ndis.h>
+#include <section_attribs.h>
+
+#define E100_TAG   '001e'
+
+#define E100_TRANSMIT_BLOCKS_MIN     8
+#define E100_TRANSMIT_BLOCKS_MAX     128
+#define E100_TRANSMIT_BLOCKS_DEFAULT 128
+#define E100_RECEIVE_BUFFERS_MIN     8
+#define E100_RECEIVE_BUFFERS_MAX     128
+#define E100_RECEIVE_BUFFERS_DEFAULT 64
+#define E100_TBD_PER_TCB             29
+#define E100_TRANSMIT_BUFFERS        4
+
+#define E100_INTERRUPT_PROCESSING_LIMIT   8
+#define E100_RECEIVE_PROCESSING_LIMIT     4
+#define E100_RECEIVE_ARRAY_SIZE           16
+
+#define E100_MULTICAST_LIST_SIZE          32
+#define E100_MAXIMUM_FRAME_SIZE           1514
+#define E100_TRANSMIT_BLOCK_SIZE          E100_MAXIMUM_FRAME_SIZE
+#define E100_RECEIVE_BLOCK_SIZE           1536
+#define E100_ETHERNET_HEADER_SIZE         14
+#define E100_MAXIMUM_VLAN_ID              0xFFF
+
+/* Make RFD unaligned to align the user data after the 14-byte ethernet header */
+#define E100_RECEIVE_BUFFER_SHIFT       0xA
+#define E100_RECEIVE_BUFFER_DATA_ALIGN  8
+
+#define E100_PACKET_FILTERS ( \
+    NDIS_PACKET_TYPE_DIRECTED | \
+    NDIS_PACKET_TYPE_MULTICAST | \
+    NDIS_PACKET_TYPE_BROADCAST | \
+    NDIS_PACKET_TYPE_PROMISCUOUS | \
+    NDIS_PACKET_TYPE_ALL_MULTICAST)
+
+#include "e100hw.h"
+
+/* We make the TCB size to be a multiple of 128 bytes for performance */
+#define E100_TCB_ALIGNMENT   128
+C_ASSERT(sizeof(FXP_CB_TRANSMIT) % E100_TCB_ALIGNMENT == 0);
+
+/* Pageable read-only data */
+#define E100_PAGED_DATA    DATA_SEG("PAGECONS")
+#if defined(_MSC_VER)
+#pragma section("PAGECONS", read)
+#endif
+
+#if defined(_M_IX86) || defined(_M_AMD64)
+/* Strict memory model, does not reorder Write-Write operations */
+#define EE_WRITE_BARRIER()    KeMemoryBarrierWithoutFence()
+#else
+#define EE_WRITE_BARRIER()    KeMemoryBarrier()
+#endif
+
+#define E100_LIST_ENTRY_FROM_PACKET(Packet) \
+    ((PLIST_ENTRY)(&(Packet)->MiniportReservedEx[0]))
+
+#define E100_PACKET_FROM_LIST_ENTRY(ListEntry) \
+    (CONTAINING_RECORD(ListEntry, NDIS_PACKET, MiniportReservedEx))
+
+#define E100_RX_CONTEXT_FROM_PACKET(Packet) \
+    ((PE100_RX_CONTEXT*)&(Packet)->MiniportReservedEx[0])
+
+#define MII_FLAG_FAILED     0x80000000
+#define MII_SUCCESS(Status) (((Status) & MII_FLAG_FAILED) == 0)
+
+#define ETH_IS_LOCALLY_ADMINISTERED(Address) \
+    ((BOOLEAN)(((PUCHAR)(Address))[0] & ((UCHAR)0x02)))
+
+#define ETH_IS_EMPTY(Address) \
+    ((BOOLEAN)((((PUCHAR)(Address))[0] | ((PUCHAR)(Address))[1] | ((PUCHAR)(Address))[2] | \
+                ((PUCHAR)(Address))[3] | ((PUCHAR)(Address))[4] | ((PUCHAR)(Address))[5]) == 0))
+
+#define E100_MEDIA_AUTO        0x01
+#define E100_MEDIA_FD          0x02
+#define E100_MEDIA_100T        0x04
+#define E100_MEDIA_PAUSE_AUTO  0x08
+#define E100_MEDIA_PAUSE_TX    0x10
+#define E100_MEDIA_PAUSE_RX    0x20
+#define E100_MEDIA_NONE        (0xFF & ~(E100_MEDIA_FD | E100_MEDIA_100T))
+
+#define E100_PHY_TYPE_UNKNOWN    0
+#define E100_PHY_TYPE_503        1
+#define E100_PHY_TYPE_DP83840    2
+
+#define E100_FLAG_IS_ICH              0x00000001 // ICH controller
+#define E100_FLAG_NO_UCODE            0x00000002 // Microcode is not applicable
+#define E100_FLAG_RX_LOCKUP_BUG       0x00000004 // Has receiver lock-up errata
+#define E100_FLAG_CU_RESUME_BUG       0x00000008 // Has FXP_SCB_COMMAND_CU_RESUME errata
+#define E100_FLAG_IRQ_SHARED          0x00000010 // Shared IRQ
+#define E100_FLAG_HAS_WOL             0x00000020 // Wake on LAN capabilities
+#define E100_FLAG_WMI_ENANLE          0x00000040 // Enable PCI WMI
+#define E100_FLAG_SAVE_BAD_PACKETS    0x00000080 // Save bad packets: bad size, CRC, etc
+#define E100_FLAG_EXT_TXCB            0x00000100 // Enable extended TxCB mode
+#define E100_FLAG_LONG_PKT            0x00000200 // Enable long packet reception
+#define E100_FLAG_82559_RXCSUM        0x00000400 // 82559 compatible RX checksum
+#define E100_FLAG_EXT_RFA             0x00000800 // Extended RFDs for checksum offload
+#define E100_FLAG_HAS_FLOW_CONTROL    0x00001000 // Has flow control
+#define E100_FLAG_VLAN_TAGGING        0x00002000 // 802.1Q VLAN tagging
+#define E100_FLAG_PACKET_PRIORITY     0x00004000 // 802.1Q packet priority
+
+typedef struct _E100_TX_CONTEXT E100_TX_CONTEXT, *PE100_TX_CONTEXT;
+
+typedef struct _E100_COALESCE_BUFFER
+{
+    SINGLE_LIST_ENTRY ListEntry;
+
+    PVOID VirtualAddress;
+    ULONG PhysicalAddress;
+
+    ULONG PhysicalAddressOriginal;
+    PVOID VirtualAddressOriginal;
+} E100_COALESCE_BUFFER, *PE100_COALESCE_BUFFER;
+
+typedef struct _E100_TX_CONTEXT
+{
+    PE100_TX_CONTEXT Next;
+    PFXP_CB_TRANSMIT Tcb;
+    PNDIS_PACKET Packet;
+    ULONG TcbPhys;
+
+    PE100_COALESCE_BUFFER Buffer;
+} E100_TX_CONTEXT, *PE100_TX_CONTEXT;
+
+typedef struct _E100_RX_CONTEXT
+{
+    LIST_ENTRY ListEntry;
+
+    ULONG Flags;
+#define E100_RX_FLAG_82559_CRC  0x00000001 // TODO not used yet
+#define E100_RX_FLAG_RECLAIM    0x80000000
+
+    PNDIS_PACKET Packet;
+    PNDIS_BUFFER RfdMdl;
+    PNDIS_BUFFER ReceiveBufferMdl;
+
+    PFXP_RFD Rfd;
+    ULONG RfdPhys;
+
+    ULONG PhysicalAddressOriginal;
+    PVOID VirtualAddressOriginal;
+} E100_RX_CONTEXT, *PE100_RX_CONTEXT;
+
+typedef struct _E100_CONTROL_BLOCK
+{
+    DECLSPEC_CACHEALIGN FXP_COUNTERS Counters;
+    DECLSPEC_CACHEALIGN FXP_CB_CONFIGURE Configuration;
+    union
+    {
+        DECLSPEC_CACHEALIGN FXP_CB_INDIVIDUAL_ADDRESS_SETUP IaSetup;
+        DECLSPEC_CACHEALIGN FXP_CB_MULTICAST_SETUP MulticastSetup;
+        DECLSPEC_CACHEALIGN FXP_CB_LOAD_MICROCODE MicrocodeSetup;
+    };
+} E100_CONTROL_BLOCK, *PE100_CONTROL_BLOCK;
+
+typedef struct _E100_STATISTICS
+{
+    ULONG64 TransmitOk;
+    ULONG64 TransmitDeferred;
+    ULONG64 TransmitHeartbeatErrors;
+    ULONG64 TransmitOneRetry;
+    ULONG64 TransmitMoreCollisions;
+    ULONG64 TransmitErrors;
+    ULONG64 TransmitExcessiveCollisions;
+    ULONG64 TransmitUnderrunErrors;
+    ULONG64 TransmitLostCarrierSense;
+    ULONG64 TransmitLateCollisions;
+    ULONG64 ReceiveOk;
+    ULONG64 ReceiveErrors;
+    ULONG64 ReceiveOverrunErrors;
+    ULONG64 ReceiveNoBuffers;
+    ULONG64 ReceiveCrcErrors;
+    ULONG64 ReceiveAlignmentErrors;
+} E100_STATISTICS, *PE100_STATISTICS;
+
+typedef struct _E100_ADAPTER
+{
+    PUCHAR IoBase;
+    ULONG Flags;
+    BOOLEAN AdapterActive;
+    BOOLEAN CommandUnitActive;
+    BOOLEAN HardError;
+    UCHAR CurrentMedia;
+    USHORT TransmitCommand;
+    UCHAR TransmitThreshold;
+    UCHAR DefaultMedia;
+    UCHAR PhyType;
+    UCHAR RevisionID;
+    ULONG VlanId;
+
+    DECLSPEC_CACHEALIGN NDIS_SPIN_LOCK SendLock;
+    PE100_TX_CONTEXT TxContext;
+    PE100_TX_CONTEXT TxFirst;
+    PE100_TX_CONTEXT TxLast;
+    ULONG TxPending;
+    ULONG TcbCount;
+    LIST_ENTRY SendQueueList;
+
+    DECLSPEC_CACHEALIGN NDIS_SPIN_LOCK ReceiveLock;
+    PE100_RX_CONTEXT RxContext;
+    LIST_ENTRY RxContextList;
+
+    UCHAR InterruptStatus;
+    UCHAR ReceiverUnitIdleTicks;
+    E100_STATISTICS Statistics;
+    NDIS_MINIPORT_INTERRUPT Interrupt;
+    PE100_CONTROL_BLOCK ControlBlock;
+    ULONG ControlBlockPa;
+    ULONG PacketFilter;
+    ULONG RfdSize;
+    PFXP_CB_TRANSMIT HeadTcb;
+    PVOID TcbOriginalVa;
+    ULONG TcbOriginalPhys;
+    ULONG HeadTcbPa;
+    ULONG PhyCapabilities;
+    ULONG PhyAddress;
+    ULONG RfdCount;
+    ULONG RfdToAllocate;
+    ULONG TbdCount;
+    ULONG MicrocodeInterruptDelay;
+    ULONG MicrocodeMaxFramesPerIntr;
+    ULONG MicrocodeMinSizeMask;
+    UCHAR PermanentMacAddress[ETH_LENGTH_OF_ADDRESS];
+    UCHAR CurrentMacAddress[ETH_LENGTH_OF_ADDRESS];
+    ULONG MulticastListSize;
+    struct
+    {
+        UCHAR MacAddress[ETH_LENGTH_OF_ADDRESS];
+    } MulticastList[E100_MULTICAST_LIST_SIZE];
+    ULONG WakeUpFlags;
+    NDIS_DEVICE_POWER_STATE PowerState;
+    NDIS_DEVICE_POWER_STATE PrevPowerState;
+    SINGLE_LIST_ENTRY SendBufferList;
+    SCATTER_GATHER_LIST LocalSgList;
+    E100_COALESCE_BUFFER CoalesceBuffer[E100_TRANSMIT_BUFFERS];
+    ULONG EepromAddressBusWidth;
+    _Interlocked_ volatile LONG ResetLock;
+    ULONG InterruptVector;
+    ULONG InterruptLevel;
+    ULONG InterruptFlags;
+    USHORT DeviceID;
+    ULONG ControlBlockOriginalPhys;
+    PVOID ControlBlockOriginal;
+    NDIS_HANDLE BufferPool;
+    NDIS_HANDLE PacketPool;
+    NDIS_HANDLE AdapterHandle;
+    NDIS_HANDLE WrapperConfigurationHandle;
+    PVOID AdapterOriginal;
+    ULONG AdapterSize;
+} E100_ADAPTER, *PE100_ADAPTER;
+
+typedef struct _E100_UCODE_INFO
+{
+    const ULONG *Microcode;
+    ULONG Length;
+    USHORT RevisionID;
+    USHORT IntDelayOffset;
+    USHORT BundleMaxOffset;
+    USHORT MinSizeMaskOffset;
+} E100_UCODE_INFO, *PE100_UCODE_INFO;
+
+CODE_SEG("INIT")
+DRIVER_INITIALIZE DriverEntry;
+
+CODE_SEG("PAGE")
+NDIS_STATUS
+NTAPI
+MiniportInitialize(
+    _Out_ PNDIS_STATUS OpenErrorStatus,
+    _Out_ PUINT SelectedMediumIndex,
+    _In_ PNDIS_MEDIUM MediumArray,
+    _In_ UINT MediumArraySize,
+    _In_ NDIS_HANDLE MiniportAdapterHandle,
+    _In_ NDIS_HANDLE WrapperConfigurationContext);
+
+BOOLEAN
+NTAPI
+MiniportCheckForHang(
+    _In_ NDIS_HANDLE MiniportAdapterContext);
+
+VOID
+NTAPI
+MiniportSendPackets(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ PPNDIS_PACKET PacketArray,
+    _In_ UINT NumberOfPackets);
+
+VOID
+NTAPI
+MiniportCancelSendPackets(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ PVOID CancelId);
+
+VOID
+NTAPI
+MiniportReturnPacket(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ PNDIS_PACKET Packet);
+
+NDIS_STATUS
+NTAPI
+MiniportQueryInformation(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ NDIS_OID Oid,
+    _In_ PVOID InformationBuffer,
+    _In_ ULONG InformationBufferLength,
+    _Out_ PULONG BytesWritten,
+    _Out_ PULONG BytesNeeded);
+
+NDIS_STATUS
+NTAPI
+MiniportSetInformation(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ NDIS_OID Oid,
+    _In_ PVOID InformationBuffer,
+    _In_ ULONG InformationBufferLength,
+    _Out_ PULONG BytesRead,
+    _Out_ PULONG BytesNeeded);
+
+VOID
+NTAPI
+MiniportIsr(
+    _Out_ PBOOLEAN InterruptRecognized,
+    _Out_ PBOOLEAN QueueMiniportHandleInterrupt,
+    _In_ NDIS_HANDLE MiniportAdapterContext);
+
+VOID
+NTAPI
+MiniportHandleInterrupt(
+    _In_ NDIS_HANDLE MiniportAdapterContext);
+
+CODE_SEG("PAGE")
+VOID
+EeFreeAdapter(
+    _In_ __drv_freesMem(Mem) PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+BOOLEAN
+EeReadEeprom(
+    _In_ PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeFindMiiPhy(
+    _In_ PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+VOID
+EePhyInit(
+    _In_ PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeSetupAdapter(
+    _In_ PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+VOID
+EeStartAdapter(
+    _In_ PE100_ADAPTER Adapter);
+
+VOID
+EeSoftReset(
+    _In_ PE100_ADAPTER Adapter);
+
+NDIS_STATUS
+EeUpdateMulticastList(
+    _In_ PE100_ADAPTER Adapter);
+
+NDIS_STATUS
+EeApplyPacketFilter(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG PacketFilter);
+
+UCHAR
+EePhyGetSpeedAndDuplex(
+    _In_ PE100_ADAPTER Adapter);
+
+BOOLEAN
+EeScbWaitForCommandClear(
+    _In_ PE100_ADAPTER Adapter);
+
+VOID
+EeSendPackets(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PPNDIS_PACKET PacketArray,
+    _In_ UINT NumberOfPackets);
+
+FORCEINLINE
+VOID
+E100_RELEASE_TX_CONTEXT(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PE100_TX_CONTEXT TxContext,
+    _In_ PFXP_CB_TRANSMIT Tcb)
+{
+    /* Reset the IPCB checksum offload bits */
+    Tcb->Tbd[0].Address = 0;
+
+    if (TxContext->Buffer)
+    {
+        PushEntryList(&Adapter->SendBufferList, &TxContext->Buffer->ListEntry);
+    }
+
+    ASSERT(Adapter->TxPending > 0);
+    --Adapter->TxPending;
+}
+
+FORCEINLINE
+UCHAR
+CSR_READ_8(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG Register)
+{
+    UCHAR Value;
+
+    NdisReadRegisterUchar((PUCHAR)(Adapter->IoBase + Register), &Value);
+    return Value;
+}
+
+FORCEINLINE
+USHORT
+CSR_READ_16(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG Register)
+{
+    USHORT Value;
+
+    NdisReadRegisterUlong((PUSHORT)(Adapter->IoBase + Register), &Value);
+    return Value;
+}
+
+FORCEINLINE
+ULONG
+CSR_READ_32(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG Register)
+{
+    ULONG Value;
+
+    NdisReadRegisterUlong((PULONG)(Adapter->IoBase + Register), &Value);
+    return Value;
+}
+
+#define CSR_WRITE_8(Adapter, Register, Value)  \
+    NdisWriteRegisterUchar((PUCHAR)((Adapter)->IoBase + (Register)), (Value));
+
+#define CSR_WRITE_16(Adapter, Register, Value)  \
+    NdisWriteRegisterUshort((PUSHORT)((Adapter)->IoBase + (Register)), (Value));
+
+#define CSR_WRITE_32(Adapter, Register, Value)  \
+    NdisWriteRegisterUlong((PULONG)((Adapter)->IoBase + (Register)), (Value));

--- a/drivers/network/dd/e100/e100.h
+++ b/drivers/network/dd/e100/e100.h
@@ -1,0 +1,613 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Main header file
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+#pragma once
+
+#if !DBG
+/* For performance reasons */
+#define NO_KERNEL_LIST_ENTRY_CHECKS
+#endif
+#include <ndis.h>
+#include <section_attribs.h>
+
+#define E100_TAG   '001e'
+
+#define E100_TRANSMIT_BLOCKS_MIN     8
+#define E100_TRANSMIT_BLOCKS_MAX     128
+#define E100_TRANSMIT_BLOCKS_DEFAULT 128
+#define E100_RECEIVE_BUFFERS_MIN     8
+#define E100_RECEIVE_BUFFERS_MAX     256
+#define E100_RECEIVE_BUFFERS_DEFAULT 64
+#define E100_TBD_PER_TCB             29
+#define E100_TRANSMIT_BUFFERS        4
+
+#define E100_INTERRUPT_PROCESSING_LIMIT   8
+#define E100_RECEIVE_PROCESSING_LIMIT     4
+#define E100_RECEIVE_ARRAY_SIZE           16
+
+#define E100_MULTICAST_LIST_SIZE          32
+#define E100_MAXIMUM_FRAME_SIZE           1514
+#define E100_TRANSMIT_BLOCK_SIZE          E100_MAXIMUM_FRAME_SIZE
+#define E100_RECEIVE_BLOCK_SIZE           1536
+#define E100_ETHERNET_HEADER_SIZE         14
+#define E100_MAXIMUM_VLAN_ID              0xFFF
+
+/* Make RFD unaligned to align the user data after the 14-byte ethernet header */
+#define E100_RECEIVE_BUFFER_SHIFT       0xA
+#define E100_RECEIVE_BUFFER_DATA_ALIGN  8
+
+#define E100_PACKET_FILTERS ( \
+    NDIS_PACKET_TYPE_DIRECTED | \
+    NDIS_PACKET_TYPE_MULTICAST | \
+    NDIS_PACKET_TYPE_BROADCAST | \
+    NDIS_PACKET_TYPE_PROMISCUOUS | \
+    NDIS_PACKET_TYPE_ALL_MULTICAST)
+
+#include "e100hw.h"
+
+/* We make the TCB size to be a multiple of 128 bytes for performance */
+#define E100_TCB_ALIGNMENT   128
+C_ASSERT(sizeof(FXP_CB_TRANSMIT) % E100_TCB_ALIGNMENT == 0);
+
+/* Pageable read-only data */
+#define E100_PAGED_DATA    DATA_SEG("PAGECONS")
+#if defined(_MSC_VER)
+#pragma section("PAGECONS", read)
+#endif
+
+#if defined(_M_IX86) || defined(_M_AMD64)
+/* Strict memory model, does not reorder Write-Write operations */
+#define EE_WRITE_BARRIER()    KeMemoryBarrierWithoutFence()
+#else
+#define EE_WRITE_BARRIER()    KeMemoryBarrier()
+#endif
+
+#define E100_LIST_ENTRY_FROM_PACKET(Packet) \
+    ((PLIST_ENTRY)(&(Packet)->MiniportReservedEx[0]))
+
+#define E100_PACKET_FROM_LIST_ENTRY(ListEntry) \
+    (CONTAINING_RECORD(ListEntry, NDIS_PACKET, MiniportReservedEx))
+
+#define E100_RX_CONTEXT_FROM_PACKET(Packet) \
+    ((PE100_RX_CONTEXT*)&(Packet)->MiniportReservedEx[0])
+
+#define MII_FLAG_FAILED     0x80000000
+#define MII_SUCCESS(Status) (((Status) & MII_FLAG_FAILED) == 0)
+
+#define ETH_IS_LOCALLY_ADMINISTERED(Address) \
+    ((((PUCHAR)(Address))[0] & 0x02) != 0)
+
+#define ETH_IS_EMPTY(Address) \
+    ((BOOLEAN)((((PUCHAR)(Address))[0] | ((PUCHAR)(Address))[1] | ((PUCHAR)(Address))[2] | \
+                ((PUCHAR)(Address))[3] | ((PUCHAR)(Address))[4] | ((PUCHAR)(Address))[5]) == 0))
+
+#define ETHERTYPE_IP  0x0800
+#define IPPROTO_TCP   6
+#define IPPROTO_UDP   17
+#define IP_MF         0x2000
+#define IP_OFFMASK    0x1FFF
+
+#define E100_MEDIA_AUTO        0x01
+#define E100_MEDIA_FD          0x02
+#define E100_MEDIA_100T        0x04
+#define E100_MEDIA_PAUSE_AUTO  0x08
+#define E100_MEDIA_PAUSE_TX    0x10
+#define E100_MEDIA_PAUSE_RX    0x20
+#define E100_MEDIA_NONE        (0xFF & ~(E100_MEDIA_FD | E100_MEDIA_100T))
+
+#define E100_PHY_TYPE_UNKNOWN    0
+#define E100_PHY_TYPE_503        1
+#define E100_PHY_TYPE_DP83840    2
+
+#define E100_FLAG_IS_ICH                   0x00000001 // ICH controller
+#define E100_FLAG_NO_UCODE                 0x00000002 // Microcode is not applicable
+#define E100_FLAG_RX_LOCKUP_BUG            0x00000004 // Has receiver lock-up errata
+#define E100_FLAG_CU_RESUME_BUG            0x00000008 // Has FXP_SCB_COMMAND_CU_RESUME errata
+#define E100_FLAG_IRQ_SHARED               0x00000010 // Shared IRQ
+#define E100_FLAG_HAS_WOL                  0x00000020 // Wake on LAN capabilities
+#define E100_FLAG_MWI_ENABLE               0x00000040 // Enable PCI MWI
+#define E100_FLAG_SAVE_BAD_PACKETS         0x00000080 // Save bad packets: bad size, CRC, etc
+#define E100_FLAG_EXT_TXCB                 0x00000100 // Enable extended TxCB mode
+#define E100_FLAG_LONG_PKT                 0x00000200 // Enable long packet reception
+#define E100_FLAG_82559_RXCSUM             0x00000400 // 82559 compatible RX checksum
+#define E100_FLAG_EXT_RFA                  0x00000800 // Extended RFDs for checksum offload
+#define E100_FLAG_HAS_FLOW_CONTROL         0x00001000 // Has flow control
+#define E100_FLAG_REDUCE_WOL_LINK_SPEED    0x00002000 // WOL link speed power saving
+#define E100_FLAG_VLAN_TAGGING             0x00004000 // 802.1Q VLAN tagging
+#define E100_FLAG_PACKET_PRIORITY          0x00008000 // 802.1Q packet priority
+#define E100_FLAG_CSUM_OFFLOAD             0x00010000 // RX/TX checksum offload
+#define E100_FLAG_LARGE_SEND_OFFLOAD       0x00020000 // Large send offload
+
+typedef struct _E100_TX_CONTEXT E100_TX_CONTEXT, *PE100_TX_CONTEXT;
+
+#include <pshpack1.h>
+typedef struct _ETH_HEADER
+{
+    UCHAR Destination[ETH_LENGTH_OF_ADDRESS];
+    UCHAR Source[ETH_LENGTH_OF_ADDRESS];
+    USHORT PayloadType;
+} ETH_HEADER, *PETH_HEADER;
+#include <poppack.h>
+
+typedef struct IPv4_HEADER
+{
+    UCHAR VersionLength;
+    UCHAR Tos;
+    USHORT TotalLength;
+    USHORT Id;
+    USHORT Offset;
+    UCHAR Ttl;
+    UCHAR Protocol;
+    USHORT Checksum;
+    ULONG Source;
+    ULONG Destination;
+} IPv4_HEADER, *PIPv4_HEADER;
+
+typedef struct _E100_WAKE_UP_FRAME
+{
+    LIST_ENTRY ListEntry;
+    ULONG FilterSize;
+    ULONG Signature;
+    ULONG PatternMask[FXP_WOL_FILTER_MASKS];
+} E100_WAKE_UP_FRAME, *PE100_WAKE_UP_FRAME;
+
+typedef struct _E100_COALESCE_BUFFER
+{
+    SINGLE_LIST_ENTRY ListEntry;
+
+    PVOID VirtualAddress;
+    ULONG PhysicalAddress;
+
+    ULONG PhysicalAddressOriginal;
+    PVOID VirtualAddressOriginal;
+} E100_COALESCE_BUFFER, *PE100_COALESCE_BUFFER;
+
+typedef struct _E100_TX_CONTEXT
+{
+    PE100_TX_CONTEXT Next;
+    PFXP_CB_TRANSMIT Tcb;
+    PNDIS_PACKET Packet;
+    PE100_COALESCE_BUFFER Buffer;
+    ULONG TcbPhys;
+} E100_TX_CONTEXT, *PE100_TX_CONTEXT;
+
+typedef struct _E100_RX_CONTEXT
+{
+    LIST_ENTRY ListEntry;
+
+    ULONG Flags;
+#define E100_RX_FLAG_RECLAIM    0x80000000
+
+    PNDIS_PACKET Packet;
+    PNDIS_BUFFER RfdMdl;
+    PNDIS_BUFFER ReceiveBufferMdl;
+
+    PFXP_RFD Rfd;
+    ULONG RfdPhys;
+
+    ULONG PhysicalAddressOriginal;
+    PVOID VirtualAddressOriginal;
+} E100_RX_CONTEXT, *PE100_RX_CONTEXT;
+
+typedef struct _E100_CONTROL_BLOCK
+{
+    DECLSPEC_CACHEALIGN FXP_COUNTERS Counters;
+    DECLSPEC_CACHEALIGN FXP_CB_CONFIGURE Configuration;
+    union
+    {
+        DECLSPEC_CACHEALIGN FXP_CB_INDIVIDUAL_ADDRESS_SETUP IaSetup;
+        DECLSPEC_CACHEALIGN FXP_CB_MULTICAST_SETUP MulticastSetup;
+        DECLSPEC_CACHEALIGN FXP_CB_LOAD_MICROCODE MicrocodeSetup;
+        DECLSPEC_CACHEALIGN FXP_CB_LOAD_FILTER FilterSetup;
+    };
+} E100_CONTROL_BLOCK, *PE100_CONTROL_BLOCK;
+
+typedef struct _E100_STATISTICS
+{
+    ULONG64 TransmitOk;
+    ULONG64 TransmitDeferred;
+    ULONG64 TransmitOneRetry;
+    ULONG64 TransmitMoreCollisions;
+    ULONG64 TransmitErrors;
+    ULONG64 TransmitExcessiveCollisions;
+    ULONG64 TransmitUnderrunErrors;
+    ULONG64 TransmitLostCarrierSense;
+    ULONG64 TransmitLateCollisions;
+    ULONG64 ReceiveOk;
+    ULONG64 ReceiveErrors;
+    ULONG64 ReceiveOverrunErrors;
+    ULONG64 ReceiveNoBuffers;
+    ULONG64 ReceiveCrcErrors;
+    ULONG64 ReceiveAlignmentErrors;
+#if DBG
+    ULONG64 TransmitTotalCollisions;
+    ULONG64 ReceiveCdtErrors;
+    ULONG64 TransmitPauseFrames;
+    ULONG64 ReceivePauseFrames;
+    ULONG64 ReceiveUnsupportedPauseFrames;
+    ULONG64 TransmitTcoFrames;
+    ULONG64 ReceiveTcoFrames;
+#endif
+} E100_STATISTICS, *PE100_STATISTICS;
+
+typedef union _E100_OFFLOAD_FLAGS
+{
+    struct
+    {
+        ULONG SendTcpChecksum:1;
+        ULONG SendUdpChecksum:1;
+        ULONG SendIpChecksum:1;
+
+        ULONG ReceiveTcpChecksum:1;
+        ULONG ReceiveUdpChecksum:1;
+        ULONG ReceiveIpChecksum:1;
+    };
+    ULONG Value;
+} E100_OFFLOAD_FLAGS, *PE100_OFFLOAD_FLAGS;
+
+typedef struct _E100_ADAPTER
+{
+    /* Frequently used read-mostly cacheline */
+    PUCHAR IoBase;
+    ULONG Flags;
+    BOOLEAN AdapterActive;
+    BOOLEAN CommandUnitActive;
+    BOOLEAN HardError;
+    UCHAR CurrentMedia;
+    USHORT TransmitCommand;
+    UCHAR TransmitThreshold;
+    UCHAR DefaultMedia;
+    E100_OFFLOAD_FLAGS Offload;
+    ULONG MaxTbdCount;
+    ULONG VlanId;
+    UCHAR PhyType;
+    UCHAR RevisionID;
+
+    DECLSPEC_CACHEALIGN NDIS_SPIN_LOCK SendLock;
+    PE100_TX_CONTEXT TxFirst;
+    PE100_TX_CONTEXT TxLast;
+    LIST_ENTRY SendQueueList;
+    ULONG TxPending;
+    ULONG TcbCount;
+    LONG TxTimeOut;
+
+    DECLSPEC_CACHEALIGN NDIS_SPIN_LOCK ReceiveLock;
+    LIST_ENTRY RxContextList;
+    PE100_RX_CONTEXT RxContext;
+    ULONG RxPending;
+
+    UCHAR InterruptStatus;
+    UCHAR ReceiverUnitIdleTicks;
+    UCHAR MediaTick;
+    E100_STATISTICS Statistics;
+    NDIS_MINIPORT_INTERRUPT Interrupt;
+    PE100_CONTROL_BLOCK ControlBlock;
+    ULONG ControlBlockPa;
+    ULONG PacketFilter;
+    ULONG RfdSize;
+    PE100_TX_CONTEXT TxContext;
+    PFXP_CB_TRANSMIT HeadTcb;
+    PVOID TcbOriginalVa;
+    ULONG TcbOriginalPhys;
+    ULONG HeadTcbPa;
+    ULONG PhyCapabilities;
+    ULONG PhyAddress;
+    ULONG RfdCount;
+    ULONG RfdToAllocate;
+    ULONG MicrocodeInterruptDelay;
+    ULONG MicrocodeMaxFramesPerIntr;
+    ULONG MicrocodeMinSizeMask;
+    USHORT DeviceID;
+    UCHAR PermanentMacAddress[ETH_LENGTH_OF_ADDRESS];
+    UCHAR CurrentMacAddress[ETH_LENGTH_OF_ADDRESS];
+    ULONG MulticastListSize;
+    struct
+    {
+        UCHAR MacAddress[ETH_LENGTH_OF_ADDRESS];
+    } MulticastList[E100_MULTICAST_LIST_SIZE];
+    ULONG WakeUpFlags;
+    ULONG FlexibleFiltersUsed;
+    LIST_ENTRY WakeUpFrameList;
+    NDIS_DEVICE_POWER_STATE PowerState;
+    NDIS_DEVICE_POWER_STATE PrevPowerState;
+    SINGLE_LIST_ENTRY SendBufferList;
+    SCATTER_GATHER_LIST LocalSgList;
+    E100_COALESCE_BUFFER CoalesceBuffer[E100_TRANSMIT_BUFFERS];
+    ULONG EepromAddressBusWidth;
+    NDIS_WORK_ITEM PowerWorkItem;
+    NDIS_WORK_ITEM ResetWorkItem;
+    _Interlocked_ volatile LONG ResetLock;
+    ULONG InterruptVector;
+    ULONG InterruptLevel;
+    ULONG InterruptFlags;
+    ULONG ControlBlockOriginalPhys;
+    PVOID ControlBlockOriginal;
+    NDIS_HANDLE BufferPool;
+    NDIS_HANDLE PacketPool;
+    NDIS_HANDLE AdapterHandle;
+    NDIS_HANDLE WrapperConfigurationHandle;
+    PVOID AdapterOriginal;
+    ULONG AdapterSize;
+} E100_ADAPTER, *PE100_ADAPTER;
+
+typedef struct _E100_UCODE_INFO
+{
+    const ULONG* Microcode;
+    ULONG Length;
+    USHORT RevisionID;
+    USHORT IntDelayOffset;
+    USHORT BundleMaxOffset;
+    USHORT MinSizeMaskOffset;
+} E100_UCODE_INFO, *PE100_UCODE_INFO;
+
+CODE_SEG("INIT")
+DRIVER_INITIALIZE DriverEntry;
+
+CODE_SEG("PAGE")
+NDIS_STATUS
+NTAPI
+MiniportInitialize(
+    _Out_ PNDIS_STATUS OpenErrorStatus,
+    _Out_ PUINT SelectedMediumIndex,
+    _In_ PNDIS_MEDIUM MediumArray,
+    _In_ UINT MediumArraySize,
+    _In_ NDIS_HANDLE MiniportAdapterHandle,
+    _In_ NDIS_HANDLE WrapperConfigurationContext);
+
+BOOLEAN
+NTAPI
+MiniportCheckForHang(
+    _In_ NDIS_HANDLE MiniportAdapterContext);
+
+VOID
+NTAPI
+MiniportSendPackets(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ PPNDIS_PACKET PacketArray,
+    _In_ UINT NumberOfPackets);
+
+VOID
+NTAPI
+MiniportCancelSendPackets(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ PVOID CancelId);
+
+VOID
+NTAPI
+MiniportReturnPacket(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ PNDIS_PACKET Packet);
+
+NDIS_STATUS
+NTAPI
+MiniportQueryInformation(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ NDIS_OID Oid,
+    _In_ PVOID InformationBuffer,
+    _In_ ULONG InformationBufferLength,
+    _Out_ PULONG BytesWritten,
+    _Out_ PULONG BytesNeeded);
+
+NDIS_STATUS
+NTAPI
+MiniportSetInformation(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ NDIS_OID Oid,
+    _In_ PVOID InformationBuffer,
+    _In_ ULONG InformationBufferLength,
+    _Out_ PULONG BytesRead,
+    _Out_ PULONG BytesNeeded);
+
+VOID
+NTAPI
+MiniportIsr(
+    _Out_ PBOOLEAN InterruptRecognized,
+    _Out_ PBOOLEAN QueueMiniportHandleInterrupt,
+    _In_ NDIS_HANDLE MiniportAdapterContext);
+
+VOID
+NTAPI
+MiniportHandleInterrupt(
+    _In_ NDIS_HANDLE MiniportAdapterContext);
+
+CODE_SEG("PAGE")
+VOID
+EeFreeAdapter(
+    _In_ __drv_freesMem(Mem) PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+VOID
+EeInitTxRing(
+    _In_ PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+BOOLEAN
+EeReadEeprom(
+    _In_ PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeFindMiiPhy(
+    _In_ PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+VOID
+EePhyInit(
+    _In_ PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+VOID
+EePhyPowerSaveDowngradeLinkSpeed(
+    _In_ PE100_ADAPTER Adapter);
+
+VOID
+EePhySetPower(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ BOOLEAN PowerUp);
+
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeSetupAdapter(
+    _In_ PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+VOID
+EeStartAdapter(
+    _In_ PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+VOID
+NTAPI
+EeResetWorker(
+    _In_ PNDIS_WORK_ITEM WorkItem,
+    _In_opt_ PVOID Context);
+
+CODE_SEG("PAGE")
+VOID
+EeStopAdapter(
+    _In_ PE100_ADAPTER Adapter);
+
+DECLSPEC_NOINLINE_FROM_PAGED
+VOID
+EeFlushTransmitQueue(
+    _In_ PE100_ADAPTER Adapter);
+
+CODE_SEG("PAGE")
+VOID
+NTAPI
+EePowerWorker(
+    _In_ PNDIS_WORK_ITEM WorkItem,
+    _In_opt_ PVOID Context);
+
+NDIS_STATUS
+EeRemoveWakeUpPattern(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PNDIS_PM_PACKET_PATTERN PmPattern);
+
+NDIS_STATUS
+EeAddWakeUpPattern(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PNDIS_PM_PACKET_PATTERN PmPattern);
+
+NDIS_STATUS
+EeGetPowerManagementCapabilities(
+    _In_ PE100_ADAPTER Adapter,
+    _Out_ PNDIS_PNP_CAPABILITIES Capabilities);
+
+VOID
+EeSoftReset(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ BOOLEAN FullReset);
+
+VOID
+EeEnableRxChecksumOffload82559(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ BOOLEAN Enable);
+
+VOID
+EeUpdateMulticastList(
+    _In_ PE100_ADAPTER Adapter);
+
+DECLSPEC_NOINLINE_FROM_PAGED
+VOID
+EeApplyPacketFilter(
+    _In_ PE100_ADAPTER Adapter);
+
+UCHAR
+EePhyGetSpeedAndDuplex(
+    _In_ PE100_ADAPTER Adapter);
+
+VOID
+EeCommandUnitExecuteCommand(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ UCHAR Command);
+
+VOID
+EeCommandUnitExecuteCommandAddr(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ UCHAR Command,
+    _In_ ULONG PhysicalAddress);
+
+BOOLEAN
+EeCommandUnitSendCommand(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ USHORT Command,
+    _In_ PFXP_CB_HEADER Header);
+
+VOID
+EeSendPackets(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PPNDIS_PACKET PacketArray,
+    _In_ UINT NumberOfPackets);
+
+FORCEINLINE
+VOID
+E100_RELEASE_TX_CONTEXT(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PE100_TX_CONTEXT TxContext,
+    _In_ PFXP_CB_TRANSMIT Tcb)
+{
+    PE100_COALESCE_BUFFER CoalesceBuffer;
+
+    /* Reset the IPCB checksum offload bits (IpScheduleLow, IpSchedule, IpActivationHigh) */
+    Tcb->Tbd[0].Address = 0;
+
+    CoalesceBuffer = TxContext->Buffer;
+    if (CoalesceBuffer)
+    {
+        TxContext->Buffer = NULL;
+        PushEntryList(&Adapter->SendBufferList, &CoalesceBuffer->ListEntry);
+    }
+
+    ASSERT(Adapter->TxPending > 0);
+    --Adapter->TxPending;
+}
+
+FORCEINLINE
+UCHAR
+CSR_READ_8(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG Register)
+{
+    UCHAR Value;
+
+    NdisReadRegisterUchar((PUCHAR)(Adapter->IoBase + Register), &Value);
+    return Value;
+}
+
+FORCEINLINE
+USHORT
+CSR_READ_16(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG Register)
+{
+    USHORT Value;
+
+    NdisReadRegisterUlong((PUSHORT)(Adapter->IoBase + Register), &Value);
+    return Value;
+}
+
+FORCEINLINE
+ULONG
+CSR_READ_32(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG Register)
+{
+    ULONG Value;
+
+    NdisReadRegisterUlong((PULONG)(Adapter->IoBase + Register), &Value);
+    return Value;
+}
+
+#define CSR_WRITE_8(Adapter, Register, Value)  \
+    NdisWriteRegisterUchar((PUCHAR)((Adapter)->IoBase + (Register)), (Value));
+
+#define CSR_WRITE_16(Adapter, Register, Value)  \
+    NdisWriteRegisterUshort((PUSHORT)((Adapter)->IoBase + (Register)), (Value));
+
+#define CSR_WRITE_32(Adapter, Register, Value)  \
+    NdisWriteRegisterUlong((PULONG)((Adapter)->IoBase + (Register)), (Value));

--- a/drivers/network/dd/e100/e100.rc
+++ b/drivers/network/dd/e100/e100.rc
@@ -1,0 +1,5 @@
+#define REACTOS_VERSION_DLL
+#define REACTOS_STR_FILE_DESCRIPTION  "Intel PRO/100 Ethernet Controller Driver"
+#define REACTOS_STR_INTERNAL_NAME     "e100"
+#define REACTOS_STR_ORIGINAL_FILENAME "e100.sys"
+#include <reactos/version.rc>

--- a/drivers/network/dd/e100/e100hw.h
+++ b/drivers/network/dd/e100/e100hw.h
@@ -1,0 +1,806 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Hardware specific definitions
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/*
+ * Hardware definitions were taken from the FreeBSD fxp driver.
+ * Copyright (c) 1995, David Greenman
+ * Copyright (c) 2001 Jonathan Lemon <jlemon@freebsd.org>
+ */
+
+#pragma once
+
+/*
+ * PCI Vendor and Device IDs
+ */
+#define PCI_VEN_INTEL        0x8086
+
+#define PCI_DEV_8255x        0x1229
+#define PCI_DEV_82559ER      0x1209
+#define PCI_DEV_82559_CB     0x1029
+#define PCI_DEV_82559        0x1030
+#define PCI_DEV_82551QM      0x1059
+
+#define PCI_DEV_ICH2         0x2449
+
+#define PCI_DEV_ICH3_1       0x1031
+#define PCI_DEV_ICH3_2       0x1032
+#define PCI_DEV_ICH3_3       0x1033
+#define PCI_DEV_ICH3_4       0x1034
+#define PCI_DEV_ICH3_5       0x1035
+#define PCI_DEV_ICH3_6       0x1036
+#define PCI_DEV_ICH3_7       0x1037
+#define PCI_DEV_ICH3_8       0x1038
+
+#define PCI_DEV_ICH4_1       0x1039
+#define PCI_DEV_ICH4_2       0x103A
+#define PCI_DEV_ICH4_3       0x103B
+#define PCI_DEV_ICH4_4       0x103C
+#define PCI_DEV_ICH4_5       0x103D
+#define PCI_DEV_ICH4_6       0x103E
+
+#define PCI_DEV_ICH5_1       0x1050
+#define PCI_DEV_ICH5_2       0x1051
+#define PCI_DEV_ICH5_3       0x1052
+#define PCI_DEV_ICH5_4       0x1053
+#define PCI_DEV_ICH5_5       0x1054
+#define PCI_DEV_ICH5_6       0x1055
+#define PCI_DEV_ICH5_7       0x1056
+#define PCI_DEV_ICH5_8       0x1057
+
+#define PCI_DEV_C_ICH_1      0x2459
+#define PCI_DEV_C_ICH_2      0x245D
+
+#define PCI_DEV_ICH6_1       0x1064
+#define PCI_DEV_ICH6_2       0x1065
+#define PCI_DEV_ICH6_3       0x1066
+#define PCI_DEV_ICH6_4       0x1067
+#define PCI_DEV_ICH6_5       0x1068
+#define PCI_DEV_ICH6_6       0x1069
+#define PCI_DEV_ICH6_7       0x106A
+#define PCI_DEV_ICH6_8       0x106B
+#define PCI_DEV_ICH6_9       0x266C
+
+#define PCI_DEV_ICH7_1       0x1091
+#define PCI_DEV_ICH7_2       0x1092
+#define PCI_DEV_ICH7_3       0x1093
+#define PCI_DEV_ICH7_4       0x1094
+#define PCI_DEV_ICH7_5       0x1095
+#define PCI_DEV_ICH7_6       0x27DC
+#define PCI_DEV_82552        0x10FE
+
+#define FXP_PCI_IO_BAR_LENGTH     0x20
+#define FXP_PCI_MMIO_BAR_LENGTH   0x1000
+
+#define FXP_WOL_PATTERN_FILTERS   16
+#define FXP_WOL_FILTER_MASKS      4
+
+/*
+ * Chip revision values
+ */
+#define FXP_REV_82557        1  // Catch all 82557 chip type
+#define FXP_REV_82558_A4     4  // 82558 A4 stepping
+#define FXP_REV_82558_B0     5  // 82558 B0 stepping
+#define FXP_REV_82559_A0     8  // 82559 A0 stepping
+#define FXP_REV_82559S_A     9  // 82559S A stepping
+#define FXP_REV_82550        12
+#define FXP_REV_82550_C      13 // 82550 C stepping
+#define FXP_REV_82551_E      14 // 82551
+#define FXP_REV_82551_F      15 // 82551
+#define FXP_REV_82551_10     16 // 82551
+
+/*
+ * Control/status registers
+ */
+#define FXP_CSR_SCB_RUSCUS      0x00 // SCB Status (1 byte)
+#define FXP_CSR_SCB_STATACK     0x01 // SCB STAT/ACK (1 byte)
+#define FXP_CSR_SCB_COMMAND     0x02 // SCB Command (1 byte)
+#define FXP_CSR_SCB_INTRCNTL    0x03 // SCB Interrupt Control (1 byte)
+#define FXP_CSR_SCB_GENERAL     0x04 // SCB General Pointer (4 bytes)
+#define FXP_CSR_PORT            0x08 // PORT Interface (4 bytes)
+#define FXP_CSR_FLASHCONTROL    0x0C // FLASH Control (2 bytes)
+#define FXP_CSR_EEPROMCONTROL   0x0E // EEPROM Control (2 bytes)
+#define FXP_CSR_MDICONTROL      0x10 // MDI Сontrol (4 bytes)
+#define FXP_CSR_FC_THRESH       0x19 // Flow Сontrol Threshold (1 byte)
+#define FXP_CSR_FC_STATUS       0x1A // Flow Сontrol Status (1 byte)
+#define FXP_CSR_PMDR            0x1B // Power management driver (1 byte)
+#define FXP_CSR_GENCONTROL      0x1C // General control (1 byte)
+#define FXP_CSR_GENSTATUS       0x1D // General status (1 byte)
+
+/*
+ * SCB Status Byte
+ * FXP_CSR_SCB_RUSCUS
+ */
+#define FXP_SCB_RUS_IDLE             0
+#define FXP_SCB_RUS_SUSPENDED        1
+#define FXP_SCB_RUS_NORESOURCES      2
+#define FXP_SCB_RUS_READY            4
+#define FXP_SCB_RUS_SUSP_NORBDS      9
+#define FXP_SCB_RUS_NORES_NORBDS     10
+#define FXP_SCB_RUS_READY_NORBDS     12
+
+#define FXP_SCB_CUS_IDLE             0
+#define FXP_SCB_CUS_SUSPENDED        1
+#define FXP_SCB_CUS_ACTIVE           2
+
+#define FXP_SCB_RUS(Value)  (((Value) >> 2) & 0x0F)
+#define FXP_SCB_CUS(Value)  (((Value) >> 6) & 0x03)
+
+/*
+ * SCB STAT/ACK Byte
+ * FXP_CSR_SCB_STATACK
+ */
+#define FXP_SCB_STATACK_FCP     0x01
+#define FXP_SCB_STATACK_ER      0x02
+#define FXP_SCB_STATACK_SWI     0x04
+#define FXP_SCB_STATACK_MDI     0x08
+#define FXP_SCB_STATACK_RNR     0x10
+#define FXP_SCB_STATACK_CNA     0x20
+#define FXP_SCB_STATACK_FR      0x40
+#define FXP_SCB_STATACK_CXTNO   0x80
+
+/*
+ * SCB Command Byte
+ * FXP_CSR_SCB_COMMAND
+ */
+#define FXP_SCB_COMMAND_RU_NOP          0x00
+#define FXP_SCB_COMMAND_RU_START        0x01
+#define FXP_SCB_COMMAND_RU_RESUME       0x02
+#define FXP_SCB_COMMAND_RU_ABORT        0x04
+#define FXP_SCB_COMMAND_RU_LOADHDS      0x05
+#define FXP_SCB_COMMAND_RU_BASE         0x06
+#define FXP_SCB_COMMAND_RU_RBDRESUME    0x07
+
+#define FXP_SCB_COMMAND_CU_NOP          0x00
+#define FXP_SCB_COMMAND_CU_START        0x10
+#define FXP_SCB_COMMAND_CU_RESUME       0x20
+#define FXP_SCB_COMMAND_CU_DUMP_ADR     0x40
+#define FXP_SCB_COMMAND_CU_DUMP         0x50
+#define FXP_SCB_COMMAND_CU_BASE         0x60
+#define FXP_SCB_COMMAND_CU_DUMPRESET    0x70
+
+/*
+ * SCB Interrupt Control Byte
+ * FXP_CSR_SCB_INTRCNTL
+ */
+#define FXP_SCB_INTR_DISABLE    0x01
+#define FXP_SCB_INTR_SWI        0x02
+#define FXP_SCB_INTMASK_FCP     0x04
+#define FXP_SCB_INTMASK_ER      0x08
+#define FXP_SCB_INTMASK_RNR     0x10
+#define FXP_SCB_INTMASK_CNA     0x20
+#define FXP_SCB_INTMASK_FR      0x40
+#define FXP_SCB_INTMASK_CXTNO   0x80
+
+/*
+ * Port Interface
+ * FXP_CSR_PORT
+ */
+#define FXP_PORT_SOFTWARE_RESET    0
+#define FXP_PORT_SELFTEST          1
+#define FXP_PORT_SELECTIVE_RESET   2
+#define FXP_PORT_DUMP              3
+
+/*
+ * EEPROM Control Register
+ * FXP_CSR_EEPROMCONTROL
+ */
+#define FXP_EEPROM_EESK        0x01
+#define FXP_EEPROM_EECS        0x02
+#define FXP_EEPROM_EEDI        0x04
+#define FXP_EEPROM_EEDO        0x08
+
+#define FXP_EEPROM_EEDI_SHIFT  2
+#define FXP_EEPROM_EEDO_SHIFT  3
+
+#define FXP_EEPROM_OPC_ERASE   0x4
+#define FXP_EEPROM_OPC_WRITE   0x5
+#define FXP_EEPROM_OPC_READ    0x6
+
+#define FXP_EEPROM_OPC_LENGTH  3
+
+/*
+ * MDI Control Register
+ * FXP_CSR_MDICONTROL
+ */
+#define FXP_MDI_DATA_MASK        0x0000FFFF
+#define FXP_MDI_READY            0x10000000
+#define FXP_MDI_IE               0x20000000
+
+#define FXP_MDI_REG_ADDR_SHIFT   16
+#define FXP_MDI_PHY_ADDR_SHIFT   21
+#define FXP_MDI_OPCODE_SHIFT     26
+
+#define FXP_MDIO_WRITE       0x01
+#define FXP_MDIO_READ        0x02
+
+#define FXP_MIIPHY_DELAYMAX   20000
+#define FXP_MIIPHY_DELAY      10
+
+/*
+ * General Status Register
+ * FXP_CSR_GENSTATUS
+ */
+#define FXP_GENSTATUS_LINK_UP    0x01
+#define FXP_GENSTATUS_LINK_100   0x02
+#define FXP_GENSTATUS_LINK_FDX   0x04
+
+/*
+ * EEPROM map
+ */
+#define FXP_EEPROM_MAP_IA0       0x00 // Station address
+#define FXP_EEPROM_MAP_IA1       0x01
+#define FXP_EEPROM_MAP_IA2       0x02
+#define FXP_EEPROM_MAP_COMPAT    0x03 // Compatibility
+#define FXP_EEPROM_MAP_CNTR      0x05 // Controller/connector type
+#define FXP_EEPROM_MAP_PRI_PHY   0x06 // Primary PHY record
+#define FXP_EEPROM_MAP_SEC_PHY   0x07 // Secondary PHY record
+#define FXP_EEPROM_MAP_PWA0      0x08 // Printed wire assembly num.
+#define FXP_EEPROM_MAP_PWA1      0x09 // Printed wire assembly num.
+#define FXP_EEPROM_MAP_ID        0x0A // EEPROM ID
+#define FXP_EEPROM_MAP_SUBSYS    0x0B // Subsystem ID
+#define FXP_EEPROM_MAP_SUBVEN    0x0C // Subsystem vendor ID
+#define FXP_EEPROM_MAP_CKSUM64   0x3F // 64-word EEPROM checksum
+#define FXP_EEPROM_MAP_CKSUM256  0xFF // 256-word EEPROM checksum
+
+#define FXP_EEPROM_MAX_WORDS  256
+
+/*
+ * PHY device types
+ */
+#define FXP_PHY_DEVICE_MASK   0x3F00
+#define FXP_PHY_SERIAL_ONLY   0x8000
+#define FXP_PHY_NONE          0
+#define FXP_PHY_82553A        1
+#define FXP_PHY_82553C        2
+#define FXP_PHY_82503         3
+#define FXP_PHY_DP83840       4
+#define FXP_PHY_80C240        5
+#define FXP_PHY_80C24         6
+#define FXP_PHY_82555         7
+#define FXP_PHY_DP83840A      10
+#define FXP_PHY_82555B        11
+
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define htole16(x)   (x)
+#define htobe16(x)   _byteswap_ushort(x)
+#define htole32(x)   (x)
+#define letoh16(x)   (x)
+#define betoh16(x)   _byteswap_ushort(x)
+#define letoh32(x)   (x)
+
+#define FXP_BITFIELD2(a, b)                     a, b
+#define FXP_BITFIELD3(a, b, c)                  a, b, c
+#define FXP_BITFIELD4(a, b, c, d)               a, b, c, d
+#define FXP_BITFIELD5(a, b, c, d, e)            a, b, c, d, e
+#define FXP_BITFIELD6(a, b, c, d, e, f)         a, b, c, d, e, f
+#define FXP_BITFIELD7(a, b, c, d, e, f, g)      a, b, c, d, e, f, g
+#define FXP_BITFIELD8(a, b, c, d, e, f, g, h)   a, b, c, d, e, f, g, h
+#else
+#define htole16(x)   _byteswap_ushort(x)
+#define htobe16(x)   (x)
+#define htole32(x)   _byteswap_ulong(x)
+#define letoh16(x)   _byteswap_ushort(x)
+#define betoh16(x)   (x)
+#define letoh32(x)   _byteswap_ulong(x)
+
+#define FXP_BITFIELD2(a, b)                     b, a
+#define FXP_BITFIELD3(a, b, c)                  c, b, a
+#define FXP_BITFIELD4(a, b, c, d)               d, c, b, a
+#define FXP_BITFIELD5(a, b, c, d, e)            e, d, c, b, a
+#define FXP_BITFIELD6(a, b, c, d, e, f)         f, e, d, c, b, a
+#define FXP_BITFIELD7(a, b, c, d, e, f, g)      g, f, e, d, c, b, a
+#define FXP_BITFIELD8(a, b, c, d, e, f, g, h)   h, g, f, e, d, c, b, a
+#endif
+
+#define ntohs(x)     betoh16(x)
+#define htons(x)     htobe16(x)
+
+/* Write to unaligned memory */
+FORCEINLINE
+VOID
+le32enc(
+    _Out_ PULONG Data,
+    _In_ ULONG Value)
+{
+#if defined(_M_IX86) || defined(_M_AMD64)
+    *Data = Value;
+#else
+    PUCHAR P = (PUCHAR)Data;
+
+    P[0] = (UCHAR)(Value >> 0);
+    P[1] = (UCHAR)(Value >> 8);
+    P[2] = (UCHAR)(Value >> 16);
+    P[3] = (UCHAR)(Value >> 24);
+#endif
+}
+
+/* Read from unaligned memory */
+FORCEINLINE
+USHORT
+be16dec(
+    _In_ const VOID* Data)
+{
+    const UCHAR* P = Data;
+
+    return ((P[0] << 8) | P[1]);
+}
+
+/*
+ * Command Block Header
+ */
+typedef struct _FXP_CB_HEADER
+{
+    USHORT Status;
+#define FXP_CB_STATUS_OK          0x2000
+#define FXP_CB_STATUS_C           0x8000
+
+#define FXP_RFD_STATUS_RCOL       0x0001 // Receive collision
+#define FXP_RFD_STATUS_IAMATCH    0x0002 // 0 = matches station address
+#define FXP_RFD_STATUS_NOAMATCH   0x0004 // 1 = does not match anything
+#define FXP_RFD_STATUS_PARSE_OK   0x0008 // Packet parse ok (82550/1 only)
+#define FXP_RFD_STATUS_S4         0x0010 // Receive error from PHY
+#define FXP_RFD_STATUS_TL         0x0020 // Type/length
+#define FXP_RFD_STATUS_FTS        0x0080 // Frame too short
+#define FXP_RFD_STATUS_OVERRUN    0x0100 // DMA overrun
+#define FXP_RFD_STATUS_RNR        0x0200 // No resources
+#define FXP_RFD_STATUS_ALIGN      0x0400 // Alignment error
+#define FXP_RFD_STATUS_CRC        0x0800 // CRC error
+#define FXP_RFD_STATUS_VLAN       0x1000 // VLAN tagged frame
+#define FXP_RFD_STATUS_OK         0x2000 // Packet received okay
+#define FXP_RFD_STATUS_C          0x8000 // Packet reception complete
+
+    USHORT Command;
+#define FXP_CB_COMMAND_NOP        0x0
+#define FXP_CB_COMMAND_IAS        0x1
+#define FXP_CB_COMMAND_CONFIG     0x2
+#define FXP_CB_COMMAND_MCAS       0x3
+#define FXP_CB_COMMAND_XMIT       0x4
+#define FXP_CB_COMMAND_UCODE      0x5
+#define FXP_CB_COMMAND_DUMP       0x6
+#define FXP_CB_COMMAND_DIAG       0x7
+#define FXP_CB_COMMAND_LOADFILT   0x8
+#define FXP_CB_COMMAND_IPCBXMIT   0x9
+
+#define FXP_CB_COMMAND_SF         0x0008 // Simple/flexible mode
+#define FXP_CB_COMMAND_I          0x2000 // Generate interrupt on completion
+#define FXP_CB_COMMAND_S          0x4000 // Suspend on completion
+#define FXP_CB_COMMAND_EL         0x8000 // End of list
+
+#define FXP_RFD_CONTROL_SF        0x0008 // Simple/flexible memory mode
+#define FXP_RFD_CONTROL_H         0x0010 // Header RFD
+#define FXP_RFD_CONTROL_S         0x4000 // Suspend after reception
+#define FXP_RFD_CONTROL_EL        0x8000 // End of list
+
+    ULONG LinkAddress;
+} FXP_CB_HEADER, *PFXP_CB_HEADER;
+
+C_ASSERT(sizeof(FXP_CB_HEADER) == 8);
+
+/*
+ * NOP Command
+ * FXP_CB_COMMAND_NOP
+ */
+typedef struct _FXP_CB_NOP
+{
+    FXP_CB_HEADER Header;
+} FXP_CB_NOP, *PFXP_CB_NOP;
+
+C_ASSERT(sizeof(FXP_CB_NOP) == 8);
+
+/*
+ * Individual Address Setup Command
+ * FXP_CB_COMMAND_IAS
+ */
+typedef struct _FXP_CB_INDIVIDUAL_ADDRESS_SETUP
+{
+    FXP_CB_HEADER Header;
+    UCHAR MacAddress[ETH_LENGTH_OF_ADDRESS];
+} FXP_CB_INDIVIDUAL_ADDRESS_SETUP, *PFXP_CB_INDIVIDUAL_ADDRESS_SETUP;
+
+/*
+ * Configure Command
+ * FXP_CB_COMMAND_CONFIG
+ */
+typedef struct _FXP_CB_CONFIGURE
+{
+    FXP_CB_HEADER Header;
+    // 0
+    UCHAR FXP_BITFIELD2(ByteCount:6,
+                        :2);
+    // 1
+    UCHAR FXP_BITFIELD3(RxFifoLimit:4,
+                        TxFifoLimit:3,
+                        :1);
+    // 2
+    UCHAR AdaptiveInterframeSpacing;
+    // 3
+    UCHAR FXP_BITFIELD5(MwiEnable:1,
+                        TypeEnable:1,
+                        ReadAlignEnable:1,
+                        TermWriteOnCl:1,
+                        :4);
+    // 4
+    UCHAR FXP_BITFIELD2(RxDmaMaxByteCount:7,
+                        :1);
+    // 5
+    UCHAR FXP_BITFIELD2(TxDmaMaxByteCount:7,
+                        Dmbc:1);
+    // 6
+    UCHAR FXP_BITFIELD8(LateScb:1,
+                        DirectDmaDisable:1,
+                        TnoInterruptOrTcoStat:1,
+                        CiInterrupt:1,
+                        ExtTxCbDisable:1,
+                        ExtStatsDisable:1,
+                        PassOverrunRx:1,
+                        SaveBadFrames:1);
+    // 7
+    UCHAR FXP_BITFIELD6(DiscardShortReceive:1,
+                        UnderunRetries:2,
+                        :2,
+                        ExtRfa:1,
+                        TwoFramesInFifo:1,
+                        DynamicTbd:1);
+    // 8
+    UCHAR FXP_BITFIELD3(MiiMode:1,
+                        :6,
+                        CsmaDisable:1);
+    // 9
+    UCHAR FXP_BITFIELD6(TcpUdpChecksum:1,
+                        :3,
+                        VlanTco:1,
+                        LinkStatusChangeWakeEnable:1,
+                        ArpWakeEnable:1,
+                        MulticastMatchWakeEnable:1);
+    // 10
+    UCHAR FXP_BITFIELD6(:1,
+                        Byte10_1:1,
+                        Byte10_2:1,
+                        Nsai:1,
+                        PreambleLength:2,
+                        Loopback:2);
+    // 11
+    UCHAR FXP_BITFIELD2(LinearPriority:3,
+                        :5);
+    // 12
+    UCHAR FXP_BITFIELD3(LinearPriorityMode:1,
+                        :3,
+                        InterframeSpacing:4);
+    // 13
+    UCHAR IpAddressLow;
+    // 14
+    UCHAR IpAddressHigh;
+    // 15
+    UCHAR FXP_BITFIELD8(PromiscuousMode:1,
+                        BroadcastDisable:1,
+                        WaitAfterWin:1,
+                        Byte15_3:1,
+                        IgnoreUl:1,
+                        SelectCrc16:1,
+                        Byte15_6:1,
+                        CrsCdt:1);
+    // 16
+    UCHAR FcDelayLsb;
+    // 17
+    UCHAR FcDelayMsb;
+    // 18
+    UCHAR FXP_BITFIELD6(StrippingEnable:1,
+                        PaddingEnable:1,
+                        RxCrcTransfer:1,
+                        LongRxOk:1,
+                        PriorityFcThreshold:3,
+                        Byte18_7:1);
+    // 19
+    UCHAR FXP_BITFIELD8(IaMatchWakeEnable:1,
+                        MagicPacketWakeDisable:1,
+                        TxFullDuplexFlowControlDisable:1,
+                        RxFullDuplexRestopFlowControl:1,
+                        RxFullDuplexRestartFlowControl:1,
+                        RejectFc:1,
+                        ForceFullDuplex:1,
+                        AutomaticFullDuplex:1);
+    // 20
+    UCHAR FXP_BITFIELD8(Byte20_0:1,
+                        Byte20_1:1,
+                        Byte20_2:1,
+                        Byte20_3:1,
+                        Byte20_4:1,
+                        PriorityFcLocation:1,
+                        MultipleIa:1,
+                        :1);
+    // 21
+    UCHAR FXP_BITFIELD5(Byte21_0:1,
+                        :1,
+                        Byte21_1:1,
+                        MulticastAll:1,
+                        :4);
+    // 22
+    UCHAR FXP_BITFIELD3(GamlaRx:1,
+                        VlanTagStrippingEnable:1,
+                        :6);
+    // 23-31
+    UCHAR Reserved[9];
+} FXP_CB_CONFIGURE, *PFXP_CB_CONFIGURE;
+
+C_ASSERT(sizeof(FXP_CB_CONFIGURE) == 8 + 32);
+
+/*
+ * Multicast Setup Command
+ * FXP_CB_COMMAND_MCAS
+ */
+typedef struct _FXP_CB_MULTICAST_SETUP
+{
+    FXP_CB_HEADER Header;
+    USHORT Count;
+    UCHAR MacAddress[E100_MULTICAST_LIST_SIZE][ETH_LENGTH_OF_ADDRESS];
+} FXP_CB_MULTICAST_SETUP, *PFXP_CB_MULTICAST_SETUP;
+
+/*
+ * Load Microcode Command
+ * FXP_CB_COMMAND_UCODE
+ */
+typedef struct _FXP_CB_LOAD_MICROCODE
+{
+    FXP_CB_HEADER Header;
+    ULONG Data[192];
+} FXP_CB_LOAD_MICROCODE, *PFXP_CB_LOAD_MICROCODE;
+
+/*
+ * Load Programmable Filter Command
+ * FXP_CB_COMMAND_LOADFILT
+ */
+typedef struct _FXP_CB_LOAD_FILTER
+{
+    FXP_CB_HEADER Header;
+    ULONG Data[FXP_WOL_PATTERN_FILTERS];
+#define FXP_FILTER_MLEN_MASK     0x38000000
+#define FXP_FILTER_FIX           0x40000000
+#define FXP_FILTER_EL            0x80000000
+
+#define FXP_FILTER_MLEN_SHIFT    27
+} FXP_CB_LOAD_FILTER, *PFXP_CB_LOAD_FILTER;
+
+C_ASSERT(sizeof(FXP_CB_LOAD_FILTER) == 8 + 64);
+
+/*
+ * Transmit Buffer Descriptor
+ */
+typedef struct _FXP_TBD
+{
+    ULONG Address;
+    ULONG Size;
+#define FXP_TBD_DYNTBD_EL         0x8000 // End of list
+} FXP_TBD, *PFXP_TBD;
+
+C_ASSERT(sizeof(FXP_TBD) == 8);
+
+/*
+ * IP Command Block
+ */
+typedef struct _FXP_IPCB
+{
+    USHORT IpScheduleLow;
+    UCHAR IpSchedule;
+#define FXP_IPCB_IP_CHECKSUM_ENABLE        0x10
+#define FXP_IPCB_TCPUDP_CHECKSUM_ENABLE    0x20
+#define FXP_IPCB_TCP_PACKET                0x40
+#define FXP_IPCB_LARGESEND_ENABLE          0x80
+
+    UCHAR IpActivationHigh;
+#define FXP_IPCB_HARDWAREPARSING_ENABLE    0x01
+#define FXP_IPCB_INSERTVLAN_ENABLE         0x02
+
+    USHORT VlanId;
+    UCHAR IpHeaderOffset;
+    UCHAR TcpHeaderOffset;
+} FXP_IPCB, *PFXP_IPCB;
+
+C_ASSERT(sizeof(FXP_IPCB) == 8);
+
+/*
+ * Transmit Command
+ * FXP_CB_COMMAND_XMIT
+ * FXP_CB_COMMAND_IPCBXMIT
+ */
+typedef struct _FXP_CB_TRANSMIT
+{
+    /*
+     * Transmit Control Block (TCB)
+     */
+    FXP_CB_HEADER Header;
+    union
+    {
+        struct
+        {
+            ULONG TbdArrayAddress;
+            USHORT ByteCount;
+            UCHAR TxThreshold;
+            UCHAR TbdNumber;
+        };
+        FXP_TBD TbdTso;
+    };
+
+    /*
+     * Flexible Mode TBD array
+     */
+    union
+    {
+        /*
+         * When the Extended TxCB mode is selected,
+         * the device reads the TCB structure and two TBDs from host memory.
+         * This means that we need at least two TBD entries in the list for this mode.
+         *
+         * When we use the FXP_CB_COMMAND_IPCBXMIT command, the first TBD
+         * in the array must be sacrificed for the TCP/IP
+         * checksum offload control bits (IPCB).
+         *
+         * We add the +1 because the 82550 may read an extra TBD
+         * after the last valid TBD in Large Send mode.
+         */
+        FXP_IPCB Ipcb;
+        FXP_TBD Tbd[E100_TBD_PER_TCB + 1];
+    };
+} FXP_CB_TRANSMIT, *PFXP_CB_TRANSMIT;
+
+C_ASSERT(E100_TBD_PER_TCB >= 2);
+
+#include <pshpack1.h>
+
+/*
+ * Receive Frame Descriptor (RFD)
+ */
+typedef struct _FXP_RFD
+{
+    FXP_CB_HEADER Header;
+    ULONG RbdAddress;
+    USHORT ActualSize;
+#define FXP_RFD_FRAME_LENGTH_MASK   0x3FFF
+
+    USHORT Size;
+
+    /*
+     * The following fields are only available when using
+     * extended receive mode on an 82550/82551 chipset.
+     */
+    struct
+    {
+        USHORT VlanId;
+        UCHAR ParserStatus;
+#define FXP_RFDX_P_CSUM_PROTOCOL_MASK       0x03
+#define FXP_RFDX_P_PARSE_BIT                0x08
+
+#define FXP_RFDX_P_TCP_PACKET               0x00
+#define FXP_RFDX_P_UDP_PACKET               0x01
+#define FXP_RFDX_P_IP_PACKET                0x03
+
+        UCHAR Reserved;
+        USHORT SecurityStatus;
+        UCHAR ChecksumStatus;
+#define FXP_RFDX_CS_IP_CSUM_BIT_VALID       0x01
+#define FXP_RFDX_CS_IP_CSUM_VALID           0x02
+#define FXP_RFDX_CS_TCPUDP_CSUM_BIT_VALID   0x10
+#define FXP_RFDX_CS_TCPUDP_CSUM_VALID       0x20
+
+        UCHAR ZerocopyStatus;
+        UCHAR Pad[8];
+    } Ex;
+
+    /* The data portion of the received frame starts here (we use the simplified mode) */
+} FXP_RFD, *PFXP_RFD;
+
+C_ASSERT(RTL_SIZEOF_THROUGH_FIELD(FXP_RFD, Size) == 16);
+C_ASSERT(sizeof(FXP_RFD) == 32);
+
+#include <poppack.h>
+
+/*
+ * Statistical Counters
+ * FXP_SCB_COMMAND_CU_DUMP
+ * FXP_SCB_COMMAND_CU_DUMPRESET
+ */
+typedef struct _FXP_COUNTERS
+{
+    ULONG TxOk;
+    ULONG TxMaxCol;
+    ULONG TxLateCol;
+    ULONG TxUnderruns;
+    ULONG TxLossCarrier;
+    ULONG TxDeffered;
+    ULONG TxSingleCol;
+    ULONG TxMiltipleCol;
+    ULONG TxTotalCol;
+    ULONG RxOk;
+    ULONG RxCrcErr;
+    ULONG RxAlignErr;
+    ULONG RxResourceErr;
+    ULONG RxOverrunErr;
+    ULONG RxCdtErr;
+    ULONG RxShortFramesErr;
+    union
+    {
+        ULONG TxFcPause;
+        ULONG CompletionStatus557;
+    };
+    ULONG RxFcPause;
+    ULONG RxFcUnsupported;
+    union
+    {
+        struct
+        {
+            USHORT TxTco;
+            USHORT RxTco;
+        };
+        ULONG CompletionStatus558;
+    };
+    ULONG CompletionStatus559;
+} FXP_COUNTERS, *PFXP_COUNTERS;
+
+C_ASSERT(sizeof(FXP_COUNTERS) == 84);
+
+#define FXP_STATS_DUMP_COMPLETE   0xA005
+#define FXP_STATS_DR_COMPLETE     0xA007
+
+#define MII_MAX_PHY_ADDRESSES    32
+
+/*
+ * PHY register definitions (IEEE 802.3)
+ */
+#define MII_CONTROL              0x00
+#define     MII_CR_COLLISION_TEST   0x0080
+#define     MII_CR_FULL_DUPLEX      0x0100
+#define     MII_CR_AUTONEG_RESTART  0x0200
+#define     MII_CR_ISOLATE          0x0400
+#define     MII_CR_POWER_DOWN       0x0800
+#define     MII_CR_AUTONEG          0x1000
+#define     MII_CR_SPEED_SELECTION  0x2000
+#define     MII_CR_LOOPBACK         0x4000
+#define     MII_CR_RESET            0x8000
+#define MII_STATUS               0x01
+#define     MII_SR_LINK_STATUS      0x0004
+#define     MII_SR_AUTONEG_COMPLETE 0x0020
+#define MII_PHY_ID1              0x02
+#define MII_PHY_ID2              0x03
+#define MII_AUTONEG_ADVERTISE    0x04
+#define     MII_ADV_CSMA            0x0001
+#define     MII_ADV_10T_HD          0x0020
+#define     MII_ADV_10T_FD          0x0040
+#define     MII_ADV_100T_HD         0x0080
+#define     MII_ADV_100T_FD         0x0100
+#define     MII_ADV_100T4           0x0200
+#define     MII_ADV_PAUSE_SYM       0x0400
+#define     MII_ADV_PAUSE_ASYM      0x0800
+#define MII_AUTONEG_LINK_PARTNER 0x05
+#define     MII_LP_10T_HD           0x0020
+#define     MII_LP_10T_FD           0x0040
+#define     MII_LP_100T_HD          0x0080
+#define     MII_LP_100T_FD          0x0100
+#define     MII_LP_100T4            0x0200
+#define     MII_LP_PAUSE_SYM        0x0400
+#define     MII_LP_PAUSE_ASYM       0x0800
+#define MII_AUTONEG_EXPANSION    0x06
+#define     MII_EXP_LP_AUTONEG      0x0001
+#define MII_MASTER_SLAVE_CONTROL 0x09
+#define     MII_MS_CR_1000T_HD      0x0100
+#define     MII_MS_CR_1000T_FD      0x0200
+#define MII_MASTER_SLAVE_STATUS  0x0A
+#define     MII_MS_SR_1000T_FD      0x0800
+
+/*
+ * National Semiconductor DP83840 MII PHY definitions
+ */
+#define PHY_DP_REG_PCS  0x17
+
+#define PHY_DP_PCS_LED4_MODE     0x0002
+#define PHY_DP_PCS_F_CONNECT     0x0020
+#define PHY_DP_PCS_BIT_8         0x0100
+#define PHY_DP_PCS_BIT_10        0x0400
+
+#define PHY_DP_REG_PAR  0x19
+
+#define PHY_DP_PAR_SPEED_10      0x0040
+
+#define PHY_IS_DP83840(PhyId)    (((PhyId) & 0xFFF0FFFF) == 0x5C002000)

--- a/drivers/network/dd/e100/e100hw.h
+++ b/drivers/network/dd/e100/e100hw.h
@@ -1,0 +1,786 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Hardware specific definitions
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/*
+ * Hardware definitions were taken from the FreeBSD fxp driver.
+ * Copyright (c) 1995, David Greenman
+ * Copyright (c) 2001 Jonathan Lemon <jlemon@freebsd.org>
+ */
+
+#pragma once
+
+/*
+ * PCI Vendor and Device IDs
+ */
+#define PCI_VEN_INTEL        0x8086
+
+#define PCI_DEV_8255x        0x1229
+#define PCI_DEV_82559ER      0x1209
+#define PCI_DEV_82559_CB     0x1029
+#define PCI_DEV_82559        0x1030
+#define PCI_DEV_82551QM      0x1059
+
+#define PCI_DEV_ICH2         0x2449
+
+#define PCI_DEV_ICH3_1       0x1031
+#define PCI_DEV_ICH3_2       0x1032
+#define PCI_DEV_ICH3_3       0x1033
+#define PCI_DEV_ICH3_4       0x1034
+#define PCI_DEV_ICH3_5       0x1035
+#define PCI_DEV_ICH3_6       0x1036
+#define PCI_DEV_ICH3_7       0x1037
+#define PCI_DEV_ICH3_8       0x1038
+
+#define PCI_DEV_ICH4_1       0x1039
+#define PCI_DEV_ICH4_2       0x103A
+#define PCI_DEV_ICH4_3       0x103B
+#define PCI_DEV_ICH4_4       0x103C
+#define PCI_DEV_ICH4_5       0x103D
+#define PCI_DEV_ICH4_6       0x103E
+
+#define PCI_DEV_ICH5_1       0x1050
+#define PCI_DEV_ICH5_2       0x1051
+#define PCI_DEV_ICH5_3       0x1052
+#define PCI_DEV_ICH5_4       0x1053
+#define PCI_DEV_ICH5_5       0x1054
+#define PCI_DEV_ICH5_6       0x1055
+#define PCI_DEV_ICH5_7       0x1056
+#define PCI_DEV_ICH5_8       0x1057
+
+#define PCI_DEV_C_ICH_1      0x2459
+#define PCI_DEV_C_ICH_2      0x245D
+
+#define PCI_DEV_ICH6_1       0x1064
+#define PCI_DEV_ICH6_2       0x1065
+#define PCI_DEV_ICH6_3       0x1066
+#define PCI_DEV_ICH6_4       0x1067
+#define PCI_DEV_ICH6_5       0x1068
+#define PCI_DEV_ICH6_6       0x1069
+#define PCI_DEV_ICH6_7       0x106A
+#define PCI_DEV_ICH6_8       0x106B
+#define PCI_DEV_ICH6_9       0x266C
+
+#define PCI_DEV_ICH7_1       0x1091
+#define PCI_DEV_ICH7_2       0x1092
+#define PCI_DEV_ICH7_3       0x1093
+#define PCI_DEV_ICH7_4       0x1094
+#define PCI_DEV_ICH7_5       0x1095
+#define PCI_DEV_ICH7_6       0x27DC
+#define PCI_DEV_82552        0x10FE
+
+#define FXP_PCI_IO_BAR_LENGTH     0x20
+#define FXP_PCI_MMIO_BAR_LENGTH   0x1000
+
+/*
+ * Chip revision values
+ */
+#define FXP_REV_82557        1  // Catch all 82557 chip type
+#define FXP_REV_82558_A4     4  // 82558 A4 stepping
+#define FXP_REV_82558_B0     5  // 82558 B0 stepping
+#define FXP_REV_82559_A0     8  // 82559 A0 stepping
+#define FXP_REV_82559S_A     9  // 82559S A stepping
+#define FXP_REV_82550        12
+#define FXP_REV_82550_C      13 // 82550 C stepping
+#define FXP_REV_82551_E      14 // 82551
+#define FXP_REV_82551_F      15 // 82551
+#define FXP_REV_82551_10     16 // 82551
+
+/*
+ * Control/status registers
+ */
+#define FXP_CSR_SCB_RUSCUS      0x00 // SCB Status (1 byte)
+#define FXP_CSR_SCB_STATACK     0x01 // SCB STAT/ACK (1 byte)
+#define FXP_CSR_SCB_COMMAND     0x02 // SCB Command (1 byte)
+#define FXP_CSR_SCB_INTRCNTL    0x03 // SCB Interrupt Control (1 byte)
+#define FXP_CSR_SCB_GENERAL     0x04 // SCB General Pointer (4 bytes)
+#define FXP_CSR_PORT            0x08 // PORT Interface (4 bytes)
+#define FXP_CSR_FLASHCONTROL    0x0C // FLASH Control (2 bytes)
+#define FXP_CSR_EEPROMCONTROL   0x0E // EEPROM Control (2 bytes)
+#define FXP_CSR_MDICONTROL      0x10 // MDI Сontrol (4 bytes)
+#define FXP_CSR_FC_THRESH       0x19 // Flow Сontrol Threshold (1 byte)
+#define FXP_CSR_FC_STATUS       0x1A // Flow Сontrol Status (1 byte)
+#define FXP_CSR_PMDR            0x1B // Power management driver (1 byte)
+#define FXP_CSR_GENCONTROL      0x1C // General control (1 byte)
+#define FXP_CSR_GENSTATUS       0x1D // General status (1 byte)
+
+/*
+ * SCB Status Byte
+ * FXP_CSR_SCB_RUSCUS
+ */
+#define FXP_SCB_RUS_IDLE             0
+#define FXP_SCB_RUS_SUSPENDED        1
+#define FXP_SCB_RUS_NORESOURCES      2
+#define FXP_SCB_RUS_READY            4
+#define FXP_SCB_RUS_SUSP_NORBDS      9
+#define FXP_SCB_RUS_NORES_NORBDS     10
+#define FXP_SCB_RUS_READY_NORBDS     12
+
+#define FXP_SCB_CUS_IDLE             0
+#define FXP_SCB_CUS_SUSPENDED        1
+#define FXP_SCB_CUS_ACTIVE           2
+
+#define FXP_SCB_RUS(Value)  (((Value) >> 2) & 0x0F)
+#define FXP_SCB_CUS(Value)  (((Value) >> 6) & 0x03)
+
+/*
+ * SCB STAT/ACK Byte
+ * FXP_CSR_SCB_STATACK
+ */
+#define FXP_SCB_STATACK_FCP     0x01
+#define FXP_SCB_STATACK_ER      0x02
+#define FXP_SCB_STATACK_SWI     0x04
+#define FXP_SCB_STATACK_MDI     0x08
+#define FXP_SCB_STATACK_RNR     0x10
+#define FXP_SCB_STATACK_CNA     0x20
+#define FXP_SCB_STATACK_FR      0x40
+#define FXP_SCB_STATACK_CXTNO   0x80
+
+/*
+ * SCB Command Byte
+ * FXP_CSR_SCB_COMMAND
+ */
+#define FXP_SCB_COMMAND_RU_NOP          0x00
+#define FXP_SCB_COMMAND_RU_START        0x01
+#define FXP_SCB_COMMAND_RU_RESUME       0x02
+#define FXP_SCB_COMMAND_RU_ABORT        0x04
+#define FXP_SCB_COMMAND_RU_LOADHDS      0x05
+#define FXP_SCB_COMMAND_RU_BASE         0x06
+#define FXP_SCB_COMMAND_RU_RBDRESUME    0x07
+
+#define FXP_SCB_COMMAND_CU_NOP          0x00
+#define FXP_SCB_COMMAND_CU_START        0x10
+#define FXP_SCB_COMMAND_CU_RESUME       0x20
+#define FXP_SCB_COMMAND_CU_DUMP_ADR     0x40
+#define FXP_SCB_COMMAND_CU_DUMP         0x50
+#define FXP_SCB_COMMAND_CU_BASE         0x60
+#define FXP_SCB_COMMAND_CU_DUMPRESET    0x70
+
+/*
+ * SCB Interrupt Control Byte
+ * FXP_CSR_SCB_INTRCNTL
+ */
+#define FXP_SCB_INTR_DISABLE    0x01
+#define FXP_SCB_INTR_SWI        0x02
+#define FXP_SCB_INTMASK_FCP     0x04
+#define FXP_SCB_INTMASK_ER      0x08
+#define FXP_SCB_INTMASK_RNR     0x10
+#define FXP_SCB_INTMASK_CNA     0x20
+#define FXP_SCB_INTMASK_FR      0x40
+#define FXP_SCB_INTMASK_CXTNO   0x80
+
+/*
+ * Port Interface
+ * FXP_CSR_PORT
+ */
+#define FXP_PORT_SOFTWARE_RESET    0
+#define FXP_PORT_SELFTEST          1
+#define FXP_PORT_SELECTIVE_RESET   2
+#define FXP_PORT_DUMP              3
+
+/*
+ * EEPROM Control Register
+ * FXP_CSR_EEPROMCONTROL
+ */
+#define FXP_EEPROM_EESK        0x01
+#define FXP_EEPROM_EECS        0x02
+#define FXP_EEPROM_EEDI        0x04
+#define FXP_EEPROM_EEDO        0x08
+
+#define FXP_EEPROM_EEDI_SHIFT  2
+#define FXP_EEPROM_EEDO_SHIFT  3
+
+#define FXP_EEPROM_OPC_ERASE   0x4
+#define FXP_EEPROM_OPC_WRITE   0x5
+#define FXP_EEPROM_OPC_READ    0x6
+
+#define FXP_EEPROM_OPC_LENGTH  3
+
+/*
+ * MDI Control Register
+ * FXP_CSR_MDICONTROL
+ */
+#define FXP_MDI_DATA_MASK        0x0000FFFF
+#define FXP_MDI_READY            0x10000000
+#define FXP_MDI_IE               0x20000000
+
+#define FXP_MDI_REG_ADDR_SHIFT   16
+#define FXP_MDI_PHY_ADDR_SHIFT   21
+#define FXP_MDI_OPCODE_SHIFT     26
+
+#define FXP_MDIO_WRITE       0x01
+#define FXP_MDIO_READ        0x02
+
+#define FXP_MIIPHY_DELAYMAX   10000
+#define FXP_MIIPHY_DELAY      20
+
+/*
+ * General Status Register
+ * FXP_CSR_GENSTATUS
+ */
+#define FXP_GENSTATUS_LINK_UP    0x01
+#define FXP_GENSTATUS_LINK_100   0x02
+#define FXP_GENSTATUS_LINK_FDX   0x04
+
+/*
+ * EEPROM map
+ */
+#define FXP_EEPROM_MAP_IA0       0x00 // Station address
+#define FXP_EEPROM_MAP_IA1       0x01
+#define FXP_EEPROM_MAP_IA2       0x02
+#define FXP_EEPROM_MAP_COMPAT    0x03 // Compatibility
+#define FXP_EEPROM_MAP_CNTR      0x05 // Controller/connector type
+#define FXP_EEPROM_MAP_PRI_PHY   0x06 // Primary PHY record
+#define FXP_EEPROM_MAP_SEC_PHY   0x07 // Secondary PHY record
+#define FXP_EEPROM_MAP_PWA0      0x08 // Printed wire assembly num.
+#define FXP_EEPROM_MAP_PWA1      0x09 // Printed wire assembly num.
+#define FXP_EEPROM_MAP_ID        0x0A // EEPROM ID
+#define FXP_EEPROM_MAP_SUBSYS    0x0B // Subsystem ID
+#define FXP_EEPROM_MAP_SUBVEN    0x0C // Subsystem vendor ID
+#define FXP_EEPROM_MAP_CKSUM64   0x3F // 64-word EEPROM checksum
+#define FXP_EEPROM_MAP_CKSUM256  0xFF // 256-word EEPROM checksum
+
+#define FXP_EEPROM_MAX_WORDS  256
+
+/*
+ * PHY device types
+ */
+#define FXP_PHY_DEVICE_MASK   0x3F00
+#define FXP_PHY_SERIAL_ONLY   0x8000
+#define FXP_PHY_NONE          0
+#define FXP_PHY_82553A        1
+#define FXP_PHY_82553C        2
+#define FXP_PHY_82503         3
+#define FXP_PHY_DP83840       4
+#define FXP_PHY_80C240        5
+#define FXP_PHY_80C24         6
+#define FXP_PHY_82555         7
+#define FXP_PHY_DP83840A      10
+#define FXP_PHY_82555B        11
+
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define htole16(x)   (x)
+#define htobe16(x)   _byteswap_ushort(x)
+#define htole32(x)   (x)
+#define letoh16(x)   (x)
+#define betoh16(x)   _byteswap_ushort(x)
+#define letoh32(x)   (x)
+
+#define FXP_BITFIELD2(a, b)                     a, b
+#define FXP_BITFIELD3(a, b, c)                  a, b, c
+#define FXP_BITFIELD4(a, b, c, d)               a, b, c, d
+#define FXP_BITFIELD5(a, b, c, d, e)            a, b, c, d, e
+#define FXP_BITFIELD6(a, b, c, d, e, f)         a, b, c, d, e, f
+#define FXP_BITFIELD7(a, b, c, d, e, f, g)      a, b, c, d, e, f, g
+#define FXP_BITFIELD8(a, b, c, d, e, f, g, h)   a, b, c, d, e, f, g, h
+#else
+#define htole16(x)   _byteswap_ushort(x)
+#define htobe16(x)   (x)
+#define htole32(x)   _byteswap_ulong(x)
+#define letoh16(x)   _byteswap_ushort(x)
+#define betoh16(x)   (x)
+#define letoh32(x)   _byteswap_ulong(x)
+
+#define FXP_BITFIELD2(a, b)                     b, a
+#define FXP_BITFIELD3(a, b, c)                  c, b, a
+#define FXP_BITFIELD4(a, b, c, d)               d, c, b, a
+#define FXP_BITFIELD5(a, b, c, d, e)            e, d, c, b, a
+#define FXP_BITFIELD6(a, b, c, d, e, f)         f, e, d, c, b, a
+#define FXP_BITFIELD7(a, b, c, d, e, f, g)      g, f, e, d, c, b, a
+#define FXP_BITFIELD8(a, b, c, d, e, f, g, h)   h, g, f, e, d, c, b, a
+#endif
+
+/* Write to unaligned memory */
+FORCEINLINE
+VOID
+le32enc(
+    _Out_ PULONG Data,
+    _In_ ULONG Value)
+{
+#if defined(_M_IX86) || defined(_M_AMD64)
+    *Data = Value;
+#else
+    PUCHAR P = (PUCHAR)Data;
+
+    P[0] = (UCHAR)(Value >> 0);
+    P[1] = (UCHAR)(Value >> 8);
+    P[2] = (UCHAR)(Value >> 16);
+    P[3] = (UCHAR)(Value >> 24);
+#endif
+}
+
+FORCEINLINE
+USHORT
+FXP_IPCB_PACK_8021Q_INFO(
+    _In_ ULONG UserPriority,
+    _In_ ULONG CanonicalFormatId,
+    _In_ ULONG VlanId)
+{
+    USHORT Control;
+
+    Control = 0;
+    Control |= (VlanId & 0xFFF);
+    Control |= (CanonicalFormatId & 1) << 12;
+    Control |= (UserPriority & 7) << 13;
+
+    return htobe16(Control);
+}
+
+FORCEINLINE
+VOID
+FXP_IPCB_UNPACK_8021Q_INFO(
+    _In_ USHORT Control,
+    _Out_ PULONG UserPriority,
+    _Out_ PULONG CanonicalFormatId,
+    _Out_ PULONG VlanId)
+{
+    Control = betoh16(Control);
+
+    *VlanId = Control & 0xFFF;
+    *CanonicalFormatId = (Control >> 12) & 1;
+    *UserPriority = (Control >> 13) & 7;
+}
+
+/*
+ * Command Block Header
+ */
+typedef struct _FXP_CB_HEADER
+{
+    USHORT Status;
+#define FXP_CB_STATUS_OK          0x2000
+#define FXP_CB_STATUS_C           0x8000
+
+#define FXP_RFD_STATUS_RCOL       0x0001 // Receive collision
+#define FXP_RFD_STATUS_IAMATCH    0x0002 // 0 = matches station address
+#define FXP_RFD_STATUS_NOAMATCH   0x0004 // 1 = does not match anything
+#define FXP_RFD_STATUS_PARSE      0x0008 // Packet parse ok (82550/1 only)
+#define FXP_RFD_STATUS_S4         0x0010 // Receive error from PHY
+#define FXP_RFD_STATUS_TL         0x0020 // Type/length
+#define FXP_RFD_STATUS_FTS        0x0080 // Frame too short
+#define FXP_RFD_STATUS_OVERRUN    0x0100 // DMA overrun
+#define FXP_RFD_STATUS_RNR        0x0200 // No resources
+#define FXP_RFD_STATUS_ALIGN      0x0400 // Alignment error
+#define FXP_RFD_STATUS_CRC        0x0800 // CRC error
+#define FXP_RFD_STATUS_VLAN       0x1000 // VLAN tagged frame
+#define FXP_RFD_STATUS_OK         0x2000 // Packet received okay
+#define FXP_RFD_STATUS_C          0x8000 // Packet reception complete
+
+    USHORT Command;
+#define FXP_CB_COMMAND_NOP        0x0
+#define FXP_CB_COMMAND_IAS        0x1
+#define FXP_CB_COMMAND_CONFIG     0x2
+#define FXP_CB_COMMAND_MCAS       0x3
+#define FXP_CB_COMMAND_XMIT       0x4
+#define FXP_CB_COMMAND_UCODE      0x5
+#define FXP_CB_COMMAND_DUMP       0x6
+#define FXP_CB_COMMAND_DIAG       0x7
+#define FXP_CB_COMMAND_LOADFILT   0x8
+#define FXP_CB_COMMAND_IPCBXMIT   0x9
+
+#define FXP_CB_COMMAND_SF         0x0008 // Simple/flexible mode
+#define FXP_CB_COMMAND_I          0x2000 // Generate interrupt on completion
+#define FXP_CB_COMMAND_S          0x4000 // Suspend on completion
+#define FXP_CB_COMMAND_EL         0x8000 // End of list
+
+#define FXP_RFD_CONTROL_SF        0x0008 // Simple/flexible memory mode
+#define FXP_RFD_CONTROL_H         0x0010 // Header RFD
+#define FXP_RFD_CONTROL_S         0x4000 // Suspend after reception
+#define FXP_RFD_CONTROL_EL        0x8000 // End of list
+
+    ULONG LinkAddress;
+} FXP_CB_HEADER, *PFXP_CB_HEADER;
+
+C_ASSERT(sizeof(FXP_CB_HEADER) == 8);
+
+/*
+ * NOP Command
+ * FXP_CB_COMMAND_NOP
+ */
+typedef struct _FXP_CB_NOP
+{
+    FXP_CB_HEADER Header;
+} FXP_CB_NOP, *PFXP_CB_NOP;
+
+C_ASSERT(sizeof(FXP_CB_NOP) == 8);
+
+/*
+ * Individual Address Setup Command
+ * FXP_CB_COMMAND_IAS
+ */
+typedef struct _FXP_CB_INDIVIDUAL_ADDRESS_SETUP
+{
+    FXP_CB_HEADER Header;
+    UCHAR MacAddress[ETH_LENGTH_OF_ADDRESS];
+} FXP_CB_INDIVIDUAL_ADDRESS_SETUP, *PFXP_CB_INDIVIDUAL_ADDRESS_SETUP;
+
+/*
+ * Configure Command
+ * FXP_CB_COMMAND_CONFIG
+ */
+typedef struct _FXP_CB_CONFIGURE
+{
+    FXP_CB_HEADER Header;
+    // 0
+    UCHAR FXP_BITFIELD2(ByteCount:6,
+                        :2);
+    // 1
+    UCHAR FXP_BITFIELD3(RxFifoLimit:4,
+                        TxFifoLimit:3,
+                        :1);
+    // 2
+    UCHAR AdaptiveInterframeSpacing;
+    // 3
+    UCHAR FXP_BITFIELD5(MwiEnable:1,
+                        TypeEnable:1,
+                        ReadAlignEnable:1,
+                        TermWriteOnCl:1,
+                        :4);
+    // 4
+    UCHAR FXP_BITFIELD2(RxDmaMaxByteCount:7,
+                        :1);
+    // 5
+    UCHAR FXP_BITFIELD2(TxDmaMaxByteCount:7,
+                        Dmbc:1);
+    // 6
+    UCHAR FXP_BITFIELD8(LateScb:1,
+                        DirectDmaDisable:1,
+                        TnoInterruptOrTcoStat:1,
+                        CiInterrupt:1,
+                        ExtTxCbDisable:1,
+                        ExtStatsDisable:1,
+                        PassOverrunRx:1,
+                        SaveBadFrames:1);
+    // 7
+    UCHAR FXP_BITFIELD6(DiscardShortReceive:1,
+                        UnderunRetries:2,
+                        :2,
+                        ExtRfa:1,
+                        TwoFramesInFifo:1,
+                        DynamicTbd:1);
+    // 8
+    UCHAR FXP_BITFIELD3(MiiMode:1,
+                        :6,
+                        CsmaDisable:1);
+    // 9
+    UCHAR FXP_BITFIELD6(TcpUdpChecksum:1,
+                        :3,
+                        VlanTco:1,
+                        LinkStatusChangeWakeEnable:1,
+                        ArpWakeEnable:1,
+                        MulticastMatchWakeEnable:1);
+    // 10
+    UCHAR FXP_BITFIELD6(:1,
+                        Byte10_1:1,
+                        Byte10_2:1,
+                        Nsai:1,
+                        PreambleLength:2,
+                        Loopback:2);
+    // 11
+    UCHAR FXP_BITFIELD2(LinearPriority:3,
+                        :5);
+    // 12
+    UCHAR FXP_BITFIELD3(LinearPriorityMode:1,
+                        :3,
+                        InterframeSpacing:4);
+    // 13
+    UCHAR IpAddressLow;
+    // 14
+    UCHAR IpAddressHigh;
+    // 15
+    UCHAR FXP_BITFIELD8(PromiscuousMode:1,
+                        BroadcastDisable:1,
+                        WaitAfterWin:1,
+                        Byte15_3:1,
+                        IgnoreUl:1,
+                        SelectCrc16:1,
+                        Byte15_6:1,
+                        CrsCdt:1);
+    // 16
+    UCHAR FcDelayLsb;
+    // 17
+    UCHAR FcDelayMsb;
+    // 18
+    UCHAR FXP_BITFIELD6(StrippingEnable:1,
+                        PaddingEnable:1,
+                        RxCrcTransfer:1,
+                        LongRxOk:1,
+                        PriorityFcThreshold:3,
+                        Byte18_7:1);
+    // 19
+    UCHAR FXP_BITFIELD8(IaMatchWakeEnable:1,
+                        MagicPacketWakeDisable:1,
+                        TxFullDuplexFlowControlDisable:1,
+                        RxFullDuplexRestopFlowControl:1,
+                        RxFullDuplexRestartFlowControl:1,
+                        RejectFc:1,
+                        ForceFullDuplex:1,
+                        AutomaticFullDuplex:1);
+    // 20
+    UCHAR FXP_BITFIELD8(Byte20_0:1,
+                        Byte20_1:1,
+                        Byte20_2:1,
+                        Byte20_3:1,
+                        Byte20_4:1,
+                        PriorityFcLocation:1,
+                        MultipleIa:1,
+                        :1);
+    // 21
+    UCHAR FXP_BITFIELD5(Byte21_0:1,
+                        :1,
+                        Byte21_1:1,
+                        MulticastAll:1,
+                        :4);
+    // 22
+    UCHAR FXP_BITFIELD3(GamlaRx:1,
+                        VlanTagStrippingEnable:1,
+                        :6);
+    // 23-31
+    UCHAR Reserved[9];
+} FXP_CB_CONFIGURE, *PFXP_CB_CONFIGURE;
+
+C_ASSERT(sizeof(FXP_CB_CONFIGURE) == 8 + 32);
+
+/*
+ * Multicast Setup Command
+ * FXP_CB_COMMAND_MCAS
+ */
+typedef struct _FXP_CB_MULTICAST_SETUP
+{
+    FXP_CB_HEADER Header;
+    USHORT Count;
+    UCHAR MacAddress[E100_MULTICAST_LIST_SIZE][ETH_LENGTH_OF_ADDRESS];
+} FXP_CB_MULTICAST_SETUP, *PFXP_CB_MULTICAST_SETUP;
+
+/*
+ * Load Microcode Command
+ * FXP_CB_COMMAND_UCODE
+ */
+typedef struct _FXP_CB_LOAD_MICROCODE
+{
+    FXP_CB_HEADER Header;
+    ULONG Data[192];
+} FXP_CB_LOAD_MICROCODE, *PFXP_CB_LOAD_MICROCODE;
+
+/*
+ * Transmit Buffer Descriptor
+ */
+typedef struct _FXP_TBD
+{
+    ULONG Address;
+    ULONG Size;
+} FXP_TBD, *PFXP_TBD;
+
+C_ASSERT(sizeof(FXP_TBD) == 8);
+
+/*
+ * IP Command Block
+ */
+typedef struct _FXP_IPCB
+{
+    USHORT IpScheduleLow;
+    UCHAR IpSchedule;
+#define FXP_IPCB_IP_CHECKSUM_ENABLE        0x10
+#define FXP_IPCB_TCPUDP_CHECKSUM_ENABLE    0x20
+#define FXP_IPCB_TCP_PACKET                0x40
+#define FXP_IPCB_LARGESEND_ENABLE          0x80
+
+    UCHAR IpActivationHigh;
+#define FXP_IPCB_HARDWAREPARSING_ENABLE    0x01
+#define FXP_IPCB_INSERTVLAN_ENABLE         0x02
+
+    USHORT VlanId;
+    UCHAR IpHeaderOffset;
+    UCHAR TcpHeaderOffset;
+} FXP_IPCB, *PFXP_IPCB;
+
+C_ASSERT(sizeof(FXP_IPCB) == 8);
+
+/*
+ * Transmit Command
+ * FXP_CB_COMMAND_XMIT
+ * FXP_CB_COMMAND_IPCBXMIT
+ */
+typedef struct _FXP_CB_TRANSMIT
+{
+    /*
+     * Transmit Control Block (TCB)
+     */
+    FXP_CB_HEADER Header;
+    union
+    {
+        struct
+        {
+            ULONG TbdArrayAddress;
+            USHORT ByteCount;
+            UCHAR TxThreshold;
+            UCHAR TbdNumber;
+        };
+        FXP_TBD TbdTso;
+    };
+
+    /*
+     * Flexible Mode TBD array
+     */
+    union
+    {
+        /*
+         * When the Extended TxCB mode is selected,
+         * the device reads the TCB structure and two TBDs from host memory.
+         * This means that we need at least two TBD entries in the list for this mode.
+         *
+         * When we use the FXP_CB_COMMAND_IPCBXMIT command, the first TBD
+         * in the array must be sacrificed for the TCP/IP
+         * checksum offload control bits (IPCB).
+         *
+         * We add the +1 because the 82550 may read an extra TBD
+         * after the last valid TBD in Large Send mode.
+         */
+        FXP_IPCB Ipcb;
+        FXP_TBD Tbd[E100_TBD_PER_TCB + 1];
+    };
+} FXP_CB_TRANSMIT, *PFXP_CB_TRANSMIT;
+
+C_ASSERT(E100_TBD_PER_TCB >= 2);
+
+/*
+ * Statistical Counters
+ * FXP_SCB_COMMAND_CU_DUMPRESET
+ */
+typedef struct _FXP_COUNTERS
+{
+    ULONG TxOk;
+    ULONG TxMaxCol;
+    ULONG TxLateCol;
+    ULONG TxUnderruns;
+    ULONG TxLossCarrier;
+    ULONG TxDeffered;
+    ULONG TxSingleCol;
+    ULONG TxMiltipleCol;
+    ULONG TxTotalCol;
+    ULONG RxOk;
+    ULONG RxCrcErr;
+    ULONG RxAlignErr;
+    ULONG RxResourceErr;
+    ULONG RxOverrunErr;
+    ULONG RxCdtErr;
+    ULONG RxShortFramesErr;
+    union
+    {
+        ULONG TxFcPause;
+        ULONG CompletionStatus557;
+    };
+    ULONG RxFcPause;
+    ULONG RxFcUnsupported;
+    union
+    {
+        struct
+        {
+            USHORT TxTco;
+            USHORT RxTco;
+        };
+        ULONG CompletionStatus558;
+    };
+    ULONG CompletionStatus559;
+} FXP_COUNTERS, *PFXP_COUNTERS;
+
+C_ASSERT(sizeof(FXP_COUNTERS) == 84);
+
+#define FXP_STATS_DUMP_COMPLETE   0xA005
+#define FXP_STATS_DR_COMPLETE     0xA007
+
+#include <pshpack1.h>
+
+/*
+ * Receive Frame Descriptor (RFD)
+ */
+typedef struct _FXP_RFD
+{
+    FXP_CB_HEADER Header;
+    ULONG RbdAddress;
+    USHORT ActualSize;
+#define FXP_RFD_FRAME_LENGTH_MASK   0x3FFF
+
+    USHORT Size;
+
+    /*
+     * The following fields are only available when using
+     * extended receive mode on an 82550/82551 chipset.
+     */
+    struct
+    {
+        USHORT VlanId;
+        UCHAR ParserStatus;
+        UCHAR Reserved;
+        USHORT SecurityStatus;
+        UCHAR ChecksumStatus;
+        UCHAR ZerocopyStatus;
+        UCHAR Pad[8];
+    } Ex;
+
+    /* The data portion of the received frame starts here (we use the simplified mode) */
+} FXP_RFD, *PFXP_RFD;
+
+C_ASSERT(RTL_SIZEOF_THROUGH_FIELD(FXP_RFD, Size) == 16);
+C_ASSERT(sizeof(FXP_RFD) == 32);
+
+#include <poppack.h>
+
+#define MII_MAX_PHY_ADDRESSES    32
+
+/*
+ * PHY register definitions (IEEE 802.3)
+ */
+#define MII_CONTROL              0x00
+#define     MII_CR_COLLISION_TEST   0x0080
+#define     MII_CR_FULL_DUPLEX      0x0100
+#define     MII_CR_AUTONEG_RESTART  0x0200
+#define     MII_CR_ISOLATE          0x0400
+#define     MII_CR_POWER_DOWN       0x0800
+#define     MII_CR_AUTONEG          0x1000
+#define     MII_CR_SPEED_SELECTION  0x2000
+#define     MII_CR_LOOPBACK         0x4000
+#define     MII_CR_RESET            0x8000
+#define MII_STATUS               0x01
+#define     MII_SR_LINK_STATUS      0x0004
+#define     MII_SR_AUTONEG_COMPLETE 0x0020
+#define MII_PHY_ID1              0x02
+#define MII_PHY_ID2              0x03
+#define MII_AUTONEG_ADVERTISE    0x04
+#define     MII_ADV_CSMA            0x0001
+#define     MII_ADV_10T_HD          0x0020
+#define     MII_ADV_10T_FD          0x0040
+#define     MII_ADV_100T_HD         0x0080
+#define     MII_ADV_100T_FD         0x0100
+#define     MII_ADV_100T4           0x0200
+#define     MII_ADV_PAUSE_SYM       0x0400
+#define     MII_ADV_PAUSE_ASYM      0x0800
+#define MII_AUTONEG_LINK_PARTNER 0x05
+#define     MII_LP_10T_HD           0x0020
+#define     MII_LP_10T_FD           0x0040
+#define     MII_LP_100T_HD          0x0080
+#define     MII_LP_100T_FD          0x0100
+#define     MII_LP_100T4            0x0200
+#define     MII_LP_PAUSE_SYM        0x0400
+#define     MII_LP_PAUSE_ASYM       0x0800
+#define MII_AUTONEG_EXPANSION    0x06
+#define     MII_EXP_LP_AUTONEG      0x0001
+#define MII_MASTER_SLAVE_CONTROL 0x09
+#define     MII_MS_CR_1000T_HD      0x0100
+#define     MII_MS_CR_1000T_FD      0x0200
+#define MII_MASTER_SLAVE_STATUS  0x0A
+#define     MII_MS_SR_1000T_FD      0x0800
+
+/*
+ * National Semiconductor DP83840 MII PHY definitions
+ */
+#define PHY_DP_REG_PCS  0x17
+
+#define PHY_DP_PCS_LED4_MODE     0x0002
+#define PHY_DP_PCS_F_CONNECT     0x0020
+#define PHY_DP_PCS_BIT_8         0x0100
+#define PHY_DP_PCS_BIT_10        0x0400
+
+#define PHY_IS_DP83840(PhyId)    (((PhyId) & 0xFFF0FFFF) == 0x5C002000)

--- a/drivers/network/dd/e100/eeprom.c
+++ b/drivers/network/dd/e100/eeprom.c
@@ -1,0 +1,301 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     EEPROM support code
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* GLOBASLS *******************************************************************/
+
+#define EEPROM_READ(Adapter, Data)  \
+    do { \
+        *Data = CSR_READ_16((Adapter), FXP_CSR_EEPROMCONTROL); \
+        NdisStallExecution(1); \
+    } while (0)
+
+#define EEPROM_WRITE(Adapter, Value)  \
+    do { \
+        CSR_WRITE_16((Adapter), FXP_CSR_EEPROMCONTROL, Value); \
+        NdisStallExecution(1); \
+    } while (0)
+
+/* FUNCTIONS ******************************************************************/
+
+static
+CODE_SEG("PAGE")
+VOID
+EeEepromShiftOut(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG Sequence,
+    _In_ ULONG BitCount)
+{
+    LONG i, Bit = 0;
+
+    PAGED_CODE();
+
+    /* Shift the data out to the EEPROM */
+    for (i = BitCount - 1; i >= 0; i--)
+    {
+        USHORT DataIn = ((Sequence >> i) & 1) << FXP_EEPROM_EEDI_SHIFT;
+
+        EEPROM_WRITE(Adapter, DataIn | FXP_EEPROM_EECS);
+        EEPROM_WRITE(Adapter, DataIn | FXP_EEPROM_EECS | FXP_EEPROM_EESK);
+        EEPROM_WRITE(Adapter, DataIn | FXP_EEPROM_EECS);
+
+        if (Adapter->EepromAddressBusWidth == (ULONG)-1)
+        {
+            Bit++;
+
+            /* Check the preceding dummy zero bit */
+            if (!(CSR_READ_16(Adapter, FXP_CSR_EEPROMCONTROL) & FXP_EEPROM_EEDO))
+            {
+                Adapter->EepromAddressBusWidth = Bit;
+                break;
+            }
+        }
+    }
+}
+
+static
+CODE_SEG("PAGE")
+USHORT
+EeEepromShiftIn(
+    _In_ PE100_ADAPTER Adapter)
+{
+    USHORT SerialData, DataOut;
+    ULONG i;
+
+    /* Shift the data in from the EEPROM */
+    SerialData = 0;
+    for (i = 0; i < RTL_BITS_OF(USHORT); ++i)
+    {
+        EEPROM_WRITE(Adapter, FXP_EEPROM_EECS | FXP_EEPROM_EESK);
+
+        EEPROM_READ(Adapter, &DataOut);
+        SerialData = (SerialData << 1) | ((DataOut >> FXP_EEPROM_EEDO_SHIFT) & 1);
+
+        EEPROM_WRITE(Adapter, FXP_EEPROM_EECS);
+    }
+
+    /* End the read cycle */
+    EEPROM_WRITE(Adapter, 0);
+
+    return SerialData;
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeEepromDetectAddressBusWidth(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PAGED_CODE();
+
+    ASSERT(Adapter->EepromAddressBusWidth == 0);
+
+    EEPROM_WRITE(Adapter, FXP_EEPROM_EECS);
+
+    EeEepromShiftOut(Adapter, FXP_EEPROM_OPC_READ, FXP_EEPROM_OPC_LENGTH);
+
+    /* Detect EEPROM size (64 or 256 words) */
+    Adapter->EepromAddressBusWidth = (ULONG)-1;
+    EeEepromShiftOut(Adapter, 0, 8);
+
+    /* Complete the read cycle */
+    (VOID)EeEepromShiftIn(Adapter);
+
+    return (Adapter->EepromAddressBusWidth != (ULONG)-1);
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeEepromChecksumValid(
+    _In_reads_(Size) const USHORT* Data,
+    _In_ ULONG Size)
+{
+    ULONG i;
+    USHORT Crc = 0;
+
+    PAGED_CODE();
+
+    for (i = 0; i < Size; ++i)
+    {
+        Crc += Data[i];
+    }
+    Crc = 0xBABA - Crc;
+
+    return (Crc == Data[Size]);
+}
+
+static
+BOOLEAN
+CODE_SEG("PAGE")
+EeEepromRead(
+    _In_ PE100_ADAPTER Adapter,
+    _Out_ PUSHORT EepromImage)
+{
+    ULONG Address, EepromWords;
+
+    if (!EeEepromDetectAddressBusWidth(Adapter))
+    {
+        ERR("Bad EEPROM\n");
+        return FALSE;
+    }
+
+    EepromWords = 1 << Adapter->EepromAddressBusWidth;
+    INFO("EEPROM Size %lu\n", EepromWords);
+    ASSERT(EepromWords <= FXP_EEPROM_MAX_WORDS);
+
+    for (Address = 0; Address < EepromWords; ++Address)
+    {
+        EEPROM_WRITE(Adapter, FXP_EEPROM_EECS);
+
+        EeEepromShiftOut(Adapter, FXP_EEPROM_OPC_READ, FXP_EEPROM_OPC_LENGTH);
+        EeEepromShiftOut(Adapter, Address, Adapter->EepromAddressBusWidth);
+
+        EepromImage[Address] = EeEepromShiftIn(Adapter);
+
+        TRACE("Data %03X: %4X\n", Address, EepromImage[Address]);
+    }
+
+    if (!EeEepromChecksumValid(EepromImage, EepromWords - 1))
+    {
+        ERR("EEPROM checksum failed\n");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+static
+BOOLEAN
+CODE_SEG("PAGE")
+EeEepromParse(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ USHORT* __restrict EepromImage)
+{
+    PAGED_CODE();
+
+    /* Read MAC address */
+    Adapter->PermanentMacAddress[0] = EepromImage[FXP_EEPROM_MAP_IA0] & 0xFF;
+    Adapter->PermanentMacAddress[1] = EepromImage[FXP_EEPROM_MAP_IA0] >> 8;
+    Adapter->PermanentMacAddress[2] = EepromImage[FXP_EEPROM_MAP_IA1] & 0xFF;
+    Adapter->PermanentMacAddress[3] = EepromImage[FXP_EEPROM_MAP_IA1] >> 8;
+    Adapter->PermanentMacAddress[4] = EepromImage[FXP_EEPROM_MAP_IA2] & 0xFF;
+    Adapter->PermanentMacAddress[5] = EepromImage[FXP_EEPROM_MAP_IA2] >> 8;
+
+    INFO("MAC: %02x:%02x:%02x:%02x:%02x:%02x\n",
+         Adapter->PermanentMacAddress[0],
+         Adapter->PermanentMacAddress[1],
+         Adapter->PermanentMacAddress[2],
+         Adapter->PermanentMacAddress[3],
+         Adapter->PermanentMacAddress[4],
+         Adapter->PermanentMacAddress[5]);
+
+    if (ETH_IS_BROADCAST(Adapter->PermanentMacAddress) ||
+        ETH_IS_EMPTY(Adapter->PermanentMacAddress) ||
+        ETH_IS_MULTICAST(Adapter->PermanentMacAddress))
+    {
+        ERR("Invalid permanent MAC address %02x:%02x:%02x:%02x:%02x:%02x\n",
+            Adapter->PermanentMacAddress[0],
+            Adapter->PermanentMacAddress[1],
+            Adapter->PermanentMacAddress[2],
+            Adapter->PermanentMacAddress[3],
+            Adapter->PermanentMacAddress[4],
+            Adapter->PermanentMacAddress[5]);
+
+        NdisWriteErrorLogEntry(Adapter->AdapterHandle, NDIS_ERROR_CODE_NETWORK_ADDRESS, 0);
+
+        return FALSE;
+    }
+
+    /* Assign revision ID */
+    if (Adapter->Flags & E100_FLAG_IS_ICH)
+    {
+        /* Treat ICH based controllers as 82559 devices */
+        Adapter->RevisionID = FXP_REV_82559_A0;
+
+        /* Do not load microcode for ICH devices */
+        Adapter->Flags |= E100_FLAG_NO_UCODE;
+    }
+    else
+    {
+        /* Lump all 82557 revisions together */
+        if ((EepromImage[FXP_EEPROM_MAP_CNTR] >> 8) == 1)
+            Adapter->RevisionID = FXP_REV_82557;
+    }
+
+    /* Check availability of WOL. 82559ER does not support WOL */
+    if ((Adapter->RevisionID >= FXP_REV_82558_A4) &&
+        (Adapter->RevisionID != FXP_REV_82559S_A))
+    {
+        if (EepromImage[FXP_EEPROM_MAP_ID] & 0x20)
+            Adapter->Flags |= E100_FLAG_HAS_WOL;
+    }
+
+    if (Adapter->RevisionID == FXP_REV_82550_C)
+    {
+       /*
+        * 82550C with server extension requires microcode to
+        * receive fragmented UDP datagrams. However if the
+        * microcode is used for client-only featured 82550C
+        * it locks up controller.
+        */
+        if (!(EepromImage[FXP_EEPROM_MAP_COMPAT] & 0x0400))
+            Adapter->Flags |= E100_FLAG_NO_UCODE;
+    }
+
+    if (Adapter->RevisionID < FXP_REV_82558_A4)
+    {
+        if ((EepromImage[FXP_EEPROM_MAP_COMPAT] & 0x03) != 0x03)
+            Adapter->Flags |= E100_FLAG_RX_LOCKUP_BUG;
+    }
+
+    /* Detect serial interface PHY (Intel 82503 or Seeq 82C24) */
+    if (Adapter->RevisionID == FXP_REV_82557)
+    {
+        if ((EepromImage[FXP_EEPROM_MAP_PRI_PHY] & FXP_PHY_DEVICE_MASK) &&
+            (EepromImage[FXP_EEPROM_MAP_PRI_PHY] & FXP_PHY_SERIAL_ONLY))
+        {
+            /* Connected to a non-MII PHY device */
+            Adapter->PhyType = E100_PHY_TYPE_503;
+        }
+    }
+
+    return TRUE;
+}
+
+CODE_SEG("PAGE")
+BOOLEAN
+EeReadEeprom(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PUSHORT EepromImage;
+    NDIS_STATUS Status;
+    BOOLEAN Success = FALSE;
+
+    PAGED_CODE();
+
+    Status = NdisAllocateMemoryWithTag((PVOID*)&EepromImage, FXP_EEPROM_MAX_WORDS * 2, E100_TAG);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return FALSE;
+
+    if (!EeEepromRead(Adapter, EepromImage))
+        goto Cleanup;
+
+    if (!EeEepromParse(Adapter, EepromImage))
+        goto Cleanup;
+
+    Success = TRUE;
+
+Cleanup:
+    NdisFreeMemory(EepromImage, FXP_EEPROM_MAX_WORDS * 2, 0);
+    return Success;
+}

--- a/drivers/network/dd/e100/eeprom.c
+++ b/drivers/network/dd/e100/eeprom.c
@@ -1,0 +1,307 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     EEPROM support code
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* GLOBASLS *******************************************************************/
+
+#define EEPROM_READ(Adapter, Data)  \
+    do { \
+        *Data = CSR_READ_16((Adapter), FXP_CSR_EEPROMCONTROL); \
+        NdisStallExecution(1); \
+    } while (0)
+
+#define EEPROM_WRITE(Adapter, Value)  \
+    do { \
+        CSR_WRITE_16((Adapter), FXP_CSR_EEPROMCONTROL, Value); \
+        NdisStallExecution(1); \
+    } while (0)
+
+/* FUNCTIONS ******************************************************************/
+
+static
+CODE_SEG("PAGE")
+VOID
+EeEepromShiftOut(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG Sequence,
+    _In_ ULONG BitCount)
+{
+    LONG i, Bit = 0;
+
+    PAGED_CODE();
+
+    /* Shift the data out to the EEPROM */
+    for (i = BitCount - 1; i >= 0; i--)
+    {
+        USHORT DataIn = ((Sequence >> i) & 1) << FXP_EEPROM_EEDI_SHIFT;
+
+        EEPROM_WRITE(Adapter, DataIn | FXP_EEPROM_EECS);
+        EEPROM_WRITE(Adapter, DataIn | FXP_EEPROM_EECS | FXP_EEPROM_EESK);
+        EEPROM_WRITE(Adapter, DataIn | FXP_EEPROM_EECS);
+
+        if (Adapter->EepromAddressBusWidth == (ULONG)-1)
+        {
+            Bit++;
+
+            /* Check the preceding dummy zero bit */
+            if (!(CSR_READ_16(Adapter, FXP_CSR_EEPROMCONTROL) & FXP_EEPROM_EEDO))
+            {
+                Adapter->EepromAddressBusWidth = Bit;
+                break;
+            }
+        }
+    }
+}
+
+static
+CODE_SEG("PAGE")
+USHORT
+EeEepromShiftIn(
+    _In_ PE100_ADAPTER Adapter)
+{
+    USHORT SerialData, DataOut;
+    ULONG i;
+
+    /* Shift the data in from the EEPROM */
+    SerialData = 0;
+    for (i = 0; i < RTL_BITS_OF(USHORT); ++i)
+    {
+        EEPROM_WRITE(Adapter, FXP_EEPROM_EECS | FXP_EEPROM_EESK);
+
+        EEPROM_READ(Adapter, &DataOut);
+        SerialData = (SerialData << 1) | ((DataOut >> FXP_EEPROM_EEDO_SHIFT) & 1);
+
+        EEPROM_WRITE(Adapter, FXP_EEPROM_EECS);
+    }
+
+    /* End the read cycle */
+    EEPROM_WRITE(Adapter, 0);
+
+    return SerialData;
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeEepromDetectAddressBusWidth(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PAGED_CODE();
+
+    ASSERT(Adapter->EepromAddressBusWidth == 0);
+
+    EEPROM_WRITE(Adapter, FXP_EEPROM_EECS);
+
+    EeEepromShiftOut(Adapter, FXP_EEPROM_OPC_READ, FXP_EEPROM_OPC_LENGTH);
+
+    /* Detect EEPROM size (64 or 256 words) */
+    Adapter->EepromAddressBusWidth = (ULONG)-1;
+    EeEepromShiftOut(Adapter, 0, 8);
+
+    /* Complete the read cycle */
+    (VOID)EeEepromShiftIn(Adapter);
+
+    return (Adapter->EepromAddressBusWidth != (ULONG)-1);
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeEepromChecksumValid(
+    _In_reads_(Size) const USHORT* Data,
+    _In_ ULONG Size)
+{
+    ULONG i;
+    USHORT Crc = 0;
+
+    PAGED_CODE();
+
+    for (i = 0; i < Size; ++i)
+    {
+        Crc += Data[i];
+    }
+    Crc = 0xBABA - Crc;
+
+    return (Crc == Data[Size]);
+}
+
+static
+BOOLEAN
+CODE_SEG("PAGE")
+EeEepromRead(
+    _In_ PE100_ADAPTER Adapter,
+    _Out_ PUSHORT EepromImage)
+{
+    ULONG Address, EepromWords;
+
+    if (!EeEepromDetectAddressBusWidth(Adapter))
+    {
+        ERR("Bad EEPROM\n");
+        return FALSE;
+    }
+
+    EepromWords = 1 << Adapter->EepromAddressBusWidth;
+    INFO("EEPROM Size %lu\n", EepromWords);
+    ASSERT(EepromWords <= FXP_EEPROM_MAX_WORDS);
+
+    for (Address = 0; Address < EepromWords; ++Address)
+    {
+        EEPROM_WRITE(Adapter, FXP_EEPROM_EECS);
+
+        EeEepromShiftOut(Adapter, FXP_EEPROM_OPC_READ, FXP_EEPROM_OPC_LENGTH);
+        EeEepromShiftOut(Adapter, Address, Adapter->EepromAddressBusWidth);
+
+        EepromImage[Address] = EeEepromShiftIn(Adapter);
+
+        TRACE("Data %03X: %4X\n", Address, EepromImage[Address]);
+    }
+
+    if (!EeEepromChecksumValid(EepromImage, EepromWords - 1))
+    {
+        ERR("EEPROM checksum failed\n");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+static
+BOOLEAN
+CODE_SEG("PAGE")
+EeEepromParse(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ USHORT* __restrict EepromImage)
+{
+    PAGED_CODE();
+
+    /* Read MAC address */
+    Adapter->PermanentMacAddress[0] = EepromImage[FXP_EEPROM_MAP_IA0] & 0xFF;
+    Adapter->PermanentMacAddress[1] = EepromImage[FXP_EEPROM_MAP_IA0] >> 8;
+    Adapter->PermanentMacAddress[2] = EepromImage[FXP_EEPROM_MAP_IA1] & 0xFF;
+    Adapter->PermanentMacAddress[3] = EepromImage[FXP_EEPROM_MAP_IA1] >> 8;
+    Adapter->PermanentMacAddress[4] = EepromImage[FXP_EEPROM_MAP_IA2] & 0xFF;
+    Adapter->PermanentMacAddress[5] = EepromImage[FXP_EEPROM_MAP_IA2] >> 8;
+
+    INFO("MAC: %02x:%02x:%02x:%02x:%02x:%02x\n",
+         Adapter->PermanentMacAddress[0],
+         Adapter->PermanentMacAddress[1],
+         Adapter->PermanentMacAddress[2],
+         Adapter->PermanentMacAddress[3],
+         Adapter->PermanentMacAddress[4],
+         Adapter->PermanentMacAddress[5]);
+
+    if (ETH_IS_BROADCAST(Adapter->PermanentMacAddress) ||
+        ETH_IS_EMPTY(Adapter->PermanentMacAddress) ||
+        ETH_IS_MULTICAST(Adapter->PermanentMacAddress))
+    {
+        ERR("Invalid permanent MAC address %02x:%02x:%02x:%02x:%02x:%02x\n",
+            Adapter->PermanentMacAddress[0],
+            Adapter->PermanentMacAddress[1],
+            Adapter->PermanentMacAddress[2],
+            Adapter->PermanentMacAddress[3],
+            Adapter->PermanentMacAddress[4],
+            Adapter->PermanentMacAddress[5]);
+
+        NdisWriteErrorLogEntry(Adapter->AdapterHandle, NDIS_ERROR_CODE_NETWORK_ADDRESS, 0);
+
+        return FALSE;
+    }
+
+    /* Assign revision ID */
+    if (Adapter->Flags & E100_FLAG_IS_ICH)
+    {
+        /* Treat ICH based controllers as 82559 devices */
+        Adapter->RevisionID = FXP_REV_82559_A0;
+
+        /* Do not load microcode for ICH devices */
+        Adapter->Flags |= E100_FLAG_NO_UCODE;
+    }
+    else
+    {
+        /* Lump all 82557 revisions together */
+        if ((EepromImage[FXP_EEPROM_MAP_CNTR] >> 8) == 1)
+            Adapter->RevisionID = FXP_REV_82557;
+    }
+
+    /* Check availability of WOL. 82559ER does not support WOL */
+    if ((Adapter->RevisionID >= FXP_REV_82558_A4) &&
+        (Adapter->RevisionID != FXP_REV_82559S_A))
+    {
+        if (EepromImage[FXP_EEPROM_MAP_ID] & 0x20)
+        {
+            INFO("Has WOL capability\n");
+            Adapter->Flags |= E100_FLAG_HAS_WOL;
+        }
+    }
+
+    if (Adapter->RevisionID == FXP_REV_82550_C)
+    {
+       /*
+        * 82550C with server extension requires microcode to
+        * receive fragmented UDP datagrams. However if the
+        * microcode is used for client-only featured 82550C
+        * it locks up controller.
+        */
+        if (!(EepromImage[FXP_EEPROM_MAP_COMPAT] & 0x0400))
+            Adapter->Flags |= E100_FLAG_NO_UCODE;
+    }
+
+    if (Adapter->RevisionID < FXP_REV_82558_A4)
+    {
+        if ((EepromImage[FXP_EEPROM_MAP_COMPAT] & 0x03) != 0x03)
+        {
+            INFO("RU workaround enabled\n");
+            Adapter->Flags |= E100_FLAG_RX_LOCKUP_BUG;
+        }
+    }
+
+    /* Detect serial interface PHY (Intel 82503 or Seeq 80C24) */
+    if (Adapter->RevisionID == FXP_REV_82557)
+    {
+        if ((EepromImage[FXP_EEPROM_MAP_PRI_PHY] & FXP_PHY_DEVICE_MASK) &&
+            (EepromImage[FXP_EEPROM_MAP_PRI_PHY] & FXP_PHY_SERIAL_ONLY))
+        {
+            /* Connected to a non-MII PHY device */
+            Adapter->PhyType = E100_PHY_TYPE_503;
+        }
+    }
+
+    return TRUE;
+}
+
+CODE_SEG("PAGE")
+BOOLEAN
+EeReadEeprom(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PUSHORT EepromImage;
+    NDIS_STATUS Status;
+    BOOLEAN Success = FALSE;
+
+    PAGED_CODE();
+
+    Status = NdisAllocateMemoryWithTag((PVOID*)&EepromImage, FXP_EEPROM_MAX_WORDS * 2, E100_TAG);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return FALSE;
+
+    if (!EeEepromRead(Adapter, EepromImage))
+        goto Cleanup;
+
+    if (!EeEepromParse(Adapter, EepromImage))
+        goto Cleanup;
+
+    Success = TRUE;
+
+Cleanup:
+    NdisFreeMemory(EepromImage, FXP_EEPROM_MAX_WORDS * 2, 0);
+    return Success;
+}

--- a/drivers/network/dd/e100/hardware.c
+++ b/drivers/network/dd/e100/hardware.c
@@ -1,0 +1,968 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Hardware specific functions
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/*
+ * HW access code was taken from the FreeBSD fxp driver.
+ * Copyright (c) 1995, David Greenman
+ * Copyright (c) 2001 Jonathan Lemon <jlemon@freebsd.org>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+#include "rcvbundl.h"
+
+#include <debug.h>
+
+/* GLOBASLS *******************************************************************/
+
+E100_PAGED_DATA static const ULONG E100MicrocodeD101a[] = D101_A_RCVBUNDLE_UCODE;
+E100_PAGED_DATA static const ULONG E100MicrocodeD101b0[] = D101_B0_RCVBUNDLE_UCODE;
+E100_PAGED_DATA static const ULONG E100MicrocodeD101ma[] = D101M_B_RCVBUNDLE_UCODE;
+E100_PAGED_DATA static const ULONG E100MicrocodeD101s[] = D101S_RCVBUNDLE_UCODE;
+E100_PAGED_DATA static const ULONG E100MicrocodeD102[] = D102_B_RCVBUNDLE_UCODE;
+E100_PAGED_DATA static const ULONG E100MicrocodeD102c[] = D102_C_RCVBUNDLE_UCODE;
+E100_PAGED_DATA static const ULONG E100MicrocodeD102e[] = D102_E_RCVBUNDLE_UCODE;
+
+E100_PAGED_DATA static const E100_UCODE_INFO E100MicrocodeTable[] =
+{
+#define UCODE(x)    x, RTL_NUMBER_OF(x)
+    {
+        UCODE(E100MicrocodeD101a), FXP_REV_82558_A4,
+        D101_CPUSAVER_DWORD, 0, 0
+    },
+    {
+        UCODE(E100MicrocodeD101b0), FXP_REV_82558_B0,
+        D101_CPUSAVER_DWORD, 0, 0
+    },
+    {
+        UCODE(E100MicrocodeD101ma), FXP_REV_82559_A0,
+        D101M_CPUSAVER_DWORD, D101M_CPUSAVER_BUNDLE_MAX_DWORD, D101M_CPUSAVER_MIN_SIZE_DWORD
+    },
+    {
+        UCODE(E100MicrocodeD101s), FXP_REV_82559S_A,
+        D101S_CPUSAVER_DWORD, D101S_CPUSAVER_BUNDLE_MAX_DWORD, D101S_CPUSAVER_MIN_SIZE_DWORD
+    },
+    {
+        UCODE(E100MicrocodeD102), FXP_REV_82550,
+        D102_B_CPUSAVER_DWORD, D102_B_CPUSAVER_BUNDLE_MAX_DWORD, D102_B_CPUSAVER_MIN_SIZE_DWORD
+    },
+    {
+        UCODE(E100MicrocodeD102c), FXP_REV_82550_C,
+        /* No support for D102_C_CPUSAVER_MIN_SIZE_DWORD in microcode */
+        D102_C_CPUSAVER_DWORD, D102_C_CPUSAVER_BUNDLE_MAX_DWORD, 0
+    },
+    {
+        UCODE(E100MicrocodeD102e), FXP_REV_82551_F,
+        D102_E_CPUSAVER_DWORD, D102_E_CPUSAVER_BUNDLE_MAX_DWORD, D102_E_CPUSAVER_MIN_SIZE_DWORD
+    },
+    {
+        UCODE(E100MicrocodeD102e), FXP_REV_82551_10,
+        D102_E_CPUSAVER_DWORD, D102_E_CPUSAVER_BUNDLE_MAX_DWORD, D102_E_CPUSAVER_MIN_SIZE_DWORD
+    },
+    { NULL, 0, 0, 0, 0 }
+#undef UCODE
+};
+
+/* FUNCTIONS ******************************************************************/
+
+VOID
+EeSoftReset(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ BOOLEAN FullReset)
+{
+    /* Do selective reset first to prevent PCI bus lock-up */
+    CSR_WRITE_32(Adapter, FXP_CSR_PORT, FXP_PORT_SELECTIVE_RESET);
+    NdisStallExecution(50);
+
+    if (FullReset)
+    {
+        CSR_WRITE_32(Adapter, FXP_CSR_PORT, FXP_PORT_SOFTWARE_RESET);
+        NdisStallExecution(50);
+    }
+
+    /* Software reset will unmask interrupts so disable them after the reset */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_INTRCNTL, FXP_SCB_INTR_DISABLE);
+}
+
+static
+PULONG
+EeGetDumpCompletionStatus(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PFXP_COUNTERS Counters)
+{
+    if (Adapter->RevisionID >= FXP_REV_82559_A0)
+        return &Counters->CompletionStatus559;
+    else if (Adapter->RevisionID >= FXP_REV_82558_A4)
+        return &Counters->CompletionStatus558;
+    else
+        return &Counters->CompletionStatus557;
+}
+
+static
+VOID
+EeDumpStatisticsCounters(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PE100_STATISTICS Statistics = &Adapter->Statistics;
+    PFXP_COUNTERS Counters = &Adapter->ControlBlock->Counters;
+    PULONG CompletionStatus;
+
+    CompletionStatus = EeGetDumpCompletionStatus(Adapter, Counters);
+    if (*CompletionStatus != htole32(FXP_STATS_DR_COMPLETE))
+        return;
+
+    *CompletionStatus = 0;
+
+    TRACE("Dump command completed successfully\n");
+
+    Statistics->TransmitOk += letoh32(Counters->TxOk);
+    Statistics->TransmitErrors += letoh32(Counters->TxMaxCol) +
+                                  letoh32(Counters->TxLateCol) +
+                                  letoh32(Counters->TxUnderruns) +
+                                  letoh32(Counters->TxLossCarrier);
+    Statistics->TransmitOneRetry += letoh32(Counters->TxSingleCol);
+    Statistics->TransmitMoreCollisions += letoh32(Counters->TxMiltipleCol);
+    Statistics->TransmitDeferred += letoh32(Counters->TxDeffered);
+    Statistics->TransmitExcessiveCollisions += letoh32(Counters->TxMaxCol);
+    Statistics->TransmitUnderrunErrors += letoh32(Counters->TxUnderruns);
+    Statistics->TransmitLostCarrierSense += letoh32(Counters->TxLossCarrier);
+    Statistics->TransmitLateCollisions += letoh32(Counters->TxLateCol);
+
+    Statistics->ReceiveOk += letoh32(Counters->RxOk);
+    Statistics->ReceiveErrors += letoh32(Counters->RxCrcErr) +
+                                 letoh32(Counters->RxAlignErr) +
+                                 letoh32(Counters->RxResourceErr) +
+                                 letoh32(Counters->RxOverrunErr) +
+                                 letoh32(Counters->RxShortFramesErr);
+    Statistics->ReceiveOverrunErrors += letoh32(Counters->RxOverrunErr);
+    Statistics->ReceiveNoBuffers += letoh32(Counters->RxResourceErr);
+    Statistics->ReceiveCrcErrors += letoh32(Counters->RxCrcErr);
+    Statistics->ReceiveAlignmentErrors += letoh32(Counters->RxAlignErr);
+
+#if DBG
+    Statistics->TransmitTotalCollisions += letoh32(Counters->TxTotalCol);
+    Statistics->ReceiveCdtErrors += letoh32(Counters->RxCdtErr);
+    Statistics->TransmitPauseFrames += letoh32(Counters->TxFcPause);
+    Statistics->ReceivePauseFrames += letoh32(Counters->RxFcPause);
+    Statistics->ReceiveUnsupportedPauseFrames += letoh32(Counters->RxFcUnsupported);
+    Statistics->TransmitTcoFrames += letoh16(Counters->TxTco);
+    Statistics->ReceiveTcoFrames += letoh16(Counters->RxTco);
+#endif
+
+    /*
+     * Errata: The receive unit may lock up upon certain types of garbage
+     * in the synchronization bits prior to the packet header.
+     */
+    if (Adapter->Flags & E100_FLAG_RX_LOCKUP_BUG)
+    {
+        if (Counters->RxOk != 0)
+        {
+            /* We have received packets */
+            Adapter->ReceiverUnitIdleTicks = 0;
+        }
+        else
+        {
+            if (++Adapter->ReceiverUnitIdleTicks > 7)
+            {
+                Adapter->ReceiverUnitIdleTicks = 0;
+
+                /* Reprogram the multicast filter */
+                INFO("We have not been received any packets, assume the receive unit has hung\n");
+                EeUpdateMulticastList(Adapter);
+            }
+        }
+    }
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    /* Bump up the FIFO threshold level to minimize Tx FIFO underrun */
+    if (Counters->TxUnderruns != 0)
+    {
+        if (Adapter->TransmitThreshold < 1536 / 8)
+        {
+            Adapter->TransmitThreshold += 512 / 8;
+            INFO("New transmit threshold %u\n", Adapter->TransmitThreshold);
+        }
+    }
+
+    /* Start another statistics dump */
+    TRACE("Dump statistics counters\n");
+    EeCommandUnitExecuteCommand(Adapter, FXP_SCB_COMMAND_CU_DUMPRESET);
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+}
+
+static
+BOOLEAN
+EeScbWaitForCommandClear(
+    _In_ PE100_ADAPTER Adapter)
+{
+    UCHAR Command;
+    ULONG i;
+
+    /* Wait up to 100 ms for the SCB to accept the previous command */
+    for (i = (100 * 1000) / 2; i > 0; i--)
+    {
+        Command = CSR_READ_8(Adapter, FXP_CSR_SCB_COMMAND);
+
+        if (Command == 0)
+            return TRUE;
+
+        NdisStallExecution(2);
+    }
+
+    ERR("SCB Timeout %02X %02X %02X\n",
+        CSR_READ_8(Adapter, FXP_CSR_SCB_COMMAND),
+        CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK),
+        CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS));
+    Adapter->HardError = TRUE;
+    return FALSE;
+}
+
+static
+BOOLEAN
+EeCommandUnitWaitForNotActive(
+    _In_ PE100_ADAPTER Adapter)
+{
+    UCHAR CuStatus;
+    ULONG i;
+
+    /* Wait up to 500 ms until the command unit is not active */
+    for (i = (500 * 1000) / 10; i > 0; i--)
+    {
+        CuStatus = FXP_SCB_CUS(CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS));
+
+        if (CuStatus != FXP_SCB_CUS_ACTIVE)
+            return TRUE;
+
+        NdisStallExecution(10);
+    }
+
+    ERR("CU Timeout %02X %02X %02X\n",
+        CSR_READ_8(Adapter, FXP_CSR_SCB_COMMAND),
+        CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK),
+        CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS));
+    Adapter->HardError = TRUE;
+    return FALSE;
+}
+
+static
+BOOLEAN
+EeCommandUnitWaitForCompiletion(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PUSHORT CbStatus)
+{
+    USHORT Status;
+    ULONG i;
+
+    /* Wait up to 500 ms for command completion */
+    for (i = (500 * 1000) / 2; i > 0; i--)
+    {
+        NdisStallExecution(2);
+
+        KeMemoryBarrierWithoutFence();
+        Status = htole16(*CbStatus);
+        if (Status & FXP_CB_STATUS_C)
+            break;
+    }
+    if (i == 0)
+    {
+        ERR("CU command timeout %02X %02X %02X %04X\n",
+            CSR_READ_8(Adapter, FXP_CSR_SCB_COMMAND),
+            CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK),
+            CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS),
+            Status);
+        Adapter->HardError = TRUE;
+        return FALSE;
+    }
+
+    if (Status & FXP_CB_STATUS_OK)
+        return TRUE;
+
+    ERR("CU command failed %02X %02X %02X %04X\n",
+        CSR_READ_8(Adapter, FXP_CSR_SCB_COMMAND),
+        CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK),
+        CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS),
+        Status);
+    Adapter->HardError = TRUE;
+    return FALSE;
+}
+
+VOID
+EeCommandUnitExecuteCommand(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ UCHAR Command)
+{
+    EeScbWaitForCommandClear(Adapter);
+
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_COMMAND, Command);
+}
+
+VOID
+EeCommandUnitExecuteCommandAddr(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ UCHAR Command,
+    _In_ ULONG PhysicalAddress)
+{
+    EeScbWaitForCommandClear(Adapter);
+
+    CSR_WRITE_32(Adapter, FXP_CSR_SCB_GENERAL, PhysicalAddress);
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_COMMAND, Command);
+}
+
+BOOLEAN
+EeCommandUnitSendCommand(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ USHORT Command,
+    _In_ PFXP_CB_HEADER Header)
+{
+    ULONG ControlBlockOffset;
+
+    TRACE("Send %X command\n", Command);
+
+    Header->Status = 0;
+    Header->Command = htole16(Command | FXP_CB_COMMAND_EL); // CU idle on completion
+    Header->LinkAddress = 0xFFFFFFFF;
+
+    EeScbWaitForCommandClear(Adapter);
+
+    if (Adapter->CommandUnitActive)
+    {
+        EeCommandUnitWaitForNotActive(Adapter);
+        Adapter->CommandUnitActive = FALSE;
+    }
+
+    ControlBlockOffset = (ULONG)((ULONG_PTR)Header - (ULONG_PTR)Adapter->ControlBlock);
+
+    CSR_WRITE_32(Adapter, FXP_CSR_SCB_GENERAL, Adapter->ControlBlockPa + ControlBlockOffset);
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_COMMAND, FXP_SCB_COMMAND_CU_START);
+
+    return EeCommandUnitWaitForCompiletion(Adapter, &Header->Status);
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeDownloadMicrocode(
+    _In_ PE100_ADAPTER Adapter)
+{
+    const E100_UCODE_INFO* Info;
+    PFXP_CB_LOAD_MICROCODE MicrocodeSetup;
+    ULONG i;
+
+    PAGED_CODE();
+
+    if (Adapter->Flags & E100_FLAG_NO_UCODE)
+        return TRUE;
+
+    for (Info = E100MicrocodeTable; Info->Microcode; ++Info)
+    {
+        if (Adapter->RevisionID == Info->RevisionID)
+            break;
+    }
+    if (!Info->Microcode)
+        return TRUE;
+
+    INFO("Download microcode: INT_DELAY %lu, BUNDLE_MAX %lu, MIN_SIZE_MASK %lX\n",
+         Adapter->MicrocodeInterruptDelay,
+         Adapter->MicrocodeMaxFramesPerIntr,
+         Adapter->MicrocodeMinSizeMask);
+
+    MicrocodeSetup = &Adapter->ControlBlock->MicrocodeSetup;
+    for (i = 0; i < Info->Length; ++i)
+    {
+        MicrocodeSetup->Data[i] = htole32(Info->Microcode[i]);
+    }
+    for (; i < RTL_NUMBER_OF(MicrocodeSetup->Data); ++i)
+    {
+        MicrocodeSetup->Data[i] = 0;
+    }
+
+    /* Apply user-specified settings */
+    if (Info->IntDelayOffset != 0)
+    {
+        MicrocodeSetup->Data[Info->IntDelayOffset] &= htole32(0xFFFF0000);
+        MicrocodeSetup->Data[Info->IntDelayOffset] |= htole32(Adapter->MicrocodeInterruptDelay);
+    }
+    if (Info->BundleMaxOffset != 0)
+    {
+        MicrocodeSetup->Data[Info->BundleMaxOffset] &= htole32(0xFFFF0000);
+        MicrocodeSetup->Data[Info->BundleMaxOffset] |= htole32(Adapter->MicrocodeMaxFramesPerIntr);
+    }
+    if (Info->MinSizeMaskOffset != 0)
+    {
+        MicrocodeSetup->Data[Info->MinSizeMaskOffset] &= htole32(0xFFFF0000);
+        MicrocodeSetup->Data[Info->MinSizeMaskOffset] |= htole32(Adapter->MicrocodeMinSizeMask);
+    }
+
+    return EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_UCODE, &MicrocodeSetup->Header);
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeSetupMacAddress(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PFXP_CB_INDIVIDUAL_ADDRESS_SETUP IaSetup;
+
+    PAGED_CODE();
+
+    IaSetup = &Adapter->ControlBlock->IaSetup;
+    RtlCopyMemory(IaSetup->MacAddress, Adapter->CurrentMacAddress, ETH_LENGTH_OF_ADDRESS);
+
+    return EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_IAS, &IaSetup->Header);
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EeStartReceiveUnit(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PE100_RX_CONTEXT RxContext;
+
+    PAGED_CODE();
+
+    ASSERT(!IsListEmpty(&Adapter->RxContextList));
+    RxContext = CONTAINING_RECORD(Adapter->RxContextList.Flink,
+                                  E100_RX_CONTEXT,
+                                  ListEntry);
+    EeCommandUnitExecuteCommandAddr(Adapter, FXP_SCB_COMMAND_RU_START, RxContext->RfdPhys);
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeSetupStatisticCounters(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PULONG CompletionStatus;
+    ULONG i, Address;
+
+    PAGED_CODE();
+
+    Address = Adapter->ControlBlockPa + FIELD_OFFSET(E100_CONTROL_BLOCK, Counters);
+    EeCommandUnitExecuteCommandAddr(Adapter, FXP_SCB_COMMAND_CU_DUMP_ADR, Address);
+
+    CompletionStatus = EeGetDumpCompletionStatus(Adapter, &Adapter->ControlBlock->Counters);
+    *CompletionStatus = 0;
+    EE_WRITE_BARRIER();
+
+    /* Clear statistics counters since they are corrupted during power down state */
+    EeCommandUnitExecuteCommand(Adapter, FXP_SCB_COMMAND_CU_DUMPRESET);
+    for (i = (100 * 1000) / 2; i > 0; i--)
+    {
+        NdisStallExecution(2);
+
+        KeMemoryBarrierWithoutFence();
+        if (*CompletionStatus == htole32(FXP_STATS_DR_COMPLETE))
+            break;
+    }
+    if (i == 0)
+    {
+        ERR("Unable to reset statistic counters\n");
+        return FALSE;
+    }
+
+    /* Discard results of the previous dump */
+    EE_WRITE_BARRIER();
+    *CompletionStatus = 0;
+
+    /* Start another statistics dump */
+    EeCommandUnitExecuteCommand(Adapter, FXP_SCB_COMMAND_CU_DUMPRESET);
+
+    return TRUE;
+}
+
+VOID
+EeEnableRxChecksumOffload82559(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ BOOLEAN Enable)
+{
+    PFXP_CB_CONFIGURE Config = &Adapter->ControlBlock->Configuration;
+
+    Config->TcpUdpChecksum = !!Enable;
+    EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_CONFIG, &Config->Header);
+}
+
+VOID
+EeUpdateMulticastList(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PFXP_CB_MULTICAST_SETUP MulticastSetup;
+    ULONG ListSize;
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    if (Adapter->PacketFilter & NDIS_PACKET_TYPE_MULTICAST)
+    {
+        ListSize = Adapter->MulticastListSize;
+    }
+    else
+    {
+        /*
+         * Writing a zero count will reset the hash table
+         * and disable the multicast filtering mechanism.
+         */
+        ListSize = 0;
+    }
+
+    MulticastSetup = &Adapter->ControlBlock->MulticastSetup;
+    MulticastSetup->Count = htole16(ListSize);
+    RtlCopyMemory(MulticastSetup->MacAddress, Adapter->MulticastList, ListSize);
+
+    EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_MCAS, &MulticastSetup->Header);
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+}
+
+DECLSPEC_NOINLINE_FROM_PAGED
+VOID
+EeApplyPacketFilter(
+    _In_ PE100_ADAPTER Adapter)
+{
+    ULONG PacketFilter = Adapter->PacketFilter;
+    PFXP_CB_CONFIGURE Config;
+
+    INFO("Packet filter value 0x%lX\n", PacketFilter);
+
+    EeUpdateMulticastList(Adapter);
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    Config = &Adapter->ControlBlock->Configuration;
+
+    if (Adapter->Flags & E100_FLAG_HAS_FLOW_CONTROL)
+    {
+        Config->RejectFc = 1;
+    }
+
+    if ((Adapter->Flags & E100_FLAG_VLAN_TAGGING) ||
+        (Adapter->Flags & E100_FLAG_PACKET_PRIORITY))
+    {
+        Config->VlanTagStrippingEnable = 1;
+    }
+    else
+    {
+        Config->VlanTagStrippingEnable = 0;
+    }
+
+    if (PacketFilter & NDIS_PACKET_TYPE_BROADCAST)
+        Config->BroadcastDisable = 0;
+    else
+        Config->BroadcastDisable = 1;
+
+    if (PacketFilter & NDIS_PACKET_TYPE_ALL_MULTICAST)
+        Config->MulticastAll = 1;
+    else
+        Config->MulticastAll = 0;
+
+    if (PacketFilter & NDIS_PACKET_TYPE_PROMISCUOUS)
+    {
+        /*
+         * We need to enable MulticastAll as well
+         * because the chip has two types of promiscuous control.
+         */
+        Config->MulticastAll = 1;
+
+        Config->RejectFc = 0;
+        Config->VlanTagStrippingEnable = 0;
+
+        Config->PromiscuousMode = 1;
+        Config->DiscardShortReceive = 0;
+        Config->StrippingEnable = 0;
+    }
+    else
+    {
+        Config->PromiscuousMode = 0;
+        Config->DiscardShortReceive = 1;
+        Config->StrippingEnable = 1;
+    }
+
+    EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_CONFIG, &Config->Header);
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+}
+
+static
+VOID
+EeSetupFlowControl(
+    _Out_ PFXP_CB_CONFIGURE Config,
+    _In_ ULONG FlowControl)
+{
+    switch (FlowControl)
+    {
+        case E100_MEDIA_PAUSE_TX:
+            Config->FcDelayLsb = 0x00;
+            Config->FcDelayMsb = 0x40;
+            Config->TxFullDuplexFlowControlDisable = 0;
+            Config->RxFullDuplexRestopFlowControl = 0;
+            Config->RxFullDuplexRestartFlowControl = 0;
+            Config->RejectFc = 1;
+            break;
+
+        case E100_MEDIA_PAUSE_RX:
+            Config->FcDelayLsb = 0x1F;
+            Config->FcDelayMsb = 0x01;
+            Config->TxFullDuplexFlowControlDisable = 1;
+            Config->RxFullDuplexRestopFlowControl = 1;
+            Config->RxFullDuplexRestartFlowControl = 1;
+            Config->RejectFc = 1;
+            break;
+
+        case E100_MEDIA_PAUSE_TX | E100_MEDIA_PAUSE_RX:
+            Config->FcDelayLsb = 0x1F;
+            Config->FcDelayMsb = 0x01;
+            Config->TxFullDuplexFlowControlDisable = 0;
+            Config->RxFullDuplexRestopFlowControl = 1;
+            Config->RxFullDuplexRestartFlowControl = 1;
+            Config->RejectFc = 1;
+            break;
+
+        default:
+            Config->FcDelayLsb = 0x00;
+            Config->FcDelayMsb = 0x40;
+            Config->TxFullDuplexFlowControlDisable = 1;
+            Config->RxFullDuplexRestopFlowControl = 0;
+            Config->RxFullDuplexRestartFlowControl = 0;
+            Config->RejectFc = 1;
+            break;
+    }
+}
+
+static
+VOID
+EeSetMedia(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PFXP_CB_CONFIGURE Config = &Adapter->ControlBlock->Configuration;
+
+    if (Adapter->Flags & E100_FLAG_HAS_FLOW_CONTROL)
+    {
+        UCHAR FlowControl = Adapter->CurrentMedia & (E100_MEDIA_PAUSE_TX | E100_MEDIA_PAUSE_RX);
+
+        EeSetupFlowControl(Config, FlowControl);
+
+        if (Adapter->PacketFilter & NDIS_PACKET_TYPE_PROMISCUOUS)
+            Config->RejectFc = 0;
+
+        EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_CONFIG, &Config->Header);
+    }
+}
+
+static
+VOID
+EeDetectMedia(
+    _In_ PE100_ADAPTER Adapter)
+{
+    UCHAR OldMedia, NewMedia;
+
+    Adapter->MediaTick++;
+
+    /* If we have a link, then we need to poll the media less frequently */
+    OldMedia = Adapter->CurrentMedia;
+    if ((OldMedia != E100_MEDIA_NONE) && (Adapter->MediaTick & 1))
+        return;
+
+    NewMedia = EePhyGetSpeedAndDuplex(Adapter);
+    if (OldMedia == NewMedia)
+        return;
+
+    INFO_VERB("Configuring MAC from %u %s-duplex to %u %s-duplex\n",
+              (OldMedia & E100_MEDIA_100T) ? 100 : 10,
+              (OldMedia & E100_MEDIA_FD) ? "full" : "half",
+              (NewMedia & E100_MEDIA_100T) ? 100 : 10,
+              (NewMedia & E100_MEDIA_FD) ? "full" : "half");
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    Adapter->CurrentMedia = NewMedia;
+    EeSetMedia(Adapter);
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+
+    if (OldMedia == E100_MEDIA_NONE || NewMedia == E100_MEDIA_NONE)
+    {
+        INFO_VERB("Link %sconnected, media is 0x%02X\n",
+                  (NewMedia != E100_MEDIA_NONE) ? "" : "dis",
+                  NewMedia);
+
+        NdisMIndicateStatus(Adapter->AdapterHandle,
+                            (NewMedia != E100_MEDIA_NONE) ?
+                            NDIS_STATUS_MEDIA_CONNECT :
+                            NDIS_STATUS_MEDIA_DISCONNECT,
+                            NULL,
+                            0);
+        NdisMIndicateStatusComplete(Adapter->AdapterHandle);
+    }
+}
+
+static
+BOOLEAN
+EeCheckForTxHang(
+    _In_ PE100_ADAPTER Adapter)
+{
+    BOOLEAN Result = FALSE;
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    if (Adapter->TxPending > 0)
+    {
+        if ((Adapter->TxTimeOut > 0) && (--Adapter->TxTimeOut == 0))
+        {
+            Result = TRUE;
+        }
+    }
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+
+    return Result;
+}
+
+BOOLEAN
+NTAPI
+MiniportCheckForHang(
+    _In_ NDIS_HANDLE MiniportAdapterContext)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+
+    if (!Adapter->AdapterActive)
+        return FALSE;
+
+    if (Adapter->HardError)
+    {
+        ERR("Hard error detected %08lX\n", CSR_READ_32(Adapter, FXP_CSR_SCB_RUSCUS));
+        return TRUE;
+    }
+
+    if (EeCheckForTxHang(Adapter))
+    {
+        ERR("Transmit timeout detected %08lX\n", CSR_READ_32(Adapter, FXP_CSR_SCB_RUSCUS));
+        return TRUE;
+    }
+
+    /*
+     * The hardware does not allow to access statistics counters
+     * without doing a fairly expensive DMA to get all of the statistics it maintains,
+     * so we do this operation here every 2 seconds in the background by a timer tick.
+     */
+    EeDumpStatisticsCounters(Adapter);
+
+    EeDetectMedia(Adapter);
+
+    return FALSE;
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EeConfigureAdapter(
+    _In_ E100_ADAPTER* __restrict Adapter,
+    _In_ FXP_CB_CONFIGURE* __restrict Config)
+{
+    BOOLEAN RxChecksumEnabled82559;
+
+    PAGED_CODE();
+
+    /* Preserve some settings across chip resets */
+    RxChecksumEnabled82559 = !!Config->TcpUdpChecksum;
+
+    RtlZeroMemory(Config, sizeof(*Config));
+    /* 0 */
+    Config->ByteCount = Adapter->Flags & E100_FLAG_EXT_RFA ? 32 : 22;
+    /* 1 */
+    Config->RxFifoLimit = 8; // 32 bytes
+    Config->TxFifoLimit = 0;
+    /* 3 */
+    Config->MwiEnable = !!(Adapter->Flags & E100_FLAG_MWI_ENABLE);
+    /* 6 */
+    Config->DirectDmaDisable = 1;
+    Config->TnoInterruptOrTcoStat = 0;
+    Config->CiInterrupt = 1; // Interrupt on CU idle
+    Config->ExtTxCbDisable = !(Adapter->Flags & E100_FLAG_EXT_TXCB);
+    Config->ExtStatsDisable = 1; // No extended counters
+    Config->PassOverrunRx = 0; // Do not pass overrun frames to host
+    Config->SaveBadFrames = !!(Adapter->Flags & E100_FLAG_SAVE_BAD_PACKETS);
+    /* 7 */
+    Config->DiscardShortReceive = 1; // Discard short packets
+    Config->UnderunRetries = 1; // One re-transmission on DMA underrun
+    Config->DynamicTbd = !!(Adapter->Flags & E100_FLAG_EXT_RFA);
+    Config->ExtRfa = !!(Adapter->Flags & E100_FLAG_EXT_RFA);
+    /* 8 */
+    Config->MiiMode = !(Adapter->PhyType == E100_PHY_TYPE_503);
+    /* 9 */
+    Config->TcpUdpChecksum = !!RxChecksumEnabled82559;
+    Config->LinkStatusChangeWakeEnable = 0;
+    /* 10 */
+    Config->Byte10_1 = 1;
+    Config->Byte10_2 = 1;
+    Config->Nsai = 1; // No SA insertion
+    Config->PreambleLength = 2; // 7 bytes
+    /* 12 */
+    Config->InterframeSpacing = 96 / 16; // 96 bits
+    /* 14 */
+    Config->IpAddressHigh = 0xF2;
+    /* 15 */
+    Config->PromiscuousMode = 0;
+    Config->BroadcastDisable = 0;
+    Config->Byte15_3 = 1;
+    Config->Byte15_6 = 1;
+    Config->CrsCdt = !!(Adapter->PhyType == E100_PHY_TYPE_503);
+    /* 18 */
+    Config->StrippingEnable = 1; // Truncate RX packet to byte count
+    Config->PaddingEnable = 1; // Pad short TX packets
+    Config->LongRxOk = !!(Adapter->Flags & E100_FLAG_LONG_PKT);
+    Config->Byte18_7 = 1;
+    /* 19 */
+    Config->MagicPacketWakeDisable = !!(Adapter->Flags & E100_FLAG_HAS_WOL); // Reject WOL frames
+    /* 20 */
+    Config->Byte20_0 = 1;
+    Config->Byte20_1 = 1;
+    Config->Byte20_2 = 1;
+    Config->Byte20_3 = 1;
+    Config->Byte20_4 = 1;
+    Config->PriorityFcLocation = 1; // Priority field in byte 31
+    /* 21 */
+    Config->Byte21_0 = 1;
+    Config->Byte21_1 = 1;
+    Config->MulticastAll = 0;
+    /* 22 */
+    Config->GamlaRx = !!(Adapter->Flags & E100_FLAG_EXT_RFA);
+    Config->VlanTagStrippingEnable = !!((Adapter->Flags & E100_FLAG_VLAN_TAGGING) ||
+                                        (Adapter->Flags & E100_FLAG_PACKET_PRIORITY));
+
+    if (Adapter->DefaultMedia & E100_MEDIA_AUTO)
+    {
+        Config->ForceFullDuplex = 0;
+        Config->AutomaticFullDuplex = 1;
+    }
+    else
+    {
+        if (Adapter->DefaultMedia & E100_MEDIA_FD)
+        {
+            Config->ForceFullDuplex = 1;
+            Config->AutomaticFullDuplex = 1;
+        }
+        else
+        {
+            Config->ForceFullDuplex = 0;
+            Config->AutomaticFullDuplex = 1;
+        }
+    }
+
+    if (Adapter->Flags & E100_FLAG_HAS_FLOW_CONTROL)
+    {
+        Config->PriorityFcThreshold = 3;
+
+        EeSetupFlowControl(Config, 0);
+    }
+    else
+    {
+        /* No hardware flow control */
+        Config->PriorityFcThreshold = 7;
+        Config->FcDelayLsb = 0;
+        Config->FcDelayMsb = 0x40;
+        Config->TxFullDuplexFlowControlDisable = 0;
+        Config->RxFullDuplexRestopFlowControl = 0;
+        Config->RxFullDuplexRestartFlowControl = 0;
+        Config->RejectFc = 0;
+    }
+
+    /* Enable 82558 and 82559 extended statistics functionality */
+    if (Adapter->RevisionID >= FXP_REV_82558_A4)
+    {
+        if (Adapter->RevisionID >= FXP_REV_82559_A0)
+        {
+            /* Extend configuration table size to 32 to include TCO configuration */
+            Config->ByteCount = 32;
+            Config->ExtStatsDisable = 1;
+
+            /* Enable TCO statistics */
+            Config->TnoInterruptOrTcoStat = 1;
+
+            /* Required to enable the use of IPCB offloading capabilities */
+            Config->GamlaRx = 1;
+        }
+        else
+        {
+            Config->ExtStatsDisable = 0;
+        }
+    }
+}
+
+CODE_SEG("PAGE")
+VOID
+EeStartAdapter(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PAGED_CODE();
+
+    Adapter->AdapterActive = TRUE;
+    _ReadWriteBarrier();
+
+    /* Clear the events caused by adapter initialization */
+    CSR_WRITE_8(Adapter,
+                FXP_CSR_SCB_STATACK,
+                0xFF & ~(FXP_SCB_STATACK_FR | FXP_SCB_STATACK_RNR | FXP_SCB_STATACK_ER));
+
+    /* Enable interrupts */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_INTRCNTL, 0);
+}
+
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeSetupAdapter(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PFXP_CB_CONFIGURE Config;
+    ULONG i;
+
+    PAGED_CODE();
+
+    Adapter->HardError = FALSE;
+    Adapter->TxTimeOut = 0;
+    Adapter->ReceiverUnitIdleTicks = 0;
+    Adapter->CommandUnitActive = FALSE;
+    Adapter->CurrentMedia = E100_MEDIA_NONE;
+
+    EeInitTxRing(Adapter);
+
+    EePhyInit(Adapter);
+
+    EeCommandUnitExecuteCommandAddr(Adapter, FXP_SCB_COMMAND_CU_BASE, 0);
+    EeCommandUnitExecuteCommandAddr(Adapter, FXP_SCB_COMMAND_RU_BASE, 0);
+
+    if (!EeDownloadMicrocode(Adapter))
+        return NDIS_STATUS_HARD_ERRORS;
+
+    if (Adapter->DefaultMedia & E100_MEDIA_PAUSE_RX)
+    {
+        /* Set pause RX FIFO threshold to 1KB */
+        CSR_WRITE_8(Adapter, FXP_CSR_FC_THRESH, 1);
+    }
+
+    Config = &Adapter->ControlBlock->Configuration;
+    EeConfigureAdapter(Adapter, Config);
+    for (i = 0; i < Config->ByteCount; ++i)
+    {
+        INFO("Config %2lu: 0x%02X\n", i, ((PUCHAR)Config)[i + sizeof(Config->Header)]);
+    }
+    if (!EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_CONFIG, &Config->Header))
+        return NDIS_STATUS_HARD_ERRORS;
+
+    if (!EeSetupMacAddress(Adapter))
+        return NDIS_STATUS_HARD_ERRORS;
+
+    if (!EeSetupStatisticCounters(Adapter))
+        return NDIS_STATUS_HARD_ERRORS;
+
+    EeStartReceiveUnit(Adapter);
+
+    return NDIS_STATUS_SUCCESS;
+}

--- a/drivers/network/dd/e100/hardware.c
+++ b/drivers/network/dd/e100/hardware.c
@@ -1,0 +1,882 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Hardware specific functions
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/*
+ * HW access code was taken from the FreeBSD fxp driver.
+ * Copyright (c) 1995, David Greenman
+ * Copyright (c) 2001 Jonathan Lemon <jlemon@freebsd.org>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+#include "rcvbundl.h"
+
+#include <debug.h>
+
+/* GLOBASLS *******************************************************************/
+
+E100_PAGED_DATA static const ULONG E100MicrocodeD101a[] = D101_A_RCVBUNDLE_UCODE;
+E100_PAGED_DATA static const ULONG E100MicrocodeD101b0[] = D101_B0_RCVBUNDLE_UCODE;
+E100_PAGED_DATA static const ULONG E100MicrocodeD101ma[] = D101M_B_RCVBUNDLE_UCODE;
+E100_PAGED_DATA static const ULONG E100MicrocodeD101s[] = D101S_RCVBUNDLE_UCODE;
+E100_PAGED_DATA static const ULONG E100MicrocodeD102[] = D102_B_RCVBUNDLE_UCODE;
+E100_PAGED_DATA static const ULONG E100MicrocodeD102c[] = D102_C_RCVBUNDLE_UCODE;
+E100_PAGED_DATA static const ULONG E100MicrocodeD102e[] = D102_E_RCVBUNDLE_UCODE;
+
+E100_PAGED_DATA static const E100_UCODE_INFO E100MicrocodeTable[] =
+{
+#define UCODE(x)    x, RTL_NUMBER_OF(x)
+    {
+        UCODE(E100MicrocodeD101a), FXP_REV_82558_A4,
+        D101_CPUSAVER_DWORD, 0, 0
+    },
+    {
+        UCODE(E100MicrocodeD101b0), FXP_REV_82558_B0,
+        D101_CPUSAVER_DWORD, 0, 0
+    },
+    {
+        UCODE(E100MicrocodeD101ma), FXP_REV_82559_A0,
+        D101M_CPUSAVER_DWORD, D101M_CPUSAVER_BUNDLE_MAX_DWORD, D101M_CPUSAVER_MIN_SIZE_DWORD
+    },
+    {
+        UCODE(E100MicrocodeD101s), FXP_REV_82559S_A,
+        D101S_CPUSAVER_DWORD, D101S_CPUSAVER_BUNDLE_MAX_DWORD, D101S_CPUSAVER_MIN_SIZE_DWORD
+    },
+    {
+        UCODE(E100MicrocodeD102), FXP_REV_82550,
+        D102_B_CPUSAVER_DWORD, D102_B_CPUSAVER_BUNDLE_MAX_DWORD, D102_B_CPUSAVER_MIN_SIZE_DWORD
+    },
+    {
+        UCODE(E100MicrocodeD102c), FXP_REV_82550_C,
+        D102_C_CPUSAVER_DWORD, D102_C_CPUSAVER_BUNDLE_MAX_DWORD, 0
+    },
+    {
+        UCODE(E100MicrocodeD102e), FXP_REV_82551_F,
+        D102_E_CPUSAVER_DWORD, D102_E_CPUSAVER_BUNDLE_MAX_DWORD, D102_E_CPUSAVER_MIN_SIZE_DWORD
+    },
+    {
+        UCODE(E100MicrocodeD102e), FXP_REV_82551_10,
+        D102_E_CPUSAVER_DWORD, D102_E_CPUSAVER_BUNDLE_MAX_DWORD, D102_E_CPUSAVER_MIN_SIZE_DWORD
+    },
+    { NULL, 0, 0, 0, 0 }
+#undef UCODE
+};
+
+/* FUNCTIONS ******************************************************************/
+
+VOID
+EeSoftReset(
+    _In_ PE100_ADAPTER Adapter)
+{
+    /* Do selective reset first to prevent PCI bus lock-up */
+    CSR_WRITE_32(Adapter, FXP_CSR_PORT, FXP_PORT_SELECTIVE_RESET);
+    NdisStallExecution(10);
+
+    CSR_WRITE_32(Adapter, FXP_CSR_PORT, FXP_PORT_SOFTWARE_RESET);
+    NdisStallExecution(10);
+
+    /* Software reset will unmask interrupts so disable them after the reset */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_INTRCNTL, FXP_SCB_INTR_DISABLE);
+}
+
+static
+PULONG
+EeGetDumpCompletionStatus(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PFXP_COUNTERS Counters)
+{
+    if (Adapter->RevisionID >= FXP_REV_82559_A0)
+        return &Counters->CompletionStatus559;
+    else if (Adapter->RevisionID >= FXP_REV_82558_A4)
+        return &Counters->CompletionStatus558;
+    else
+        return &Counters->CompletionStatus557;
+}
+
+static
+VOID
+EeDumpStatisticsCounters(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PE100_STATISTICS Statistics = &Adapter->Statistics;
+    PFXP_COUNTERS Counters = &Adapter->ControlBlock->Counters;
+    PULONG CompletionStatus;
+
+    CompletionStatus = EeGetDumpCompletionStatus(Adapter, Counters);
+    if (*CompletionStatus != htole32(FXP_STATS_DR_COMPLETE))
+        return;
+
+    *CompletionStatus = 0;
+
+    TRACE("Dump command completed successfully\n");
+
+    Statistics->TransmitOk += letoh32(Counters->TxOk);
+    Statistics->TransmitErrors += letoh32(Counters->TxMaxCol) +
+                                  letoh32(Counters->TxLateCol) +
+                                  letoh32(Counters->TxUnderruns) +
+                                  letoh32(Counters->TxLossCarrier);
+    Statistics->TransmitOneRetry += letoh32(Counters->TxSingleCol);
+    Statistics->TransmitMoreCollisions += letoh32(Counters->TxMiltipleCol);
+    Statistics->TransmitDeferred += letoh32(Counters->TxDeffered);
+    Statistics->TransmitExcessiveCollisions += letoh32(Counters->TxMaxCol);
+    Statistics->TransmitUnderrunErrors += letoh32(Counters->TxUnderruns);
+    Statistics->TransmitLostCarrierSense += letoh32(Counters->TxLossCarrier);
+    Statistics->TransmitLateCollisions += letoh32(Counters->TxLateCol);
+
+    Statistics->ReceiveOk += letoh32(Counters->RxOk);
+    Statistics->ReceiveErrors += letoh32(Counters->RxCrcErr) +
+                                 letoh32(Counters->RxAlignErr) +
+                                 letoh32(Counters->RxResourceErr) +
+                                 letoh32(Counters->RxOverrunErr) +
+                                 letoh32(Counters->RxShortFramesErr);
+    Statistics->ReceiveOverrunErrors += letoh32(Counters->RxOverrunErr);
+    Statistics->ReceiveNoBuffers += letoh32(Counters->RxResourceErr);
+    Statistics->ReceiveCrcErrors += letoh32(Counters->RxCrcErr);
+    Statistics->ReceiveAlignmentErrors += letoh32(Counters->RxAlignErr);
+
+    /*
+     * Errata: The receive unit may lock up upon certain types of garbage
+     * in the synchronization bits prior to the packet header.
+     */
+    if (Adapter->Flags & E100_FLAG_RX_LOCKUP_BUG)
+    {
+        if (Counters->RxOk != 0)
+        {
+            /* We have received packets */
+            Adapter->ReceiverUnitIdleTicks = 0;
+        }
+        else
+        {
+            if (++Adapter->ReceiverUnitIdleTicks > 7)
+            {
+                Adapter->ReceiverUnitIdleTicks = 0;
+
+                /* Reprogram the multicast filter */
+                INFO("We have not been received any packets, assume the receive unit has hung\n");
+                EeUpdateMulticastList(Adapter);
+            }
+        }
+    }
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    /* Update the FIFO threshold level to minimize Tx FIFO underrun */
+    if (Counters->TxUnderruns != 0)
+    {
+        if (Adapter->TransmitThreshold < 192)
+        {
+            Adapter->TransmitThreshold += 64;
+            INFO("New transmit threshold %u\n", Adapter->TransmitThreshold);
+        }
+    }
+
+    /* Start another statistics dump if possible */
+    if (CSR_READ_8(Adapter, FXP_CSR_SCB_COMMAND) == 0)
+    {
+        TRACE("Dump statistics counters\n");
+        CSR_WRITE_8(Adapter, FXP_CSR_SCB_COMMAND, FXP_SCB_COMMAND_CU_DUMPRESET);
+    }
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+}
+
+BOOLEAN
+EeScbWaitForCommandClear(
+    _In_ PE100_ADAPTER Adapter)
+{
+    UCHAR Command;
+    ULONG i;
+
+    /* Wait up to 100 ms for the SCB to accept the previous command */
+    for (i = (100 * 1000) / 2; i > 0; i--)
+    {
+        Command = CSR_READ_8(Adapter, FXP_CSR_SCB_COMMAND);
+
+        if (Command == 0)
+            return TRUE;
+
+        NdisStallExecution(2);
+    }
+
+    ERR("SCB Timeout %02X %02X %02X\n",
+        CSR_READ_8(Adapter, FXP_CSR_SCB_COMMAND),
+        CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK),
+        CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS));
+    Adapter->HardError = TRUE;
+    return FALSE;
+}
+
+static
+BOOLEAN
+EeCommandUnitWaitForNotActive(
+    _In_ PE100_ADAPTER Adapter)
+{
+    UCHAR CuStatus;
+    ULONG i;
+
+    /* Wait up to 500 ms until the command unit is not active */
+    for (i = (500 * 1000) / 10; i > 0; i--)
+    {
+        CuStatus = FXP_SCB_CUS(CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS));
+
+        if (CuStatus != FXP_SCB_CUS_ACTIVE)
+            return TRUE;
+
+        NdisStallExecution(10);
+    }
+
+    ERR("CU Timeout %02X %02X %02X\n",
+        CSR_READ_8(Adapter, FXP_CSR_SCB_COMMAND),
+        CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK),
+        CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS));
+    Adapter->HardError = TRUE;
+    return FALSE;
+}
+
+static
+BOOLEAN
+EeCommandUnitWaitForCompiletion(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PUSHORT CbStatus)
+{
+    USHORT Status;
+    ULONG i;
+
+    /* Wait up to 500 ms for command completion */
+    for (i = (500 * 1000) / 2; i > 0; i--)
+    {
+        NdisStallExecution(2);
+
+        KeMemoryBarrierWithoutFence();
+        Status = htole16(*CbStatus);
+        if (Status & FXP_CB_STATUS_C)
+            break;
+    }
+    if (i == 0)
+    {
+        ERR("CU command timeout %02X %02X %02X %04X\n",
+            CSR_READ_8(Adapter, FXP_CSR_SCB_COMMAND),
+            CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK),
+            CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS),
+            Status);
+        Adapter->HardError = TRUE;
+        return FALSE;
+    }
+
+    if (Status & FXP_CB_STATUS_OK)
+        return TRUE;
+
+    ERR("CU command failed %02X %02X %02X %04X\n",
+        CSR_READ_8(Adapter, FXP_CSR_SCB_COMMAND),
+        CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK),
+        CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS),
+        Status);
+    Adapter->HardError = TRUE;
+    return FALSE;
+}
+
+static
+BOOLEAN
+EeCommandUnitSendCommand(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ USHORT Command,
+    _In_ PFXP_CB_HEADER Header)
+{
+    ULONG ControlBlockOffset;
+
+    TRACE("Send %X command\n", Command);
+
+    Header->Status = 0;
+    Header->Command = htole16(Command | FXP_CB_COMMAND_EL); // CU idle on completion
+    Header->LinkAddress = 0xFFFFFFFF;
+
+    EeScbWaitForCommandClear(Adapter);
+
+    if (Adapter->CommandUnitActive)
+    {
+        EeCommandUnitWaitForNotActive(Adapter);
+        Adapter->CommandUnitActive = FALSE;
+    }
+
+    ControlBlockOffset = (ULONG)((ULONG_PTR)Header - (ULONG_PTR)Adapter->ControlBlock);
+
+    CSR_WRITE_32(Adapter, FXP_CSR_SCB_GENERAL, Adapter->ControlBlockPa + ControlBlockOffset);
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_COMMAND, FXP_SCB_COMMAND_CU_START);
+
+    return EeCommandUnitWaitForCompiletion(Adapter, &Header->Status);
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeCommandUnitExecuteCommand(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ UCHAR Command,
+    _In_ ULONG PhysicalAddress)
+{
+    PAGED_CODE();
+
+    if (!EeScbWaitForCommandClear(Adapter))
+        return FALSE;
+
+    CSR_WRITE_32(Adapter, FXP_CSR_SCB_GENERAL, PhysicalAddress);
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_COMMAND, Command);
+    return TRUE;
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeDownloadMicrocode(
+    _In_ PE100_ADAPTER Adapter)
+{
+    const E100_UCODE_INFO* Info;
+    PFXP_CB_LOAD_MICROCODE MicrocodeSetup;
+    ULONG i;
+
+    PAGED_CODE();
+
+    if (Adapter->Flags & E100_FLAG_NO_UCODE)
+        return TRUE;
+
+    for (Info = E100MicrocodeTable; Info->Microcode; ++Info)
+    {
+        if (Adapter->RevisionID == Info->RevisionID)
+            break;
+    }
+    if (!Info->Microcode)
+        return TRUE;
+
+    INFO("Download microcode: INT_DELAY %lu, BUNDLE_MAX %lu, MIN_SIZE_MASK %lX\n",
+         Adapter->MicrocodeInterruptDelay,
+         Adapter->MicrocodeMaxFramesPerIntr,
+         Adapter->MicrocodeMinSizeMask);
+
+    MicrocodeSetup = &Adapter->ControlBlock->MicrocodeSetup;
+    for (i = 0; i < Info->Length; ++i)
+    {
+        MicrocodeSetup->Data[i] = htole32(Info->Microcode[i]);
+    }
+    for (; i < RTL_NUMBER_OF(MicrocodeSetup->Data); ++i)
+    {
+        MicrocodeSetup->Data[i] = 0;
+    }
+
+    /* Apply user-specified settings */
+    if (Info->IntDelayOffset != 0)
+    {
+        MicrocodeSetup->Data[Info->IntDelayOffset] &= htole32(0xFFFF0000);
+        MicrocodeSetup->Data[Info->IntDelayOffset] |= htole32(Adapter->MicrocodeInterruptDelay);
+    }
+    if (Info->BundleMaxOffset != 0)
+    {
+        MicrocodeSetup->Data[Info->BundleMaxOffset] &= htole32(0xFFFF0000);
+        MicrocodeSetup->Data[Info->BundleMaxOffset] |= htole32(Adapter->MicrocodeMaxFramesPerIntr);
+    }
+    if (Info->MinSizeMaskOffset != 0)
+    {
+        MicrocodeSetup->Data[Info->MinSizeMaskOffset] &= htole32(0xFFFF0000);
+        MicrocodeSetup->Data[Info->MinSizeMaskOffset] |= htole32(Adapter->MicrocodeMinSizeMask);
+    }
+
+    return EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_UCODE, &MicrocodeSetup->Header);
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeSetupMacAddress(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PFXP_CB_INDIVIDUAL_ADDRESS_SETUP IaSetup;
+
+    PAGED_CODE();
+
+    IaSetup = &Adapter->ControlBlock->IaSetup;
+    NdisMoveMemory(IaSetup->MacAddress, Adapter->CurrentMacAddress, ETH_LENGTH_OF_ADDRESS);
+
+    return EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_IAS, &IaSetup->Header);
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeStartReceiveUnit(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PE100_RX_CONTEXT RxContext;
+
+    PAGED_CODE();
+
+    RxContext = CONTAINING_RECORD(Adapter->RxContextList.Flink,
+                                  E100_RX_CONTEXT,
+                                  ListEntry);
+
+    return EeCommandUnitExecuteCommand(Adapter, FXP_SCB_COMMAND_RU_START, RxContext->RfdPhys);
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeSetupStatisticCounters(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PULONG CompletionStatus;
+    ULONG i, Address;
+
+    PAGED_CODE();
+
+    Address = Adapter->ControlBlockPa + FIELD_OFFSET(E100_CONTROL_BLOCK, Counters);
+    if (!EeCommandUnitExecuteCommand(Adapter, FXP_SCB_COMMAND_CU_DUMP_ADR, Address))
+        return FALSE;
+
+    CompletionStatus = EeGetDumpCompletionStatus(Adapter, &Adapter->ControlBlock->Counters);
+    *CompletionStatus = 0;
+    EE_WRITE_BARRIER();
+
+    /* Clear statistics counters since they are corrupted during power down state */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_COMMAND, FXP_SCB_COMMAND_CU_DUMPRESET);
+    for (i = (100 * 1000) / 2; i > 0; i--)
+    {
+        NdisStallExecution(2);
+
+        KeMemoryBarrierWithoutFence();
+        if (*CompletionStatus == htole32(FXP_STATS_DR_COMPLETE))
+            break;
+    }
+    if (i == 0)
+    {
+        ERR("Unable to reset statistic counters\n");
+        return FALSE;
+    }
+
+    /* Discard results of the previous dump */
+    EE_WRITE_BARRIER();
+    *CompletionStatus = 0;
+
+    /* Start another statistics dump */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_COMMAND, FXP_SCB_COMMAND_CU_DUMPRESET);
+
+    return TRUE;
+}
+
+NDIS_STATUS
+EeUpdateMulticastList(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PFXP_CB_MULTICAST_SETUP MulticastSetup;
+    ULONG ListSize;
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    if (Adapter->PacketFilter & NDIS_PACKET_TYPE_MULTICAST)
+    {
+        ListSize = Adapter->MulticastListSize;
+    }
+    else
+    {
+        /*
+         * Writing a zero count will reset the hash table
+         * and disable the multicast filtering mechanism.
+         */
+        ListSize = 0;
+    }
+
+    MulticastSetup = &Adapter->ControlBlock->MulticastSetup;
+    MulticastSetup->Count = htole16(ListSize);
+    NdisMoveMemory(MulticastSetup->MacAddress, Adapter->MulticastList, ListSize);
+
+    EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_MCAS, &MulticastSetup->Header);
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+NDIS_STATUS
+EeApplyPacketFilter(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG PacketFilter)
+{
+    PFXP_CB_CONFIGURE Config;
+    ULONG OldPacketFilter;
+
+    INFO("Packet filter value 0x%lx\n", PacketFilter);
+
+    OldPacketFilter = Adapter->PacketFilter;
+
+    if (PacketFilter == OldPacketFilter)
+        return NDIS_STATUS_SUCCESS;
+
+    Adapter->PacketFilter = PacketFilter;
+
+    if ((OldPacketFilter ^ PacketFilter) & NDIS_PACKET_TYPE_MULTICAST)
+    {
+        EeUpdateMulticastList(Adapter);
+    }
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    Config = &Adapter->ControlBlock->Configuration;
+    Config->PromiscuousMode = !!(PacketFilter & NDIS_PACKET_TYPE_PROMISCUOUS);
+    Config->BroadcastDisable = !(PacketFilter & NDIS_PACKET_TYPE_BROADCAST);
+    Config->MulticastAll = !!((PacketFilter & NDIS_PACKET_TYPE_ALL_MULTICAST) ||
+                              (PacketFilter & NDIS_PACKET_TYPE_PROMISCUOUS));
+
+    Config->SaveBadFrames = !!((Adapter->Flags & E100_FLAG_SAVE_BAD_PACKETS) ||
+                               (PacketFilter & NDIS_PACKET_TYPE_PROMISCUOUS));
+    Config->DiscardShortReceive = !(PacketFilter & NDIS_PACKET_TYPE_PROMISCUOUS);
+    Config->StrippingEnable = !(PacketFilter & NDIS_PACKET_TYPE_PROMISCUOUS);
+    Config->VlanTagStrippingEnable = !!((Adapter->Flags & E100_FLAG_VLAN_TAGGING) &&
+                                        !(PacketFilter & NDIS_PACKET_TYPE_PROMISCUOUS));
+
+    EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_CONFIG, &Config->Header);
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+VOID
+EeSetupFlowControl(
+    _Out_ PFXP_CB_CONFIGURE Config,
+    _In_ ULONG FlowControl)
+{
+    switch (FlowControl)
+    {
+        case E100_MEDIA_PAUSE_TX:
+            Config->FcDelayLsb = 0x00;
+            Config->FcDelayMsb = 0x40;
+            Config->TxFullDuplexFlowControlDisable = 0;
+            Config->RxFullDuplexRestopFlowControl = 0;
+            Config->RxFullDuplexRestartFlowControl = 0;
+            Config->RejectFc = 1;
+            break;
+
+        case E100_MEDIA_PAUSE_RX:
+            Config->FcDelayLsb = 0x1F;
+            Config->FcDelayMsb = 0x01;
+            Config->TxFullDuplexFlowControlDisable = 1;
+            Config->RxFullDuplexRestopFlowControl = 1;
+            Config->RxFullDuplexRestartFlowControl = 1;
+            Config->RejectFc = 1;
+            break;
+
+        case E100_MEDIA_PAUSE_TX | E100_MEDIA_PAUSE_RX:
+            Config->FcDelayLsb = 0x1F;
+            Config->FcDelayMsb = 0x01;
+            Config->TxFullDuplexFlowControlDisable = 0;
+            Config->RxFullDuplexRestopFlowControl = 1;
+            Config->RxFullDuplexRestartFlowControl = 1;
+            Config->RejectFc = 1;
+            break;
+
+        default:
+            Config->FcDelayLsb = 0x00;
+            Config->FcDelayMsb = 0x40;
+            Config->TxFullDuplexFlowControlDisable = 1;
+            Config->RxFullDuplexRestopFlowControl = 0;
+            Config->RxFullDuplexRestartFlowControl = 0;
+            Config->RejectFc = 0;
+            break;
+    }
+}
+
+static
+VOID
+EeSetSpeedAndDuplex(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PFXP_CB_CONFIGURE Config = &Adapter->ControlBlock->Configuration;
+
+    EeSetupFlowControl(Config, Adapter->CurrentMedia & (E100_MEDIA_PAUSE_TX | E100_MEDIA_PAUSE_RX));
+
+    EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_CONFIG, &Config->Header);
+}
+
+BOOLEAN
+NTAPI
+MiniportCheckForHang(
+    _In_ NDIS_HANDLE MiniportAdapterContext)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    UCHAR OldMedia, NewMedia;
+
+    if (!Adapter->AdapterActive)
+        return FALSE;
+
+    if (Adapter->HardError)
+    {
+        ERR("Hard error detected %08lX\n", CSR_READ_32(Adapter, FXP_CSR_SCB_RUSCUS));
+        return TRUE;
+    }
+
+    /*
+     * The hardware does not allow to access statistics counters
+     * without doing a fairly expensive DMA to get all of the statistics it maintains,
+     * so we do this operation here every 2 seconds in the background by a timer tick.
+     */
+    EeDumpStatisticsCounters(Adapter);
+
+    NewMedia = EePhyGetSpeedAndDuplex(Adapter);
+    OldMedia = Adapter->CurrentMedia;
+    if (OldMedia != NewMedia)
+    {
+        INFO_VERB("Configuring MAC from %u %s-duplex to %u %s-duplex\n",
+                  (OldMedia & E100_MEDIA_100T) ? 100 : 10,
+                  (OldMedia & E100_MEDIA_FD) ? "full" : "half",
+                  (NewMedia & E100_MEDIA_100T) ? 100 : 10,
+                  (NewMedia & E100_MEDIA_FD) ? "full" : "half");
+
+        NdisAcquireSpinLock(&Adapter->SendLock);
+
+        Adapter->CurrentMedia = NewMedia;
+        EeSetSpeedAndDuplex(Adapter);
+
+        NdisReleaseSpinLock(&Adapter->SendLock);
+
+        if (OldMedia == E100_MEDIA_NONE || NewMedia == E100_MEDIA_NONE)
+        {
+            INFO_VERB("Link %sconnected, media is 0x%02X\n",
+                      (NewMedia != E100_MEDIA_NONE) ? "" : "dis",
+                      NewMedia);
+
+            NdisMIndicateStatus(Adapter->AdapterHandle,
+                                (NewMedia != E100_MEDIA_NONE) ?
+                                NDIS_STATUS_MEDIA_CONNECT :
+                                NDIS_STATUS_MEDIA_DISCONNECT,
+                                NULL,
+                                0);
+            NdisMIndicateStatusComplete(Adapter->AdapterHandle);
+        }
+    }
+
+    return FALSE;
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EeConfigureAdapter(
+    _In_ E100_ADAPTER* __restrict Adapter,
+    _In_ FXP_CB_CONFIGURE* __restrict Config)
+{
+    PAGED_CODE();
+
+    NdisZeroMemory(Config, sizeof(*Config));
+    /* 0 */
+    Config->ByteCount = Adapter->Flags & E100_FLAG_EXT_RFA ? 32 : 22;
+    /* 1 */
+    Config->RxFifoLimit = 8; // 32 bytes
+    Config->TxFifoLimit = 0;
+    /* 3 */
+    Config->MwiEnable = !!(Adapter->Flags & E100_FLAG_WMI_ENANLE);
+    /* 6 */
+    Config->DirectDmaDisable = 1;
+    Config->TnoInterruptOrTcoStat = 0;
+    Config->CiInterrupt = 1; // Interrupt on CU idle
+    Config->ExtTxCbDisable = !(Adapter->Flags & E100_FLAG_EXT_TXCB);
+    Config->ExtStatsDisable = 1; // No extended counters
+    Config->PassOverrunRx = 0; // Do not pass overrun frames to host
+    Config->SaveBadFrames = !!(Adapter->Flags & E100_FLAG_SAVE_BAD_PACKETS);
+    /* 7 */
+    Config->DiscardShortReceive = 1; // Discard short packets
+    Config->UnderunRetries = 1; // One re-transmission on DMA underrun
+    Config->DynamicTbd = !!(Adapter->Flags & E100_FLAG_EXT_RFA);
+    Config->ExtRfa = !!(Adapter->Flags & E100_FLAG_EXT_RFA);
+    /* 8 */
+    Config->MiiMode = !(Adapter->PhyType == E100_PHY_TYPE_503);
+    /* 9 */
+    Config->TcpUdpChecksum = 0; // TODO
+    /* 10 */
+    Config->Byte10_1 = 1;
+    Config->Byte10_2 = 1;
+    Config->Nsai = 1; // No SA insertion
+    Config->PreambleLength = 2; // 7 bytes
+    /* 12 */
+    Config->InterframeSpacing = 96 / 16; // 96 bits
+    /* 14 */
+    Config->IpAddressHigh = 0xF2;
+    /* 15 */
+    Config->PromiscuousMode = 0;
+    Config->BroadcastDisable = 0;
+    Config->Byte15_3 = 1;
+    Config->Byte15_6 = 1;
+    Config->CrsCdt = !!(Adapter->PhyType == E100_PHY_TYPE_503);
+    /* 18 */
+    Config->StrippingEnable = 1; // Truncate RX packet to byte count
+    Config->PaddingEnable = 1; // Pad short TX packets
+    Config->LongRxOk = !!(Adapter->Flags & E100_FLAG_LONG_PKT);
+    Config->Byte18_7 = 1;
+    /* 19 */
+    Config->MagicPacketWakeDisable = !(Adapter->Flags & E100_FLAG_HAS_WOL);
+    Config->ForceFullDuplex = 0;
+    Config->AutomaticFullDuplex = 1; // Enable FDX# pin
+    /* 20 */
+    Config->Byte20_0 = 1;
+    Config->Byte20_1 = 1;
+    Config->Byte20_2 = 1;
+    Config->Byte20_3 = 1;
+    Config->Byte20_4 = 1;
+    Config->PriorityFcLocation = 1; // Priority field in byte 31
+    /* 21 */
+    Config->Byte21_0 = 1;
+    Config->Byte21_1 = 1;
+    Config->MulticastAll = 0;
+    /* 22 */
+    Config->GamlaRx = !!(Adapter->Flags & E100_FLAG_EXT_RFA);
+    Config->VlanTagStrippingEnable = !!(Adapter->Flags & E100_FLAG_VLAN_TAGGING);
+
+    if (Adapter->DefaultMedia & E100_MEDIA_AUTO)
+    {
+        Config->ForceFullDuplex = 0;
+        Config->AutomaticFullDuplex = 1;
+    }
+    else
+    {
+        if (Adapter->DefaultMedia & E100_MEDIA_FD)
+        {
+            Config->ForceFullDuplex = 1;
+            Config->AutomaticFullDuplex = 1;
+        }
+        else
+        {
+            Config->ForceFullDuplex = 0;
+            Config->AutomaticFullDuplex = !(Adapter->RevisionID == FXP_REV_82557);
+        }
+    }
+
+    if (Adapter->Flags & E100_FLAG_HAS_FLOW_CONTROL)
+    {
+        Config->PriorityFcThreshold = 3;
+
+        EeSetupFlowControl(Config, 0);
+    }
+    else
+    {
+        /* No hardware flow control */
+        Config->PriorityFcThreshold = 7;
+        Config->FcDelayLsb = 0;
+        Config->FcDelayMsb = 0x40;
+        Config->TxFullDuplexFlowControlDisable = 0;
+        Config->RxFullDuplexRestopFlowControl = 0;
+        Config->RxFullDuplexRestartFlowControl = 0;
+        Config->RejectFc = 0;
+    }
+
+    /* Enable 82558 and 82559 extended statistics functionality */
+    if (Adapter->RevisionID >= FXP_REV_82558_A4)
+    {
+        if (Adapter->RevisionID >= FXP_REV_82559_A0)
+        {
+            /* Extend configuration table size to 32 to include TCO configuration */
+            Config->ByteCount = 32;
+            Config->ExtStatsDisable = 1;
+
+            /* Enable TCO statistics */
+            Config->TnoInterruptOrTcoStat = 1;
+            Config->GamlaRx = 1;
+        }
+        else
+        {
+            Config->ExtStatsDisable = 0;
+        }
+    }
+
+    // TODO: Byte 9 wake on link 0x20
+}
+
+CODE_SEG("PAGE")
+VOID
+EeStartAdapter(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PAGED_CODE();
+
+    Adapter->AdapterActive = TRUE;
+
+    /* Enable interrupts */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_INTRCNTL, 0);
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EeInitTxRing(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PAGED_CODE();
+
+    Adapter->TxLast = &Adapter->TxContext[Adapter->TcbCount - 1];
+    Adapter->TxFirst = Adapter->TxLast->Next;
+    Adapter->TxPending = 0;
+
+    InitializeListHead(&Adapter->SendQueueList);
+}
+
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeSetupAdapter(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PFXP_CB_CONFIGURE Config;
+    ULONG i;
+
+    PAGED_CODE();
+
+    // TODO: Move this to reset?
+    Adapter->HardError = FALSE;
+
+    Adapter->ReceiverUnitIdleTicks = 0;
+    Adapter->CommandUnitActive = FALSE;
+    Adapter->CurrentMedia = E100_MEDIA_NONE;
+
+    // TODO: Clear the WOL events here?
+
+    EeInitTxRing(Adapter);
+
+    EePhyInit(Adapter);
+
+    if (!EeCommandUnitExecuteCommand(Adapter, FXP_SCB_COMMAND_CU_BASE, 0))
+        return NDIS_STATUS_HARD_ERRORS;
+
+    if (!EeCommandUnitExecuteCommand(Adapter, FXP_SCB_COMMAND_RU_BASE, 0))
+        return NDIS_STATUS_HARD_ERRORS;
+
+    if (!EeDownloadMicrocode(Adapter))
+        return NDIS_STATUS_HARD_ERRORS;
+
+    if (Adapter->DefaultMedia & E100_MEDIA_PAUSE_RX)
+    {
+        /* Set pause RX FIFO threshold to 1KB */
+        CSR_WRITE_8(Adapter, FXP_CSR_FC_THRESH, 1);
+    }
+
+    Config = &Adapter->ControlBlock->Configuration;
+    EeConfigureAdapter(Adapter, Config);
+    for (i = 0; i < Config->ByteCount; ++i)
+    {
+        INFO("Config %2lu: 0x%02X\n", i, ((PUCHAR)Config)[i + sizeof(Config->Header)]);
+    }
+    if (!EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_CONFIG, &Config->Header))
+        return NDIS_STATUS_HARD_ERRORS;
+
+    if (!EeSetupMacAddress(Adapter))
+        return NDIS_STATUS_HARD_ERRORS;
+
+    if (!EeSetupStatisticCounters(Adapter))
+        return NDIS_STATUS_HARD_ERRORS;
+
+    if (!EeStartReceiveUnit(Adapter))
+        return NDIS_STATUS_HARD_ERRORS;
+
+    // TODO: Send multicast to restore filter on power up?
+
+    return NDIS_STATUS_SUCCESS;
+}

--- a/drivers/network/dd/e100/init.c
+++ b/drivers/network/dd/e100/init.c
@@ -1,0 +1,1251 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Miniport initialization helper routines
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* GLOBALS ********************************************************************/
+
+#define EE_MEM_BLOCK_SIZE_CONTROL(Adapter) \
+    (sizeof(*(Adapter)->ControlBlock) + SYSTEM_CACHE_ALIGNMENT_SIZE - 1)
+
+#define EE_MEM_BLOCK_SIZE_TCB(Adapter) \
+    ((Adapter)->TcbCount * sizeof(FXP_CB_TRANSMIT) + E100_TCB_ALIGNMENT - 1)
+
+#define EE_MEM_BLOCK_SIZE_RFD(Adapter) \
+    ((Adapter)->RfdSize + E100_RECEIVE_BLOCK_SIZE + \
+     E100_RECEIVE_BUFFER_SHIFT + \
+     SYSTEM_CACHE_ALIGNMENT_SIZE - 1) \
+
+#define EE_MEM_BLOCK_SIZE_TX_BUFFER \
+    (E100_TRANSMIT_BLOCK_SIZE + SYSTEM_CACHE_ALIGNMENT_SIZE - 1)
+
+E100_PAGED_DATA static const struct
+{
+    USHORT DeviceID;
+    USHORT Flags;
+} E100ControllerList[] =
+{
+    { PCI_DEV_8255x,    0 },
+    { PCI_DEV_82559ER,  0 },
+    { PCI_DEV_82559_CB, 0 },
+    { PCI_DEV_82559,    0 },
+    { PCI_DEV_82551QM,  0 },
+
+    { PCI_DEV_ICH2,     E100_FLAG_IS_ICH },
+
+    { PCI_DEV_ICH3_1,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_2,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_3,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_4,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_5,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_6,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_7,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_8,   E100_FLAG_IS_ICH },
+
+    { PCI_DEV_ICH4_1,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH4_2,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH4_3,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH4_4,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH4_5,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH4_6,   E100_FLAG_IS_ICH },
+
+    { PCI_DEV_ICH5_1,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_2,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_3,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_4,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_5,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_6,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_7,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_8,   E100_FLAG_IS_ICH },
+
+    { PCI_DEV_C_ICH_1,  E100_FLAG_IS_ICH },
+    { PCI_DEV_C_ICH_2,  E100_FLAG_IS_ICH },
+
+    { PCI_DEV_ICH6_1,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_2,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_3,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_4,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_5,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_6,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_7,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_8,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_9,   E100_FLAG_IS_ICH },
+
+    { PCI_DEV_ICH7_1,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH7_2,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH7_3,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH7_4,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH7_5,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH7_6,   E100_FLAG_IS_ICH },
+    { PCI_DEV_82552,    E100_FLAG_IS_ICH },
+};
+
+/* FUNCTIONS ******************************************************************/
+
+static
+CODE_SEG("PAGE")
+VOID
+EeConfigQueryInteger(
+    _In_ NDIS_HANDLE ConfigurationHandle,
+    _In_ PCWSTR EntryName,
+    _Out_ PULONG EntryContext,
+    _In_ ULONG DefaultValue,
+    _In_ ULONG Minimum,
+    _In_ ULONG Maximum)
+{
+    NDIS_STATUS Status;
+    UNICODE_STRING Keyword;
+    PNDIS_CONFIGURATION_PARAMETER ConfigurationParameter;
+
+    PAGED_CODE();
+
+    NdisInitUnicodeString(&Keyword, EntryName);
+    NdisReadConfiguration(&Status,
+                          &ConfigurationParameter,
+                          ConfigurationHandle,
+                          &Keyword,
+                          NdisParameterInteger);
+    if (Status != NDIS_STATUS_SUCCESS)
+    {
+        TRACE("'%S' request failed, default to %u\n", EntryName, DefaultValue);
+
+        *EntryContext = DefaultValue;
+        return;
+    }
+
+    if (ConfigurationParameter->ParameterData.IntegerData >= Minimum &&
+        ConfigurationParameter->ParameterData.IntegerData <= Maximum)
+    {
+        *EntryContext = ConfigurationParameter->ParameterData.IntegerData;
+    }
+    else
+    {
+        WARN("'%S' value out of range\n", EntryName);
+
+        *EntryContext = DefaultValue;
+    }
+
+    INFO("Set '%S' to %lu\n", EntryName, *EntryContext);
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeReadConfiguration(
+    _In_ PE100_ADAPTER Adapter)
+{
+    NDIS_STATUS Status;
+    NDIS_HANDLE ConfigurationHandle;
+    PUCHAR NetworkAddress;
+    UINT Length;
+    ULONG GenericUlong;
+
+    PAGED_CODE();
+
+    NdisOpenConfiguration(&Status,
+                          &ConfigurationHandle,
+                          Adapter->WrapperConfigurationHandle);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    EeConfigQueryInteger(ConfigurationHandle,
+                         L"SpeedDuplex",
+                         &GenericUlong,
+                         0,
+                         0,
+                         4);
+    switch (GenericUlong)
+    {
+        case 0:
+            Adapter->DefaultMedia = E100_MEDIA_AUTO;
+            break;
+        case 1:
+            Adapter->DefaultMedia = 0;
+            break;
+        case 2:
+            Adapter->DefaultMedia = E100_MEDIA_FD;
+            break;
+        case 3:
+            Adapter->DefaultMedia = E100_MEDIA_100T;
+            break;
+        case 4:
+            Adapter->DefaultMedia = E100_MEDIA_100T | E100_MEDIA_FD;
+            break;
+
+        default:
+            ASSERT(FALSE);
+            UNREACHABLE;
+    }
+
+    /* Flow control */
+    if (Adapter->Flags & E100_FLAG_HAS_FLOW_CONTROL)
+    {
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"FlowControl",
+                             &GenericUlong,
+                             1,
+                             0,
+                             4);
+        if (!(Adapter->DefaultMedia & E100_MEDIA_AUTO))
+        {
+            if (GenericUlong == 1)
+            {
+                WARN("Cannot enable auto-negotiation of pause frames for forced link\n");
+                GenericUlong = 0;
+            }
+            else if (!(Adapter->DefaultMedia & E100_MEDIA_FD) && (GenericUlong != 0))
+            {
+                WARN("Cannot enable pause frames for half-duplex forced link\n");
+                GenericUlong = 0;
+            }
+        }
+        switch (GenericUlong)
+        {
+            case 0:
+                break;
+            case 1:
+                Adapter->DefaultMedia |= E100_MEDIA_PAUSE_AUTO |
+                                         E100_MEDIA_PAUSE_TX |
+                                         E100_MEDIA_PAUSE_RX;
+                break;
+            case 2:
+                Adapter->DefaultMedia |= E100_MEDIA_PAUSE_RX;
+                break;
+            case 3:
+                Adapter->DefaultMedia |= E100_MEDIA_PAUSE_TX;
+                break;
+            case 4:
+                Adapter->DefaultMedia |= E100_MEDIA_PAUSE_TX | E100_MEDIA_PAUSE_RX;
+                break;
+
+            default:
+                ASSERT(FALSE);
+                UNREACHABLE;
+        }
+    }
+
+    EeConfigQueryInteger(ConfigurationHandle,
+                         L"TcbNum",
+                         &GenericUlong,
+                         E100_TRANSMIT_BLOCKS_DEFAULT,
+                         E100_TRANSMIT_BLOCKS_MIN,
+                         E100_TRANSMIT_BLOCKS_MAX);
+    Adapter->TcbCount = GenericUlong;
+
+    EeConfigQueryInteger(ConfigurationHandle,
+                         L"RfdNum",
+                         &GenericUlong,
+                         E100_RECEIVE_BUFFERS_DEFAULT,
+                         E100_RECEIVE_BUFFERS_MIN,
+                         E100_RECEIVE_BUFFERS_MAX);
+    Adapter->RfdToAllocate = GenericUlong;
+
+    /* Intel microcode parameters */
+    if (!(Adapter->Flags & E100_FLAG_NO_UCODE))
+    {
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"IntDelay",
+                             &GenericUlong,
+                             1536,
+                             0,
+                             65535);
+        Adapter->MicrocodeInterruptDelay = GenericUlong;
+
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"BundleMax",
+                             &GenericUlong,
+                             6,
+                             1,
+                             65535);
+        Adapter->MicrocodeMaxFramesPerIntr = GenericUlong;
+
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"BundleSmall",
+                             &GenericUlong,
+                             1,
+                             0,
+                             1);
+        Adapter->MicrocodeMinSizeMask = GenericUlong ? 0xFFFF : 0xFF80;
+    }
+
+    /* VLAN tagging */
+    if (Adapter->Flags & E100_FLAG_EXT_RFA)
+    {
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"Priority",
+                             &GenericUlong,
+                             1,
+                             0,
+                             1);
+        if (GenericUlong)
+            Adapter->Flags |= E100_FLAG_PACKET_PRIORITY;
+
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"VlanTag",
+                             &GenericUlong,
+                             1,
+                             0,
+                             1);
+        if (GenericUlong)
+            Adapter->Flags |= E100_FLAG_VLAN_TAGGING;
+
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"VlanID",
+                             &GenericUlong,
+                             0,
+                             0,
+                             E100_MAXIMUM_VLAN_ID);
+        Adapter->VlanId = GenericUlong;
+    }
+
+    NdisReadNetworkAddress(&Status,
+                           (PVOID*)&NetworkAddress,
+                           &Length,
+                           ConfigurationHandle);
+    if ((Status == NDIS_STATUS_SUCCESS) && (Length == ETH_LENGTH_OF_ADDRESS))
+    {
+        if (ETH_IS_MULTICAST(NetworkAddress) ||
+            ETH_IS_EMPTY(NetworkAddress) ||
+            ETH_IS_BROADCAST(NetworkAddress) ||
+            !ETH_IS_LOCALLY_ADMINISTERED(NetworkAddress))
+        {
+            ERR("Invalid software MAC address: %02x:%02x:%02x:%02x:%02x:%02x\n",
+                NetworkAddress[0],
+                NetworkAddress[1],
+                NetworkAddress[2],
+                NetworkAddress[3],
+                NetworkAddress[4],
+                NetworkAddress[5]);
+            Status = NDIS_STATUS_INVALID_ADDRESS;
+        }
+    }
+    else
+    {
+        Status = NDIS_STATUS_INVALID_ADDRESS;
+    }
+    if (Status == NDIS_STATUS_SUCCESS)
+    {
+        INFO("Using software MAC address\n");
+        NdisMoveMemory(Adapter->CurrentMacAddress,
+                       NetworkAddress,
+                       ETH_LENGTH_OF_ADDRESS);
+    }
+    else
+    {
+        NdisMoveMemory(Adapter->CurrentMacAddress,
+                       Adapter->PermanentMacAddress,
+                       ETH_LENGTH_OF_ADDRESS);
+    }
+
+    NdisCloseConfiguration(ConfigurationHandle);
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EeGetTransmitBufferAllocSize(
+    _Out_ PULONG BuffersPerPage,
+    _Out_ PULONG BlockSize)
+{
+    ULONG NumPerPage;
+
+    PAGED_CODE();
+
+    NumPerPage = PAGE_SIZE / EE_MEM_BLOCK_SIZE_TX_BUFFER;
+    NumPerPage = max(NumPerPage, 1);
+
+    *BlockSize = NumPerPage * EE_MEM_BLOCK_SIZE_TX_BUFFER;
+    *BuffersPerPage = NumPerPage;
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EeGetRfdAllocSize(
+    _In_ PE100_ADAPTER Adapter,
+    _Out_ PULONG BuffersPerPage,
+    _Out_ PULONG BlockSize)
+{
+    ULONG NumPerPage;
+
+    PAGED_CODE();
+
+    NumPerPage = PAGE_SIZE / EE_MEM_BLOCK_SIZE_RFD(Adapter);
+    NumPerPage = max(NumPerPage, 1);
+
+    *BlockSize = NumPerPage * EE_MEM_BLOCK_SIZE_RFD(Adapter);
+    *BuffersPerPage = NumPerPage;
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeAllocateRfd(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PE100_RX_CONTEXT RxContext,
+    _In_ PVOID VirtualAddress,
+    _In_ NDIS_PHYSICAL_ADDRESS PhysicalAddress)
+{
+    NDIS_STATUS Status;
+
+    PAGED_CODE();
+
+    VirtualAddress = ALIGN_UP_POINTER_BY(VirtualAddress, SYSTEM_CACHE_ALIGNMENT_SIZE);
+    PhysicalAddress.QuadPart = ALIGN_UP_BY(PhysicalAddress.QuadPart, SYSTEM_CACHE_ALIGNMENT_SIZE);
+
+    /* NOTE: This makes the LinkAddress and RbdAddress fields to be not aligned to 4 bytes */
+    ASSERT(((ULONG_PTR)VirtualAddress % E100_RECEIVE_BUFFER_DATA_ALIGN) == 0);
+    ASSERT((PhysicalAddress.QuadPart % E100_RECEIVE_BUFFER_DATA_ALIGN) == 0);
+    VirtualAddress = (PVOID)((ULONG_PTR)VirtualAddress + E100_RECEIVE_BUFFER_SHIFT);
+    PhysicalAddress.QuadPart += E100_RECEIVE_BUFFER_SHIFT;
+
+    RxContext->Rfd = VirtualAddress;
+    RxContext->RfdPhys = PhysicalAddress.LowPart;
+
+    NdisAllocatePacket(&Status, &RxContext->Packet, Adapter->PacketPool);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    *E100_RX_CONTEXT_FROM_PACKET(RxContext->Packet) = RxContext;
+
+    /* Allocate MDL for RFD */
+    NdisAllocateBuffer(&Status,
+                       &RxContext->RfdMdl,
+                       Adapter->BufferPool,
+                       RxContext->Rfd,
+                       Adapter->RfdSize);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    /* Allocate MDL for receive buffer */
+    NdisAllocateBuffer(&Status,
+                       &RxContext->ReceiveBufferMdl,
+                       Adapter->BufferPool,
+                       (PVOID)((ULONG_PTR)RxContext->Rfd + Adapter->RfdSize),
+                       E100_RECEIVE_BLOCK_SIZE);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    NDIS_SET_PACKET_HEADER_SIZE(RxContext->Packet, E100_ETHERNET_HEADER_SIZE);
+    NdisChainBufferAtFront(RxContext->Packet, RxContext->ReceiveBufferMdl);
+
+    return TRUE;
+
+Failure:
+    if (RxContext->RfdMdl)
+        NdisFreeBuffer(RxContext->RfdMdl);
+    if (RxContext->ReceiveBufferMdl)
+        NdisFreeBuffer(RxContext->ReceiveBufferMdl);
+    if (RxContext->Packet)
+        NdisFreePacket(RxContext->Packet);
+
+    return FALSE;
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeAllocateReceiveBuffers(
+    _In_ PE100_ADAPTER Adapter)
+{
+    NDIS_STATUS Status;
+    ULONG i;
+    PVOID VirtualAddress;
+    NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+    ULONG RfdPerPage, BlockSize;
+
+    PAGED_CODE();
+
+    InitializeListHead(&Adapter->RxContextList);
+
+    NdisAllocatePacketPool(&Status,
+                           &Adapter->PacketPool,
+                           Adapter->RfdToAllocate,
+                           PROTOCOL_RESERVED_SIZE_IN_PACKET);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    NdisAllocateBufferPool(&Status,
+                           &Adapter->BufferPool,
+                           Adapter->RfdToAllocate);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    Status = NdisAllocateMemoryWithTag((PVOID*)&Adapter->RxContext,
+                                       sizeof(*Adapter->RxContext) * Adapter->RfdToAllocate,
+                                       E100_TAG);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+    NdisZeroMemory(Adapter->RxContext, sizeof(*Adapter->RxContext) * Adapter->RfdToAllocate);
+
+    /* Allocate one-page chunks to reduce memory usage */
+    EeGetRfdAllocSize(Adapter, &RfdPerPage, &BlockSize);
+
+    /* Allocate RFDs */
+    for (i = 0; i < Adapter->RfdToAllocate; ++i)
+    {
+        PE100_RX_CONTEXT RxContext = &Adapter->RxContext[i];
+
+        if ((i % RfdPerPage) == 0)
+        {
+            /* Allocate a chunk of memory */
+            NdisMAllocateSharedMemory(Adapter->AdapterHandle,
+                                      BlockSize,
+                                      TRUE, /* Cached */
+                                      &VirtualAddress,
+                                      &PhysicalAddress);
+            if (!VirtualAddress)
+            {
+                WARN("RFD allocation failed, total buffers %lu\n", Adapter->RfdCount);
+                break;
+            }
+            NdisZeroMemory(VirtualAddress, BlockSize);
+
+            /* 32-bit DMA */
+            ASSERT(PhysicalAddress.HighPart == 0);
+
+            RxContext->VirtualAddressOriginal = VirtualAddress;
+            RxContext->PhysicalAddressOriginal = PhysicalAddress.LowPart;
+        }
+
+        if (!EeAllocateRfd(Adapter, RxContext, VirtualAddress, PhysicalAddress))
+        {
+            WARN("RFD allocation failed, total buffers %lu\n", Adapter->RfdCount);
+            break;
+        }
+
+        /* Split the allocation */
+        VirtualAddress = (PVOID)((ULONG_PTR)VirtualAddress + EE_MEM_BLOCK_SIZE_RFD(Adapter));
+        PhysicalAddress.QuadPart += EE_MEM_BLOCK_SIZE_RFD(Adapter);
+
+        ++Adapter->RfdCount;
+    }
+
+    if (Adapter->RfdCount < E100_RECEIVE_BUFFERS_MIN)
+        return NDIS_STATUS_RESOURCES;
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeAllocateTransmitBlocks(
+    _In_ PE100_ADAPTER Adapter)
+{
+    NDIS_STATUS Status;
+    NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+
+    PAGED_CODE();
+
+    NdisMAllocateSharedMemory(Adapter->AdapterHandle,
+                              EE_MEM_BLOCK_SIZE_TCB(Adapter),
+                              FALSE, /* Non-cached */
+                              &Adapter->TcbOriginalVa,
+                              &PhysicalAddress);
+    if (!Adapter->TcbOriginalVa)
+        return NDIS_STATUS_RESOURCES;
+    NdisZeroMemory(Adapter->TcbOriginalVa, EE_MEM_BLOCK_SIZE_TCB(Adapter));
+
+    /* 32-bit DMA */
+    ASSERT(PhysicalAddress.HighPart == 0);
+
+    Adapter->TcbOriginalPhys = PhysicalAddress.LowPart;
+
+    Adapter->HeadTcbPa = ALIGN_UP_BY(Adapter->TcbOriginalPhys, E100_TCB_ALIGNMENT);
+    Adapter->HeadTcb = ALIGN_UP_POINTER_BY(Adapter->TcbOriginalVa, E100_TCB_ALIGNMENT);
+
+    Status = NdisAllocateMemoryWithTag((PVOID*)&Adapter->TxContext,
+                                       sizeof(*Adapter->TxContext) * Adapter->TcbCount,
+                                       E100_TAG);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+    NdisZeroMemory(Adapter->TxContext, sizeof(*Adapter->TxContext) * Adapter->TcbCount);
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeAllocateTransmitBuffers(
+    _In_ PE100_ADAPTER Adapter)
+{
+    ULONG i;
+    PVOID VirtualAddress;
+    NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+    ULONG BuffersPerPage, BlockSize;
+
+    PAGED_CODE();
+
+    /* Allocate one-page chunks to reduce memory usage */
+    EeGetTransmitBufferAllocSize(&BuffersPerPage, &BlockSize);
+
+    for (i = 0; i < E100_TRANSMIT_BUFFERS; ++i)
+    {
+        PE100_COALESCE_BUFFER CoalesceBuffer = &Adapter->CoalesceBuffer[i];
+
+        if ((i % BuffersPerPage) == 0)
+        {
+            /* Allocate a chunk of memory */
+            NdisMAllocateSharedMemory(Adapter->AdapterHandle,
+                                      BlockSize,
+                                      TRUE, /* Cached */
+                                      &VirtualAddress,
+                                      &PhysicalAddress);
+            if (!VirtualAddress)
+                return NDIS_STATUS_RESOURCES;
+            NdisZeroMemory(VirtualAddress, BlockSize);
+
+            /* 32-bit DMA */
+            ASSERT(PhysicalAddress.HighPart == 0);
+
+            CoalesceBuffer->VirtualAddressOriginal = VirtualAddress;
+            CoalesceBuffer->PhysicalAddressOriginal = PhysicalAddress.LowPart;
+        }
+
+        CoalesceBuffer->VirtualAddress =
+            ALIGN_UP_POINTER_BY(VirtualAddress, SYSTEM_CACHE_ALIGNMENT_SIZE);
+        CoalesceBuffer->PhysicalAddress =
+            ALIGN_UP_BY(PhysicalAddress.LowPart, SYSTEM_CACHE_ALIGNMENT_SIZE);
+
+        PushEntryList(&Adapter->SendBufferList, &CoalesceBuffer->ListEntry);
+
+        /* Split the allocation */
+        VirtualAddress = (PVOID)((ULONG_PTR)VirtualAddress + EE_MEM_BLOCK_SIZE_TX_BUFFER);
+        PhysicalAddress.QuadPart += EE_MEM_BLOCK_SIZE_TX_BUFFER;
+    }
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeAllocateControlBlock(
+    _In_ PE100_ADAPTER Adapter)
+{
+    NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+
+    PAGED_CODE();
+
+    NdisMAllocateSharedMemory(Adapter->AdapterHandle,
+                              EE_MEM_BLOCK_SIZE_CONTROL(Adapter),
+                              FALSE, /* Non-cached */
+                              &Adapter->ControlBlockOriginal,
+                              &PhysicalAddress);
+    if (!Adapter->ControlBlockOriginal)
+        return NDIS_STATUS_RESOURCES;
+    NdisZeroMemory(Adapter->ControlBlockOriginal, EE_MEM_BLOCK_SIZE_CONTROL(Adapter));
+
+    /* 32-bit DMA */
+    ASSERT(PhysicalAddress.HighPart == 0);
+
+    Adapter->ControlBlockOriginalPhys = PhysicalAddress.LowPart;
+
+    Adapter->ControlBlockPa = ALIGN_UP_BY(PhysicalAddress.LowPart, SYSTEM_CACHE_ALIGNMENT_SIZE);
+    Adapter->ControlBlock = ALIGN_UP_POINTER_BY(Adapter->ControlBlockOriginal,
+                                                SYSTEM_CACHE_ALIGNMENT_SIZE);
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeAllocateMemory(
+    _In_ PE100_ADAPTER Adapter)
+{
+    NDIS_STATUS Status;
+
+    PAGED_CODE();
+
+    Status = NdisMInitializeScatterGatherDma(Adapter->AdapterHandle,
+                                             FALSE, /* 32-bit DMA */
+                                             E100_MAXIMUM_FRAME_SIZE);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    Status = EeAllocateControlBlock(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    Status = EeAllocateTransmitBlocks(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    Status = EeAllocateTransmitBuffers(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    Status = EeAllocateReceiveBuffers(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    NdisAllocateSpinLock(&Adapter->SendLock);
+    NdisAllocateSpinLock(&Adapter->ReceiveLock);
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EeCreateTxRing(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PE100_TX_CONTEXT PrevTxContext, TxContext;
+    PFXP_CB_TRANSMIT PrevTcb, Tcb;
+    ULONG i, TcbPa;
+
+    PAGED_CODE();
+
+    PrevTxContext = &Adapter->TxContext[Adapter->TcbCount - 1];
+    TxContext = Adapter->TxContext;
+    PrevTcb = &Adapter->HeadTcb[Adapter->TcbCount - 1];
+    Tcb = Adapter->HeadTcb;
+    TcbPa = Adapter->HeadTcbPa;
+
+    for (i = 0; i < Adapter->TcbCount; ++i)
+    {
+        Tcb->Header.Status = 0;
+        Tcb->Header.Command = htole16(FXP_CB_COMMAND_NOP | FXP_CB_COMMAND_S);
+        PrevTcb->Header.LinkAddress = htole32(TcbPa);
+        if (Adapter->Flags & E100_FLAG_EXT_TXCB)
+        {
+            /* The TBD address points to the third TBD in this mode */
+            Tcb->TbdArrayAddress = htole32(TcbPa + FIELD_OFFSET(FXP_CB_TRANSMIT, Tbd[2]));
+        }
+        else
+        {
+            Tcb->TbdArrayAddress = htole32(TcbPa + FIELD_OFFSET(FXP_CB_TRANSMIT, Tbd[0]));
+        }
+
+        TxContext->Tcb = Tcb;
+        TxContext->TcbPhys = TcbPa;
+        PrevTxContext->Next = TxContext;
+
+        PrevTxContext = TxContext;
+        PrevTcb = Tcb;
+
+        TxContext++;
+        Tcb++;
+        TcbPa += sizeof(*Tcb);
+    }
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EeCreateRxRing(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PE100_RX_CONTEXT RxContext = Adapter->RxContext;
+    PFXP_RFD Rfd = NULL;
+    ULONG i;
+
+    PAGED_CODE();
+
+    for (i = 0; i < Adapter->RfdCount; ++i)
+    {
+        /* Attach a new buffer to the receive chain */
+        if (Rfd)
+        {
+            le32enc(&Rfd->Header.LinkAddress, RxContext->RfdPhys);
+        }
+
+        Rfd = RxContext->Rfd;
+        Rfd->Header.Status = 0;
+        Rfd->Header.Command = 0;
+        le32enc(&Rfd->Header.LinkAddress, 0xFFFFFFFF);
+        le32enc(&Rfd->RbdAddress, 0xFFFFFFFF);
+        Rfd->Size = htole16(E100_RECEIVE_BLOCK_SIZE);
+        Rfd->ActualSize = 0;
+
+        InsertTailList(&Adapter->RxContextList, &RxContext->ListEntry);
+
+        RxContext++;
+    }
+    Rfd->Header.Command = htole16(FXP_RFD_CONTROL_EL);
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeInitializeAdapterResources(
+    _In_ PE100_ADAPTER Adapter)
+{
+    NDIS_STATUS Status;
+    PNDIS_RESOURCE_LIST AssignedResources = NULL;
+    PCM_PARTIAL_RESOURCE_DESCRIPTOR IoDescriptor = NULL;
+    PCM_PARTIAL_RESOURCE_DESCRIPTOR InterruptDescriptor = NULL;
+    UINT i, ResourceListSize = 0;
+
+    PAGED_CODE();
+
+    NdisMQueryAdapterResources(&Status,
+                               Adapter->WrapperConfigurationHandle,
+                               AssignedResources,
+                               &ResourceListSize);
+    if (Status != NDIS_STATUS_RESOURCES)
+        return NDIS_STATUS_FAILURE;
+
+    Status = NdisAllocateMemoryWithTag((PVOID*)&AssignedResources,
+                                       ResourceListSize,
+                                       E100_TAG);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    NdisMQueryAdapterResources(&Status,
+                               Adapter->WrapperConfigurationHandle,
+                               AssignedResources,
+                               &ResourceListSize);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Cleanup;
+
+    for (i = 0; i < AssignedResources->Count; ++i)
+    {
+        PCM_PARTIAL_RESOURCE_DESCRIPTOR Descriptor;
+
+        Descriptor = &AssignedResources->PartialDescriptors[i];
+        switch (Descriptor->Type)
+        {
+            case CmResourceTypeMemory:
+            {
+                if (!IoDescriptor && (Descriptor->u.Memory.Length == FXP_PCI_MMIO_BAR_LENGTH))
+                    IoDescriptor = Descriptor;
+                break;
+            }
+
+            case CmResourceTypeInterrupt:
+            {
+                if (!InterruptDescriptor)
+                    InterruptDescriptor = Descriptor;
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+
+    if (!IoDescriptor || !InterruptDescriptor)
+    {
+        Status = NDIS_STATUS_RESOURCES;
+        goto Cleanup;
+    }
+
+    Adapter->InterruptVector = InterruptDescriptor->u.Interrupt.Vector;
+    Adapter->InterruptLevel = InterruptDescriptor->u.Interrupt.Level;
+    Adapter->InterruptFlags = InterruptDescriptor->Flags;
+    if (InterruptDescriptor->ShareDisposition == CmResourceShareShared)
+        Adapter->Flags |= E100_FLAG_IRQ_SHARED;
+
+    Status = NdisMMapIoSpace((PVOID*)&Adapter->IoBase,
+                             Adapter->AdapterHandle,
+                             IoDescriptor->u.Memory.Start,
+                             FXP_PCI_MMIO_BAR_LENGTH);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Cleanup;
+
+    INFO("IO Base %p\n", Adapter->IoBase);
+    INFO("IRQ Level %u, Vector %u\n",
+         Adapter->InterruptLevel,
+         Adapter->InterruptVector);
+    INFO("IRQ ShareDisposition %u, InterruptFlags %lx\n",
+         InterruptDescriptor->ShareDisposition,
+         InterruptDescriptor->Flags);
+
+Cleanup:
+    NdisFreeMemory(AssignedResources, ResourceListSize, 0);
+
+    return Status;
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeRecognizeHardware(
+    _In_ PE100_ADAPTER Adapter)
+{
+    UCHAR Buffer[RTL_SIZEOF_THROUGH_FIELD(PCI_COMMON_CONFIG, CacheLineSize)];
+    PPCI_COMMON_CONFIG PciConfig = (PPCI_COMMON_CONFIG)Buffer; // Partial PCI header
+    ULONG i, Bytes, Flags;
+
+    PAGED_CODE();
+
+    Bytes = NdisReadPciSlotInformation(Adapter->AdapterHandle,
+                                       0,
+                                       FIELD_OFFSET(PCI_COMMON_CONFIG, VendorID),
+                                       Buffer,
+                                       sizeof(Buffer));
+    if (Bytes != sizeof(Buffer))
+        return NDIS_STATUS_FAILURE;
+
+    if (PciConfig->VendorID != PCI_VEN_INTEL)
+        return NDIS_STATUS_FAILURE;
+
+    for (i = 0; i < RTL_NUMBER_OF(E100ControllerList); ++i)
+    {
+        Flags = E100ControllerList[i].Flags;
+
+        if (PciConfig->DeviceID == E100ControllerList[i].DeviceID)
+            break;
+    }
+    if (i == RTL_NUMBER_OF(E100ControllerList))
+        return NDIS_STATUS_NOT_RECOGNIZED;
+
+    INFO("Starting controller %04X:%04X.%02X\n",
+         PciConfig->VendorID,
+         PciConfig->DeviceID,
+         PciConfig->RevisionID);
+
+    Adapter->DeviceID = PciConfig->DeviceID;
+    Adapter->RevisionID = PciConfig->RevisionID;
+    Adapter->Flags = Flags;
+
+    if (PciConfig->Command & PCI_ENABLE_WRITE_AND_INVALIDATE)
+    {
+        INFO("WMI enabled\n");
+        Adapter->Flags |= E100_FLAG_WMI_ENANLE;
+    }
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+PE100_ADAPTER
+EeAllocateAdapter(
+    _In_ NDIS_HANDLE MiniportAdapterHandle,
+    _In_ NDIS_HANDLE WrapperConfigurationContext)
+{
+    PE100_ADAPTER Adapter;
+    PVOID UnalignedAdapter;
+    ULONG Alignment, AdapterSize;
+    NDIS_STATUS Status;
+
+    PAGED_CODE();
+
+    Alignment = NdisGetSharedDataAlignment();
+    AdapterSize = sizeof(*Adapter) + Alignment - 1;
+
+    Status = NdisAllocateMemoryWithTag((PVOID*)&UnalignedAdapter, AdapterSize, E100_TAG);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return NULL;
+    NdisZeroMemory(UnalignedAdapter, AdapterSize);
+
+    Adapter = ALIGN_UP_POINTER_BY(UnalignedAdapter, Alignment);
+    Adapter->AdapterOriginal = UnalignedAdapter;
+    Adapter->AdapterSize = AdapterSize;
+    Adapter->AdapterHandle = MiniportAdapterHandle;
+    Adapter->WrapperConfigurationHandle = WrapperConfigurationContext;
+    return Adapter;
+}
+
+CODE_SEG("PAGE")
+VOID
+EeFreeAdapter(
+    _In_ __drv_freesMem(Mem) PE100_ADAPTER Adapter)
+{
+    ULONG i;
+
+    PAGED_CODE();
+
+    if (Adapter->Interrupt.InterruptObject)
+    {
+        NdisMDeregisterInterrupt(&Adapter->Interrupt);
+    }
+
+    if (Adapter->IoBase)
+    {
+        NdisMUnmapIoSpace(Adapter->AdapterHandle,
+                          Adapter->IoBase,
+                          FXP_PCI_MMIO_BAR_LENGTH);
+    }
+
+    if (Adapter->ControlBlockOriginal)
+    {
+        NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+
+        PhysicalAddress.QuadPart = Adapter->ControlBlockOriginalPhys;
+        NdisMFreeSharedMemory(Adapter->AdapterHandle,
+                              EE_MEM_BLOCK_SIZE_CONTROL(Adapter),
+                              FALSE, /* Non-cached */
+                              Adapter->ControlBlockOriginal,
+                              PhysicalAddress);
+    }
+
+    if (Adapter->TxContext)
+    {
+        NdisFreeMemory(Adapter->TxContext, sizeof(*Adapter->TxContext) * Adapter->TcbCount, 0);
+    }
+
+    if (Adapter->TcbOriginalVa)
+    {
+        NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+
+        PhysicalAddress.QuadPart = Adapter->TcbOriginalPhys;
+        NdisMFreeSharedMemory(Adapter->AdapterHandle,
+                              EE_MEM_BLOCK_SIZE_TCB(Adapter),
+                              FALSE, /* Non-cached */
+                              Adapter->TcbOriginalVa,
+                              PhysicalAddress);
+    }
+
+    if (Adapter->RxContext)
+    {
+        ULONG RfdPerPage, BlockSize;
+
+        EeGetRfdAllocSize(Adapter, &RfdPerPage, &BlockSize);
+
+        for (i = 0; i < Adapter->RfdToAllocate; ++i)
+        {
+            PE100_RX_CONTEXT RxContext = &Adapter->RxContext[i];
+
+            if (RxContext->VirtualAddressOriginal)
+            {
+                NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+
+                PhysicalAddress.QuadPart = RxContext->PhysicalAddressOriginal;
+                NdisMFreeSharedMemory(Adapter->AdapterHandle,
+                                      BlockSize,
+                                      TRUE, /* Cached */
+                                      RxContext->VirtualAddressOriginal,
+                                      PhysicalAddress);
+
+                if (RxContext->RfdMdl)
+                    NdisFreeBuffer(RxContext->RfdMdl);
+                if (RxContext->ReceiveBufferMdl)
+                    NdisFreeBuffer(RxContext->ReceiveBufferMdl);
+                if (RxContext->Packet)
+                    NdisFreePacket(RxContext->Packet);
+            }
+        }
+
+        NdisFreeMemory(Adapter->RxContext, sizeof(*Adapter->RxContext) * Adapter->RfdToAllocate, 0);
+    }
+
+    if (Adapter->CoalesceBuffer[0].VirtualAddress)
+    {
+        ULONG BuffersPerPage, BlockSize;
+
+        EeGetTransmitBufferAllocSize(&BuffersPerPage, &BlockSize);
+
+        for (i = 0; i < E100_TRANSMIT_BUFFERS; ++i)
+        {
+            PE100_COALESCE_BUFFER CoalesceBuffer = &Adapter->CoalesceBuffer[i];
+
+            if (CoalesceBuffer->VirtualAddressOriginal)
+            {
+                NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+
+                PhysicalAddress.QuadPart = CoalesceBuffer->PhysicalAddressOriginal;
+                NdisMFreeSharedMemory(Adapter->AdapterHandle,
+                                      BlockSize,
+                                      FALSE, /* Non-cached */
+                                      CoalesceBuffer->VirtualAddressOriginal,
+                                      PhysicalAddress);
+            }
+        }
+    }
+
+    if (Adapter->PacketPool)
+        NdisFreePacketPool(Adapter->PacketPool);
+    if (Adapter->BufferPool)
+        NdisFreeBufferPool(Adapter->BufferPool);
+
+    if (Adapter->SendLock.SpinLock)
+        NdisFreeSpinLock(&Adapter->SendLock);
+    if (Adapter->ReceiveLock.SpinLock)
+        NdisFreeSpinLock(&Adapter->ReceiveLock);
+
+    NdisFreeMemory(Adapter->AdapterOriginal, sizeof(*Adapter), 0);
+}
+
+CODE_SEG("PAGE")
+NDIS_STATUS
+NTAPI
+MiniportInitialize(
+    _Out_ PNDIS_STATUS OpenErrorStatus,
+    _Out_ PUINT SelectedMediumIndex,
+    _In_ PNDIS_MEDIUM MediumArray,
+    _In_ UINT MediumArraySize,
+    _In_ NDIS_HANDLE MiniportAdapterHandle,
+    _In_ NDIS_HANDLE WrapperConfigurationContext)
+{
+    PE100_ADAPTER Adapter;
+    NDIS_STATUS Status;
+    UINT i;
+
+    INFO("Called\n");
+
+    PAGED_CODE();
+
+    for (i = 0; i < MediumArraySize; ++i)
+    {
+        if (MediumArray[i] == NdisMedium802_3)
+        {
+            *SelectedMediumIndex = i;
+            break;
+        }
+    }
+    if (i == MediumArraySize)
+    {
+        ERR("No supported media\n");
+        return NDIS_STATUS_UNSUPPORTED_MEDIA;
+    }
+
+    Adapter = EeAllocateAdapter(MiniportAdapterHandle, WrapperConfigurationContext);
+    if (!Adapter)
+    {
+        ERR("Failed to allocate adapter context\n");
+        return NDIS_STATUS_RESOURCES;
+    }
+
+    NdisMSetAttributesEx(MiniportAdapterHandle,
+                         Adapter,
+                         2, /* CheckForHangTimeInSeconds */
+                         NDIS_ATTRIBUTE_BUS_MASTER |
+                         NDIS_ATTRIBUTE_DESERIALIZE |
+                         NDIS_ATTRIBUTE_USES_SAFE_BUFFER_APIS,
+                         NdisInterfacePci);
+
+    Status = EeRecognizeHardware(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    Status = EeInitializeAdapterResources(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    EeSoftReset(Adapter);
+
+    if (!EeReadEeprom(Adapter))
+        goto Failure;
+
+    Adapter->TbdCount = E100_TBD_PER_TCB;
+    Adapter->TransmitThreshold = 64;
+
+    if (Adapter->RevisionID == FXP_REV_82557)
+    {
+        /* Older chips do not support MWI */
+        Adapter->Flags &= ~E100_FLAG_WMI_ENANLE;
+
+        /* A hack to get long VLAN frames on a 82557 */
+        Adapter->Flags |= E100_FLAG_SAVE_BAD_PACKETS;
+    }
+    else
+    {
+        /* The 82558 and later chips have flow control */
+        Adapter->Flags |= E100_FLAG_HAS_FLOW_CONTROL;
+
+        /* Turn on the extended TxCB feature */
+        Adapter->Flags |= E100_FLAG_EXT_TXCB;
+
+        /* Enable reception of long frames for VLAN */
+        Adapter->Flags |= E100_FLAG_LONG_PKT;
+
+        /* For 82559 or later chips, RX checksum offload is supported */
+        if (Adapter->RevisionID >= FXP_REV_82559_A0)
+        {
+            /* 82559ER does not support RX checksum offloading */
+            if (Adapter->DeviceID != PCI_DEV_82559ER)
+                Adapter->Flags |= E100_FLAG_82559_RXCSUM;
+        }
+    }
+
+    /* Enable use of extended RFDs and TCBs for 82550 and later chips */
+    if ((Adapter->RevisionID == FXP_REV_82550) ||
+        (Adapter->RevisionID == FXP_REV_82550_C) ||
+        (Adapter->RevisionID == FXP_REV_82551_E) ||
+        (Adapter->RevisionID == FXP_REV_82551_F) ||
+        (Adapter->RevisionID == FXP_REV_82551_10))
+    {
+        /* We need extended TxCB support too */
+        ASSERT(Adapter->Flags & E100_FLAG_EXT_TXCB);
+
+        /* -1 for IPCB */
+        --Adapter->TbdCount;
+
+        Adapter->RfdSize = sizeof(FXP_RFD);
+        Adapter->TransmitCommand = htole16(FXP_CB_COMMAND_IPCBXMIT |
+                                           FXP_CB_COMMAND_SF |
+                                           FXP_CB_COMMAND_S |
+                                           FXP_CB_COMMAND_I);
+
+        /* Use extended RFA instead of 82559 checksum mode */
+        Adapter->Flags |= E100_FLAG_EXT_RFA;
+        Adapter->Flags &= ~E100_FLAG_82559_RXCSUM;
+    }
+    else
+    {
+        Adapter->RfdSize = RTL_SIZEOF_THROUGH_FIELD(FXP_RFD, Size);
+        Adapter->TransmitCommand = htole16(FXP_CB_COMMAND_XMIT |
+                                           FXP_CB_COMMAND_SF |
+                                           FXP_CB_COMMAND_S |
+                                           FXP_CB_COMMAND_I);
+    }
+
+    Status = EeReadConfiguration(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    Status = EeAllocateMemory(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    EeCreateTxRing(Adapter);
+    EeCreateRxRing(Adapter);
+
+    Status = EeFindMiiPhy(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    // TODO: Improve
+    if (Adapter->Flags & E100_FLAG_HAS_WOL)
+    {
+        CSR_WRITE_8(Adapter, FXP_CSR_PMDR, CSR_READ_8(Adapter, FXP_CSR_PMDR));
+
+    }
+
+    Status = EeSetupAdapter(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Disable;
+
+    Status = NdisMRegisterInterrupt(&Adapter->Interrupt,
+                                    Adapter->AdapterHandle,
+                                    Adapter->InterruptVector,
+                                    Adapter->InterruptLevel,
+                                    TRUE, /* Request ISR calls */
+                                    !!(Adapter->Flags & E100_FLAG_IRQ_SHARED),
+                                    (Adapter->InterruptFlags & CM_RESOURCE_INTERRUPT_LATCHED) ?
+                                    NdisInterruptLatched : NdisInterruptLevelSensitive);
+    if (Status != NDIS_STATUS_SUCCESS)
+    {
+        ERR("Unable to register interrupt\n");
+        goto Disable;
+    }
+
+    EeStartAdapter(Adapter);
+
+    return NDIS_STATUS_SUCCESS;
+
+Disable:
+    EeSoftReset(Adapter);
+Failure:
+    ERR("Initialization failed with status %08lx\n", Status);
+
+    EeFreeAdapter(Adapter);
+    return Status;
+}

--- a/drivers/network/dd/e100/init.c
+++ b/drivers/network/dd/e100/init.c
@@ -1,0 +1,1325 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Miniport initialization helper routines
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* GLOBALS ********************************************************************/
+
+#define EE_MEM_BLOCK_SIZE_CONTROL(Adapter) \
+    (sizeof(*(Adapter)->ControlBlock) + SYSTEM_CACHE_ALIGNMENT_SIZE - 1)
+
+#define EE_MEM_BLOCK_SIZE_TCB(Adapter) \
+    ((Adapter)->TcbCount * sizeof(FXP_CB_TRANSMIT) + E100_TCB_ALIGNMENT - 1)
+
+#define EE_MEM_BLOCK_SIZE_RFD(Adapter) \
+    ((Adapter)->RfdSize + E100_RECEIVE_BLOCK_SIZE + \
+     E100_RECEIVE_BUFFER_SHIFT + \
+     SYSTEM_CACHE_ALIGNMENT_SIZE - 1) \
+
+#define EE_MEM_BLOCK_SIZE_TX_BUFFER \
+    (E100_TRANSMIT_BLOCK_SIZE + SYSTEM_CACHE_ALIGNMENT_SIZE - 1)
+
+E100_PAGED_DATA static const struct
+{
+    USHORT DeviceID;
+    USHORT Flags;
+} E100ControllerList[] =
+{
+    { PCI_DEV_8255x,    0 },
+    { PCI_DEV_82559ER,  0 },
+    { PCI_DEV_82559_CB, 0 },
+    { PCI_DEV_82559,    0 },
+    { PCI_DEV_82551QM,  0 },
+
+    { PCI_DEV_ICH2,     E100_FLAG_IS_ICH },
+
+    { PCI_DEV_ICH3_1,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_2,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_3,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_4,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_5,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_6,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_7,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH3_8,   E100_FLAG_IS_ICH },
+
+    { PCI_DEV_ICH4_1,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH4_2,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH4_3,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH4_4,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH4_5,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH4_6,   E100_FLAG_IS_ICH },
+
+    { PCI_DEV_ICH5_1,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_2,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_3,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_4,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_5,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_6,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_7,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH5_8,   E100_FLAG_IS_ICH },
+
+    { PCI_DEV_C_ICH_1,  E100_FLAG_IS_ICH },
+    { PCI_DEV_C_ICH_2,  E100_FLAG_IS_ICH },
+
+    { PCI_DEV_ICH6_1,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_2,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_3,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_4,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_5,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_6,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_7,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_8,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH6_9,   E100_FLAG_IS_ICH },
+
+    { PCI_DEV_ICH7_1,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH7_2,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH7_3,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH7_4,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH7_5,   E100_FLAG_IS_ICH },
+    { PCI_DEV_ICH7_6,   E100_FLAG_IS_ICH },
+    { PCI_DEV_82552,    E100_FLAG_IS_ICH },
+};
+
+/* FUNCTIONS ******************************************************************/
+
+static
+CODE_SEG("PAGE")
+VOID
+EeConfigQueryInteger(
+    _In_ NDIS_HANDLE ConfigurationHandle,
+    _In_ PCWSTR EntryName,
+    _Out_ PULONG EntryContext,
+    _In_ ULONG DefaultValue,
+    _In_ ULONG Minimum,
+    _In_ ULONG Maximum)
+{
+    NDIS_STATUS Status;
+    UNICODE_STRING Keyword;
+    PNDIS_CONFIGURATION_PARAMETER ConfigurationParameter;
+
+    PAGED_CODE();
+
+    NdisInitUnicodeString(&Keyword, EntryName);
+    NdisReadConfiguration(&Status,
+                          &ConfigurationParameter,
+                          ConfigurationHandle,
+                          &Keyword,
+                          NdisParameterInteger);
+    if (Status != NDIS_STATUS_SUCCESS)
+    {
+        TRACE("'%S' request failed, default to %lu\n", EntryName, DefaultValue);
+
+        *EntryContext = DefaultValue;
+        return;
+    }
+
+    if (ConfigurationParameter->ParameterData.IntegerData >= Minimum &&
+        ConfigurationParameter->ParameterData.IntegerData <= Maximum)
+    {
+        *EntryContext = ConfigurationParameter->ParameterData.IntegerData;
+    }
+    else
+    {
+        WARN("'%S' value out of range\n", EntryName);
+
+        *EntryContext = DefaultValue;
+    }
+
+    INFO("Set '%S' to %lu\n", EntryName, *EntryContext);
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeReadConfiguration(
+    _In_ PE100_ADAPTER Adapter)
+{
+    NDIS_STATUS Status;
+    NDIS_HANDLE ConfigurationHandle;
+    PUCHAR NetworkAddress;
+    UINT Length;
+    ULONG GenericUlong;
+
+    PAGED_CODE();
+
+    NdisOpenConfiguration(&Status,
+                          &ConfigurationHandle,
+                          Adapter->WrapperConfigurationHandle);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    EeConfigQueryInteger(ConfigurationHandle,
+                         L"TcbNum",
+                         &GenericUlong,
+                         E100_TRANSMIT_BLOCKS_DEFAULT,
+                         E100_TRANSMIT_BLOCKS_MIN,
+                         E100_TRANSMIT_BLOCKS_MAX);
+    Adapter->TcbCount = GenericUlong;
+
+    EeConfigQueryInteger(ConfigurationHandle,
+                         L"RfdNum",
+                         &GenericUlong,
+                         E100_RECEIVE_BUFFERS_DEFAULT,
+                         E100_RECEIVE_BUFFERS_MIN,
+                         E100_RECEIVE_BUFFERS_MAX);
+    Adapter->RfdToAllocate = GenericUlong;
+
+    EeConfigQueryInteger(ConfigurationHandle,
+                         L"SpeedDuplex",
+                         &GenericUlong,
+                         0,
+                         0,
+                         4);
+    switch (GenericUlong)
+    {
+        case 0:
+            Adapter->DefaultMedia = E100_MEDIA_AUTO;
+            break;
+        case 1:
+            Adapter->DefaultMedia = 0;
+            break;
+        case 2:
+            Adapter->DefaultMedia = E100_MEDIA_FD;
+            break;
+        case 3:
+            Adapter->DefaultMedia = E100_MEDIA_100T;
+            break;
+        case 4:
+            Adapter->DefaultMedia = E100_MEDIA_100T | E100_MEDIA_FD;
+            break;
+
+        default:
+            ASSERT(FALSE);
+            UNREACHABLE;
+    }
+
+    /* Flow control */
+    if (Adapter->Flags & E100_FLAG_HAS_FLOW_CONTROL)
+    {
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"FlowControl",
+                             &GenericUlong,
+                             1,
+                             0,
+                             4);
+        if (!(Adapter->DefaultMedia & E100_MEDIA_AUTO))
+        {
+            if (GenericUlong == 1)
+            {
+                WARN("Cannot enable auto-negotiation of pause frames for forced link\n");
+                GenericUlong = 0;
+            }
+            else if (!(Adapter->DefaultMedia & E100_MEDIA_FD) && (GenericUlong != 0))
+            {
+                WARN("Cannot enable pause frames for half-duplex forced link\n");
+                GenericUlong = 0;
+            }
+        }
+        switch (GenericUlong)
+        {
+            case 0:
+                break;
+            case 1:
+                Adapter->DefaultMedia |= E100_MEDIA_PAUSE_AUTO |
+                                         E100_MEDIA_PAUSE_TX |
+                                         E100_MEDIA_PAUSE_RX;
+                break;
+            case 2:
+                Adapter->DefaultMedia |= E100_MEDIA_PAUSE_RX;
+                break;
+            case 3:
+                Adapter->DefaultMedia |= E100_MEDIA_PAUSE_TX;
+                break;
+            case 4:
+                Adapter->DefaultMedia |= E100_MEDIA_PAUSE_TX | E100_MEDIA_PAUSE_RX;
+                break;
+
+            default:
+                ASSERT(FALSE);
+                UNREACHABLE;
+        }
+    }
+
+    /* Intel microcode parameters */
+    if (!(Adapter->Flags & E100_FLAG_NO_UCODE))
+    {
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"UCodeIntDelay",
+                             &GenericUlong,
+                             1536,
+                             0,
+                             65535);
+        Adapter->MicrocodeInterruptDelay = GenericUlong;
+
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"UCodeBundleMax",
+                             &GenericUlong,
+                             6,
+                             1,
+                             65535);
+        Adapter->MicrocodeMaxFramesPerIntr = GenericUlong;
+
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"UCodeBundleSmall",
+                             &GenericUlong,
+                             1,
+                             0,
+                             1);
+        Adapter->MicrocodeMinSizeMask = GenericUlong ? 0xFFFF : 0xFF80;
+    }
+
+    /* WOL */
+    if ((Adapter->Flags & E100_FLAG_HAS_WOL) || (Adapter->RevisionID == FXP_REV_82559S_A))
+    {
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"WolLinkSpeed",
+                             &GenericUlong,
+                             1,
+                             0,
+                             1);
+        if (GenericUlong)
+            Adapter->Flags |= E100_FLAG_REDUCE_WOL_LINK_SPEED;
+    }
+
+    /* RX/TX checksum offload */
+    if ((Adapter->Flags & E100_FLAG_82559_RXCSUM) || (Adapter->Flags & E100_FLAG_EXT_RFA))
+    {
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"ChecksumOffload",
+                             &GenericUlong,
+                             1,
+                             0,
+                             1);
+        if (GenericUlong)
+            Adapter->Flags |= E100_FLAG_CSUM_OFFLOAD;
+    }
+
+    /* VLAN tagging and LSO */
+    if (Adapter->Flags & E100_FLAG_EXT_RFA)
+    {
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"VlanPrio",
+                             &GenericUlong,
+                             1,
+                             0,
+                             1);
+        if (GenericUlong)
+            Adapter->Flags |= E100_FLAG_PACKET_PRIORITY;
+
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"VlanTag",
+                             &GenericUlong,
+                             1,
+                             0,
+                             1);
+        if (GenericUlong)
+            Adapter->Flags |= E100_FLAG_VLAN_TAGGING;
+
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"VlanID",
+                             &GenericUlong,
+                             0,
+                             0,
+                             E100_MAXIMUM_VLAN_ID);
+        Adapter->VlanId = GenericUlong;
+
+        EeConfigQueryInteger(ConfigurationHandle,
+                             L"LargeSendOffload",
+                             &GenericUlong,
+                             1,
+                             0,
+                             1);
+        if (GenericUlong)
+            Adapter->Flags |= E100_FLAG_LARGE_SEND_OFFLOAD;
+    }
+
+    NdisReadNetworkAddress(&Status,
+                           (PVOID*)&NetworkAddress,
+                           &Length,
+                           ConfigurationHandle);
+    if ((Status == NDIS_STATUS_SUCCESS) && (Length == ETH_LENGTH_OF_ADDRESS))
+    {
+        if (ETH_IS_MULTICAST(NetworkAddress) ||
+            ETH_IS_EMPTY(NetworkAddress) ||
+            ETH_IS_BROADCAST(NetworkAddress) ||
+            !ETH_IS_LOCALLY_ADMINISTERED(NetworkAddress))
+        {
+            ERR("Invalid software MAC address: %02x:%02x:%02x:%02x:%02x:%02x\n",
+                NetworkAddress[0],
+                NetworkAddress[1],
+                NetworkAddress[2],
+                NetworkAddress[3],
+                NetworkAddress[4],
+                NetworkAddress[5]);
+            Status = NDIS_STATUS_INVALID_ADDRESS;
+        }
+    }
+    else
+    {
+        Status = NDIS_STATUS_INVALID_ADDRESS;
+    }
+    if (Status == NDIS_STATUS_SUCCESS)
+    {
+        INFO("Using software MAC address\n");
+        RtlCopyMemory(Adapter->CurrentMacAddress,
+                       NetworkAddress,
+                       ETH_LENGTH_OF_ADDRESS);
+    }
+    else
+    {
+        RtlCopyMemory(Adapter->CurrentMacAddress,
+                       Adapter->PermanentMacAddress,
+                       ETH_LENGTH_OF_ADDRESS);
+    }
+
+    NdisCloseConfiguration(ConfigurationHandle);
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EeGetTransmitBufferAllocSize(
+    _Out_ PULONG BuffersPerPage,
+    _Out_ PULONG BlockSize)
+{
+    ULONG NumPerPage;
+
+    PAGED_CODE();
+
+    NumPerPage = PAGE_SIZE / EE_MEM_BLOCK_SIZE_TX_BUFFER;
+    NumPerPage = max(NumPerPage, 1);
+
+    *BlockSize = NumPerPage * EE_MEM_BLOCK_SIZE_TX_BUFFER;
+    *BuffersPerPage = NumPerPage;
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EeGetRfdAllocSize(
+    _In_ PE100_ADAPTER Adapter,
+    _Out_ PULONG BuffersPerPage,
+    _Out_ PULONG BlockSize)
+{
+    ULONG NumPerPage;
+
+    PAGED_CODE();
+
+    NumPerPage = PAGE_SIZE / EE_MEM_BLOCK_SIZE_RFD(Adapter);
+    NumPerPage = max(NumPerPage, 1);
+
+    *BlockSize = NumPerPage * EE_MEM_BLOCK_SIZE_RFD(Adapter);
+    *BuffersPerPage = NumPerPage;
+}
+
+static
+CODE_SEG("PAGE")
+BOOLEAN
+EeAllocateRfd(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PE100_RX_CONTEXT RxContext,
+    _In_ PVOID VirtualAddress,
+    _In_ NDIS_PHYSICAL_ADDRESS PhysicalAddress)
+{
+    NDIS_STATUS Status;
+
+    PAGED_CODE();
+
+    VirtualAddress = ALIGN_UP_POINTER_BY(VirtualAddress, SYSTEM_CACHE_ALIGNMENT_SIZE);
+    PhysicalAddress.QuadPart = ALIGN_UP_BY(PhysicalAddress.QuadPart, SYSTEM_CACHE_ALIGNMENT_SIZE);
+
+    /* NOTE: This makes the LinkAddress and RbdAddress fields to be not aligned to 4 bytes */
+    ASSERT(((ULONG_PTR)VirtualAddress % E100_RECEIVE_BUFFER_DATA_ALIGN) == 0);
+    ASSERT((PhysicalAddress.QuadPart % E100_RECEIVE_BUFFER_DATA_ALIGN) == 0);
+    VirtualAddress = (PVOID)((ULONG_PTR)VirtualAddress + E100_RECEIVE_BUFFER_SHIFT);
+    PhysicalAddress.QuadPart += E100_RECEIVE_BUFFER_SHIFT;
+
+    RxContext->Rfd = VirtualAddress;
+    RxContext->RfdPhys = PhysicalAddress.LowPart;
+
+    NdisAllocatePacket(&Status, &RxContext->Packet, Adapter->PacketPool);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    *E100_RX_CONTEXT_FROM_PACKET(RxContext->Packet) = RxContext;
+
+    /* Allocate MDL for RFD */
+    NdisAllocateBuffer(&Status,
+                       &RxContext->RfdMdl,
+                       Adapter->BufferPool,
+                       RxContext->Rfd,
+                       Adapter->RfdSize);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    /* Allocate MDL for receive buffer */
+    NdisAllocateBuffer(&Status,
+                       &RxContext->ReceiveBufferMdl,
+                       Adapter->BufferPool,
+                       (PVOID)((ULONG_PTR)RxContext->Rfd + Adapter->RfdSize),
+                       E100_RECEIVE_BLOCK_SIZE);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    NDIS_SET_PACKET_HEADER_SIZE(RxContext->Packet, E100_ETHERNET_HEADER_SIZE);
+    NdisChainBufferAtFront(RxContext->Packet, RxContext->ReceiveBufferMdl);
+
+    return TRUE;
+
+Failure:
+    if (RxContext->RfdMdl)
+    {
+        NdisFreeBuffer(RxContext->RfdMdl);
+        RxContext->RfdMdl = NULL;
+    }
+    if (RxContext->ReceiveBufferMdl)
+    {
+        NdisFreeBuffer(RxContext->ReceiveBufferMdl);
+        RxContext->ReceiveBufferMdl = NULL;
+    }
+    if (RxContext->Packet)
+    {
+        NdisFreePacket(RxContext->Packet);
+        RxContext->Packet = NULL;
+    }
+
+    return FALSE;
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeAllocateReceiveBuffers(
+    _In_ PE100_ADAPTER Adapter)
+{
+    NDIS_STATUS Status;
+    ULONG i;
+    PVOID VirtualAddress;
+    NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+    ULONG RfdPerPage, BlockSize;
+
+    PAGED_CODE();
+
+    InitializeListHead(&Adapter->RxContextList);
+
+    NdisAllocatePacketPool(&Status,
+                           &Adapter->PacketPool,
+                           Adapter->RfdToAllocate,
+                           PROTOCOL_RESERVED_SIZE_IN_PACKET);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    NdisAllocateBufferPool(&Status,
+                           &Adapter->BufferPool,
+                           Adapter->RfdToAllocate);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    Status = NdisAllocateMemoryWithTag((PVOID*)&Adapter->RxContext,
+                                       sizeof(*Adapter->RxContext) * Adapter->RfdToAllocate,
+                                       E100_TAG);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+    RtlZeroMemory(Adapter->RxContext, sizeof(*Adapter->RxContext) * Adapter->RfdToAllocate);
+
+    /* Allocate one-page chunks to reduce memory usage */
+    EeGetRfdAllocSize(Adapter, &RfdPerPage, &BlockSize);
+
+    /* Allocate RFDs */
+    for (i = 0; i < Adapter->RfdToAllocate; ++i)
+    {
+        PE100_RX_CONTEXT RxContext = &Adapter->RxContext[i];
+
+        if ((i % RfdPerPage) == 0)
+        {
+            /* Allocate a chunk of memory */
+            NdisMAllocateSharedMemory(Adapter->AdapterHandle,
+                                      BlockSize,
+                                      TRUE, /* Cached */
+                                      &VirtualAddress,
+                                      &PhysicalAddress);
+            if (!VirtualAddress)
+            {
+                WARN("RFD allocation failed, total buffers %lu\n", Adapter->RfdCount);
+                break;
+            }
+            RtlZeroMemory(VirtualAddress, BlockSize);
+
+            /* 32-bit DMA */
+            ASSERT(PhysicalAddress.HighPart == 0);
+
+            RxContext->VirtualAddressOriginal = VirtualAddress;
+            RxContext->PhysicalAddressOriginal = PhysicalAddress.LowPart;
+        }
+
+        if (!EeAllocateRfd(Adapter, RxContext, VirtualAddress, PhysicalAddress))
+        {
+            WARN("RFD allocation failed, total buffers %lu\n", Adapter->RfdCount);
+            break;
+        }
+
+        /* Split the allocation */
+        VirtualAddress = (PVOID)((ULONG_PTR)VirtualAddress + EE_MEM_BLOCK_SIZE_RFD(Adapter));
+        PhysicalAddress.QuadPart += EE_MEM_BLOCK_SIZE_RFD(Adapter);
+
+        ++Adapter->RfdCount;
+    }
+
+    if (Adapter->RfdCount < E100_RECEIVE_BUFFERS_MIN)
+        return NDIS_STATUS_RESOURCES;
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeAllocateTransmitBlocks(
+    _In_ PE100_ADAPTER Adapter)
+{
+    NDIS_STATUS Status;
+    NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+
+    PAGED_CODE();
+
+    NdisMAllocateSharedMemory(Adapter->AdapterHandle,
+                              EE_MEM_BLOCK_SIZE_TCB(Adapter),
+                              FALSE, /* Non-cached */
+                              &Adapter->TcbOriginalVa,
+                              &PhysicalAddress);
+    if (!Adapter->TcbOriginalVa)
+        return NDIS_STATUS_RESOURCES;
+
+    /* 32-bit DMA */
+    ASSERT(PhysicalAddress.HighPart == 0);
+
+    Adapter->TcbOriginalPhys = PhysicalAddress.LowPart;
+
+    Adapter->HeadTcbPa = ALIGN_UP_BY(Adapter->TcbOriginalPhys, E100_TCB_ALIGNMENT);
+    Adapter->HeadTcb = ALIGN_UP_POINTER_BY(Adapter->TcbOriginalVa, E100_TCB_ALIGNMENT);
+
+    Status = NdisAllocateMemoryWithTag((PVOID*)&Adapter->TxContext,
+                                       sizeof(*Adapter->TxContext) * Adapter->TcbCount,
+                                       E100_TAG);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+    RtlZeroMemory(Adapter->TxContext, sizeof(*Adapter->TxContext) * Adapter->TcbCount);
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeAllocateTransmitBuffers(
+    _In_ PE100_ADAPTER Adapter)
+{
+    ULONG i;
+    PVOID VirtualAddress;
+    NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+    ULONG BuffersPerPage, BlockSize;
+
+    PAGED_CODE();
+
+    /* Allocate one-page chunks to reduce memory usage */
+    EeGetTransmitBufferAllocSize(&BuffersPerPage, &BlockSize);
+
+    for (i = 0; i < E100_TRANSMIT_BUFFERS; ++i)
+    {
+        PE100_COALESCE_BUFFER CoalesceBuffer = &Adapter->CoalesceBuffer[i];
+
+        if ((i % BuffersPerPage) == 0)
+        {
+            /* Allocate a chunk of memory */
+            NdisMAllocateSharedMemory(Adapter->AdapterHandle,
+                                      BlockSize,
+                                      FALSE, /* Non-cached */
+                                      &VirtualAddress,
+                                      &PhysicalAddress);
+            if (!VirtualAddress)
+                return NDIS_STATUS_RESOURCES;
+            RtlZeroMemory(VirtualAddress, BlockSize);
+
+            /* 32-bit DMA */
+            ASSERT(PhysicalAddress.HighPart == 0);
+
+            CoalesceBuffer->VirtualAddressOriginal = VirtualAddress;
+            CoalesceBuffer->PhysicalAddressOriginal = PhysicalAddress.LowPart;
+        }
+
+        CoalesceBuffer->VirtualAddress =
+            ALIGN_UP_POINTER_BY(VirtualAddress, SYSTEM_CACHE_ALIGNMENT_SIZE);
+        CoalesceBuffer->PhysicalAddress =
+            ALIGN_UP_BY(PhysicalAddress.LowPart, SYSTEM_CACHE_ALIGNMENT_SIZE);
+
+        PushEntryList(&Adapter->SendBufferList, &CoalesceBuffer->ListEntry);
+
+        /* Split the allocation */
+        VirtualAddress = (PVOID)((ULONG_PTR)VirtualAddress + EE_MEM_BLOCK_SIZE_TX_BUFFER);
+        PhysicalAddress.QuadPart += EE_MEM_BLOCK_SIZE_TX_BUFFER;
+    }
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeAllocateControlBlock(
+    _In_ PE100_ADAPTER Adapter)
+{
+    NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+
+    PAGED_CODE();
+
+    NdisMAllocateSharedMemory(Adapter->AdapterHandle,
+                              EE_MEM_BLOCK_SIZE_CONTROL(Adapter),
+                              FALSE, /* Non-cached */
+                              &Adapter->ControlBlockOriginal,
+                              &PhysicalAddress);
+    if (!Adapter->ControlBlockOriginal)
+        return NDIS_STATUS_RESOURCES;
+    RtlZeroMemory(Adapter->ControlBlockOriginal, EE_MEM_BLOCK_SIZE_CONTROL(Adapter));
+
+    /* 32-bit DMA */
+    ASSERT(PhysicalAddress.HighPart == 0);
+
+    Adapter->ControlBlockOriginalPhys = PhysicalAddress.LowPart;
+
+    Adapter->ControlBlockPa = ALIGN_UP_BY(PhysicalAddress.LowPart, SYSTEM_CACHE_ALIGNMENT_SIZE);
+    Adapter->ControlBlock = ALIGN_UP_POINTER_BY(Adapter->ControlBlockOriginal,
+                                                SYSTEM_CACHE_ALIGNMENT_SIZE);
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeAllocateMemory(
+    _In_ PE100_ADAPTER Adapter)
+{
+    NDIS_STATUS Status;
+
+    PAGED_CODE();
+
+    Status = NdisMInitializeScatterGatherDma(Adapter->AdapterHandle,
+                                             FALSE, /* 32-bit DMA */
+                                             E100_MAXIMUM_FRAME_SIZE);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    Status = EeAllocateControlBlock(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    Status = EeAllocateTransmitBlocks(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    Status = EeAllocateTransmitBuffers(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    Status = EeAllocateReceiveBuffers(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    NdisAllocateSpinLock(&Adapter->SendLock);
+    NdisAllocateSpinLock(&Adapter->ReceiveLock);
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+CODE_SEG("PAGE")
+VOID
+EeInitTxRing(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PE100_TX_CONTEXT PrevTxContext, TxContext;
+    PFXP_CB_TRANSMIT PrevTcb, Tcb;
+    ULONG i, TcbPa;
+
+    PAGED_CODE();
+
+    RtlZeroMemory(Adapter->HeadTcb, sizeof(*Tcb) * Adapter->TcbCount);
+
+    PrevTxContext = &Adapter->TxContext[Adapter->TcbCount - 1];
+    TxContext = Adapter->TxContext;
+    PrevTcb = &Adapter->HeadTcb[Adapter->TcbCount - 1];
+    Tcb = Adapter->HeadTcb;
+    TcbPa = Adapter->HeadTcbPa;
+
+    for (i = 0; i < Adapter->TcbCount; ++i)
+    {
+        Tcb->Header.Status = 0;
+        Tcb->Header.Command = htole16(FXP_CB_COMMAND_NOP | FXP_CB_COMMAND_S);
+
+        if (Adapter->Flags & E100_FLAG_EXT_TXCB)
+        {
+            /* The TBD address points to the third TBD in this mode */
+            Tcb->TbdArrayAddress = htole32(TcbPa + FIELD_OFFSET(FXP_CB_TRANSMIT, Tbd[2]));
+        }
+        else
+        {
+            Tcb->TbdArrayAddress = htole32(TcbPa + FIELD_OFFSET(FXP_CB_TRANSMIT, Tbd[0]));
+        }
+
+        PrevTcb->Header.LinkAddress = htole32(TcbPa);
+
+        TxContext->Tcb = Tcb;
+        TxContext->TcbPhys = TcbPa;
+        PrevTxContext->Next = TxContext;
+
+        PrevTxContext = TxContext;
+        PrevTcb = Tcb;
+
+        TxContext++;
+        Tcb++;
+        TcbPa += sizeof(*Tcb);
+    }
+
+    Adapter->TxLast = &Adapter->TxContext[Adapter->TcbCount - 1];
+    Adapter->TxFirst = Adapter->TxLast->Next;
+    Adapter->TxPending = 0;
+
+    InitializeListHead(&Adapter->SendQueueList);
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EeCreateRxChain(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PE100_RX_CONTEXT RxContext = Adapter->RxContext;
+    PE100_RX_CONTEXT LastRxContext = NULL;
+    ULONG i;
+
+    PAGED_CODE();
+
+    for (i = 0; i < Adapter->RfdCount; ++i)
+    {
+        PFXP_RFD Rfd;
+
+        if (LastRxContext)
+        {
+            le32enc(&LastRxContext->Rfd->Header.LinkAddress, RxContext->RfdPhys);
+            NdisFlushBuffer(LastRxContext->RfdMdl, TRUE);
+        }
+
+        Rfd = RxContext->Rfd;
+        Rfd->Header.Status = 0;
+        Rfd->Header.Command = 0;
+        le32enc(&Rfd->Header.LinkAddress, 0xFFFFFFFF);
+        le32enc(&Rfd->RbdAddress, 0xFFFFFFFF);
+        Rfd->Size = htole16(E100_RECEIVE_BLOCK_SIZE);
+        Rfd->ActualSize = 0;
+
+        InsertTailList(&Adapter->RxContextList, &RxContext->ListEntry);
+
+        LastRxContext = RxContext;
+        RxContext++;
+    }
+
+    /* Last entry */
+    LastRxContext->Rfd->Header.Command = htole16(FXP_RFD_CONTROL_EL);
+    NdisFlushBuffer(LastRxContext->RfdMdl, TRUE);
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeInitializeAdapterResources(
+    _In_ PE100_ADAPTER Adapter)
+{
+    NDIS_STATUS Status;
+    PNDIS_RESOURCE_LIST AssignedResources = NULL;
+    PCM_PARTIAL_RESOURCE_DESCRIPTOR IoDescriptor = NULL;
+    PCM_PARTIAL_RESOURCE_DESCRIPTOR InterruptDescriptor = NULL;
+    UINT i, ResourceListSize = 0;
+
+    PAGED_CODE();
+
+    NdisMQueryAdapterResources(&Status,
+                               Adapter->WrapperConfigurationHandle,
+                               AssignedResources,
+                               &ResourceListSize);
+    if (Status != NDIS_STATUS_RESOURCES)
+        return NDIS_STATUS_FAILURE;
+
+    Status = NdisAllocateMemoryWithTag((PVOID*)&AssignedResources,
+                                       ResourceListSize,
+                                       E100_TAG);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return Status;
+
+    NdisMQueryAdapterResources(&Status,
+                               Adapter->WrapperConfigurationHandle,
+                               AssignedResources,
+                               &ResourceListSize);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Cleanup;
+
+    for (i = 0; i < AssignedResources->Count; ++i)
+    {
+        PCM_PARTIAL_RESOURCE_DESCRIPTOR Descriptor;
+
+        Descriptor = &AssignedResources->PartialDescriptors[i];
+        switch (Descriptor->Type)
+        {
+            case CmResourceTypeMemory:
+            {
+                if (!IoDescriptor && (Descriptor->u.Memory.Length == FXP_PCI_MMIO_BAR_LENGTH))
+                    IoDescriptor = Descriptor;
+                break;
+            }
+
+            case CmResourceTypeInterrupt:
+            {
+                if (!InterruptDescriptor)
+                    InterruptDescriptor = Descriptor;
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+
+    if (!IoDescriptor || !InterruptDescriptor)
+    {
+        Status = NDIS_STATUS_RESOURCES;
+        goto Cleanup;
+    }
+
+    Adapter->InterruptVector = InterruptDescriptor->u.Interrupt.Vector;
+    Adapter->InterruptLevel = InterruptDescriptor->u.Interrupt.Level;
+    Adapter->InterruptFlags = InterruptDescriptor->Flags;
+    if (InterruptDescriptor->ShareDisposition == CmResourceShareShared)
+        Adapter->Flags |= E100_FLAG_IRQ_SHARED;
+
+    Status = NdisMMapIoSpace((PVOID*)&Adapter->IoBase,
+                             Adapter->AdapterHandle,
+                             IoDescriptor->u.Memory.Start,
+                             FXP_PCI_MMIO_BAR_LENGTH);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Cleanup;
+
+    INFO("IO Base %p\n", Adapter->IoBase);
+    INFO("IRQ Level %u, Vector %u\n",
+         Adapter->InterruptLevel,
+         Adapter->InterruptVector);
+    INFO("IRQ ShareDisposition %u, InterruptFlags %lx\n",
+         InterruptDescriptor->ShareDisposition,
+         InterruptDescriptor->Flags);
+
+Cleanup:
+    NdisFreeMemory(AssignedResources, ResourceListSize, 0);
+
+    return Status;
+}
+
+static
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeRecognizeHardware(
+    _In_ PE100_ADAPTER Adapter)
+{
+    UCHAR Buffer[RTL_SIZEOF_THROUGH_FIELD(PCI_COMMON_CONFIG, CacheLineSize)];
+    PPCI_COMMON_CONFIG PciConfig = (PPCI_COMMON_CONFIG)Buffer; // Partial PCI header
+    ULONG i, Bytes, Flags;
+
+    PAGED_CODE();
+
+    Bytes = NdisReadPciSlotInformation(Adapter->AdapterHandle,
+                                       0,
+                                       FIELD_OFFSET(PCI_COMMON_CONFIG, VendorID),
+                                       Buffer,
+                                       sizeof(Buffer));
+    if (Bytes != sizeof(Buffer))
+        return NDIS_STATUS_FAILURE;
+
+    if (PciConfig->VendorID != PCI_VEN_INTEL)
+        return NDIS_STATUS_FAILURE;
+
+    for (i = 0; i < RTL_NUMBER_OF(E100ControllerList); ++i)
+    {
+        Flags = E100ControllerList[i].Flags;
+
+        if (PciConfig->DeviceID == E100ControllerList[i].DeviceID)
+            break;
+    }
+    if (i == RTL_NUMBER_OF(E100ControllerList))
+        return NDIS_STATUS_NOT_RECOGNIZED;
+
+    INFO("Starting controller %04X:%04X.%02X\n",
+         PciConfig->VendorID,
+         PciConfig->DeviceID,
+         PciConfig->RevisionID);
+
+    Adapter->DeviceID = PciConfig->DeviceID;
+    Adapter->RevisionID = PciConfig->RevisionID;
+    Adapter->Flags = Flags;
+
+    if (PciConfig->Command & PCI_ENABLE_WRITE_AND_INVALIDATE)
+    {
+        INFO("MWI enabled\n");
+        Adapter->Flags |= E100_FLAG_MWI_ENABLE;
+    }
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+CODE_SEG("PAGE")
+PE100_ADAPTER
+EeAllocateAdapter(
+    _In_ NDIS_HANDLE MiniportAdapterHandle,
+    _In_ NDIS_HANDLE WrapperConfigurationContext)
+{
+    PE100_ADAPTER Adapter;
+    PVOID UnalignedAdapter;
+    ULONG Alignment, AdapterSize;
+    NDIS_STATUS Status;
+
+    PAGED_CODE();
+
+    Alignment = NdisGetSharedDataAlignment();
+    AdapterSize = sizeof(*Adapter) + Alignment - 1;
+
+    Status = NdisAllocateMemoryWithTag((PVOID*)&UnalignedAdapter, AdapterSize, E100_TAG);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return NULL;
+    RtlZeroMemory(UnalignedAdapter, AdapterSize);
+
+    Adapter = ALIGN_UP_POINTER_BY(UnalignedAdapter, Alignment);
+    Adapter->AdapterOriginal = UnalignedAdapter;
+    Adapter->AdapterSize = AdapterSize;
+    Adapter->AdapterHandle = MiniportAdapterHandle;
+    Adapter->WrapperConfigurationHandle = WrapperConfigurationContext;
+    return Adapter;
+}
+
+CODE_SEG("PAGE")
+VOID
+EeFreeAdapter(
+    _In_ __drv_freesMem(Mem) PE100_ADAPTER Adapter)
+{
+    ULONG i;
+
+    PAGED_CODE();
+
+    /* The ISR handler has to be unregistered first */
+    if (Adapter->Interrupt.InterruptObject)
+    {
+        NdisMDeregisterInterrupt(&Adapter->Interrupt);
+    }
+
+    if (Adapter->IoBase)
+    {
+        NdisMUnmapIoSpace(Adapter->AdapterHandle,
+                          Adapter->IoBase,
+                          FXP_PCI_MMIO_BAR_LENGTH);
+    }
+
+    if (Adapter->ControlBlockOriginal)
+    {
+        NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+
+        PhysicalAddress.QuadPart = Adapter->ControlBlockOriginalPhys;
+        NdisMFreeSharedMemory(Adapter->AdapterHandle,
+                              EE_MEM_BLOCK_SIZE_CONTROL(Adapter),
+                              FALSE, /* Non-cached */
+                              Adapter->ControlBlockOriginal,
+                              PhysicalAddress);
+    }
+
+    if (Adapter->TxContext)
+    {
+        NdisFreeMemory(Adapter->TxContext, sizeof(*Adapter->TxContext) * Adapter->TcbCount, 0);
+    }
+
+    if (Adapter->TcbOriginalVa)
+    {
+        NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+
+        PhysicalAddress.QuadPart = Adapter->TcbOriginalPhys;
+        NdisMFreeSharedMemory(Adapter->AdapterHandle,
+                              EE_MEM_BLOCK_SIZE_TCB(Adapter),
+                              FALSE, /* Non-cached */
+                              Adapter->TcbOriginalVa,
+                              PhysicalAddress);
+    }
+
+    if (Adapter->RxContext)
+    {
+        ULONG RfdPerPage, BlockSize;
+
+        EeGetRfdAllocSize(Adapter, &RfdPerPage, &BlockSize);
+
+        for (i = 0; i < Adapter->RfdToAllocate; ++i)
+        {
+            PE100_RX_CONTEXT RxContext = &Adapter->RxContext[i];
+
+            if (RxContext->VirtualAddressOriginal)
+            {
+                NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+
+                PhysicalAddress.QuadPart = RxContext->PhysicalAddressOriginal;
+                NdisMFreeSharedMemory(Adapter->AdapterHandle,
+                                      BlockSize,
+                                      TRUE, /* Cached */
+                                      RxContext->VirtualAddressOriginal,
+                                      PhysicalAddress);
+
+                if (RxContext->RfdMdl)
+                    NdisFreeBuffer(RxContext->RfdMdl);
+                if (RxContext->ReceiveBufferMdl)
+                    NdisFreeBuffer(RxContext->ReceiveBufferMdl);
+                if (RxContext->Packet)
+                    NdisFreePacket(RxContext->Packet);
+            }
+        }
+
+        NdisFreeMemory(Adapter->RxContext, sizeof(*Adapter->RxContext) * Adapter->RfdToAllocate, 0);
+    }
+
+    if (Adapter->CoalesceBuffer[0].VirtualAddress)
+    {
+        ULONG BuffersPerPage, BlockSize;
+
+        EeGetTransmitBufferAllocSize(&BuffersPerPage, &BlockSize);
+
+        for (i = 0; i < E100_TRANSMIT_BUFFERS; ++i)
+        {
+            PE100_COALESCE_BUFFER CoalesceBuffer = &Adapter->CoalesceBuffer[i];
+
+            if (CoalesceBuffer->VirtualAddressOriginal)
+            {
+                NDIS_PHYSICAL_ADDRESS PhysicalAddress;
+
+                PhysicalAddress.QuadPart = CoalesceBuffer->PhysicalAddressOriginal;
+                NdisMFreeSharedMemory(Adapter->AdapterHandle,
+                                      BlockSize,
+                                      FALSE, /* Non-cached */
+                                      CoalesceBuffer->VirtualAddressOriginal,
+                                      PhysicalAddress);
+            }
+        }
+    }
+
+    while (!IsListEmpty(&Adapter->WakeUpFrameList))
+    {
+        PLIST_ENTRY Entry = RemoveHeadList(&Adapter->WakeUpFrameList);
+        PE100_WAKE_UP_FRAME WakeFrame = CONTAINING_RECORD(Entry, E100_WAKE_UP_FRAME, ListEntry);
+
+        NdisFreeMemory(WakeFrame, sizeof(*WakeFrame), 0);
+    }
+
+    if (Adapter->PacketPool)
+        NdisFreePacketPool(Adapter->PacketPool);
+    if (Adapter->BufferPool)
+        NdisFreeBufferPool(Adapter->BufferPool);
+
+    if (Adapter->SendLock.SpinLock)
+        NdisFreeSpinLock(&Adapter->SendLock);
+    if (Adapter->ReceiveLock.SpinLock)
+        NdisFreeSpinLock(&Adapter->ReceiveLock);
+
+    NdisFreeMemory(Adapter->AdapterOriginal, sizeof(*Adapter), 0);
+}
+
+CODE_SEG("PAGE")
+NDIS_STATUS
+NTAPI
+MiniportInitialize(
+    _Out_ PNDIS_STATUS OpenErrorStatus,
+    _Out_ PUINT SelectedMediumIndex,
+    _In_ PNDIS_MEDIUM MediumArray,
+    _In_ UINT MediumArraySize,
+    _In_ NDIS_HANDLE MiniportAdapterHandle,
+    _In_ NDIS_HANDLE WrapperConfigurationContext)
+{
+    PE100_ADAPTER Adapter;
+    NDIS_STATUS Status;
+    UINT i;
+
+    INFO("Called\n");
+
+    PAGED_CODE();
+
+    for (i = 0; i < MediumArraySize; ++i)
+    {
+        if (MediumArray[i] == NdisMedium802_3)
+        {
+            *SelectedMediumIndex = i;
+            break;
+        }
+    }
+    if (i == MediumArraySize)
+    {
+        ERR("No supported media\n");
+        return NDIS_STATUS_UNSUPPORTED_MEDIA;
+    }
+
+    Adapter = EeAllocateAdapter(MiniportAdapterHandle, WrapperConfigurationContext);
+    if (!Adapter)
+    {
+        ERR("Failed to allocate adapter context\n");
+        return NDIS_STATUS_RESOURCES;
+    }
+    NdisInitializeWorkItem(&Adapter->ResetWorkItem, EeResetWorker, Adapter);
+    NdisInitializeWorkItem(&Adapter->PowerWorkItem, EePowerWorker, Adapter);
+
+    InitializeListHead(&Adapter->WakeUpFrameList);
+
+    Adapter->PowerState = NdisDeviceStateD0;
+    Adapter->PrevPowerState = Adapter->PowerState;
+
+    NdisMSetAttributesEx(MiniportAdapterHandle,
+                         Adapter,
+                         2, /* CheckForHangTimeInSeconds */
+                         NDIS_ATTRIBUTE_BUS_MASTER |
+                         NDIS_ATTRIBUTE_DESERIALIZE |
+                         NDIS_ATTRIBUTE_USES_SAFE_BUFFER_APIS,
+                         NdisInterfacePci);
+
+    Status = EeRecognizeHardware(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    Status = EeInitializeAdapterResources(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    EeSoftReset(Adapter, TRUE);
+
+    if (!EeReadEeprom(Adapter))
+        goto Failure;
+
+    Adapter->MaxTbdCount = E100_TBD_PER_TCB;
+    Adapter->TransmitThreshold = 512 / 8;
+
+    if (Adapter->RevisionID == FXP_REV_82557)
+    {
+        /* Older chips do not support MWI */
+        Adapter->Flags &= ~E100_FLAG_MWI_ENABLE;
+
+        /* A hack to get long VLAN frames on a 82557 */
+        Adapter->Flags |= E100_FLAG_SAVE_BAD_PACKETS;
+    }
+    else
+    {
+        /* The 82558 and later chips have flow control */
+        Adapter->Flags |= E100_FLAG_HAS_FLOW_CONTROL;
+
+        /* Turn on the extended TxCB feature */
+        Adapter->Flags |= E100_FLAG_EXT_TXCB;
+
+        /* Enable reception of long frames for VLAN */
+        Adapter->Flags |= E100_FLAG_LONG_PKT;
+
+        /* For 82559 or later chips, RX checksum offload is supported */
+        if (Adapter->RevisionID >= FXP_REV_82559_A0)
+        {
+            /* 82559ER does not support RX checksum offloading */
+            if (Adapter->DeviceID != PCI_DEV_82559ER)
+                Adapter->Flags |= E100_FLAG_82559_RXCSUM;
+        }
+    }
+
+    /* Enable use of extended RFDs and TCBs for 82550 and later chips */
+    if ((Adapter->RevisionID == FXP_REV_82550) ||
+        (Adapter->RevisionID == FXP_REV_82550_C) ||
+        (Adapter->RevisionID == FXP_REV_82551_E) ||
+        (Adapter->RevisionID == FXP_REV_82551_F) ||
+        (Adapter->RevisionID == FXP_REV_82551_10))
+    {
+        /* We need extended TxCB support too */
+        ASSERT(Adapter->Flags & E100_FLAG_EXT_TXCB);
+
+        /* -1 for IPCB */
+        --Adapter->MaxTbdCount;
+
+        Adapter->RfdSize = sizeof(FXP_RFD);
+        Adapter->TransmitCommand = htole16(FXP_CB_COMMAND_IPCBXMIT |
+                                           FXP_CB_COMMAND_SF |
+                                           FXP_CB_COMMAND_S |
+                                           FXP_CB_COMMAND_I);
+
+        /* Use extended RFA instead of 82559 checksum mode */
+        Adapter->Flags |= E100_FLAG_EXT_RFA;
+        Adapter->Flags &= ~E100_FLAG_82559_RXCSUM;
+    }
+    else
+    {
+        Adapter->RfdSize = RTL_SIZEOF_THROUGH_FIELD(FXP_RFD, Size);
+        Adapter->TransmitCommand = htole16(FXP_CB_COMMAND_XMIT |
+                                           FXP_CB_COMMAND_SF |
+                                           FXP_CB_COMMAND_S |
+                                           FXP_CB_COMMAND_I);
+    }
+
+    Status = EeReadConfiguration(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    Status = EeAllocateMemory(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    EeCreateRxChain(Adapter);
+
+    Status = EeFindMiiPhy(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Failure;
+
+    if ((Adapter->Flags & E100_FLAG_HAS_WOL) || (Adapter->RevisionID == FXP_REV_82559S_A))
+    {
+        /* Clear wakeup events */
+        CSR_WRITE_8(Adapter, FXP_CSR_PMDR, CSR_READ_8(Adapter, FXP_CSR_PMDR));
+    }
+
+    EePhySetPower(Adapter, TRUE);
+
+    Status = EeSetupAdapter(Adapter);
+    if (Status != NDIS_STATUS_SUCCESS)
+        goto Disable;
+
+    Status = NdisMRegisterInterrupt(&Adapter->Interrupt,
+                                    Adapter->AdapterHandle,
+                                    Adapter->InterruptVector,
+                                    Adapter->InterruptLevel,
+                                    TRUE, /* Request ISR calls */
+                                    !!(Adapter->Flags & E100_FLAG_IRQ_SHARED),
+                                    (Adapter->InterruptFlags & CM_RESOURCE_INTERRUPT_LATCHED) ?
+                                    NdisInterruptLatched : NdisInterruptLevelSensitive);
+    if (Status != NDIS_STATUS_SUCCESS)
+    {
+        ERR("Unable to register interrupt\n");
+        goto Disable;
+    }
+
+    EeStartAdapter(Adapter);
+
+    return NDIS_STATUS_SUCCESS;
+
+Disable:
+    EeSoftReset(Adapter, FALSE);
+Failure:
+    ERR("Initialization failed with status %08lx\n", Status);
+
+    EeFreeAdapter(Adapter);
+    return Status;
+}

--- a/drivers/network/dd/e100/interrupt.c
+++ b/drivers/network/dd/e100/interrupt.c
@@ -1,0 +1,637 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Interrupt handling
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* FUNCTIONS ******************************************************************/
+
+static
+VOID
+EeStartReceive(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PE100_RX_CONTEXT RxContext;
+    UCHAR RuState;
+
+    /*
+     * Since we also check the FXP_RFD_STATUS_RNR bit to prevent the restart latency
+     * we cannot assume the RNR state here.
+     * Thus, make sure the RU has entered the no resource condition.
+     */
+    RuState = FXP_SCB_RUS(CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS));
+    TRACE("Starting RU %02X\n", RuState);
+    if (RuState != FXP_SCB_RUS_NORESOURCES)
+        return;
+
+    ASSERT(!IsListEmpty(&Adapter->RxContextList));
+    RxContext = CONTAINING_RECORD(Adapter->RxContextList.Flink,
+                                  E100_RX_CONTEXT,
+                                  ListEntry);
+    EeCommandUnitExecuteCommandAddr(Adapter, FXP_SCB_COMMAND_RU_START, RxContext->RfdPhys);
+}
+
+static
+VOID
+EeReleaseRfd(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PE100_RX_CONTEXT RxContext)
+{
+    PFXP_RFD Rfd;
+
+    RxContext->Flags = 0;
+
+    Rfd = RxContext->Rfd;
+    Rfd->Header.Status = 0;
+    Rfd->Header.Command = htole16(FXP_RFD_CONTROL_EL);
+    le32enc(&Rfd->Header.LinkAddress, 0xFFFFFFFF);
+    le32enc(&Rfd->RbdAddress, 0xFFFFFFFF);
+    Rfd->ActualSize = 0; // Clear the F and EOF bits
+
+    NdisFlushBuffer(RxContext->RfdMdl, TRUE);
+
+    /* Attach the RFD to the end of receive chain */
+    if (!IsListEmpty(&Adapter->RxContextList))
+    {
+        PE100_RX_CONTEXT LastRxContext;
+        PFXP_RFD LastRfd;
+
+        LastRxContext = CONTAINING_RECORD(Adapter->RxContextList.Blink,
+                                          E100_RX_CONTEXT,
+                                          ListEntry);
+        LastRfd = LastRxContext->Rfd;
+
+        EE_WRITE_BARRIER();
+        le32enc(&LastRfd->Header.LinkAddress, RxContext->RfdPhys);
+        NdisFlushBuffer(LastRxContext->RfdMdl, TRUE);
+
+        EE_WRITE_BARRIER();
+        LastRfd->Header.Command = 0;
+        NdisFlushBuffer(LastRxContext->RfdMdl, TRUE);
+    }
+
+    InsertTailList(&Adapter->RxContextList, &RxContext->ListEntry);
+}
+
+VOID
+NTAPI
+MiniportReturnPacket(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ PNDIS_PACKET Packet)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    PE100_RX_CONTEXT RxContext;
+
+    RxContext = *E100_RX_CONTEXT_FROM_PACKET(Packet);
+
+    NdisAcquireSpinLock(&Adapter->ReceiveLock);
+
+    ASSERT(Adapter->RxPending > 0);
+    --Adapter->RxPending;
+
+    EeReleaseRfd(Adapter, RxContext);
+
+    NdisReleaseSpinLock(&Adapter->ReceiveLock);
+}
+
+static
+VOID
+EeIndicateReceivePackets(
+    _In_ PE100_ADAPTER Adapter,
+    _In_reads_(PacketsToIndicate) PNDIS_PACKET* ReceiveArray,
+    _In_ ULONG PacketsToIndicate)
+{
+    PNDIS_PACKET Packet;
+    PE100_RX_CONTEXT RxContext;
+    ULONG i;
+
+    NdisDprReleaseSpinLock(&Adapter->ReceiveLock);
+
+    NdisMIndicateReceivePacket(Adapter->AdapterHandle,
+                               ReceiveArray,
+                               PacketsToIndicate);
+
+    NdisDprAcquireSpinLock(&Adapter->ReceiveLock);
+
+    for (i = 0; i < PacketsToIndicate; ++i)
+    {
+        Packet = ReceiveArray[i];
+        RxContext = *E100_RX_CONTEXT_FROM_PACKET(Packet);
+
+        /* Reuse the RFD immediately */
+        if (RxContext->Flags & E100_RX_FLAG_RECLAIM)
+        {
+            EeReleaseRfd(Adapter, RxContext);
+        }
+    }
+}
+
+static
+USHORT
+EeIpv4PseudoHeaderChecksum(
+    _In_ ULONG SourceAddress,
+    _In_ ULONG DestinationAddress,
+    _In_ ULONG TcpSegmentLength)
+{
+    ULONG Crc;
+
+    Crc = TcpSegmentLength;
+    Crc += (SourceAddress >> 16) & 0xFFFF;
+    Crc += (SourceAddress >> 0) & 0xFFFF;
+    Crc += (DestinationAddress >> 16) & 0xFFFF;
+    Crc += (DestinationAddress >> 0) & 0xFFFF;
+
+    Crc = ((Crc >> 16) & 0xFFFF) + (Crc & 0xFFFF);
+
+    if (Crc > 0xFFFF)
+        Crc -= 0xFFFF;
+
+    return Crc;
+}
+
+static
+VOID
+EeHandleRxChecksum82559(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PUCHAR PacketData,
+    _In_ ULONG PacketLength,
+    _Out_ PNDIS_PACKET Packet)
+{
+    NDIS_TCP_IP_CHECKSUM_PACKET_INFO CsInfo;
+    PIPv4_HEADER IpHeader;
+    USHORT HeaderAndPayloadLength, Crc;
+    PETH_HEADER EthHeader;
+
+    CsInfo.Value = 0;
+
+    if (PacketLength < (E100_ETHERNET_HEADER_SIZE + sizeof(*IpHeader)))
+        goto Exit;
+
+    EthHeader = (PVOID)PacketData;
+    if (EthHeader->PayloadType != htons(ETHERTYPE_IP))
+        goto Exit;
+
+    IpHeader = (PVOID)(PacketData + E100_ETHERNET_HEADER_SIZE);
+    if (((IpHeader->VersionLength & 0xF0) >> 4) != 4)
+        goto Exit;
+
+    /* No checksum offload on IPv4 fragments */
+    if (IpHeader->Offset & htons(IP_MF | IP_OFFMASK))
+        goto Exit;
+
+    if (!((IpHeader->Protocol == IPPROTO_TCP && Adapter->Offload.ReceiveTcpChecksum) ||
+          (IpHeader->Protocol == IPPROTO_UDP && Adapter->Offload.ReceiveUdpChecksum)))
+    {
+        goto Exit;
+    }
+
+    HeaderAndPayloadLength = ntohs(IpHeader->TotalLength) - ((IpHeader->VersionLength & 0x0F) << 2);
+
+    /* The 82559 checksum word is appended at the end of the packet */
+    Crc = be16dec(PacketData + PacketLength);
+
+    /*
+     * Verify the TCP/UDP checksum by adding the hardware checksum
+     * to the IPv4 pseudo header checksum.
+     * Since the sum of all fields in a valid IPv4 header is 0xFFFF,
+     * we do not need to substract these fields from the 82559 checksum word.
+     */
+    Crc = EeIpv4PseudoHeaderChecksum(IpHeader->Source,
+                                     IpHeader->Destination,
+                                     htons(Crc + HeaderAndPayloadLength + IpHeader->Protocol));
+
+    if (IpHeader->Protocol == IPPROTO_TCP)
+    {
+        if (Crc == 0xFFFF)
+            CsInfo.Receive.NdisPacketTcpChecksumSucceeded = 1;
+        else
+            CsInfo.Receive.NdisPacketTcpChecksumFailed = 1;
+    }
+    else
+    {
+        if (Crc == 0xFFFF)
+            CsInfo.Receive.NdisPacketUdpChecksumSucceeded = 1;
+        else
+            CsInfo.Receive.NdisPacketUdpChecksumFailed = 1;
+    }
+
+Exit:
+    NDIS_PER_PACKET_INFO_FROM_PACKET(Packet, TcpIpChecksumPacketInfo) = UlongToPtr(CsInfo.Value);
+}
+
+static
+VOID
+EeHandleRxChecksum82550(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ USHORT RfdStatus,
+    _In_ UCHAR ParserStatus,
+    _In_ UCHAR ChecksumStatus,
+    _Out_ PNDIS_PACKET Packet)
+{
+    NDIS_TCP_IP_CHECKSUM_PACKET_INFO CsInfo;
+
+    CsInfo.Value = 0;
+
+    if (RfdStatus & FXP_RFD_STATUS_PARSE_OK)
+    {
+        if (Adapter->Offload.ReceiveIpChecksum)
+        {
+            if (ChecksumStatus & FXP_RFDX_CS_IP_CSUM_BIT_VALID)
+            {
+                if (ChecksumStatus & FXP_RFDX_CS_IP_CSUM_VALID)
+                    CsInfo.Receive.NdisPacketIpChecksumSucceeded = 1;
+                else
+                    CsInfo.Receive.NdisPacketIpChecksumFailed = 1;
+            }
+        }
+
+        if (ChecksumStatus & FXP_RFDX_CS_TCPUDP_CSUM_BIT_VALID)
+        {
+            if ((ParserStatus & FXP_RFDX_P_CSUM_PROTOCOL_MASK) == FXP_RFDX_P_TCP_PACKET)
+            {
+                if (Adapter->Offload.ReceiveTcpChecksum)
+                {
+                    if (ChecksumStatus & FXP_RFDX_CS_TCPUDP_CSUM_VALID)
+                        CsInfo.Receive.NdisPacketTcpChecksumSucceeded = 1;
+                    else
+                        CsInfo.Receive.NdisPacketTcpChecksumFailed = 1;
+                }
+            }
+            else if ((ParserStatus & FXP_RFDX_P_CSUM_PROTOCOL_MASK) == FXP_RFDX_P_UDP_PACKET)
+            {
+                if (Adapter->Offload.ReceiveUdpChecksum)
+                {
+                    if (ChecksumStatus & FXP_RFDX_CS_TCPUDP_CSUM_VALID)
+                        CsInfo.Receive.NdisPacketUdpChecksumSucceeded = 1;
+                    else
+                        CsInfo.Receive.NdisPacketUdpChecksumFailed = 1;
+                }
+            }
+        }
+    }
+
+    NDIS_PER_PACKET_INFO_FROM_PACKET(Packet, TcpIpChecksumPacketInfo) = UlongToPtr(CsInfo.Value);
+}
+
+static
+VOID
+EeHandleRxVlan(
+    _In_ USHORT RfdStatus,
+    _In_ USHORT RfdVlanId,
+    _Out_ PNDIS_PACKET Packet)
+{
+    NDIS_PACKET_8021Q_INFO VlanTag;
+
+    VlanTag.Value = NDIS_PER_PACKET_INFO_FROM_PACKET(Packet, Ieee8021QInfo);
+
+    if (RfdStatus & FXP_RFD_STATUS_VLAN)
+    {
+        USHORT Control = ntohs(RfdVlanId);
+
+        VlanTag.TagHeader.VlanId = Control & 0xFFF;
+        VlanTag.TagHeader.CanonicalFormatId = (Control >> 12) & 1;
+        VlanTag.TagHeader.UserPriority = (Control >> 13) & 7;
+    }
+    else
+    {
+        VlanTag.Value = NULL;
+    }
+
+    NDIS_PER_PACKET_INFO_FROM_PACKET(Packet, Ieee8021QInfo) = VlanTag.Value;
+}
+
+static
+BOOLEAN
+EeHandleRxReceivedFrames(
+    _In_ PE100_ADAPTER Adapter,
+    _Out_ PBOOLEAN OutOfBuffers)
+{
+    BOOLEAN CallAgain = TRUE;
+    ULONG PacketsToIndicate = 0;
+    PNDIS_PACKET ReceiveArray[E100_RECEIVE_ARRAY_SIZE];
+
+    while (PacketsToIndicate < RTL_NUMBER_OF(ReceiveArray))
+    {
+        PE100_RX_CONTEXT RxContext;
+        PFXP_RFD Rfd;
+        USHORT Status;
+        ULONG PacketLength;
+        PNDIS_PACKET Packet;
+
+        ASSERT(!IsListEmpty(&Adapter->RxContextList));
+        RxContext = CONTAINING_RECORD(Adapter->RxContextList.Flink,
+                                      E100_RX_CONTEXT,
+                                      ListEntry);
+
+        /* RFD headers are in cached memory */
+        NdisFlushBuffer(RxContext->RfdMdl, FALSE);
+
+        Rfd = RxContext->Rfd;
+
+        Status = letoh16(Rfd->Header.Status);
+        if (!(Status & FXP_RFD_STATUS_C))
+        {
+            CallAgain = FALSE;
+            break;
+        }
+
+        NT_VERIFY(RemoveHeadList(&Adapter->RxContextList) != NULL);
+
+        if (Status & FXP_RFD_STATUS_RNR)
+        {
+            *OutOfBuffers = TRUE;
+        }
+
+        if (!(Status & FXP_RFD_STATUS_OK))
+        {
+            /*
+             * We enable saving of bad packets on the 82557 in order to receive VLAN frames.
+             * However, this requires additional checks.
+             */
+            if (Adapter->Flags & E100_FLAG_SAVE_BAD_PACKETS)
+            {
+                if (Status & (FXP_RFD_STATUS_OVERRUN |
+                              FXP_RFD_STATUS_RNR |
+                              FXP_RFD_STATUS_ALIGN |
+                              FXP_RFD_STATUS_CRC))
+                {
+                    EeReleaseRfd(Adapter, RxContext);
+                    continue;
+                }
+            }
+            else
+            {
+                EeReleaseRfd(Adapter, RxContext);
+                continue;
+            }
+        }
+
+        PacketLength = letoh16(Rfd->ActualSize) & FXP_RFD_FRAME_LENGTH_MASK;
+
+        if (((Adapter->Offload.ReceiveTcpChecksum) ||
+             (Adapter->Offload.ReceiveUdpChecksum)) &&
+            (Adapter->Flags & E100_FLAG_82559_RXCSUM))
+        {
+            /* Omit the checksum word */
+            ASSERT(PacketLength >= 2);
+            PacketLength -= 2;
+        }
+
+        TRACE("RX packet (len %lu)\n", PacketLength);
+
+        NdisAdjustBufferLength(RxContext->ReceiveBufferMdl, PacketLength);
+
+        /* Receive buffer is a part of RFD */
+        NdisFlushBuffer(RxContext->ReceiveBufferMdl, FALSE);
+
+        Packet = RxContext->Packet;
+
+        if (Adapter->Flags & E100_FLAG_EXT_RFA)
+        {
+            /* Check VLAN tag stripping */
+            if ((Adapter->Flags & E100_FLAG_VLAN_TAGGING) ||
+                (Adapter->Flags & E100_FLAG_PACKET_PRIORITY))
+            {
+                EeHandleRxVlan(Status, Rfd->Ex.VlanId, Packet);
+            }
+
+            if (Adapter->Offload.ReceiveTcpChecksum ||
+                Adapter->Offload.ReceiveUdpChecksum ||
+                Adapter->Offload.ReceiveIpChecksum)
+            {
+                EeHandleRxChecksum82550(Adapter,
+                                        Status,
+                                        Rfd->Ex.ParserStatus,
+                                        Rfd->Ex.ChecksumStatus,
+                                        Packet);
+            }
+        }
+        else
+        {
+            if (Adapter->Offload.ReceiveTcpChecksum ||
+                Adapter->Offload.ReceiveUdpChecksum)
+            {
+                ULONG RfdSize = RTL_SIZEOF_THROUGH_FIELD(FXP_RFD, Size);
+
+                EeHandleRxChecksum82559(Adapter,
+                                        (PUCHAR)((ULONG_PTR)RxContext->Rfd + RfdSize),
+                                        PacketLength,
+                                        Packet);
+            }
+        }
+
+        ReceiveArray[PacketsToIndicate++] = Packet;
+
+        if (IsListEmpty(&Adapter->RxContextList))
+        {
+            RxContext->Flags |= E100_RX_FLAG_RECLAIM;
+            NDIS_SET_PACKET_STATUS(Packet, NDIS_STATUS_RESOURCES);
+
+            CallAgain = FALSE;
+            break;
+        }
+        else
+        {
+            NDIS_SET_PACKET_STATUS(Packet, NDIS_STATUS_SUCCESS);
+
+            ++Adapter->RxPending;
+        }
+    }
+
+    /* Pass the packets up */
+    if (PacketsToIndicate)
+    {
+        EeIndicateReceivePackets(Adapter, ReceiveArray, PacketsToIndicate);
+    }
+
+    return CallAgain;
+}
+
+static
+VOID
+EeHandleRx(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ UCHAR InterruptStatus)
+{
+    ULONG i;
+    BOOLEAN OutOfBuffers = FALSE;
+
+    NdisDprAcquireSpinLock(&Adapter->ReceiveLock);
+
+    for (i = 0; i < E100_RECEIVE_PROCESSING_LIMIT; ++i)
+    {
+        if (!EeHandleRxReceivedFrames(Adapter, &OutOfBuffers))
+            break;
+    }
+
+    if (OutOfBuffers || (InterruptStatus & FXP_SCB_STATACK_RNR))
+    {
+        NdisDprAcquireSpinLock(&Adapter->SendLock);
+        EeStartReceive(Adapter);
+        NdisDprReleaseSpinLock(&Adapter->SendLock);
+    }
+
+    NdisDprReleaseSpinLock(&Adapter->ReceiveLock);
+}
+
+static
+VOID
+EeHandleTxCompletedFrames(
+    _In_ PE100_ADAPTER Adapter,
+    _Inout_ PLIST_ENTRY SendReadyList)
+{
+    PE100_TX_CONTEXT TxContext;
+
+    for (TxContext = Adapter->TxFirst; Adapter->TxPending > 0; TxContext = TxContext->Next)
+    {
+        PFXP_CB_TRANSMIT Tcb = TxContext->Tcb;
+
+        if (!(Tcb->Header.Status & letoh16(FXP_CB_STATUS_C)))
+            break;
+
+        InsertTailList(SendReadyList, E100_LIST_ENTRY_FROM_PACKET(TxContext->Packet));
+
+        E100_RELEASE_TX_CONTEXT(Adapter, TxContext, Tcb);
+    }
+
+    Adapter->TxFirst = TxContext;
+}
+
+static
+VOID
+EeHandleTx(
+    _In_ PE100_ADAPTER Adapter)
+{
+    LIST_ENTRY SendReadyList;
+
+    TRACE("Handle TX\n");
+
+    InitializeListHead(&SendReadyList);
+
+    NdisDprAcquireSpinLock(&Adapter->SendLock);
+
+    EeHandleTxCompletedFrames(Adapter, &SendReadyList);
+
+    if (!IsListEmpty(&Adapter->SendQueueList))
+    {
+        EeSendPackets(Adapter, NULL, 0);
+    }
+
+    NdisDprReleaseSpinLock(&Adapter->SendLock);
+
+    while (!IsListEmpty(&SendReadyList))
+    {
+        PLIST_ENTRY Entry = RemoveHeadList(&SendReadyList);
+
+        TRACE("Complete TX packet %p\n", E100_PACKET_FROM_LIST_ENTRY(Entry));
+
+        NdisMSendComplete(Adapter->AdapterHandle,
+                          E100_PACKET_FROM_LIST_ENTRY(Entry),
+                          NDIS_STATUS_SUCCESS);
+    }
+}
+
+VOID
+NTAPI
+MiniportHandleInterrupt(
+    _In_ NDIS_HANDLE MiniportAdapterContext)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    UCHAR InterruptStatus;
+    ULONG IoLimit;
+
+    if (!Adapter->AdapterActive)
+        return;
+
+    IoLimit = E100_INTERRUPT_PROCESSING_LIMIT;
+    InterruptStatus = Adapter->InterruptStatus;
+
+    TRACE("DPC Enter %02X\n", InterruptStatus);
+
+    while (TRUE)
+    {
+        /* Handling transmit interrupts */
+        if (InterruptStatus & (FXP_SCB_STATACK_CXTNO | FXP_SCB_STATACK_CNA))
+        {
+            EeHandleTx(Adapter);
+        }
+
+        /* Handling receive interrupts */
+        if (InterruptStatus & (FXP_SCB_STATACK_FR | FXP_SCB_STATACK_RNR))
+        {
+            EeHandleRx(Adapter, InterruptStatus);
+        }
+
+        /* Limit in order to avoid doing too much work at DPC level */
+        if (!--IoLimit)
+            break;
+
+        /* Check if new events have occurred */
+        InterruptStatus = CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK);
+        if (InterruptStatus == 0xFF || InterruptStatus == 0)
+            break;
+
+        /* Acknowledge the events */
+        CSR_WRITE_8(Adapter, FXP_CSR_SCB_STATACK, InterruptStatus);
+
+        TRACE("DPC Continue %02X\n", InterruptStatus);
+    }
+
+    /* Re-enable interrupts (clear the FXP_SCB_INTR_DISABLE bit) */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_INTRCNTL, 0);
+}
+
+VOID
+NTAPI
+MiniportIsr(
+    _Out_ PBOOLEAN InterruptRecognized,
+    _Out_ PBOOLEAN QueueMiniportHandleInterrupt,
+    _In_ NDIS_HANDLE MiniportAdapterContext)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    ULONG InterruptStatus;
+
+    /*
+     * Read both interrupt registers at once. This eliminates having
+     * to call NdisMSynchronizeWithInterrupt() when re-enabling device interrupts
+     * in MiniportHandleInterrupt().
+     */
+    InterruptStatus = CSR_READ_32(Adapter, FXP_CSR_SCB_RUSCUS);
+
+    /* Interrupts have been disabled previously */
+    if (InterruptStatus & (FXP_SCB_INTR_DISABLE << 24))
+        goto NotOurs;
+
+    /* Extract the FXP_CSR_SCB_STATACK bits */
+    InterruptStatus = (InterruptStatus >> 8) & 0xFF;
+    if (InterruptStatus == 0xFF || InterruptStatus == 0)
+        goto NotOurs;
+
+    TRACE("ISR %02lX\n", InterruptStatus);
+
+    /*
+     * Disable further interrupts.
+     * Setting the M bit to 1 disables the device from asserting its INTA# pin on the PCI bus.
+     */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_INTRCNTL, FXP_SCB_INTR_DISABLE);
+
+    /* Acknowledge interrupts */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_STATACK, InterruptStatus);
+
+    Adapter->InterruptStatus = InterruptStatus;
+
+    *InterruptRecognized = TRUE;
+    *QueueMiniportHandleInterrupt = TRUE;
+    return;
+
+NotOurs:
+    *InterruptRecognized = FALSE;
+    *QueueMiniportHandleInterrupt = FALSE;
+}

--- a/drivers/network/dd/e100/interrupt.c
+++ b/drivers/network/dd/e100/interrupt.c
@@ -1,0 +1,448 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Interrupt handling
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* FUNCTIONS ******************************************************************/
+
+static
+VOID
+EeStartReceive(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PE100_RX_CONTEXT RxContext;
+    UCHAR RuState;
+
+    /*
+     * Since we also check the FXP_RFD_STATUS_RNR bit to prevent the restart latency
+     * we cannot assume the RNR state here.
+     * Thus, make sure the RU has entered the no resource condition.
+     */
+    RuState = FXP_SCB_RUS(CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS));
+    TRACE("Starting RU %02X\n", RuState);
+    if (RuState != FXP_SCB_RUS_NORESOURCES)
+        return;
+
+    EeScbWaitForCommandClear(Adapter);
+
+    ASSERT(!IsListEmpty(&Adapter->RxContextList));
+    RxContext = CONTAINING_RECORD(Adapter->RxContextList.Flink,
+                                  E100_RX_CONTEXT,
+                                  ListEntry);
+
+    CSR_WRITE_32(Adapter, FXP_CSR_SCB_GENERAL, RxContext->RfdPhys);
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_COMMAND, FXP_SCB_COMMAND_RU_START);
+}
+
+static
+VOID
+EeReleaseRfd(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PE100_RX_CONTEXT RxContext)
+{
+    PFXP_RFD Rfd;
+
+    RxContext->Flags = 0;
+
+    Rfd = RxContext->Rfd;
+    Rfd->Header.Status = 0;
+    Rfd->Header.Command = htole16(FXP_RFD_CONTROL_EL);
+    le32enc(&Rfd->Header.LinkAddress, 0xFFFFFFFF);
+    le32enc(&Rfd->RbdAddress, 0xFFFFFFFF);
+    Rfd->ActualSize = 0;
+
+    if (!IsListEmpty(&Adapter->RxContextList))
+    {
+        PE100_RX_CONTEXT LastRxContext;
+        PFXP_RFD LastRfd;
+
+        NdisFlushBuffer(RxContext->RfdMdl, TRUE);
+
+        LastRxContext = CONTAINING_RECORD(Adapter->RxContextList.Blink,
+                                          E100_RX_CONTEXT,
+                                          ListEntry);
+        LastRfd = LastRxContext->Rfd;
+
+        /* Attach a new buffer to the receive chain */
+        EE_WRITE_BARRIER();
+        le32enc(&LastRfd->Header.LinkAddress, RxContext->RfdPhys);
+        EE_WRITE_BARRIER();
+        LastRfd->Header.Command = 0;
+    }
+
+    InsertTailList(&Adapter->RxContextList, &RxContext->ListEntry);
+}
+
+VOID
+NTAPI
+MiniportReturnPacket(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ PNDIS_PACKET Packet)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    PE100_RX_CONTEXT RxContext;
+
+    RxContext = *E100_RX_CONTEXT_FROM_PACKET(Packet);
+
+    NdisAcquireSpinLock(&Adapter->ReceiveLock);
+
+    EeReleaseRfd(Adapter, RxContext);
+
+    NdisReleaseSpinLock(&Adapter->ReceiveLock);
+}
+
+static
+VOID
+EeIndicateReceivePackets(
+    _In_ PE100_ADAPTER Adapter,
+    _In_reads_(PacketsToIndicate) PNDIS_PACKET* ReceiveArray,
+    _In_ ULONG PacketsToIndicate)
+{
+    PNDIS_PACKET Packet;
+    PE100_RX_CONTEXT RxContext;
+    ULONG i;
+
+    NdisDprReleaseSpinLock(&Adapter->ReceiveLock);
+
+    NdisMIndicateReceivePacket(Adapter->AdapterHandle,
+                               ReceiveArray,
+                               PacketsToIndicate);
+
+    NdisDprAcquireSpinLock(&Adapter->ReceiveLock);
+
+    for (i = 0; i < PacketsToIndicate; ++i)
+    {
+        Packet = ReceiveArray[i];
+        RxContext = *E100_RX_CONTEXT_FROM_PACKET(Packet);
+
+        /* Reuse the RCB immediately */
+        if (RxContext->Flags & E100_RX_FLAG_RECLAIM)
+        {
+            EeReleaseRfd(Adapter, RxContext);
+        }
+    }
+}
+
+static
+BOOLEAN
+EeHandleRxReceivedFrames(
+    _In_ PE100_ADAPTER Adapter,
+    _Out_ PBOOLEAN OutOfBuffers)
+{
+    BOOLEAN CallAgain = TRUE;
+    ULONG PacketsToIndicate = 0;
+    PNDIS_PACKET ReceiveArray[E100_RECEIVE_ARRAY_SIZE];
+
+    while (PacketsToIndicate < RTL_NUMBER_OF(ReceiveArray))
+    {
+        PE100_RX_CONTEXT RxContext;
+        PFXP_RFD Rfd;
+        USHORT Status;
+        ULONG PacketLength;
+        PNDIS_PACKET Packet;
+
+        ASSERT(!IsListEmpty(&Adapter->RxContextList));
+        RxContext = CONTAINING_RECORD(Adapter->RxContextList.Flink,
+                                      E100_RX_CONTEXT,
+                                      ListEntry);
+
+        /* RFD headers are in cached memory */
+        NdisFlushBuffer(RxContext->RfdMdl, FALSE);
+
+        Rfd = RxContext->Rfd;
+
+        Status = letoh16(Rfd->Header.Status);
+        if (!(Status & FXP_RFD_STATUS_C))
+        {
+            CallAgain = FALSE;
+            break;
+        }
+
+        NT_VERIFY(RemoveHeadList(&Adapter->RxContextList) != NULL);
+
+        if (Status & FXP_RFD_STATUS_RNR)
+        {
+            *OutOfBuffers = TRUE;
+        }
+
+        if (!(Status & FXP_RFD_STATUS_OK))
+        {
+            /*
+             * We enable saving of bad packets on the 82557 in order to receive VLAN frames.
+             * However, this requires additional checks.
+             */
+            if (Adapter->Flags & E100_FLAG_SAVE_BAD_PACKETS)
+            {
+                if (Status & (FXP_RFD_STATUS_OVERRUN |
+                              FXP_RFD_STATUS_RNR |
+                              FXP_RFD_STATUS_ALIGN |
+                              FXP_RFD_STATUS_CRC))
+                {
+                    EeReleaseRfd(Adapter, RxContext);
+                    continue;
+                }
+            }
+            else
+            {
+                EeReleaseRfd(Adapter, RxContext);
+                continue;
+            }
+        }
+
+        PacketLength = letoh16(Rfd->ActualSize) & FXP_RFD_FRAME_LENGTH_MASK;
+        if (RxContext->Flags & E100_RX_FLAG_82559_CRC)
+        {
+            /* Omit the checksum */
+            PacketLength -= 2;
+        }
+
+        TRACE("RX packet (len %lu)\n", PacketLength);
+
+        NdisAdjustBufferLength(RxContext->ReceiveBufferMdl, PacketLength);
+
+        /* Receive buffer is a part of RFD */
+        NdisFlushBuffer(RxContext->ReceiveBufferMdl, FALSE);
+
+        Packet = RxContext->Packet;
+
+        /* Check VLAN tag stripping */
+        if ((Adapter->Flags & E100_FLAG_VLAN_TAGGING) ||
+            (Adapter->Flags & E100_FLAG_PACKET_PRIORITY))
+        {
+            NDIS_PACKET_8021Q_INFO VlanPriInfo;
+
+            ASSERT(Adapter->Flags & E100_FLAG_EXT_RFA);
+
+            VlanPriInfo.Value = NDIS_PER_PACKET_INFO_FROM_PACKET(Packet, Ieee8021QInfo);
+
+            if (Status & FXP_RFD_STATUS_VLAN)
+            {
+                ULONG UserPriority, CanonicalFormatId, VlanId;
+
+                FXP_IPCB_UNPACK_8021Q_INFO(Rfd->Ex.VlanId,
+                                           &UserPriority,
+                                           &CanonicalFormatId,
+                                           &VlanId);
+                VlanPriInfo.TagHeader.UserPriority = UserPriority;
+                VlanPriInfo.TagHeader.CanonicalFormatId = CanonicalFormatId;
+                VlanPriInfo.TagHeader.VlanId = VlanId;
+            }
+            else
+            {
+                VlanPriInfo.Value = NULL;
+            }
+
+            NDIS_PER_PACKET_INFO_FROM_PACKET(Packet, Ieee8021QInfo) = VlanPriInfo.Value;
+        }
+
+        ReceiveArray[PacketsToIndicate++] = Packet;
+
+        if (IsListEmpty(&Adapter->RxContextList))
+        {
+            RxContext->Flags |= E100_RX_FLAG_RECLAIM;
+            NDIS_SET_PACKET_STATUS(Packet, NDIS_STATUS_RESOURCES);
+
+            CallAgain = FALSE;
+            break;
+        }
+        else
+        {
+            NDIS_SET_PACKET_STATUS(Packet, NDIS_STATUS_SUCCESS);
+        }
+    }
+
+    /* Pass the packets up */
+    if (PacketsToIndicate)
+    {
+        EeIndicateReceivePackets(Adapter, ReceiveArray, PacketsToIndicate);
+    }
+
+    return CallAgain;
+}
+
+static
+VOID
+EeHandleRx(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ UCHAR InterruptStatus)
+{
+    ULONG i;
+    BOOLEAN OutOfBuffers = FALSE;
+
+    NdisDprAcquireSpinLock(&Adapter->ReceiveLock);
+
+    for (i = 0; i < E100_RECEIVE_PROCESSING_LIMIT; ++i)
+    {
+        if (!EeHandleRxReceivedFrames(Adapter, &OutOfBuffers))
+            break;
+    }
+
+    if (OutOfBuffers || (InterruptStatus & FXP_SCB_STATACK_RNR))
+    {
+        NdisDprAcquireSpinLock(&Adapter->SendLock);
+        EeStartReceive(Adapter);
+        NdisDprReleaseSpinLock(&Adapter->SendLock);
+    }
+
+    NdisDprReleaseSpinLock(&Adapter->ReceiveLock);
+}
+
+static
+VOID
+EeHandleTxCompletedFrames(
+    _In_ PE100_ADAPTER Adapter,
+    _Inout_ PLIST_ENTRY SendReadyList)
+{
+    PE100_TX_CONTEXT TxContext;
+
+    for (TxContext = Adapter->TxFirst; Adapter->TxPending > 0; TxContext = TxContext->Next)
+    {
+        PFXP_CB_TRANSMIT Tcb = TxContext->Tcb;
+
+        if (!(Tcb->Header.Status & letoh16(FXP_CB_STATUS_C)))
+            break;
+
+        InsertTailList(SendReadyList, E100_LIST_ENTRY_FROM_PACKET(TxContext->Packet));
+
+        E100_RELEASE_TX_CONTEXT(Adapter, TxContext, Tcb);
+    }
+
+    Adapter->TxFirst = TxContext;
+}
+
+static
+VOID
+EeHandleTx(
+    _In_ PE100_ADAPTER Adapter)
+{
+    LIST_ENTRY SendReadyList;
+
+    TRACE("Handle TX\n");
+
+    InitializeListHead(&SendReadyList);
+
+    NdisDprAcquireSpinLock(&Adapter->SendLock);
+
+    EeHandleTxCompletedFrames(Adapter, &SendReadyList);
+
+    if (!IsListEmpty(&Adapter->SendQueueList))
+    {
+        EeSendPackets(Adapter, NULL, 0);
+    }
+
+    NdisDprReleaseSpinLock(&Adapter->SendLock);
+
+    while (!IsListEmpty(&SendReadyList))
+    {
+        PLIST_ENTRY Entry = RemoveHeadList(&SendReadyList);
+
+        TRACE("Complete TX packet %p\n", E100_PACKET_FROM_LIST_ENTRY(Entry));
+
+        NdisMSendComplete(Adapter->AdapterHandle,
+                          E100_PACKET_FROM_LIST_ENTRY(Entry),
+                          NDIS_STATUS_SUCCESS);
+    }
+}
+
+VOID
+NTAPI
+MiniportHandleInterrupt(
+    _In_ NDIS_HANDLE MiniportAdapterContext)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    UCHAR InterruptStatus;
+    ULONG IoLimit;
+
+    if (!Adapter->AdapterActive)
+        return;
+
+    IoLimit = E100_INTERRUPT_PROCESSING_LIMIT;
+    InterruptStatus = Adapter->InterruptStatus;
+
+    TRACE("DPC Enter %02X\n", InterruptStatus);
+
+    while (TRUE)
+    {
+        /* Handling transmit interrupts */
+        if (InterruptStatus & (FXP_SCB_STATACK_CXTNO | FXP_SCB_STATACK_CNA))
+        {
+            EeHandleTx(Adapter);
+        }
+
+        /* Handling receive interrupts */
+        if (InterruptStatus & (FXP_SCB_STATACK_FR | FXP_SCB_STATACK_RNR))
+        {
+            EeHandleRx(Adapter, InterruptStatus);
+        }
+
+        /* Limit in order to avoid doing too much work at DPC level */
+        if (!--IoLimit)
+            break;
+
+        /* Check if new events have occurred */
+        InterruptStatus = CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK);
+        if (InterruptStatus == 0xFF || InterruptStatus == 0)
+            break;
+
+        /* Acknowledge the events */
+        CSR_WRITE_8(Adapter, FXP_CSR_SCB_STATACK, InterruptStatus);
+
+        TRACE("DPC Continue %02X\n", InterruptStatus);
+    }
+
+    /* Reenable interrupts (clear the FXP_SCB_INTR_DISABLE bit) */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_INTRCNTL, 0);
+}
+
+VOID
+NTAPI
+MiniportIsr(
+    _Out_ PBOOLEAN InterruptRecognized,
+    _Out_ PBOOLEAN QueueMiniportHandleInterrupt,
+    _In_ NDIS_HANDLE MiniportAdapterContext)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    ULONG InterruptStatus;
+
+    /*
+     * Read both interrupt registers at once. This eliminates having
+     * to call NdisMSynchronizeWithInterrupt() when re-enabling device interrupts
+     * in MiniportHandleInterrupt().
+     */
+    InterruptStatus = CSR_READ_32(Adapter, FXP_CSR_SCB_RUSCUS);
+
+    /* Interrupts have been disabled previously */
+    if (InterruptStatus & (FXP_SCB_INTR_DISABLE << 24))
+        goto NotOurs;
+
+    /* Extract the FXP_CSR_SCB_STATACK bits */
+    InterruptStatus = (InterruptStatus >> 8) & 0xFF;
+    if (InterruptStatus == 0xFF || InterruptStatus == 0)
+        goto NotOurs;
+
+    TRACE("ISR %02lX\n", InterruptStatus);
+
+    /* Disable further interrupts */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_INTRCNTL, FXP_SCB_INTR_DISABLE);
+
+    /* Acknowledge interrupts */
+    CSR_WRITE_8(Adapter, FXP_CSR_SCB_STATACK, InterruptStatus);
+
+    Adapter->InterruptStatus = InterruptStatus;
+
+    *InterruptRecognized = TRUE;
+    *QueueMiniportHandleInterrupt = TRUE;
+    return;
+
+NotOurs:
+    *InterruptRecognized = FALSE;
+    *QueueMiniportHandleInterrupt = FALSE;
+}

--- a/drivers/network/dd/e100/nete100.inf
+++ b/drivers/network/dd/e100/nete100.inf
@@ -1,0 +1,334 @@
+; NETE100.INF
+
+; Installation file for Intel PRO/100 NICs
+
+[Version]
+Signature  = "$Windows NT$"
+;Signature  = "$ReactOS$"
+LayoutFile = layout.inf
+Class      = Net
+ClassGUID  = {4D36E972-E325-11CE-BFC1-08002BE10318}
+Provider   = %ReactOS%
+DriverVer  = 08/22/2026,1.00
+
+[DestinationDirs]
+DefaultDestDir=12
+
+[Manufacturer]
+%IntelMfg%=IntelMfg
+
+[ControlFlags]
+ExcludeFromSelect=*
+
+[IntelMfg]
+%i557%=E557.ndi,PCI\VEN_8086&DEV_1229&REV_01
+%i557%=E557.ndi,PCI\VEN_8086&DEV_1229&REV_02
+%i557%=E557.ndi,PCI\VEN_8086&DEV_1229&REV_03
+%i558%=E100.ndi,PCI\VEN_8086&DEV_1229&REV_04
+%i558%=E100.ndi,PCI\VEN_8086&DEV_1229&REV_05
+%i559%=E100.ndi,PCI\VEN_8086&DEV_1229&REV_06
+%i559%=E100.ndi,PCI\VEN_8086&DEV_1229&REV_07
+%i559%=E101.ndi,PCI\VEN_8086&DEV_1229&REV_08
+%i55xER%=E101.ndi,PCI\VEN_8086&DEV_1229&REV_09
+%i550%=E550.ndi,PCI\VEN_8086&DEV_1229&REV_0C
+%i550%=E550.ndi,PCI\VEN_8086&DEV_1229&REV_0D
+%i550%=E550.ndi,PCI\VEN_8086&DEV_1229&REV_0E
+%i551%=E550.ndi,PCI\VEN_8086&DEV_1229&REV_0F
+%i551%=E550.ndi,PCI\VEN_8086&DEV_1229&REV_10
+%i557%=E550.ndi,PCI\VEN_8086&DEV_1229
+%i55xER%=E550.ndi,PCI\VEN_8086&DEV_1209
+%i559%=E550.ndi,PCI\VEN_8086&DEV_1029
+%i559%=E550.ndi,PCI\VEN_8086&DEV_1030
+%i551QM%=E550.ndi,PCI\VEN_8086&DEV_1059
+%i552%=ICH.ndi,PCI\VEN_8086&DEV_10FE
+%ICH2%=ICH.ndi,PCI\VEN_8086&DEV_2449
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1031
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1032
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1033
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1034
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1035
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1036
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1037
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1038
+%ICH4%=ICH.ndi,PCI\VEN_8086&DEV_1039
+%ICH4%=ICH.ndi,PCI\VEN_8086&DEV_103A
+%ICH4%=ICH.ndi,PCI\VEN_8086&DEV_103B
+%ICH4%=ICH.ndi,PCI\VEN_8086&DEV_103C
+%ICH4%=ICH.ndi,PCI\VEN_8086&DEV_103D
+%ICH4%=ICH.ndi,PCI\VEN_8086&DEV_103E
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1050
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1051
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1052
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1053
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1054
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1055
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1056
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1057
+%CICH%=ICH.ndi,PCI\VEN_8086&DEV_2459
+%CICH%=ICH.ndi,PCI\VEN_8086&DEV_245D
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_1064
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_1065
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_1066
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_1067
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_1068
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_1069
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_106A
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_106B
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_266C
+%ICH7%=ICH.ndi,PCI\VEN_8086&DEV_1091
+%ICH7%=ICH.ndi,PCI\VEN_8086&DEV_1092
+%ICH7%=ICH.ndi,PCI\VEN_8086&DEV_1093
+%ICH7%=ICH.ndi,PCI\VEN_8086&DEV_1094
+%ICH7%=ICH.ndi,PCI\VEN_8086&DEV_1095
+%ICH7%=ICH.ndi,PCI\VEN_8086&DEV_27DC
+
+[E557.ndi.NT]
+Characteristics=0x84
+BusType=5
+CopyFiles=E100_CopyFiles.NT
+AddReg=E100_COMMON
+
+[E100.ndi.NT]
+Characteristics=0x84
+BusType=5
+CopyFiles=E100_CopyFiles.NT
+AddReg=E100_COMMON, E100_FLOW_WOL, E100_UCODE
+
+[E101.ndi.NT]
+Characteristics=0x84
+BusType=5
+CopyFiles=E100_CopyFiles.NT
+AddReg=E100_COMMON, E100_FLOW_WOL, E100_UCODE, E100_CSUM
+
+[E550.ndi.NT]
+Characteristics=0x84
+BusType=5
+CopyFiles=E100_CopyFiles.NT
+AddReg=E100_COMMON, E100_FLOW_WOL, E100_UCODE, E100_CSUM, E100_IPCB
+
+[ICH.ndi.NT]
+Characteristics=0x84
+BusType=5
+CopyFiles=E100_CopyFiles.NT
+AddReg=E100_COMMON, E100_FLOW_WOL, E100_CSUM
+
+[E100_CopyFiles.NT]
+e100.sys
+
+[E557.ndi.NT.Services]
+AddService=e100, 2, E100_Service_Inst, E100_EventLog
+
+[E100.ndi.NT.Services]
+AddService=e100, 2, E100_Service_Inst, E100_EventLog
+
+[E101.ndi.NT.Services]
+AddService=e100, 2, E100_Service_Inst, E100_EventLog
+
+[E550.ndi.NT.Services]
+AddService=e100, 2, E100_Service_Inst, E100_EventLog
+
+[ICH.ndi.NT.Services]
+AddService=e100, 2, E100_Service_Inst, E100_EventLog
+
+[E100_COMMON]
+HKR,Ndi,            Service,    0, "e100"
+HKR,Ndi\Interfaces, UpperRange, 0, "ndis5"
+HKR,Ndi\Interfaces, LowerRange, 0, "ethernet"
+
+HKR,Ndi\params\NetworkAddress, ParamDesc, 0, %NA%
+HKR,Ndi\params\NetworkAddress, type,      0, "edit"
+HKR,Ndi\params\NetworkAddress, LimitText, 0, "12"
+HKR,Ndi\params\NetworkAddress, UpperCase, 0, "1"
+HKR,Ndi\params\NetworkAddress, default,   0, " "
+HKR,Ndi\params\NetworkAddress, optional,  0, "1"
+
+HKR,Ndi\params\SpeedDuplex,      ParamDesc, 0, %SD%
+HKR,Ndi\params\SpeedDuplex,      type,      0, "enum"
+HKR,Ndi\params\SpeedDuplex,      default,   0, "0"
+HKR,Ndi\params\SpeedDuplex\enum, "0",       0, "%Auto%"
+HKR,Ndi\params\SpeedDuplex\enum, "1",       0, "10HD"
+HKR,Ndi\params\SpeedDuplex\enum, "2",       0, "10FD"
+HKR,Ndi\params\SpeedDuplex\enum, "3",       0, "100HD"
+HKR,Ndi\params\SpeedDuplex\enum, "4",       0, "100FD"
+
+HKR,Ndi\params\TcbNum, ParamDesc, 0, %TCB%
+HKR,Ndi\params\TcbNum, type,      0, "int"
+HKR,Ndi\params\TcbNum, default,   0, "128"
+HKR,Ndi\params\TcbNum, min,       0, "8"
+HKR,Ndi\params\TcbNum, max,       0, "128"
+HKR,Ndi\params\TcbNum, step,      0, "1"
+HKR,Ndi\params\TcbNum, base,      0, "10"
+
+HKR,Ndi\params\RfdNum, ParamDesc, 0, %RFD%
+HKR,Ndi\params\RfdNum, type,      0, "int"
+HKR,Ndi\params\RfdNum, default,   0, "64"
+HKR,Ndi\params\RfdNum, min,       0, "8"
+HKR,Ndi\params\RfdNum, max,       0, "256"
+HKR,Ndi\params\RfdNum, step,      0, "1"
+HKR,Ndi\params\RfdNum, base,      0, "10"
+
+[E100_FLOW_WOL]
+HKR,Ndi\params\FlowControl,      ParamDesc, 0, %FC%
+HKR,Ndi\params\FlowControl,      type,      0, "enum"
+HKR,Ndi\params\FlowControl,      default,   0, "1"
+HKR,Ndi\params\FlowControl\enum, "0",       0, "%No%"
+HKR,Ndi\params\FlowControl\enum, "1",       0, "%Auto%"
+HKR,Ndi\params\FlowControl\enum, "2",       0, "%FR%"
+HKR,Ndi\params\FlowControl\enum, "3",       0, "%FT%"
+HKR,Ndi\params\FlowControl\enum, "4",       0, "%FRT%"
+
+HKR,Ndi\params\WolLinkSpeed,      ParamDesc, 0, %WSPD%
+HKR,Ndi\params\WolLinkSpeed,      type,      0, "enum"
+HKR,Ndi\params\WolLinkSpeed,      default,   0, "1"
+HKR,Ndi\params\WolLinkSpeed\enum, "0",       0, "%Auto%"
+HKR,Ndi\params\WolLinkSpeed\enum, "1",       0, "10MB"
+
+[E100_CSUM]
+HKR,Ndi\params\ChecksumOffload,      ParamDesc, 0, %CO%
+HKR,Ndi\params\ChecksumOffload,      type,      0, "enum"
+HKR,Ndi\params\ChecksumOffload,      default,   0, "1"
+HKR,Ndi\params\ChecksumOffload\enum, "0",       0, "%No%"
+HKR,Ndi\params\ChecksumOffload\enum, "1",       0, "%Yes%"
+
+[E100_UCODE]
+HKR,Ndi\params\UCodeIntDelay, ParamDesc, 0, %IDEL%
+HKR,Ndi\params\UCodeIntDelay, type,      0, "int"
+HKR,Ndi\params\UCodeIntDelay, default,   0, "1536"
+HKR,Ndi\params\UCodeIntDelay, min,       0, "0"
+HKR,Ndi\params\UCodeIntDelay, max,       0, "65535"
+HKR,Ndi\params\UCodeIntDelay, step,      0, "1"
+HKR,Ndi\params\UCodeIntDelay, base,      0, "10"
+
+HKR,Ndi\params\UCodeBundleMax, ParamDesc, 0, %BMAX%
+HKR,Ndi\params\UCodeBundleMax, type,      0, "int"
+HKR,Ndi\params\UCodeBundleMax, default,   0, "6"
+HKR,Ndi\params\UCodeBundleMax, min,       0, "1"
+HKR,Ndi\params\UCodeBundleMax, max,       0, "65535"
+HKR,Ndi\params\UCodeBundleMax, step,      0, "1"
+HKR,Ndi\params\UCodeBundleMax, base,      0, "10"
+
+HKR,Ndi\params\UCodeBundleSmall,      ParamDesc, 0, %BSML%
+HKR,Ndi\params\UCodeBundleSmall,      type,      0, "enum"
+HKR,Ndi\params\UCodeBundleSmall,      default,   0, "1"
+HKR,Ndi\params\UCodeBundleSmall\enum, "0",       0, "%No%"
+HKR,Ndi\params\UCodeBundleSmall\enum, "1",       0, "%Yes%"
+
+[E100_IPCB]
+HKR,Ndi\params\VlanPrio,      ParamDesc, 0, %PP%
+HKR,Ndi\params\VlanPrio,      type,      0, "enum"
+HKR,Ndi\params\VlanPrio,      default,   0, "1"
+HKR,Ndi\params\VlanPrio\enum, "0",       0, "%No%"
+HKR,Ndi\params\VlanPrio\enum, "1",       0, "%Yes%"
+
+HKR,Ndi\params\VlanTag,      ParamDesc, 0, %VT%
+HKR,Ndi\params\VlanTag,      type,      0, "enum"
+HKR,Ndi\params\VlanTag,      default,   0, "1"
+HKR,Ndi\params\VlanTag\enum, "0",       0, "%No%"
+HKR,Ndi\params\VlanTag\enum, "1",       0, "%Yes%"
+
+HKR,Ndi\params\VlanID, ParamDesc, 0, %VI%
+HKR,Ndi\params\VlanID, type,      0, "long"
+HKR,Ndi\params\VlanID, default,   0, "0"
+HKR,Ndi\params\VlanID, min,       0, "0"
+HKR,Ndi\params\VlanID, max,       0, "4095"
+HKR,Ndi\params\VlanID, step,      0, "1"
+HKR,Ndi\params\VlanID, base,      0, "10"
+
+HKR,Ndi\params\LargeSendOffload,      ParamDesc, 0, %LS%
+HKR,Ndi\params\LargeSendOffload,      type,      0, "enum"
+HKR,Ndi\params\LargeSendOffload,      default,   0, "1"
+HKR,Ndi\params\LargeSendOffload\enum, "0",       0, "%No%"
+HKR,Ndi\params\LargeSendOffload\enum, "1",       0, "%Yes%"
+
+[E100_Service_Inst]
+ServiceType=1
+StartType=3
+ErrorControl=1
+ServiceBinary=%12%\e100.sys
+LoadOrderGroup=NDIS
+
+[E100_EventLog]
+AddReg=E100_EventLog_AddReg
+
+[E100_EventLog_AddReg]
+HKR,,EventMessageFile, 0x00020000, "%%SystemRoot%%\System32\netevent.dll"
+HKR,,TypesSupported,   0x00010001, 7
+
+[Strings]
+; Non-localizable
+ReactOS="ReactOS Team"
+IntelMfg="Intel"
+VI="VLAN ID"
+
+NA="Network Address"
+SD="Speed & Duplex"
+Auto="Auto"
+No="No"
+Yes="Yes"
+FC="Flow Control"
+FR="Rx Pause"
+FT="Tx Pause"
+FRT="Rx & Tx Pause"
+IDEL="Interrupt Delay"
+BMAX="Max Frames Per Interrupt"
+BSML="Bundle Small Frames"
+TCB="Transmit Buffers"
+RFD="Receive Buffers"
+PP="Packet Priority"
+VT="VLAN Tagging"
+WSPD="WOL Link Speed"
+CO="Checksum Offload"
+LS="Large Send Offload"
+
+i557="Intel 82557 PRO/100 Ethernet Controller"
+i558="Intel 82558 PRO/100 Ethernet Controller"
+i559="Intel 82559 PRO/100 Ethernet Controller"
+i550="Intel 82550 PRO/100 Ethernet Controller"
+i551="Intel 82551 PRO/100 Ethernet Controller"
+i55xER="Intel 8255xER PRO/100 Ethernet Controller"
+i551QM="Intel 82551QM PRO/100 M Mobile Ethernet Controller"
+i552="Intel 82552 PRO/100 Ethernet Controller"
+ICH2="Intel ICH2 PRO/100 Ethernet Controller"
+ICH3="Intel ICH3 PRO/100 Ethernet Controller"
+ICH4="Intel ICH4 PRO/100 Ethernet Controller"
+ICH5="Intel ICH5 PRO/100 Ethernet Controller"
+CICH="Intel C-ICH PRO/100 Ethernet Controller"
+ICH6="Intel ICH6 PRO/100 Ethernet Controller"
+ICH7="Intel ICH7 PRO/100 Ethernet Controller"
+
+[Strings.0419]
+NA="Сетевой адрес"
+SD="Скорость и дуплекс"
+Auto="Авто"
+No="Нет"
+Yes="Да"
+FC="Управление потоком"
+FR="Кадры паузы приема"
+FT="Кадры паузы передачи"
+FRT="Кадры паузы приема и передачи"
+IDEL="Задержка прерывания"
+BMAX="Максимальное число кадров на прерывание"
+BSML="Компоновать короткие кадры"
+TCB="Буферы передачи"
+RFD="Буферы приема"
+PP="Приоритет кадров"
+VT="Маркировка кадров"
+WSPD="Скорость соединения после выключения"
+CO="Разгрузка контрольной суммы"
+LS="Разгрузка при большой отправке"
+
+i557="Intel 82557 PRO/100 сетевой контроллер"
+i558="Intel 82558 PRO/100 сетевой контроллер"
+i559="Intel 82559 PRO/100 сетевой контроллер"
+i550="Intel 82550 PRO/100 сетевой контроллер"
+i551="Intel 82551 PRO/100 сетевой контроллер"
+i55xER="Intel 8255xER PRO/100 сетевой контроллер"
+i551QM="Intel 82551QM PRO/100 M Mobile сетевой контроллер"
+i552="Intel 82552 PRO/100 сетевой контроллер"
+ICH2="Intel ICH2 PRO/100 сетевой контроллер"
+ICH3="Intel ICH3 PRO/100 сетевой контроллер"
+ICH4="Intel ICH4 PRO/100 сетевой контроллер"
+ICH5="Intel ICH5 PRO/100 сетевой контроллер"
+CICH="Intel C-ICH PRO/100 сетевой контроллер"
+ICH6="Intel ICH6 PRO/100 сетевой контроллер"
+ICH7="Intel ICH7 PRO/100 сетевой контроллер"

--- a/drivers/network/dd/e100/nete100.inf
+++ b/drivers/network/dd/e100/nete100.inf
@@ -1,0 +1,263 @@
+; NETE100.INF
+
+; Installation file for Intel PRO/100 NICs
+
+[Version]
+Signature  = "$Windows NT$"
+;Signature  = "$ReactOS$"
+LayoutFile = layout.inf
+Class      = Net
+ClassGUID  = {4D36E972-E325-11CE-BFC1-08002BE10318}
+Provider   = %ReactOS%
+DriverVer  = 06/11/2026,1.00
+
+[DestinationDirs]
+DefaultDestDir=12
+
+[Manufacturer]
+%IntelMfg%=IntelMfg
+
+[ControlFlags]
+ExcludeFromSelect=*
+
+[IntelMfg]
+%i8255x%=E100.ndi,PCI\VEN_8086&DEV_1229
+%i82559ER%=E100.ndi,PCI\VEN_8086&DEV_1209
+%i82559CB%=E100.ndi,PCI\VEN_8086&DEV_1029
+%i82559%=E100.ndi,PCI\VEN_8086&DEV_1030
+%i82551QM%=E100.ndi,PCI\VEN_8086&DEV_1059
+%i82552%=ICH.ndi,PCI\VEN_8086&DEV_10FE
+%ICH2%=ICH.ndi,PCI\VEN_8086&DEV_2449
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1031
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1032
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1033
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1034
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1035
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1036
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1037
+%ICH3%=ICH.ndi,PCI\VEN_8086&DEV_1038
+%ICH4%=ICH.ndi,PCI\VEN_8086&DEV_1039
+%ICH4%=ICH.ndi,PCI\VEN_8086&DEV_103A
+%ICH4%=ICH.ndi,PCI\VEN_8086&DEV_103B
+%ICH4%=ICH.ndi,PCI\VEN_8086&DEV_103C
+%ICH4%=ICH.ndi,PCI\VEN_8086&DEV_103D
+%ICH4%=ICH.ndi,PCI\VEN_8086&DEV_103E
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1050
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1051
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1052
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1053
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1054
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1055
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1056
+%ICH5%=ICH.ndi,PCI\VEN_8086&DEV_1057
+%CICH%=ICH.ndi,PCI\VEN_8086&DEV_2459
+%CICH%=ICH.ndi,PCI\VEN_8086&DEV_245D
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_1064
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_1065
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_1066
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_1067
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_1068
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_1069
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_106A
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_106B
+%ICH6%=ICH.ndi,PCI\VEN_8086&DEV_266C
+%ICH7%=ICH.ndi,PCI\VEN_8086&DEV_1091
+%ICH7%=ICH.ndi,PCI\VEN_8086&DEV_1092
+%ICH7%=ICH.ndi,PCI\VEN_8086&DEV_1093
+%ICH7%=ICH.ndi,PCI\VEN_8086&DEV_1094
+%ICH7%=ICH.ndi,PCI\VEN_8086&DEV_1095
+%ICH7%=ICH.ndi,PCI\VEN_8086&DEV_27DC
+
+[E100.ndi.NT]
+Characteristics=0x84
+BusType=5
+CopyFiles=E100_CopyFiles.NT
+AddReg=E100_COMMON, E100_UCODE, E100_VLAN
+
+[ICH.ndi.NT]
+Characteristics=0x84
+BusType=5
+CopyFiles=E100_CopyFiles.NT
+AddReg=E100_COMMON
+
+[E100_CopyFiles.NT]
+e100.sys
+
+[E100.ndi.NT.Services]
+AddService=e100, 2, E100_Service_Inst, E100_EventLog
+
+[ICH.ndi.NT.Services]
+AddService=e100, 2, E100_Service_Inst, E100_EventLog
+
+[E100_COMMON]
+HKR,Ndi,            Service,    0, "e100"
+HKR,Ndi\Interfaces, UpperRange, 0, "ndis5"
+HKR,Ndi\Interfaces, LowerRange, 0, "ethernet"
+
+HKR,Ndi\params\NetworkAddress, ParamDesc, 0, %NA%
+HKR,Ndi\params\NetworkAddress, type,      0, "edit"
+HKR,Ndi\params\NetworkAddress, LimitText, 0, "12"
+HKR,Ndi\params\NetworkAddress, UpperCase, 0, "1"
+HKR,Ndi\params\NetworkAddress, default,   0, " "
+HKR,Ndi\params\NetworkAddress, optional,  0, "1"
+
+HKR,Ndi\params\SpeedDuplex,      ParamDesc, 0, %SD%
+HKR,Ndi\params\SpeedDuplex,      type,      0, "enum"
+HKR,Ndi\params\SpeedDuplex,      default,   0, "0"
+HKR,Ndi\params\SpeedDuplex\enum, "0",       0, "%Auto%"
+HKR,Ndi\params\SpeedDuplex\enum, "1",       0, "10HD"
+HKR,Ndi\params\SpeedDuplex\enum, "2",       0, "10FD"
+HKR,Ndi\params\SpeedDuplex\enum, "3",       0, "100HD"
+HKR,Ndi\params\SpeedDuplex\enum, "4",       0, "100FD"
+
+HKR,Ndi\params\FlowControl,      ParamDesc, 0, %FC%
+HKR,Ndi\params\FlowControl,      type,      0, "enum"
+HKR,Ndi\params\FlowControl,      default,   0, "1"
+HKR,Ndi\params\FlowControl\enum, "0",       0, "%No%"
+HKR,Ndi\params\FlowControl\enum, "1",       0, "%Auto%"
+HKR,Ndi\params\FlowControl\enum, "2",       0, "%FRx%"
+HKR,Ndi\params\FlowControl\enum, "3",       0, "%FTx%"
+HKR,Ndi\params\FlowControl\enum, "4",       0, "%FBoth%"
+
+HKR,Ndi\params\TcbNum, ParamDesc, 0, %TCB%
+HKR,Ndi\params\TcbNum, type,      0, "int"
+HKR,Ndi\params\TcbNum, default,   0, "128"
+HKR,Ndi\params\TcbNum, min,       0, "8"
+HKR,Ndi\params\TcbNum, max,       0, "128"
+HKR,Ndi\params\TcbNum, step,      0, "1"
+HKR,Ndi\params\TcbNum, base,      0, "10"
+
+HKR,Ndi\params\RfdNum, ParamDesc, 0, %RFD%
+HKR,Ndi\params\RfdNum, type,      0, "int"
+HKR,Ndi\params\RfdNum, default,   0, "64"
+HKR,Ndi\params\RfdNum, min,       0, "8"
+HKR,Ndi\params\RfdNum, max,       0, "128"
+HKR,Ndi\params\RfdNum, step,      0, "1"
+HKR,Ndi\params\RfdNum, base,      0, "10"
+
+[E100_UCODE]
+HKR,Ndi\params\IntDelay, ParamDesc, 0, %IDEL%
+HKR,Ndi\params\IntDelay, type,      0, "int"
+HKR,Ndi\params\IntDelay, default,   0, "1536"
+HKR,Ndi\params\IntDelay, min,       0, "0"
+HKR,Ndi\params\IntDelay, max,       0, "65535"
+HKR,Ndi\params\IntDelay, step,      0, "1"
+HKR,Ndi\params\IntDelay, base,      0, "10"
+
+HKR,Ndi\params\BundleMax, ParamDesc, 0, %BMAX%
+HKR,Ndi\params\BundleMax, type,      0, "int"
+HKR,Ndi\params\BundleMax, default,   0, "6"
+HKR,Ndi\params\BundleMax, min,       0, "1"
+HKR,Ndi\params\BundleMax, max,       0, "65535"
+HKR,Ndi\params\BundleMax, step,      0, "1"
+HKR,Ndi\params\BundleMax, base,      0, "10"
+
+HKR,Ndi\params\BundleSmall,      ParamDesc, 0, %BSML%
+HKR,Ndi\params\BundleSmall,      type,      0, "enum"
+HKR,Ndi\params\BundleSmall,      default,   0, "1"
+HKR,Ndi\params\BundleSmall\enum, "0",       0, "%No%"
+HKR,Ndi\params\BundleSmall\enum, "1",       0, "%Yes%"
+
+[E100_VLAN]
+HKR,Ndi\params\Priority,      ParamDesc, 0, %PP%
+HKR,Ndi\params\Priority,      type,      0, "enum"
+HKR,Ndi\params\Priority,      default,   0, "1"
+HKR,Ndi\params\Priority\enum, "0",       0, "%No%"
+HKR,Ndi\params\Priority\enum, "1",       0, "%Yes%"
+
+HKR,Ndi\params\VlanTag,      ParamDesc, 0, %VT%
+HKR,Ndi\params\VlanTag,      type,      0, "enum"
+HKR,Ndi\params\VlanTag,      default,   0, "1"
+HKR,Ndi\params\VlanTag\enum, "0",       0, "%No%"
+HKR,Ndi\params\VlanTag\enum, "1",       0, "%Yes%"
+
+HKR,Ndi\params\VlanID, ParamDesc, 0, %VI%
+HKR,Ndi\params\VlanID, type,      0, "long"
+HKR,Ndi\params\VlanID, default,   0, "0"
+HKR,Ndi\params\VlanID, min,       0, "0"
+HKR,Ndi\params\VlanID, max,       0, "4095"
+HKR,Ndi\params\VlanID, step,      0, "1"
+HKR,Ndi\params\VlanID, base,      0, "10"
+
+[E100_Service_Inst]
+ServiceType=1
+StartType=3
+ErrorControl=1
+ServiceBinary=%12%\e100.sys
+LoadOrderGroup=NDIS
+
+[E100_EventLog]
+AddReg=E100_EventLog_AddReg
+
+[E100_EventLog_AddReg]
+HKR,,EventMessageFile, 0x00020000, "%%SystemRoot%%\System32\netevent.dll"
+HKR,,TypesSupported,   0x00010001, 7
+
+[Strings]
+; Non-localizable
+ReactOS="ReactOS Team"
+IntelMfg="Intel"
+VI="VLAN ID"
+
+NA="Network Address"
+SD="Speed & Duplex"
+Auto="Auto"
+No="No"
+Yes="Yes"
+FC="Flow Control"
+FRx="Rx Pause"
+FTx="Tx Pause"
+FBoth="Rx & Tx Pause"
+IDEL="Interrupt Delay"
+BMAX="Max Frames Per Interrupt"
+BSML="Bundle Small Frames"
+TCB="Transmit Buffers"
+RFD="Receive Buffers"
+PP="Packet Priority"
+VT="VLAN Tagging"
+
+i8255x="Intel 8255x PRO/100 Ethernet Controller"
+i82559ER="Intel 82559ER Embedded PRO/100 Ethernet Controller"
+i82559CB="Intel 82559 PCI/CardBus PRO/100 Ethernet Controller"
+i82559="Intel 82559 PRO/100 Ethernet Controller"
+i82551QM="Intel 82551QM PRO/100 M Mobile Ethernet Controller"
+i82552="Intel 82552 PRO/100 Ethernet Controller"
+ICH2="Intel ICH2 PRO/100 Ethernet Controller"
+ICH3="Intel ICH3 PRO/100 Ethernet Controller"
+ICH4="Intel ICH4 PRO/100 Ethernet Controller"
+ICH5="Intel ICH5 PRO/100 Ethernet Controller"
+CICH="Intel C-ICH PRO/100 Ethernet Controller"
+ICH6="Intel ICH6 PRO/100 Ethernet Controller"
+ICH7="Intel ICH7 PRO/100 Ethernet Controller"
+
+[Strings.0419]
+NA="Сетевой адрес"
+SD="Скорость и дуплекс"
+Auto="Авто"
+No="Нет"
+Yes="Да"
+FC="Управление потоком"
+FRx="Кадры паузы приема"
+FTx="Кадры паузы передачи"
+FBoth="Кадры паузы приема и передачи"
+IDEL="Задержка прерывания"
+BMAX="Максимальное число кадров на прерывание"
+BSML="Компоновать короткие кадры"
+TCB="Буферы передачи"
+RFD="Буферы приема"
+PP="Приоритет кадров"
+VT="Маркировка кадров"
+
+i8255x="Intel 8255x PRO/100 сетевой контроллер"
+i82559ER="Intel 82559ER Embedded PRO/100 сетевой контроллер"
+i82559CB="Intel 82559 PCI/CardBus PRO/100 сетевой контроллер"
+i82559="Intel 82559 PRO/100 сетевой контроллер"
+i82551QM="Intel 82551QM PRO/100 M Mobile сетевой контроллер"
+i82552="Intel 82552 PRO/100 сетевой контроллер"
+ICH2="Intel ICH2 PRO/100 сетевой контроллер"
+ICH3="Intel ICH3 PRO/100 сетевой контроллер"
+ICH4="Intel ICH4 PRO/100 сетевой контроллер"
+ICH5="Intel ICH5 PRO/100 сетевой контроллер"
+CICH="Intel C-ICH PRO/100 сетевой контроллер"
+ICH6="Intel ICH6 PRO/100 сетевой контроллер"
+ICH7="Intel ICH7 PRO/100 сетевой контроллер"

--- a/drivers/network/dd/e100/phy.c
+++ b/drivers/network/dd/e100/phy.c
@@ -1,0 +1,304 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     PHY layer setup and management
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* FUNCTIONS ******************************************************************/
+
+static
+ULONG
+MiiWrite(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG RegAddress,
+    _In_ ULONG Data)
+{
+    ULONG i;
+
+    CSR_WRITE_32(Adapter,
+                 FXP_CSR_MDICONTROL,
+                 (FXP_MDIO_WRITE      << FXP_MDI_OPCODE_SHIFT) |
+                 (Adapter->PhyAddress << FXP_MDI_PHY_ADDR_SHIFT) |
+                 (RegAddress          << FXP_MDI_REG_ADDR_SHIFT) |
+                 Data);
+
+    for (i = FXP_MIIPHY_DELAYMAX; i > 0; i--)
+    {
+        NdisStallExecution(FXP_MIIPHY_DELAY);
+
+        if (CSR_READ_32(Adapter, FXP_CSR_MDICONTROL) & FXP_MDI_READY)
+            break;
+    }
+    if (i == 0)
+    {
+        ERR("PHY[%lu] MII reg %lx read timed out\n", Adapter->PhyAddress, RegAddress);
+        return MII_FLAG_FAILED;
+    }
+
+    return 0;
+}
+
+static
+ULONG
+MiiRead(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG RegAddress)
+{
+    ULONG i, Csr;
+
+    CSR_WRITE_32(Adapter,
+                 FXP_CSR_MDICONTROL,
+                 (FXP_MDIO_READ       << FXP_MDI_OPCODE_SHIFT) |
+                 (Adapter->PhyAddress << FXP_MDI_PHY_ADDR_SHIFT) |
+                 (RegAddress          << FXP_MDI_REG_ADDR_SHIFT));
+
+    for (i = FXP_MIIPHY_DELAYMAX; i > 0; i--)
+    {
+        NdisStallExecution(FXP_MIIPHY_DELAY);
+
+        Csr = CSR_READ_32(Adapter, FXP_CSR_MDICONTROL);
+        if (Csr & FXP_MDI_READY)
+            break;
+    }
+
+    if (i == 0)
+    {
+        ERR("PHY[%lu] MII reg %lx write timed out\n", Adapter->PhyAddress, RegAddress);
+        return MII_FLAG_FAILED;
+    }
+
+    Csr &= FXP_MDI_DATA_MASK;
+
+    return Csr;
+}
+
+static
+UCHAR
+Phy503GetSpeedAndDuplex(
+    _In_ PE100_ADAPTER Adapter)
+{
+    if (!(Adapter->DefaultMedia & E100_MEDIA_AUTO))
+        return Adapter->DefaultMedia;
+
+    /*
+     * The serial PHY supports only 10Mbps half-duplex operation
+     * (the user can force 10Mbps full duplex) and it lacks
+     * a link activity indicator, so we assume that the link is always up.
+     */
+    return 0;
+}
+
+UCHAR
+EePhyGetSpeedAndDuplex(
+    _In_ PE100_ADAPTER Adapter)
+{
+    ULONG MiiStatus, MiiAdvertise, MiiLinkPartnerAbility, AdvLpa;
+    UCHAR CurrentMedia;
+
+    if (Adapter->PhyType == E100_PHY_TYPE_503)
+        return Phy503GetSpeedAndDuplex(Adapter);
+
+    /* Optimization for later chips */
+    if (Adapter->RevisionID >= FXP_REV_82559_A0)
+    {
+        if (!(CSR_READ_8(Adapter, FXP_CSR_GENSTATUS) & FXP_GENSTATUS_LINK_UP))
+            return E100_MEDIA_NONE;
+
+        if (!(Adapter->DefaultMedia & E100_MEDIA_AUTO))
+            return Adapter->DefaultMedia;
+    }
+
+    /* The link status is a latched-low bit, read it twice */
+    MiiRead(Adapter, MII_STATUS);
+    MiiStatus = MiiRead(Adapter, MII_STATUS);
+    if (!(MiiStatus & MII_SR_LINK_STATUS))
+        return E100_MEDIA_NONE;
+
+    /* If we are forcing speed and duplex */
+    if (!(Adapter->DefaultMedia & E100_MEDIA_AUTO))
+        return Adapter->DefaultMedia;
+
+    /* Check auto-negotiation is complete */
+    if (!(MiiStatus & MII_SR_AUTONEG_COMPLETE))
+        return E100_MEDIA_NONE;
+
+    MiiAdvertise = MiiRead(Adapter, MII_AUTONEG_ADVERTISE);
+    MiiLinkPartnerAbility = MiiRead(Adapter, MII_AUTONEG_LINK_PARTNER);
+
+    AdvLpa = MiiAdvertise & MiiLinkPartnerAbility;
+    TRACE("MII ADV:%04lX LPA:%04lX = %04lX\n", MiiAdvertise, MiiLinkPartnerAbility, AdvLpa);
+
+    if (AdvLpa & MII_LP_100T_FD)
+        CurrentMedia = E100_MEDIA_FD | E100_MEDIA_100T;
+    else if (AdvLpa & MII_LP_100T4)
+        CurrentMedia = E100_MEDIA_100T;
+    else if (AdvLpa & MII_LP_100T_HD)
+        CurrentMedia = E100_MEDIA_100T;
+    else if (AdvLpa & MII_LP_10T_FD)
+        CurrentMedia = E100_MEDIA_FD;
+    else
+        CurrentMedia = 0;
+
+    if (CurrentMedia & E100_MEDIA_FD)
+    {
+        if (Adapter->DefaultMedia & E100_MEDIA_PAUSE_AUTO)
+        {
+            if (MiiAdvertise & MiiLinkPartnerAbility & MII_ADV_PAUSE_SYM)
+            {
+                CurrentMedia |= E100_MEDIA_PAUSE_TX | E100_MEDIA_PAUSE_RX;
+            }
+            else if (MiiAdvertise & MiiLinkPartnerAbility & MII_ADV_PAUSE_ASYM)
+            {
+                if (MiiAdvertise & MII_ADV_PAUSE_SYM)
+                    CurrentMedia |= E100_MEDIA_PAUSE_RX;
+                else if (MiiLinkPartnerAbility & MII_ADV_PAUSE_SYM)
+                    CurrentMedia |= E100_MEDIA_PAUSE_TX;
+            }
+        }
+        else
+        {
+            CurrentMedia |= Adapter->DefaultMedia & (E100_MEDIA_PAUSE_TX | E100_MEDIA_PAUSE_RX);
+        }
+    }
+
+    return CurrentMedia;
+}
+
+CODE_SEG("PAGE")
+VOID
+EePhyInit(
+    _In_ PE100_ADAPTER Adapter)
+{
+    ULONG Value, MiiAdvertise, MiiControl;
+
+    PAGED_CODE();
+
+    if (Adapter->PhyType == E100_PHY_TYPE_503)
+        return;
+
+    if (Adapter->PhyType == E100_PHY_TYPE_DP83840)
+    {
+        /* This is mandatory to enable full-duplex operation on some boards */
+        Value = MiiRead(Adapter, PHY_DP_REG_PCS);
+        Value |= PHY_DP_PCS_LED4_MODE |
+                 PHY_DP_PCS_F_CONNECT |
+                 PHY_DP_PCS_BIT_8 |
+                 PHY_DP_PCS_BIT_10;
+        MiiWrite(Adapter, PHY_DP_REG_PCS, Value);
+    }
+
+    MiiAdvertise = MiiRead(Adapter, MII_AUTONEG_ADVERTISE);
+    MiiAdvertise |= MII_ADV_CSMA;
+    MiiAdvertise &= ~(MII_ADV_10T_HD |
+                      MII_ADV_10T_FD |
+                      MII_ADV_100T_HD |
+                      MII_ADV_100T_FD |
+                      MII_ADV_100T4 |
+                      MII_ADV_PAUSE_SYM |
+                      MII_ADV_PAUSE_ASYM);
+
+    MiiControl = MiiRead(Adapter, MII_CONTROL);
+
+    if (Adapter->DefaultMedia & E100_MEDIA_AUTO)
+    {
+        MiiControl |= MII_CR_AUTONEG | MII_CR_AUTONEG_RESTART;
+
+        MiiAdvertise |= Adapter->PhyCapabilities;
+    }
+    else
+    {
+        MiiControl &= ~(MII_CR_AUTONEG | MII_CR_AUTONEG_RESTART);
+
+        if (Adapter->DefaultMedia & E100_MEDIA_FD)
+            MiiControl |= MII_CR_FULL_DUPLEX;
+        else
+            MiiControl &= ~MII_CR_FULL_DUPLEX;
+
+        if (Adapter->DefaultMedia & E100_MEDIA_100T)
+            MiiControl |= MII_CR_SPEED_SELECTION;
+        else
+            MiiControl &= ~MII_CR_SPEED_SELECTION;
+    }
+
+    if (Adapter->DefaultMedia & E100_MEDIA_PAUSE_RX)
+        MiiAdvertise |= MII_ADV_PAUSE_SYM | MII_ADV_PAUSE_ASYM;
+
+    if (Adapter->DefaultMedia & E100_MEDIA_PAUSE_TX)
+        MiiAdvertise |= MII_ADV_PAUSE_ASYM;
+
+    MiiWrite(Adapter, MII_AUTONEG_ADVERTISE, MiiAdvertise);
+    MiiWrite(Adapter, MII_CONTROL, MiiControl);
+}
+
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeFindMiiPhy(
+    _In_ PE100_ADAPTER Adapter)
+{
+    ULONG PhyAddress;
+
+    PAGED_CODE();
+
+    if (Adapter->PhyType == E100_PHY_TYPE_503)
+    {
+        INFO_VERB("Using non-MII PHY\n");
+        return NDIS_STATUS_SUCCESS;
+    }
+
+    /* Look for the first connected PHY */
+    for (PhyAddress = 1; PhyAddress <= MII_MAX_PHY_ADDRESSES; ++PhyAddress)
+    {
+        ULONG MiiStatus, PhyId;
+#if DBG
+        ULONG MiiControl, MiiAdvertise;
+#endif
+
+        /* Check the PHY 0 last */
+        Adapter->PhyAddress = PhyAddress % MII_MAX_PHY_ADDRESSES;
+
+        /*
+         * Read the status register. Some PHYs, such as the ML6692,
+         * don't implement the IEEE ID registers.
+         */
+        if (!MII_SUCCESS(MiiRead(Adapter, MII_STATUS)))
+            continue;
+        MiiStatus = MiiRead(Adapter, MII_STATUS);
+        if (!MII_SUCCESS(MiiStatus))
+            continue;
+        if (MiiStatus == 0xFFFF || MiiStatus == 0)
+            continue;
+
+        Adapter->PhyCapabilities = (MiiStatus & 0xFFFF) >> 6;
+
+        PhyId = MiiRead(Adapter, MII_PHY_ID1);
+        PhyId |= MiiRead(Adapter, MII_PHY_ID2) << 16;
+
+#if DBG
+        MiiControl = MiiRead(Adapter, MII_CONTROL);
+        MiiAdvertise = MiiRead(Adapter, MII_AUTONEG_ADVERTISE);
+
+        INFO_VERB("Found PHY at address %lu: ID %08lX, Ctrl %04X, Status %04X, Adv %04X\n",
+                  PhyAddress,
+                  PhyId,
+                  MiiControl,
+                  MiiStatus,
+                  MiiAdvertise);
+#endif
+
+        if (PHY_IS_DP83840(PhyId))
+        {
+            Adapter->PhyType = E100_PHY_TYPE_DP83840;
+        }
+
+        return NDIS_STATUS_SUCCESS;
+    }
+
+    return NDIS_STATUS_FAILURE;
+}

--- a/drivers/network/dd/e100/phy.c
+++ b/drivers/network/dd/e100/phy.c
@@ -1,0 +1,392 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     PHY layer setup and management
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* FUNCTIONS ******************************************************************/
+
+static
+ULONG
+MiiWrite(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG RegAddress,
+    _In_ ULONG Data)
+{
+    ULONG i;
+
+    CSR_WRITE_32(Adapter,
+                 FXP_CSR_MDICONTROL,
+                 (FXP_MDIO_WRITE      << FXP_MDI_OPCODE_SHIFT) |
+                 (Adapter->PhyAddress << FXP_MDI_PHY_ADDR_SHIFT) |
+                 (RegAddress          << FXP_MDI_REG_ADDR_SHIFT) |
+                 Data);
+
+    for (i = FXP_MIIPHY_DELAYMAX; i > 0; i--)
+    {
+        NdisStallExecution(FXP_MIIPHY_DELAY);
+
+        if (CSR_READ_32(Adapter, FXP_CSR_MDICONTROL) & FXP_MDI_READY)
+            break;
+    }
+    if (i == 0)
+    {
+        ERR("PHY[%lu] MII reg %lx read timed out\n", Adapter->PhyAddress, RegAddress);
+        Adapter->HardError = TRUE;
+        return MII_FLAG_FAILED;
+    }
+
+    return 0;
+}
+
+static
+ULONG
+MiiRead(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ ULONG RegAddress)
+{
+    ULONG i, Csr;
+
+    CSR_WRITE_32(Adapter,
+                 FXP_CSR_MDICONTROL,
+                 (FXP_MDIO_READ       << FXP_MDI_OPCODE_SHIFT) |
+                 (Adapter->PhyAddress << FXP_MDI_PHY_ADDR_SHIFT) |
+                 (RegAddress          << FXP_MDI_REG_ADDR_SHIFT));
+
+    for (i = FXP_MIIPHY_DELAYMAX; i > 0; i--)
+    {
+        NdisStallExecution(FXP_MIIPHY_DELAY);
+
+        Csr = CSR_READ_32(Adapter, FXP_CSR_MDICONTROL);
+        if (Csr & FXP_MDI_READY)
+            break;
+    }
+
+    if (i == 0)
+    {
+        ERR("PHY[%lu] MII reg %lx write timed out\n", Adapter->PhyAddress, RegAddress);
+
+        /*
+         * The chip should be able to complete the management frame
+         * even if there is no PHY at a given address.
+         */
+        Adapter->HardError = TRUE;
+
+        return MII_FLAG_FAILED;
+    }
+
+    Csr &= FXP_MDI_DATA_MASK;
+
+    return Csr;
+}
+
+static
+UCHAR
+EePhy503GetSpeedAndDuplex(
+    _In_ PE100_ADAPTER Adapter)
+{
+    if (!(Adapter->DefaultMedia & E100_MEDIA_AUTO))
+        return Adapter->DefaultMedia & ~E100_MEDIA_100T;
+
+    /*
+     * The serial PHY supports only 10Mbps half-duplex operation
+     * (the user can force 10Mbps full duplex) and it lacks
+     * a link activity indicator, so we assume that the link is always up.
+     */
+    return 0;
+}
+
+UCHAR
+EePhyGetSpeedAndDuplex(
+    _In_ PE100_ADAPTER Adapter)
+{
+    ULONG MiiStatus, MiiAdvertise, MiiLinkPartnerAbility, AdvLpa;
+    UCHAR CurrentMedia;
+
+    if (Adapter->PhyType == E100_PHY_TYPE_503)
+        return EePhy503GetSpeedAndDuplex(Adapter);
+
+    /* Optimization for later chips */
+    if (Adapter->RevisionID >= FXP_REV_82559_A0)
+    {
+        if (!(CSR_READ_8(Adapter, FXP_CSR_GENSTATUS) & FXP_GENSTATUS_LINK_UP))
+            return E100_MEDIA_NONE;
+
+        if (!(Adapter->DefaultMedia & E100_MEDIA_AUTO))
+            return Adapter->DefaultMedia;
+    }
+
+    /* The link status is a latched-low bit, read it twice */
+    MiiRead(Adapter, MII_STATUS);
+    MiiStatus = MiiRead(Adapter, MII_STATUS);
+    if (!(MiiStatus & MII_SR_LINK_STATUS))
+        return E100_MEDIA_NONE;
+
+    /* If we are forcing speed and duplex */
+    if (!(Adapter->DefaultMedia & E100_MEDIA_AUTO))
+        return Adapter->DefaultMedia;
+
+    /* Check auto-negotiation is complete */
+    if (!(MiiStatus & MII_SR_AUTONEG_COMPLETE))
+        return E100_MEDIA_NONE;
+
+    MiiAdvertise = MiiRead(Adapter, MII_AUTONEG_ADVERTISE);
+    MiiLinkPartnerAbility = MiiRead(Adapter, MII_AUTONEG_LINK_PARTNER);
+
+    AdvLpa = MiiAdvertise & MiiLinkPartnerAbility;
+    TRACE("MII ADV:%04lX LPA:%04lX = %04lX\n", MiiAdvertise, MiiLinkPartnerAbility, AdvLpa);
+
+    if (AdvLpa & MII_LP_100T_FD)
+        CurrentMedia = E100_MEDIA_FD | E100_MEDIA_100T;
+    else if (AdvLpa & MII_LP_100T4)
+        CurrentMedia = E100_MEDIA_100T;
+    else if (AdvLpa & MII_LP_100T_HD)
+        CurrentMedia = E100_MEDIA_100T;
+    else if (AdvLpa & MII_LP_10T_FD)
+        CurrentMedia = E100_MEDIA_FD;
+    else
+        CurrentMedia = 0;
+
+    /* Resolve flow control */
+    if (CurrentMedia & E100_MEDIA_FD)
+    {
+        if (Adapter->DefaultMedia & E100_MEDIA_PAUSE_AUTO)
+        {
+            if (MiiAdvertise & MiiLinkPartnerAbility & MII_ADV_PAUSE_SYM)
+            {
+                CurrentMedia |= E100_MEDIA_PAUSE_TX | E100_MEDIA_PAUSE_RX;
+            }
+            else if (MiiAdvertise & MiiLinkPartnerAbility & MII_ADV_PAUSE_ASYM)
+            {
+                if (MiiAdvertise & MII_ADV_PAUSE_SYM)
+                    CurrentMedia |= E100_MEDIA_PAUSE_RX;
+                else if (MiiLinkPartnerAbility & MII_ADV_PAUSE_SYM)
+                    CurrentMedia |= E100_MEDIA_PAUSE_TX;
+            }
+        }
+        else
+        {
+            CurrentMedia |= Adapter->DefaultMedia & (E100_MEDIA_PAUSE_TX | E100_MEDIA_PAUSE_RX);
+        }
+    }
+
+    return CurrentMedia;
+}
+
+CODE_SEG("PAGE")
+VOID
+EePhyPowerSaveDowngradeLinkSpeed(
+    _In_ PE100_ADAPTER Adapter)
+{
+    ULONG MiiAdvertise, MiiLinkPartnerAbility, AdvLpa, MiiControl;
+
+    PAGED_CODE();
+
+    if (!(Adapter->Flags & E100_FLAG_REDUCE_WOL_LINK_SPEED))
+        return;
+
+    if (Adapter->PhyType == E100_PHY_TYPE_503)
+        return;
+
+    if (!(Adapter->DefaultMedia & E100_MEDIA_AUTO))
+        return;
+
+    MiiAdvertise = MiiRead(Adapter, MII_AUTONEG_ADVERTISE);
+    MiiLinkPartnerAbility = MiiRead(Adapter, MII_AUTONEG_LINK_PARTNER);
+
+    /* Switch to 10Mb if possible */
+    AdvLpa = MiiAdvertise & MiiLinkPartnerAbility;
+    if (!(AdvLpa & (MII_LP_10T_FD | MII_LP_10T_HD)))
+        return;
+
+    MiiAdvertise &= ~(MII_ADV_100T_HD |
+                      MII_ADV_100T_FD |
+                      MII_ADV_100T4);
+    MiiWrite(Adapter, MII_AUTONEG_ADVERTISE, MiiAdvertise);
+
+    MiiControl = MiiRead(Adapter, MII_CONTROL);
+    MiiControl |= MII_CR_AUTONEG | MII_CR_AUTONEG_RESTART;
+    MiiWrite(Adapter, MII_CONTROL, MiiControl);
+}
+
+VOID
+EePhySetPower(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ BOOLEAN PowerUp)
+{
+    ULONG OldMiiControl, MiiControl;
+
+    if (Adapter->PhyType == E100_PHY_TYPE_503)
+        return;
+
+    if (PowerUp)
+    {
+        OldMiiControl = MiiRead(Adapter, MII_CONTROL);
+
+        MiiControl = OldMiiControl;
+        MiiControl &= ~(MII_CR_POWER_DOWN | MII_CR_ISOLATE);
+
+        if (MiiControl != OldMiiControl)
+        {
+            MiiWrite(Adapter, MII_CONTROL, MiiControl);
+
+            if (OldMiiControl & MII_CR_POWER_DOWN)
+                NdisStallExecution(1);
+        }
+    }
+    else
+    {
+        MiiWrite(Adapter, MII_CONTROL, MII_CR_POWER_DOWN | MII_CR_ISOLATE);
+    }
+}
+
+CODE_SEG("PAGE")
+VOID
+EePhyInit(
+    _In_ PE100_ADAPTER Adapter)
+{
+    ULONG Value, MiiAdvertise, MiiControl;
+
+    PAGED_CODE();
+
+    if (Adapter->PhyType == E100_PHY_TYPE_503)
+        return;
+
+    if (Adapter->PhyType == E100_PHY_TYPE_DP83840)
+    {
+        /* This enables full-duplex operation on some PRO/100 boards */
+        Value = MiiRead(Adapter, PHY_DP_REG_PCS);
+        Value |= PHY_DP_PCS_LED4_MODE |
+                 PHY_DP_PCS_F_CONNECT |
+                 PHY_DP_PCS_BIT_8 |
+                 PHY_DP_PCS_BIT_10;
+        MiiWrite(Adapter, PHY_DP_REG_PCS, Value);
+    }
+
+    MiiAdvertise = MiiRead(Adapter, MII_AUTONEG_ADVERTISE);
+    MiiAdvertise |= MII_ADV_CSMA;
+    MiiAdvertise &= ~(MII_ADV_10T_HD |
+                      MII_ADV_10T_FD |
+                      MII_ADV_100T_HD |
+                      MII_ADV_100T_FD |
+                      MII_ADV_100T4 |
+                      MII_ADV_PAUSE_SYM |
+                      MII_ADV_PAUSE_ASYM);
+
+    MiiControl = MiiRead(Adapter, MII_CONTROL);
+
+    if (Adapter->DefaultMedia & E100_MEDIA_AUTO)
+    {
+        MiiControl |= MII_CR_AUTONEG | MII_CR_AUTONEG_RESTART;
+
+        MiiAdvertise |= Adapter->PhyCapabilities;
+    }
+    else
+    {
+        MiiControl &= ~(MII_CR_AUTONEG | MII_CR_AUTONEG_RESTART);
+
+        if (Adapter->DefaultMedia & E100_MEDIA_FD)
+            MiiControl |= MII_CR_FULL_DUPLEX;
+        else
+            MiiControl &= ~MII_CR_FULL_DUPLEX;
+
+        if (Adapter->DefaultMedia & E100_MEDIA_100T)
+            MiiControl |= MII_CR_SPEED_SELECTION;
+        else
+            MiiControl &= ~MII_CR_SPEED_SELECTION;
+    }
+
+    if (Adapter->DefaultMedia & E100_MEDIA_PAUSE_RX)
+        MiiAdvertise |= MII_ADV_PAUSE_SYM | MII_ADV_PAUSE_ASYM;
+
+    if (Adapter->DefaultMedia & E100_MEDIA_PAUSE_TX)
+        MiiAdvertise |= MII_ADV_PAUSE_ASYM;
+
+    MiiWrite(Adapter, MII_AUTONEG_ADVERTISE, MiiAdvertise);
+    MiiWrite(Adapter, MII_CONTROL, MiiControl);
+}
+
+CODE_SEG("PAGE")
+NDIS_STATUS
+EeFindMiiPhy(
+    _In_ PE100_ADAPTER Adapter)
+{
+    ULONG PhyAddress;
+
+    PAGED_CODE();
+
+    if (Adapter->PhyType == E100_PHY_TYPE_503)
+    {
+        INFO_VERB("Using non-MII PHY\n");
+        return NDIS_STATUS_SUCCESS;
+    }
+
+    /* Look for the first connected PHY */
+    for (PhyAddress = 1; PhyAddress <= MII_MAX_PHY_ADDRESSES; ++PhyAddress)
+    {
+        ULONG MiiStatus, PhyId;
+#if DBG
+        ULONG MiiControl, MiiAdvertise;
+#endif
+
+        /* Check the PHY 0 last */
+        Adapter->PhyAddress = PhyAddress % MII_MAX_PHY_ADDRESSES;
+
+        /*
+         * Read the status register. Some PHYs, such as the ML6692,
+         * don't implement the IEEE ID registers.
+         */
+        if (!MII_SUCCESS(MiiRead(Adapter, MII_STATUS)))
+            return NDIS_STATUS_FAILURE;
+        MiiStatus = MiiRead(Adapter, MII_STATUS);
+        if (!MII_SUCCESS(MiiStatus))
+            return NDIS_STATUS_FAILURE;
+        if (MiiStatus == 0xFFFF || MiiStatus == 0)
+            continue;
+
+        Adapter->PhyCapabilities = (MiiStatus & 0xFFFF) >> 6;
+
+        PhyId = MiiRead(Adapter, MII_PHY_ID1);
+        PhyId |= MiiRead(Adapter, MII_PHY_ID2) << 16;
+
+#if DBG
+        MiiControl = MiiRead(Adapter, MII_CONTROL);
+        MiiAdvertise = MiiRead(Adapter, MII_AUTONEG_ADVERTISE);
+
+        INFO_VERB("Found PHY at address %lu: ID %08lX, Ctrl %04X, Status %04X, Adv %04X\n",
+                  PhyAddress,
+                  PhyId,
+                  MiiControl,
+                  MiiStatus,
+                  MiiAdvertise);
+#endif
+
+        if (PHY_IS_DP83840(PhyId))
+        {
+            Adapter->PhyType = E100_PHY_TYPE_DP83840;
+        }
+
+        /*
+         * Currently, the 82562EH PHY is not supported yet.
+         * Intel docs 298303-002 and 290687-002 mention some possible applications of the PHY,
+         * but I don't think it was ever sold as a product.
+         */
+        if ((PhyId & 0xFFF0FFFF) == 0x017002A8)
+        {
+            ERR("If you see this, please report to the ReactOS team!\n");
+            ASSERT(FALSE);
+            return NDIS_STATUS_FAILURE;
+        }
+
+        return NDIS_STATUS_SUCCESS;
+    }
+
+    return NDIS_STATUS_FAILURE;
+}

--- a/drivers/network/dd/e100/power.c
+++ b/drivers/network/dd/e100/power.c
@@ -1,0 +1,34 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Power management
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* FUNCTIONS ******************************************************************/
+
+NDIS_STATUS
+EeRemoveWakeUpPattern(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PNDIS_PM_PACKET_PATTERN PmPattern)
+{
+    // TODO: Not implemented
+    ERR("FIXME: Not implemented\n");
+    return NDIS_STATUS_NOT_SUPPORTED;
+}
+
+NDIS_STATUS
+EeAddWakeUpPattern(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PNDIS_PM_PACKET_PATTERN PmPattern)
+{
+    // TODO: Not implemented
+    ERR("FIXME: Not implemented\n");
+    return NDIS_STATUS_NOT_SUPPORTED;
+}

--- a/drivers/network/dd/e100/power.c
+++ b/drivers/network/dd/e100/power.c
@@ -1,0 +1,366 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Power management
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* FUNCTIONS ******************************************************************/
+
+static
+CODE_SEG("PAGE")
+VOID
+EeDownloadFlexiblePacketFilters(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PFXP_CB_LOAD_FILTER FilterSetup = &Adapter->ControlBlock->FilterSetup;
+    PULONG FilterData = &FilterSetup->Data[0];
+    PULONG LastFilterHeader;
+    PLIST_ENTRY Entry;
+    ULONG i;
+
+    PAGED_CODE();
+
+    /* Build the list of programmable filters */
+    for (Entry = Adapter->WakeUpFrameList.Flink;
+         Entry != &Adapter->WakeUpFrameList;
+         Entry = Entry->Flink)
+    {
+        PE100_WAKE_UP_FRAME WakeFrame = CONTAINING_RECORD(Entry, E100_WAKE_UP_FRAME, ListEntry);
+        ULONG MaskLength;
+
+        LastFilterHeader = FilterData;
+
+        /* Store the type dword */
+        ASSERT(WakeFrame->FilterSize > 0 && WakeFrame->FilterSize <= FXP_WOL_FILTER_MASKS);
+        switch (WakeFrame->FilterSize)
+        {
+            default:
+                MaskLength = 0;
+                break;
+            case 2:
+                MaskLength = 1;
+                break;
+            case 3:
+                MaskLength = 3;
+                break;
+            case 4:
+                MaskLength = 7;
+                break;
+        }
+        *FilterData++ = htole32((MaskLength << FXP_FILTER_MLEN_SHIFT) | WakeFrame->Signature);
+
+        /* Store the mask dwords */
+        for (i = 0; i < WakeFrame->FilterSize; ++i)
+        {
+            *FilterData++ = htole32(WakeFrame->PatternMask[i]);
+        }
+    }
+
+    /* Last active filter */
+    *LastFilterHeader |= htole32(FXP_FILTER_EL);
+
+    EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_LOADFILT, &FilterSetup->Header);
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EeProgramWakeUpEvents(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PAGED_CODE();
+
+    if ((Adapter->WakeUpFlags & NDIS_PNP_WAKE_UP_LINK_CHANGE) ||
+        (Adapter->WakeUpFlags & NDIS_PNP_WAKE_UP_MAGIC_PACKET))
+    {
+        PFXP_CB_CONFIGURE Config = &Adapter->ControlBlock->Configuration;
+
+        if (Adapter->WakeUpFlags & NDIS_PNP_WAKE_UP_LINK_CHANGE)
+        {
+            Config->LinkStatusChangeWakeEnable = 1;
+        }
+
+        if (Adapter->WakeUpFlags & NDIS_PNP_WAKE_UP_MAGIC_PACKET)
+        {
+            ASSERT(Adapter->Flags & E100_FLAG_HAS_WOL);
+
+            Config->MagicPacketWakeDisable = 0;
+        }
+
+        EeCommandUnitSendCommand(Adapter, FXP_CB_COMMAND_CONFIG, &Config->Header);
+    }
+
+    /*
+     * If wake on interesting packet is required then
+     * the FXP_CB_COMMAND_LOADFILT must be the last CU command issued by the driver
+     * before the 8255x is set to the power down state.
+     */
+    if ((Adapter->WakeUpFlags & NDIS_PNP_WAKE_UP_PATTERN_MATCH) &&
+        !IsListEmpty(&Adapter->WakeUpFrameList))
+    {
+        ASSERT(Adapter->Flags & E100_FLAG_HAS_WOL);
+
+        EeDownloadFlexiblePacketFilters(Adapter);
+    }
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EePowerDown(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PAGED_CODE();
+
+    EeStopAdapter(Adapter);
+
+    /* Put the CU and RU into the idle state and disable interrupts */
+    EeSoftReset(Adapter, FALSE);
+
+    EeFlushTransmitQueue(Adapter);
+
+    if (Adapter->WakeUpFlags != 0)
+    {
+        EePhyPowerSaveDowngradeLinkSpeed(Adapter);
+        EeProgramWakeUpEvents(Adapter);
+    }
+    else
+    {
+        EePhySetPower(Adapter, FALSE);
+    }
+}
+
+static
+CODE_SEG("PAGE")
+VOID
+EePowerUp(
+    _In_ PE100_ADAPTER Adapter)
+{
+    PAGED_CODE();
+
+    if (Adapter->WakeUpFlags != 0)
+    {
+        /* Clear wakeup events */
+        CSR_WRITE_8(Adapter, FXP_CSR_PMDR, CSR_READ_8(Adapter, FXP_CSR_PMDR));
+    }
+    else
+    {
+        EePhySetPower(Adapter, TRUE);
+    }
+
+    EeSoftReset(Adapter, FALSE);
+
+    EeSetupAdapter(Adapter);
+
+    /* Restore the RX filter */
+    EeApplyPacketFilter(Adapter);
+
+    EeStartAdapter(Adapter);
+}
+
+CODE_SEG("PAGE")
+VOID
+NTAPI
+EePowerWorker(
+    _In_ PNDIS_WORK_ITEM WorkItem,
+    _In_opt_ PVOID Context)
+{
+    PE100_ADAPTER Adapter = Context;
+
+    UNREFERENCED_PARAMETER(WorkItem);
+
+    PAGED_CODE();
+
+    INFO("Power state %lu\n", Adapter->PowerState);
+
+    ASSERT(Adapter->RevisionID != FXP_REV_82557);
+
+    if (Adapter->PowerState == NdisDeviceStateD0)
+    {
+        EePowerUp(Adapter);
+    }
+    else
+    {
+        EePowerDown(Adapter);
+    }
+    Adapter->PrevPowerState = Adapter->PowerState;
+
+    NdisMSetInformationComplete(Adapter->AdapterHandle, NDIS_STATUS_SUCCESS);
+}
+
+static
+ULONG
+EeBuildFrameSignature(
+    _In_ ULONG PatternSize,
+    _In_ const UCHAR* PatternMask,
+    _In_ const UCHAR* PatternData)
+{
+    ULONG i, j = 0, Crc = 0;
+
+    for (i = 0; i < PatternSize; ++i)
+    {
+        if (PatternMask[i / 8] & (1 << (i % 8)))
+        {
+            ULONG Shift = (j++ % 3) * 8;
+
+            if (Crc & 0x80000000)
+                Crc = ((Crc << 1) ^ (PatternData[i] << Shift)) ^ 0x04C11DB7;
+            else
+                Crc = ((Crc << 1) ^ (PatternData[i] << Shift));
+        }
+    }
+
+    return Crc & 0xFFFFFF;
+}
+
+static
+ULONG
+EeFlexibleFilterSize(
+    _In_ ULONG MaskSize)
+{
+    ULONG FilterSize;
+
+    /* Filter mask dwords */
+    FilterSize = MaskSize / sizeof(ULONG);
+    if (MaskSize % sizeof(ULONG))
+        FilterSize++;
+
+    return FilterSize;
+}
+
+NDIS_STATUS
+EeAddWakeUpPattern(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PNDIS_PM_PACKET_PATTERN PmPattern)
+{
+    ULONG MaskSize, FilterSize;
+    PE100_WAKE_UP_FRAME WakeFrame;
+    NDIS_STATUS Status;
+
+    MaskSize = min(PmPattern->MaskSize, FXP_WOL_FILTER_MASKS * sizeof(ULONG));
+
+    FilterSize = EeFlexibleFilterSize(MaskSize);
+    if (Adapter->FlexibleFiltersUsed + (FilterSize + 1) > FXP_WOL_PATTERN_FILTERS)
+        return NDIS_STATUS_RESOURCES;
+
+    Status = NdisAllocateMemoryWithTag((PVOID*)&WakeFrame, sizeof(*WakeFrame), E100_TAG);
+    if (Status != NDIS_STATUS_SUCCESS)
+        return NDIS_STATUS_RESOURCES;
+    RtlZeroMemory(WakeFrame, sizeof(*WakeFrame));
+
+    /* +1 to include the filter type dword */
+    Adapter->FlexibleFiltersUsed += FilterSize + 1;
+
+    WakeFrame->FilterSize = FilterSize;
+    WakeFrame->Signature = EeBuildFrameSignature(MaskSize * RTL_BITS_OF(UCHAR),
+                                                 (PUCHAR)PmPattern + sizeof(*PmPattern),
+                                                 (PUCHAR)PmPattern + PmPattern->PatternOffset);
+    RtlCopyMemory(&WakeFrame->PatternMask,
+                  (PUCHAR)PmPattern + sizeof(*PmPattern),
+                  MaskSize);
+
+    InsertTailList(&Adapter->WakeUpFrameList, &WakeFrame->ListEntry);
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+NDIS_STATUS
+EeRemoveWakeUpPattern(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PNDIS_PM_PACKET_PATTERN PmPattern)
+{
+    PLIST_ENTRY Entry;
+    ULONG MaskSize, FilterSize, Signature;
+
+    MaskSize = min(PmPattern->MaskSize, FXP_WOL_FILTER_MASKS * sizeof(ULONG));
+
+    FilterSize = EeFlexibleFilterSize(MaskSize);
+
+    Signature = EeBuildFrameSignature(MaskSize * RTL_BITS_OF(UCHAR),
+                                      (PUCHAR)PmPattern + sizeof(*PmPattern),
+                                      (PUCHAR)PmPattern + PmPattern->PatternOffset);
+
+    for (Entry = Adapter->WakeUpFrameList.Flink;
+         Entry != &Adapter->WakeUpFrameList;
+         Entry = Entry->Flink)
+    {
+        PE100_WAKE_UP_FRAME WakeFrame = CONTAINING_RECORD(Entry, E100_WAKE_UP_FRAME, ListEntry);
+
+        if (WakeFrame->FilterSize != FilterSize)
+            continue;
+
+        if (WakeFrame->Signature != Signature)
+            continue;
+
+        if (!RtlEqualMemory(&WakeFrame->PatternMask,
+                            (PUCHAR)PmPattern + sizeof(*PmPattern),
+                            MaskSize))
+        {
+            continue;
+        }
+
+        RemoveEntryList(&WakeFrame->ListEntry);
+
+        Adapter->FlexibleFiltersUsed -= WakeFrame->FilterSize + 1;
+
+        NdisFreeMemory(WakeFrame, sizeof(*WakeFrame), 0);
+        return NDIS_STATUS_SUCCESS;
+    }
+
+    return NDIS_STATUS_INVALID_DATA;
+}
+
+NDIS_STATUS
+EeGetPowerManagementCapabilities(
+    _In_ PE100_ADAPTER Adapter,
+    _Out_ PNDIS_PNP_CAPABILITIES Capabilities)
+{
+    /* The 82557 has no power management support */
+    if (Adapter->RevisionID == FXP_REV_82557)
+        return NDIS_STATUS_NOT_SUPPORTED;
+
+    if (!(Adapter->Flags & E100_FLAG_HAS_WOL))
+    {
+        Capabilities->WakeUpCapabilities.MinMagicPacketWakeUp = NdisDeviceStateUnspecified;
+        Capabilities->WakeUpCapabilities.MinPatternWakeUp = NdisDeviceStateUnspecified;
+
+        /* The 82559ER can only wake on link status change */
+        if (Adapter->RevisionID == FXP_REV_82559S_A)
+            Capabilities->WakeUpCapabilities.MinLinkChangeWakeUp = NdisDeviceStateD3;
+        else
+            Capabilities->WakeUpCapabilities.MinLinkChangeWakeUp = NdisDeviceStateUnspecified;
+    }
+    else
+    {
+        if (Adapter->RevisionID == FXP_REV_82558_A4)
+        {
+            Capabilities->WakeUpCapabilities.MinMagicPacketWakeUp = NdisDeviceStateD1;
+            Capabilities->WakeUpCapabilities.MinPatternWakeUp = NdisDeviceStateUnspecified;
+            Capabilities->WakeUpCapabilities.MinLinkChangeWakeUp = NdisDeviceStateUnspecified;
+        }
+        else
+        {
+            Capabilities->WakeUpCapabilities.MinMagicPacketWakeUp = NdisDeviceStateD3;
+            Capabilities->WakeUpCapabilities.MinPatternWakeUp = NdisDeviceStateD3;
+            Capabilities->WakeUpCapabilities.MinLinkChangeWakeUp = NdisDeviceStateD3;
+        }
+
+        /*
+         * The 82558 B-step requires the driver to download a specific microcode
+         * to support flexible packet filtering (which has never been released to the public).
+         */
+        if (Adapter->RevisionID == FXP_REV_82558_B0)
+        {
+            Capabilities->WakeUpCapabilities.MinPatternWakeUp = NdisDeviceStateUnspecified;
+        }
+    }
+
+    return NDIS_STATUS_SUCCESS;
+}

--- a/drivers/network/dd/e100/rcvbundl.h
+++ b/drivers/network/dd/e100/rcvbundl.h
@@ -1,0 +1,1258 @@
+/*-
+SPDX-License-Identifier: BSD-3-Clause
+
+Copyright (c) 1999-2001, Intel Corporation
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of Intel Corporation nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/*
+ */
+/*
+rcvbundl.h
+
+Author:  Patrick J Luhmann (PJL)
+Date:    05/30/2000
+Version: 3.28
+
+This file contains the loadable micro code arrays to implement receive bundling on the
+D101 A-step, D101 B-step, D101M (B-step only), D101S, D102 B-step,
+D102 B-step with TCO work around, D102 C-step and D102 E-step.
+
+Each controller has its own specific micro code array.  The array for one controller
+is totally incompatible with any other controller, and if used will most likely
+cause the controller to lock up and stop responding to the driver.  Each micro
+code array has its own parameter offsets (described below), and they each have
+their own version number (which should not be confused with the version of the
+rcvbundl.h file given above).
+
+*/
+
+
+
+/*************************************************************************
+*  CPUSaver parameters
+*
+*  All CPUSaver parameters are 16-bit literals that are part of a
+*  "move immediate value" instruction.  By changing the value of
+*  the literal in the instruction before the code is loaded, the
+*  driver can change algorithm.
+*
+*  CPUSAVER_DWORD - This is the location of the instruction that loads
+*    the dead-man timer with its initial value.  By writing a 16-bit
+*    value to the low word of this instruction, the driver can change
+*    the timer value.  The current default is either x600 or x800;
+*    experiments show that the value probably should stay within the
+*    range of x200 - x1000.
+*
+*  CPUSAVER_BUNDLE_MAX_DWORD - This is the location of the instruction
+*    that sets the maximum number of frames that will be bundled.  In
+*    some situations, such as the TCP windowing algorithm, it may be
+*    better to limit the growth of the bundle size than let it go as
+*    high as it can, because that could cause too much added latency.
+*    The default is six, because this is the number of packets in the
+*    default TCP window size.  A value of 1 would make CPUSaver indicate
+*    an interrupt for every frame received.  If you do not want to put
+*    a limit on the bundle size, set this value to xFFFF.
+*
+*  CPUSAVER_MIN_SIZE_DWORD - This is the location of the instruction
+*    that contains a bit-mask describing the minimum size frame that
+*    will be bundled.  The default masks the lower 7 bits, which means
+*    that any frame less than 128 bytes in length will not be bundled,
+*    but will instead immediately generate an interrupt.  This does
+*    not affect the current bundle in any way.  Any frame that is 128
+*    bytes or large will be bundled normally.  This feature is meant
+*    to provide immediate indication of ACK frames in a TCP environment.
+*    Customers were seeing poor performance when a machine with CPUSaver
+*    enabled was sending but not receiving.  The delay introduced when
+*    the ACKs were received was enough to reduce total throughput, because
+*    the sender would sit idle until the ACK was finally seen.
+*
+*    The current default is 0xFF80, which masks out the lower 7 bits.
+*    This means that any frame which is x7F (127) bytes or smaller
+*    will cause an immediate interrupt.  Because this value must be a
+*    bit mask, there are only a few valid values that can be used.  To
+*    turn this feature off, the driver can write the value xFFFF to the
+*    lower word of this instruction (in the same way that the other
+*    parameters are used).  Likewise, a value of 0xF800 (2047) would
+*    cause an interrupt to be generated for every frame, because all
+*    standard Ethernet frames are <= 2047 bytes in length.
+*************************************************************************/
+
+
+
+/********************************************************/
+/*  CPUSaver micro code for the D101A                   */
+/********************************************************/
+
+/*  Version 2.0  */
+
+/*  This value is the same for both A and B step of 558.  */
+#define D101_CPUSAVER_DWORD         72
+
+
+#define     D101_A_RCVBUNDLE_UCODE \
+{\
+0x03B301BB, \
+0x0046FFFF, \
+0xFFFFFFFF, \
+0x051DFFFF, \
+0xFFFFFFFF, \
+0xFFFFFFFF, \
+0x000C0001, \
+0x00101212, \
+0x000C0008, \
+0x003801BC, \
+0x00000000, \
+0x00124818, \
+0x000C1000, \
+0x00220809, \
+0x00010200, \
+0x00124818, \
+0x000CFFFC, \
+0x003803B5, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x0010009C, \
+0x0024B81D, \
+0x00130836, \
+0x000C0001, \
+0x0026081C, \
+0x0020C81B, \
+0x00130824, \
+0x00222819, \
+0x00101213, \
+0x00041000, \
+0x003A03B3, \
+0x00010200, \
+0x00101B13, \
+0x00238081, \
+0x00213049, \
+0x0038003B, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x0010009C, \
+0x0024B83E, \
+0x00130826, \
+0x000C0001, \
+0x0026083B, \
+0x00010200, \
+0x00134824, \
+0x000C0001, \
+0x00101213, \
+0x00041000, \
+0x0038051E, \
+0x00101313, \
+0x00010400, \
+0x00380521, \
+0x00050600, \
+0x00100824, \
+0x00101310, \
+0x00041000, \
+0x00080600, \
+0x00101B10, \
+0x0038051E, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+}
+
+
+/********************************************************/
+/*  CPUSaver micro code for the D101B                   */
+/********************************************************/
+
+/*  Version 2.0  */
+
+#define     D101_B0_RCVBUNDLE_UCODE \
+{\
+0x03B401BC, \
+0x0047FFFF, \
+0xFFFFFFFF, \
+0x051EFFFF, \
+0xFFFFFFFF, \
+0xFFFFFFFF, \
+0x000C0001, \
+0x00101B92, \
+0x000C0008, \
+0x003801BD, \
+0x00000000, \
+0x00124818, \
+0x000C1000, \
+0x00220809, \
+0x00010200, \
+0x00124818, \
+0x000CFFFC, \
+0x003803B6, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x0010009C, \
+0x0024B81D, \
+0x0013082F, \
+0x000C0001, \
+0x0026081C, \
+0x0020C81B, \
+0x00130837, \
+0x00222819, \
+0x00101B93, \
+0x00041000, \
+0x003A03B4, \
+0x00010200, \
+0x00101793, \
+0x00238082, \
+0x0021304A, \
+0x0038003C, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x0010009C, \
+0x0024B83E, \
+0x00130826, \
+0x000C0001, \
+0x0026083B, \
+0x00010200, \
+0x00134837, \
+0x000C0001, \
+0x00101B93, \
+0x00041000, \
+0x0038051F, \
+0x00101313, \
+0x00010400, \
+0x00380522, \
+0x00050600, \
+0x00100837, \
+0x00101310, \
+0x00041000, \
+0x00080600, \
+0x00101790, \
+0x0038051F, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+}
+
+
+/********************************************************/
+/*  CPUSaver micro code for the D101M (B-step only)     */
+/********************************************************/
+
+/*  Version 2.10  */
+
+/*  Parameter values for the D101M B-step  */
+#define D101M_CPUSAVER_DWORD                78
+#define D101M_CPUSAVER_BUNDLE_MAX_DWORD     65
+#define D101M_CPUSAVER_MIN_SIZE_DWORD       126
+
+
+#define D101M_B_RCVBUNDLE_UCODE \
+{\
+0x00550215, \
+0xFFFF0437, \
+0xFFFFFFFF, \
+0x06A70789, \
+0xFFFFFFFF, \
+0x0558FFFF, \
+0x000C0001, \
+0x00101312, \
+0x000C0008, \
+0x00380216, \
+0x0010009C, \
+0x00204056, \
+0x002380CC, \
+0x00380056, \
+0x0010009C, \
+0x00244C0B, \
+0x00000800, \
+0x00124818, \
+0x00380438, \
+0x00000000, \
+0x00140000, \
+0x00380555, \
+0x00308000, \
+0x00100662, \
+0x00100561, \
+0x000E0408, \
+0x00134861, \
+0x000C0002, \
+0x00103093, \
+0x00308000, \
+0x00100624, \
+0x00100561, \
+0x000E0408, \
+0x00100861, \
+0x000C007E, \
+0x00222C21, \
+0x000C0002, \
+0x00103093, \
+0x00380C7A, \
+0x00080000, \
+0x00103090, \
+0x00380C7A, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x0010009C, \
+0x00244C2D, \
+0x00010004, \
+0x00041000, \
+0x003A0437, \
+0x00044010, \
+0x0038078A, \
+0x00000000, \
+0x00100099, \
+0x00206C7A, \
+0x0010009C, \
+0x00244C48, \
+0x00130824, \
+0x000C0001, \
+0x00101213, \
+0x00260C75, \
+0x00041000, \
+0x00010004, \
+0x00130826, \
+0x000C0006, \
+0x002206A8, \
+0x0013C926, \
+0x00101313, \
+0x003806A8, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00080600, \
+0x00101B10, \
+0x00050004, \
+0x00100826, \
+0x00101210, \
+0x00380C34, \
+0x00000000, \
+0x00000000, \
+0x0021155B, \
+0x00100099, \
+0x00206559, \
+0x0010009C, \
+0x00244559, \
+0x00130836, \
+0x000C0000, \
+0x00220C62, \
+0x000C0001, \
+0x00101B13, \
+0x00229C0E, \
+0x00210C0E, \
+0x00226C0E, \
+0x00216C0E, \
+0x0022FC0E, \
+0x00215C0E, \
+0x00214C0E, \
+0x00380555, \
+0x00010004, \
+0x00041000, \
+0x00278C67, \
+0x00040800, \
+0x00018100, \
+0x003A0437, \
+0x00130826, \
+0x000C0001, \
+0x00220559, \
+0x00101313, \
+0x00380559, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00130831, \
+0x0010090B, \
+0x00124813, \
+0x000CFF80, \
+0x002606AB, \
+0x00041000, \
+0x003806A8, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+}
+
+
+/********************************************************/
+/*  CPUSaver micro code for the D101S                   */
+/********************************************************/
+
+/*  Version 1.20  */
+
+/*  Parameter values for the D101S  */
+#define D101S_CPUSAVER_DWORD                78
+#define D101S_CPUSAVER_BUNDLE_MAX_DWORD     67
+#define D101S_CPUSAVER_MIN_SIZE_DWORD       129
+
+
+#define D101S_RCVBUNDLE_UCODE \
+{\
+0x00550242, \
+0xFFFF047E, \
+0xFFFFFFFF, \
+0x06FF0818, \
+0xFFFFFFFF, \
+0x05A6FFFF, \
+0x000C0001, \
+0x00101312, \
+0x000C0008, \
+0x00380243, \
+0x0010009C, \
+0x00204056, \
+0x002380D0, \
+0x00380056, \
+0x0010009C, \
+0x00244F8B, \
+0x00000800, \
+0x00124818, \
+0x0038047F, \
+0x00000000, \
+0x00140000, \
+0x003805A3, \
+0x00308000, \
+0x00100610, \
+0x00100561, \
+0x000E0408, \
+0x00134861, \
+0x000C0002, \
+0x00103093, \
+0x00308000, \
+0x00100624, \
+0x00100561, \
+0x000E0408, \
+0x00100861, \
+0x000C007E, \
+0x00222FA1, \
+0x000C0002, \
+0x00103093, \
+0x00380F90, \
+0x00080000, \
+0x00103090, \
+0x00380F90, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x0010009C, \
+0x00244FAD, \
+0x00010004, \
+0x00041000, \
+0x003A047E, \
+0x00044010, \
+0x00380819, \
+0x00000000, \
+0x00100099, \
+0x00206FFD, \
+0x0010009A, \
+0x0020AFFD, \
+0x0010009C, \
+0x00244FC8, \
+0x00130824, \
+0x000C0001, \
+0x00101213, \
+0x00260FF8, \
+0x00041000, \
+0x00010004, \
+0x00130826, \
+0x000C0006, \
+0x00220700, \
+0x0013C926, \
+0x00101313, \
+0x00380700, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00080600, \
+0x00101B10, \
+0x00050004, \
+0x00100826, \
+0x00101210, \
+0x00380FB6, \
+0x00000000, \
+0x00000000, \
+0x002115A9, \
+0x00100099, \
+0x002065A7, \
+0x0010009A, \
+0x0020A5A7, \
+0x0010009C, \
+0x002445A7, \
+0x00130836, \
+0x000C0000, \
+0x00220FE4, \
+0x000C0001, \
+0x00101B13, \
+0x00229F8E, \
+0x00210F8E, \
+0x00226F8E, \
+0x00216F8E, \
+0x0022FF8E, \
+0x00215F8E, \
+0x00214F8E, \
+0x003805A3, \
+0x00010004, \
+0x00041000, \
+0x00278FE9, \
+0x00040800, \
+0x00018100, \
+0x003A047E, \
+0x00130826, \
+0x000C0001, \
+0x002205A7, \
+0x00101313, \
+0x003805A7, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00130831, \
+0x0010090B, \
+0x00124813, \
+0x000CFF80, \
+0x00260703, \
+0x00041000, \
+0x00380700, \
+0x00000000, \
+}
+
+
+/********************************************************/
+/*  CPUSaver micro code for the D102 B-step             */
+/********************************************************/
+
+/*  Version 2.0  */
+
+/*
+    This version of CPUSaver is different from all others in
+    a different way.  It combines the CPUSaver algorithm with
+    fixes for bugs in the B-step hardware (specifically, bugs
+    with Inline Receive).
+    Thus, when CPUSaver is disabled, this micro code image will
+    still need to be loaded.  Before this happens, the hit addresses
+    for the CPUSaver algorithm must be set to 0x1FFFF.  The hit
+    addresses for CPUSaver are (starting with 0, and remember that
+
+*/
+
+/*  Parameter values for the D102 B-step  */
+#define D102_B_CPUSAVER_DWORD                91
+#define D102_B_CPUSAVER_BUNDLE_MAX_DWORD     115
+#define D102_B_CPUSAVER_MIN_SIZE_DWORD       70
+
+
+#define     D102_B_RCVBUNDLE_UCODE \
+{\
+0x006F0276, \
+0x02BF0E93, \
+0x1FFF0ED9, \
+0x0D2508FA, \
+0x04D21FFF, \
+0x0EA10892, \
+0x00300001, \
+0x0140D871, \
+0x00300008, \
+0x00E00277, \
+0x01406C57, \
+0x00816073, \
+0x008700FA, \
+0x00E00070, \
+0x00E00E94, \
+0x00200004, \
+0x01410000, \
+0x014B6F6F, \
+0x0030FFFF, \
+0x01486F72, \
+0x00E81F9B, \
+0x00E00EA3, \
+0x003C0040, \
+0x00380920, \
+0x00C02000, \
+0x0150ED38, \
+0x0150EE39, \
+0x0150EF3A, \
+0x003C0040, \
+0x01506F0D, \
+0x01600E72, \
+0x00380AE0, \
+0x00E002C0, \
+0x00300001, \
+0x014C0000, \
+0x008404DC, \
+0x014C6F72, \
+0x00E01F9D, \
+0x01406C51, \
+0x0080DFC2, \
+0x01406C52, \
+0x00815FC2, \
+0x01406C57, \
+0x00917FD5, \
+0x00E01FE6, \
+0x00000000, \
+0x01406C57, \
+0x00919FAD, \
+0x00038800, \
+0x00300000, \
+0x00E81FF2, \
+0x014D6FC4, \
+0x00E008FB, \
+0x00000000, \
+0x00822D30, \
+0x01406C51, \
+0x0080CD26, \
+0x01406C52, \
+0x00814D26, \
+0x01406C57, \
+0x00916D26, \
+0x014C6FD7, \
+0x00300000, \
+0x00841FDB, \
+0x00300001, \
+0x0140D772, \
+0x00E012B3, \
+0x014C6F91, \
+0x0150710B, \
+0x01496F72, \
+0x0030FF80, \
+0x00940EDD, \
+0x00102000, \
+0x00E00EDA, \
+0x01406C57, \
+0x00917FFD, \
+0x00001000, \
+0x00E01FFD, \
+0x00138800, \
+0x00300001, \
+0x00E81FF2, \
+0x00202500, \
+0x00E81F9B, \
+0x01600EC5, \
+0x00E00893, \
+0x00000000, \
+0x01406CD5, \
+0x0091EEA3, \
+0x00904EA3, \
+0x00901F89, \
+0x00E00EA3, \
+0x00200600, \
+0x0140D76F, \
+0x00138400, \
+0x01406FD8, \
+0x0140D96F, \
+0x00E01FE6, \
+0x00038400, \
+0x00102000, \
+0x00971FE0, \
+0x00101000, \
+0x00050200, \
+0x00E804D2, \
+0x014C6FD8, \
+0x00300001, \
+0x00840D26, \
+0x0140D872, \
+0x00E00D26, \
+0x014C6FD9, \
+0x00300001, \
+0x0140D972, \
+0x00941FBD, \
+0x00102000, \
+0x00038400, \
+0x014C6FD8, \
+0x00300006, \
+0x00840EDA, \
+0x014F71D8, \
+0x0140D872, \
+0x00E00EDA, \
+0x00340020, \
+0x014C6FED, \
+0x01603472, \
+0x016035EE, \
+0x016036EF, \
+0x00300004, \
+0x01611C71, \
+0x00300014, \
+0x00200A00, \
+0x00E810B9, \
+0x00600000, \
+0x01496F50, \
+0x00E004D3, \
+0x00000000, \
+}
+
+
+
+
+/********************************************************/
+/*  TCO micro code for the D102 B-step             */
+/********************************************************/
+
+/*  Version 2.0  */
+
+/*
+    This version is a fix to TCO bug. This version can be loaded instead
+    the CPUSaver version by modifing the registry key "LoadTcoUCodeInsteadOfCpuSaver"
+
+*/
+
+
+#define     D102_B_TCO_UCODE \
+{\
+0x1FFF0ED3, \
+0x02BF0E93, \
+0x1FFF1FFF, \
+0x1FFF08FA, \
+0x1FFF1FFF, \
+0x0EA10892, \
+0x00906ED8, \
+0x01406C55, \
+0x00E00ED4, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00E00E94, \
+0x00200004, \
+0x01410000, \
+0x014B6F6F, \
+0x0030FFFF, \
+0x01486F72, \
+0x00E81F9B, \
+0x00E00EA3, \
+0x003C0040, \
+0x00380920, \
+0x00C02000, \
+0x0150ED38, \
+0x0150EE39, \
+0x0150EF3A, \
+0x003C0040, \
+0x01506F0D, \
+0x01600E72, \
+0x00380AE0, \
+0x00E002C0, \
+0x00300001, \
+0x014C0000, \
+0x008404DC, \
+0x014C6F72, \
+0x00E01F9D, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x01406C57, \
+0x00919FAD, \
+0x00038800, \
+0x00300000, \
+0x00E81FD5, \
+0x014D6FC4, \
+0x00E008FB, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00138800, \
+0x00300001, \
+0x00E81FD5, \
+0x00202500, \
+0x00E81F9B, \
+0x01600EC5, \
+0x00E00893, \
+0x00000000, \
+0x01406CD5, \
+0x0091EEA3, \
+0x00904EA3, \
+0x00901F89, \
+0x00E00EA3, \
+0x00340020, \
+0x014C6FED, \
+0x01603472, \
+0x016035EE, \
+0x016036EF, \
+0x00300004, \
+0x01611C71, \
+0x00300014, \
+0x00200A00, \
+0x00E810B9, \
+0x00600000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+}
+
+
+
+/********************************************************/
+/*  Micro code for the D102 C-step                      */
+/********************************************************/
+
+/*  Parameter values for the D102 C-step  */
+#define D102_C_CPUSAVER_DWORD                46
+#define D102_C_CPUSAVER_BUNDLE_MAX_DWORD     54
+#define D102_C_CPUSAVER_MIN_SIZE_DWORD      133 /* not implemented */
+
+
+
+
+
+#if 0
+// this uCode include the CPU Saver and the TCO work around
+//for IP fragments.
+#endif
+#define     D102_C_RCVBUNDLE_UCODE \
+{ \
+0x00700279, \
+0x0E6104E2, \
+0x02BF0CAE, \
+0x1519150C, \
+0x1FFF0E5B, \
+0x1FFF1FFF, \
+0x00E014D8, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00E014DC, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00E014F4, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00E014E0, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00E014E7, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00141000, \
+0x015D6F0D, \
+0x00E002C0, \
+0x00000000, \
+0x00200600, \
+0x00E0150D, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00300006, \
+0x00E0151A, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00906E65, \
+0x00800E60, \
+0x00E00E5D, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+}
+
+/********************************************************/
+/*  Micro code for the D102 E-step                      */
+/********************************************************/
+
+/*  Parameter values for the D102 E-step  */
+#define D102_E_CPUSAVER_DWORD                   42
+#define D102_E_CPUSAVER_BUNDLE_MAX_DWORD        54
+#define D102_E_CPUSAVER_MIN_SIZE_DWORD          46
+
+#define     D102_E_RCVBUNDLE_UCODE \
+{\
+0x007D028F, \
+0x0E4204F9, \
+0x14ED0C85, \
+0x14FA14E9, \
+0x0EF70E36, \
+0x1FFF1FFF, \
+0x00E014B9, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00E014BD, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00E014D5, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00E014C1, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00E014C8, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00200600, \
+0x00E014EE, \
+0x00000000, \
+0x00000000, \
+0x0030FF80, \
+0x00940E46, \
+0x00038200, \
+0x00102000, \
+0x00E00E43, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00300006, \
+0x00E014FB, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00906E41, \
+0x00800E3C, \
+0x00E00E39, \
+0x00000000, \
+0x00906EFD, \
+0x00900EFD, \
+0x00E00EF8, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+0x00000000, \
+}

--- a/drivers/network/dd/e100/requests.c
+++ b/drivers/network/dd/e100/requests.c
@@ -1,0 +1,553 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Miniport information callbacks
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* GLOBASLS *******************************************************************/
+
+static const NDIS_OID E100SupportedOidList[] =
+{
+    OID_GEN_SUPPORTED_LIST,
+    OID_GEN_CURRENT_PACKET_FILTER,
+    OID_GEN_HARDWARE_STATUS,
+    OID_GEN_MEDIA_SUPPORTED,
+    OID_GEN_MEDIA_IN_USE,
+    OID_GEN_MAXIMUM_LOOKAHEAD,
+    OID_GEN_MAXIMUM_FRAME_SIZE,
+    OID_GEN_MAXIMUM_SEND_PACKETS,
+    OID_GEN_LINK_SPEED,
+    OID_GEN_TRANSMIT_BUFFER_SPACE,
+    OID_GEN_RECEIVE_BUFFER_SPACE,
+    OID_GEN_RECEIVE_BLOCK_SIZE,
+    OID_GEN_TRANSMIT_BLOCK_SIZE,
+    OID_GEN_VENDOR_ID,
+    OID_GEN_VENDOR_DESCRIPTION,
+    OID_GEN_VENDOR_DRIVER_VERSION,
+    OID_GEN_CURRENT_LOOKAHEAD,
+    OID_GEN_DRIVER_VERSION,
+    OID_GEN_MAXIMUM_TOTAL_SIZE,
+    OID_GEN_MAC_OPTIONS,
+    OID_GEN_MEDIA_CONNECT_STATUS,
+    OID_GEN_VLAN_ID,
+    OID_802_3_PERMANENT_ADDRESS,
+    OID_802_3_CURRENT_ADDRESS,
+    OID_802_3_MULTICAST_LIST,
+    OID_802_3_MAXIMUM_LIST_SIZE,
+
+    /* Statistics */
+    OID_GEN_XMIT_OK,
+    OID_GEN_RCV_OK,
+    OID_GEN_XMIT_ERROR,
+    OID_GEN_RCV_ERROR,
+    OID_GEN_RCV_NO_BUFFER,
+    OID_GEN_RCV_CRC_ERROR,
+    OID_GEN_TRANSMIT_QUEUE_LENGTH,
+    OID_802_3_RCV_ERROR_ALIGNMENT,
+    OID_802_3_XMIT_ONE_COLLISION,
+    OID_802_3_XMIT_MORE_COLLISIONS,
+    OID_802_3_XMIT_DEFERRED,
+    OID_802_3_XMIT_MAX_COLLISIONS,
+    OID_802_3_RCV_OVERRUN,
+    OID_802_3_XMIT_UNDERRUN,
+    OID_802_3_XMIT_HEARTBEAT_FAILURE,
+    OID_802_3_XMIT_TIMES_CRS_LOST,
+    OID_802_3_XMIT_LATE_COLLISIONS,
+
+    /* Offload */
+    // OID_TCP_TASK_OFFLOAD,
+
+    /* Power management */
+    // OID_PNP_CAPABILITIES,
+    // OID_PNP_SET_POWER,
+    // OID_PNP_QUERY_POWER,
+    // OID_PNP_ADD_WAKE_UP_PATTERN,
+    // OID_PNP_REMOVE_WAKE_UP_PATTERN,
+    // OID_PNP_ENABLE_WAKE_UP
+};
+
+/* FUNCTIONS ******************************************************************/
+
+static
+VOID
+EeQueryStatisticCounter(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ NDIS_OID Oid,
+    _Out_ PULONG64 Counter)
+{
+    switch (Oid)
+    {
+        case OID_GEN_XMIT_OK:
+            *Counter = Adapter->Statistics.TransmitOk;
+            break;
+        case OID_GEN_RCV_OK:
+            *Counter = Adapter->Statistics.ReceiveOk;
+            break;
+        case OID_GEN_XMIT_ERROR:
+            *Counter = Adapter->Statistics.TransmitErrors;
+            break;
+        case OID_GEN_RCV_ERROR:
+            *Counter = Adapter->Statistics.ReceiveErrors;
+            break;
+        case OID_GEN_RCV_NO_BUFFER:
+            *Counter = Adapter->Statistics.ReceiveNoBuffers;
+            break;
+        case OID_GEN_RCV_CRC_ERROR:
+            *Counter = Adapter->Statistics.ReceiveCrcErrors;
+            break;
+        case OID_802_3_RCV_ERROR_ALIGNMENT:
+            *Counter = Adapter->Statistics.ReceiveAlignmentErrors;
+            break;
+        case OID_802_3_XMIT_ONE_COLLISION:
+            *Counter = Adapter->Statistics.TransmitOneRetry;
+            break;
+        case OID_802_3_XMIT_MORE_COLLISIONS:
+            *Counter = Adapter->Statistics.TransmitMoreCollisions;
+            break;
+        case OID_802_3_XMIT_DEFERRED:
+            *Counter = Adapter->Statistics.TransmitDeferred;
+            break;
+        case OID_802_3_XMIT_MAX_COLLISIONS:
+            *Counter = Adapter->Statistics.TransmitExcessiveCollisions;
+            break;
+        case OID_802_3_RCV_OVERRUN:
+            *Counter = Adapter->Statistics.ReceiveOverrunErrors;
+            break;
+        case OID_802_3_XMIT_UNDERRUN:
+            *Counter = Adapter->Statistics.TransmitUnderrunErrors;
+            break;
+        case OID_802_3_XMIT_HEARTBEAT_FAILURE:
+            *Counter = Adapter->Statistics.TransmitHeartbeatErrors;
+            break;
+        case OID_802_3_XMIT_TIMES_CRS_LOST:
+            *Counter = Adapter->Statistics.TransmitLostCarrierSense;
+            break;
+        case OID_802_3_XMIT_LATE_COLLISIONS:
+            *Counter = Adapter->Statistics.TransmitLateCollisions;
+            break;
+
+        default:
+            ASSERT(FALSE);
+            UNREACHABLE;
+            break;
+    }
+}
+
+NDIS_STATUS
+NTAPI
+MiniportQueryInformation(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ NDIS_OID Oid,
+    _In_ PVOID InformationBuffer,
+    _In_ ULONG InformationBufferLength,
+    _Out_ PULONG BytesWritten,
+    _Out_ PULONG BytesNeeded)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    NDIS_STATUS Status = NDIS_STATUS_SUCCESS;
+    ULONG InfoLength;
+    PVOID InfoPtr;
+    union _GENERIC_INFORMATION
+    {
+        USHORT Ushort;
+        ULONG Ulong;
+        ULONG64 Ulong64;
+        NDIS_MEDIUM Medium;
+        NDIS_HARDWARE_STATUS Status;
+        NDIS_DEVICE_POWER_STATE PowerState;
+    } GenericInfo;
+
+    InfoLength = sizeof(ULONG);
+    InfoPtr = &GenericInfo;
+
+    switch (Oid)
+    {
+        case OID_GEN_SUPPORTED_LIST:
+            InfoPtr = (PVOID)&E100SupportedOidList;
+            InfoLength = sizeof(E100SupportedOidList);
+            break;
+
+        case OID_GEN_CURRENT_PACKET_FILTER:
+            GenericInfo.Ulong = Adapter->PacketFilter;
+            break;
+
+        case OID_802_3_MULTICAST_LIST:
+            InfoPtr = Adapter->MulticastList;
+            InfoLength = Adapter->MulticastListSize;
+            break;
+
+        case OID_802_3_MAXIMUM_LIST_SIZE:
+            GenericInfo.Ulong = E100_MULTICAST_LIST_SIZE;
+            break;
+
+        case OID_GEN_MEDIA_SUPPORTED:
+        case OID_GEN_MEDIA_IN_USE:
+        {
+            GenericInfo.Medium = NdisMedium802_3;
+            InfoLength = sizeof(NDIS_MEDIUM);
+            break;
+        }
+
+        case OID_GEN_HARDWARE_STATUS:
+        {
+            /* The card has been physically ejected */
+            if (CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK) == 0xFF)
+                GenericInfo.Status = NdisHardwareStatusNotReady;
+            else
+                GenericInfo.Status = NdisHardwareStatusReady;
+
+            InfoLength = sizeof(NDIS_HARDWARE_STATUS);
+            break;
+        }
+
+        case OID_GEN_MAXIMUM_FRAME_SIZE:
+        case OID_GEN_MAXIMUM_LOOKAHEAD:
+        case OID_GEN_CURRENT_LOOKAHEAD:
+            GenericInfo.Ulong = E100_MAXIMUM_FRAME_SIZE - E100_ETHERNET_HEADER_SIZE;
+            break;
+
+        case OID_GEN_MAXIMUM_TOTAL_SIZE:
+            GenericInfo.Ulong = E100_MAXIMUM_FRAME_SIZE;
+            break;
+
+        case OID_GEN_TRANSMIT_BLOCK_SIZE:
+            GenericInfo.Ulong = E100_TRANSMIT_BLOCK_SIZE;
+            break;
+
+        case OID_GEN_TRANSMIT_BUFFER_SPACE:
+            GenericInfo.Ulong = E100_TRANSMIT_BLOCK_SIZE * Adapter->TcbCount;
+            break;
+
+        case OID_GEN_RECEIVE_BLOCK_SIZE:
+            GenericInfo.Ulong = E100_RECEIVE_BLOCK_SIZE;
+            break;
+
+        case OID_GEN_RECEIVE_BUFFER_SPACE:
+            GenericInfo.Ulong = E100_RECEIVE_BLOCK_SIZE * Adapter->RfdCount;
+            break;
+
+        case OID_GEN_LINK_SPEED:
+            if (Adapter->CurrentMedia & E100_MEDIA_100T)
+                GenericInfo.Ulong = 100 * 10000;
+            else
+                GenericInfo.Ulong = 10 * 10000;
+            break;
+
+        case OID_GEN_VENDOR_ID:
+            GenericInfo.Ulong = 0;
+            GenericInfo.Ulong |= (Adapter->PermanentMacAddress[0] << 16);
+            GenericInfo.Ulong |= (Adapter->PermanentMacAddress[1] << 8);
+            GenericInfo.Ulong |= (Adapter->PermanentMacAddress[2] & 0xFF);
+            break;
+
+        case OID_GEN_VENDOR_DESCRIPTION:
+        {
+            static const CHAR VendorDesc[] = "i8255x compatible Ethernet Controller";
+            InfoPtr = (PVOID)&VendorDesc;
+            InfoLength = sizeof(VendorDesc);
+            break;
+        }
+
+        case OID_GEN_VENDOR_DRIVER_VERSION:
+            /* 1.0.0 */
+            GenericInfo.Ulong = 0x100;
+            break;
+
+        case OID_GEN_DRIVER_VERSION:
+        {
+            InfoLength = sizeof(USHORT);
+            GenericInfo.Ushort = (NDIS_MINIPORT_MAJOR_VERSION << 8) | NDIS_MINIPORT_MINOR_VERSION;
+            break;
+        }
+
+        case OID_GEN_MAXIMUM_SEND_PACKETS:
+            GenericInfo.Ulong = Adapter->TcbCount;
+            break;
+
+        case OID_GEN_MAC_OPTIONS:
+            GenericInfo.Ulong = NDIS_MAC_OPTION_COPY_LOOKAHEAD_DATA |
+                                NDIS_MAC_OPTION_TRANSFERS_NOT_PEND |
+                                NDIS_MAC_OPTION_NO_LOOPBACK;
+
+            if (Adapter->Flags & E100_FLAG_PACKET_PRIORITY)
+                GenericInfo.Ulong |= NDIS_MAC_OPTION_8021P_PRIORITY;
+            if (Adapter->Flags & E100_FLAG_VLAN_TAGGING)
+                GenericInfo.Ulong |= NDIS_MAC_OPTION_8021Q_VLAN;
+            break;
+
+        case OID_GEN_MEDIA_CONNECT_STATUS:
+            if (Adapter->CurrentMedia == E100_MEDIA_NONE)
+                GenericInfo.Ulong = NdisMediaStateDisconnected;
+            else
+                GenericInfo.Ulong = NdisMediaStateConnected;
+            break;
+
+        case OID_802_3_PERMANENT_ADDRESS:
+            InfoPtr = Adapter->PermanentMacAddress;
+            InfoLength = ETH_LENGTH_OF_ADDRESS;
+            break;
+
+        case OID_802_3_CURRENT_ADDRESS:
+            InfoPtr = Adapter->CurrentMacAddress;
+            InfoLength = ETH_LENGTH_OF_ADDRESS;
+            break;
+
+        case OID_GEN_PHYSICAL_MEDIUM:
+            GenericInfo.Ulong = NdisPhysicalMedium802_3;
+            break;
+
+        case OID_GEN_XMIT_OK:
+        case OID_GEN_RCV_OK:
+        case OID_GEN_XMIT_ERROR:
+        case OID_GEN_RCV_ERROR:
+        case OID_GEN_RCV_NO_BUFFER:
+        case OID_GEN_RCV_CRC_ERROR:
+        case OID_802_3_RCV_ERROR_ALIGNMENT:
+        case OID_802_3_XMIT_ONE_COLLISION:
+        case OID_802_3_XMIT_MORE_COLLISIONS:
+        case OID_802_3_XMIT_DEFERRED:
+        case OID_802_3_XMIT_MAX_COLLISIONS:
+        case OID_802_3_RCV_OVERRUN:
+        case OID_802_3_XMIT_UNDERRUN:
+        case OID_802_3_XMIT_HEARTBEAT_FAILURE:
+        case OID_802_3_XMIT_TIMES_CRS_LOST:
+        case OID_802_3_XMIT_LATE_COLLISIONS:
+        {
+            EeQueryStatisticCounter(Adapter, Oid, &GenericInfo.Ulong64);
+
+            *BytesNeeded = sizeof(ULONG64);
+            if (InformationBufferLength < sizeof(ULONG))
+            {
+                *BytesWritten = 0;
+                return NDIS_STATUS_BUFFER_TOO_SHORT;
+            }
+            if (InformationBufferLength >= sizeof(ULONG64))
+            {
+                *BytesWritten = sizeof(ULONG64);
+                NdisMoveMemory(InformationBuffer, InfoPtr, sizeof(ULONG64));
+            }
+            else
+            {
+                *BytesWritten = sizeof(ULONG);
+                NdisMoveMemory(InformationBuffer, InfoPtr, sizeof(ULONG));
+            }
+
+            return NDIS_STATUS_SUCCESS;
+        }
+
+        case OID_GEN_TRANSMIT_QUEUE_LENGTH:
+            NdisAcquireSpinLock(&Adapter->SendLock);
+            GenericInfo.Ulong = Adapter->TcbCount - Adapter->TxPending;
+            NdisReleaseSpinLock(&Adapter->SendLock);
+            break;
+
+        case OID_GEN_VLAN_ID:
+        {
+            if (!(Adapter->Flags & E100_FLAG_VLAN_TAGGING))
+            {
+                Status = NDIS_STATUS_NOT_SUPPORTED;
+                break;
+            }
+
+            GenericInfo.Ulong = Adapter->VlanId;
+            break;
+        }
+
+        // TODO
+        // case OID_TCP_TASK_OFFLOAD:
+
+        case OID_PNP_CAPABILITIES:
+        {
+            PNDIS_PNP_CAPABILITIES Capabilities;
+
+            InfoLength = sizeof(NDIS_PNP_CAPABILITIES);
+
+            if (InformationBufferLength < InfoLength)
+            {
+                *BytesWritten = 0;
+                *BytesNeeded = InfoLength;
+                return NDIS_STATUS_BUFFER_TOO_SHORT;
+            }
+
+            *BytesWritten = InfoLength;
+            *BytesNeeded = 0;
+
+            Capabilities = InformationBuffer;
+            Capabilities->WakeUpCapabilities.MinMagicPacketWakeUp = NdisDeviceStateD3;
+            Capabilities->WakeUpCapabilities.MinPatternWakeUp = NdisDeviceStateD3;
+            Capabilities->WakeUpCapabilities.MinLinkChangeWakeUp = NdisDeviceStateD3;
+
+            /* All hardware is PM-aware */
+            return NDIS_STATUS_SUCCESS; // TODO: Check the 82557
+        }
+
+        case OID_PNP_QUERY_POWER:
+            return NDIS_STATUS_SUCCESS;
+
+        case OID_PNP_ENABLE_WAKE_UP:
+            GenericInfo.Ulong = Adapter->WakeUpFlags & (NDIS_PNP_WAKE_UP_MAGIC_PACKET |
+                                                        NDIS_PNP_WAKE_UP_PATTERN_MATCH |
+                                                        NDIS_PNP_WAKE_UP_LINK_CHANGE);
+            break;
+
+        default:
+            Status = NDIS_STATUS_INVALID_OID;
+            break;
+    }
+
+    if (Status == NDIS_STATUS_SUCCESS)
+    {
+        if (InfoLength > InformationBufferLength)
+        {
+            *BytesWritten = 0;
+            *BytesNeeded = InfoLength;
+            Status = NDIS_STATUS_BUFFER_TOO_SHORT;
+        }
+        else
+        {
+            NdisMoveMemory(InformationBuffer, InfoPtr, InfoLength);
+            *BytesWritten = InfoLength;
+            *BytesNeeded = 0;
+        }
+    }
+    else
+    {
+        *BytesWritten = 0;
+        *BytesNeeded = 0;
+    }
+
+    return Status;
+}
+
+NDIS_STATUS
+NTAPI
+MiniportSetInformation(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ NDIS_OID Oid,
+    _In_ PVOID InformationBuffer,
+    _In_ ULONG InformationBufferLength,
+    _Out_ PULONG BytesRead,
+    _Out_ PULONG BytesNeeded)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    NDIS_STATUS Status = NDIS_STATUS_SUCCESS;
+    ULONG GenericUlong;
+
+    *BytesRead = 0;
+    *BytesNeeded = 0;
+
+    switch (Oid)
+    {
+        case OID_GEN_CURRENT_PACKET_FILTER:
+        {
+            if (InformationBufferLength < sizeof(ULONG))
+            {
+                *BytesNeeded = sizeof(ULONG);
+                Status = NDIS_STATUS_INVALID_LENGTH;
+                break;
+            }
+
+            *BytesRead = sizeof(ULONG);
+            NdisMoveMemory(&GenericUlong, InformationBuffer, sizeof(ULONG));
+
+            if (GenericUlong & ~E100_PACKET_FILTERS)
+            {
+                Status = NDIS_STATUS_NOT_SUPPORTED;
+                break;
+            }
+
+            Status = EeApplyPacketFilter(Adapter, GenericUlong);
+            break;
+        }
+
+        case OID_802_3_MULTICAST_LIST:
+        {
+            ULONG Size;
+
+            if (InformationBufferLength % ETH_LENGTH_OF_ADDRESS)
+            {
+                *BytesNeeded = (InformationBufferLength / ETH_LENGTH_OF_ADDRESS) *
+                               ETH_LENGTH_OF_ADDRESS;
+                Status = NDIS_STATUS_INVALID_LENGTH;
+                break;
+            }
+
+            Size = E100_MULTICAST_LIST_SIZE * ETH_LENGTH_OF_ADDRESS;
+            if (InformationBufferLength > Size)
+            {
+                *BytesNeeded = Size;
+                Status = NDIS_STATUS_MULTICAST_FULL;
+                break;
+            }
+
+            *BytesRead = InformationBufferLength;
+            NdisMoveMemory(Adapter->MulticastList, InformationBuffer, InformationBufferLength);
+
+            Adapter->MulticastListSize = InformationBufferLength;
+
+            Status = EeUpdateMulticastList(Adapter);
+            break;
+        }
+
+        case OID_GEN_CURRENT_LOOKAHEAD:
+        {
+            if (InformationBufferLength < sizeof(ULONG))
+            {
+                *BytesNeeded = sizeof(ULONG);
+                Status = NDIS_STATUS_INVALID_LENGTH;
+                break;
+            }
+
+            /* Nothing to do */
+            *BytesRead = sizeof(ULONG);
+            break;
+        }
+
+        case OID_GEN_VLAN_ID:
+        {
+            if (InformationBufferLength < sizeof(ULONG))
+            {
+                *BytesNeeded = sizeof(ULONG);
+                Status = NDIS_STATUS_INVALID_LENGTH;
+                break;
+            }
+
+            if (!(Adapter->Flags & E100_FLAG_VLAN_TAGGING))
+            {
+                Status = NDIS_STATUS_NOT_SUPPORTED;
+                break;
+            }
+
+            *BytesRead = sizeof(ULONG);
+            NdisMoveMemory(&GenericUlong, InformationBuffer, sizeof(ULONG));
+
+            if (GenericUlong > E100_MAXIMUM_VLAN_ID)
+            {
+                Status = NDIS_STATUS_FAILURE;
+                break;
+            }
+
+            Adapter->VlanId = GenericUlong;
+            break;
+        }
+
+        // TODO
+        // case OID_PNP_ENABLE_WAKE_UP:
+        // case OID_PNP_ADD_WAKE_UP_PATTERN:
+        // case OID_PNP_REMOVE_WAKE_UP_PATTERN:
+        // case OID_PNP_SET_POWER:
+
+        default:
+            Status = NDIS_STATUS_NOT_SUPPORTED;
+            break;
+    }
+
+    return Status;
+}

--- a/drivers/network/dd/e100/requests.c
+++ b/drivers/network/dd/e100/requests.c
@@ -1,0 +1,815 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Miniport information callbacks
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* GLOBASLS *******************************************************************/
+
+static const NDIS_OID E100SupportedOidList[] =
+{
+    OID_GEN_SUPPORTED_LIST,
+    OID_GEN_CURRENT_PACKET_FILTER,
+    OID_GEN_HARDWARE_STATUS,
+    OID_GEN_MEDIA_SUPPORTED,
+    OID_GEN_MEDIA_IN_USE,
+    OID_GEN_MAXIMUM_LOOKAHEAD,
+    OID_GEN_MAXIMUM_FRAME_SIZE,
+    OID_GEN_MAXIMUM_SEND_PACKETS,
+    OID_GEN_LINK_SPEED,
+    OID_GEN_TRANSMIT_BUFFER_SPACE,
+    OID_GEN_RECEIVE_BUFFER_SPACE,
+    OID_GEN_RECEIVE_BLOCK_SIZE,
+    OID_GEN_TRANSMIT_BLOCK_SIZE,
+    OID_GEN_VENDOR_ID,
+    OID_GEN_VENDOR_DESCRIPTION,
+    OID_GEN_VENDOR_DRIVER_VERSION,
+    OID_GEN_CURRENT_LOOKAHEAD,
+    OID_GEN_DRIVER_VERSION,
+    OID_GEN_MAXIMUM_TOTAL_SIZE,
+    OID_GEN_MAC_OPTIONS,
+    OID_GEN_MEDIA_CONNECT_STATUS,
+    OID_GEN_VLAN_ID,
+    OID_802_3_PERMANENT_ADDRESS,
+    OID_802_3_CURRENT_ADDRESS,
+    OID_802_3_MULTICAST_LIST,
+    OID_802_3_MAXIMUM_LIST_SIZE,
+
+    /* Statistics */
+    OID_GEN_XMIT_OK,
+    OID_GEN_RCV_OK,
+    OID_GEN_XMIT_ERROR,
+    OID_GEN_RCV_ERROR,
+    OID_GEN_RCV_NO_BUFFER,
+    OID_GEN_RCV_CRC_ERROR,
+    OID_GEN_TRANSMIT_QUEUE_LENGTH,
+    OID_802_3_RCV_ERROR_ALIGNMENT,
+    OID_802_3_XMIT_ONE_COLLISION,
+    OID_802_3_XMIT_MORE_COLLISIONS,
+    OID_802_3_XMIT_DEFERRED,
+    OID_802_3_XMIT_MAX_COLLISIONS,
+    OID_802_3_RCV_OVERRUN,
+    OID_802_3_XMIT_UNDERRUN,
+    OID_802_3_XMIT_HEARTBEAT_FAILURE,
+    OID_802_3_XMIT_TIMES_CRS_LOST,
+    OID_802_3_XMIT_LATE_COLLISIONS,
+
+    /* Offload */
+    OID_TCP_TASK_OFFLOAD,
+
+    /* Power management */
+    OID_PNP_CAPABILITIES,
+    OID_PNP_SET_POWER,
+    OID_PNP_QUERY_POWER,
+    OID_PNP_ADD_WAKE_UP_PATTERN,
+    OID_PNP_REMOVE_WAKE_UP_PATTERN,
+    OID_PNP_ENABLE_WAKE_UP
+};
+
+/* FUNCTIONS ******************************************************************/
+
+static
+VOID
+EeQueryStatisticCounter(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ NDIS_OID Oid,
+    _Out_ PULONG64 Counter)
+{
+    switch (Oid)
+    {
+        case OID_GEN_XMIT_OK:
+            *Counter = Adapter->Statistics.TransmitOk;
+            break;
+        case OID_GEN_RCV_OK:
+            *Counter = Adapter->Statistics.ReceiveOk;
+            break;
+        case OID_GEN_XMIT_ERROR:
+            *Counter = Adapter->Statistics.TransmitErrors;
+            break;
+        case OID_GEN_RCV_ERROR:
+            *Counter = Adapter->Statistics.ReceiveErrors;
+            break;
+        case OID_GEN_RCV_NO_BUFFER:
+            *Counter = Adapter->Statistics.ReceiveNoBuffers;
+            break;
+        case OID_GEN_RCV_CRC_ERROR:
+            *Counter = Adapter->Statistics.ReceiveCrcErrors;
+            break;
+        case OID_802_3_RCV_ERROR_ALIGNMENT:
+            *Counter = Adapter->Statistics.ReceiveAlignmentErrors;
+            break;
+        case OID_802_3_XMIT_ONE_COLLISION:
+            *Counter = Adapter->Statistics.TransmitOneRetry;
+            break;
+        case OID_802_3_XMIT_MORE_COLLISIONS:
+            *Counter = Adapter->Statistics.TransmitMoreCollisions;
+            break;
+        case OID_802_3_XMIT_DEFERRED:
+            *Counter = Adapter->Statistics.TransmitDeferred;
+            break;
+        case OID_802_3_XMIT_MAX_COLLISIONS:
+            *Counter = Adapter->Statistics.TransmitExcessiveCollisions;
+            break;
+        case OID_802_3_RCV_OVERRUN:
+            *Counter = Adapter->Statistics.ReceiveOverrunErrors;
+            break;
+        case OID_802_3_XMIT_UNDERRUN:
+            *Counter = Adapter->Statistics.TransmitUnderrunErrors;
+            break;
+        case OID_802_3_XMIT_HEARTBEAT_FAILURE:
+            __fallthrough;
+        case OID_802_3_XMIT_TIMES_CRS_LOST:
+            *Counter = Adapter->Statistics.TransmitLostCarrierSense;
+            break;
+        case OID_802_3_XMIT_LATE_COLLISIONS:
+            *Counter = Adapter->Statistics.TransmitLateCollisions;
+            break;
+
+        default:
+            ASSERT(FALSE);
+            UNREACHABLE;
+            break;
+    }
+}
+
+static
+NDIS_STATUS
+EeGetTcpTaskOffload(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PNDIS_TASK_OFFLOAD_HEADER TaskOffloadHeader,
+    _In_ ULONG InformationBufferLength,
+    _Out_ PULONG BytesWritten,
+    _Out_ PULONG BytesNeeded)
+{
+    PNDIS_TASK_OFFLOAD TaskOffload;
+    ULONG InfoLength;
+
+    *BytesWritten = 0;
+    *BytesNeeded = 0;
+
+    // TODO: LSO support is not implemented yet
+    if (!(Adapter->Flags & E100_FLAG_CSUM_OFFLOAD))
+    {
+        return NDIS_STATUS_NOT_SUPPORTED;
+    }
+
+    ASSERT((Adapter->Flags & E100_FLAG_82559_RXCSUM) ||
+           (Adapter->Flags & E100_FLAG_EXT_RFA));
+
+    InfoLength = sizeof(*TaskOffloadHeader);
+    if (Adapter->Flags & E100_FLAG_CSUM_OFFLOAD)
+    {
+        InfoLength += FIELD_OFFSET(NDIS_TASK_OFFLOAD, TaskBuffer) +
+                      sizeof(NDIS_TASK_TCP_IP_CHECKSUM);
+    }
+    if (InformationBufferLength < InfoLength)
+    {
+        *BytesNeeded = InfoLength;
+        return NDIS_STATUS_BUFFER_TOO_SHORT;
+    }
+
+    if ((TaskOffloadHeader->EncapsulationFormat.Encapsulation != IEEE_802_3_Encapsulation) &&
+        (TaskOffloadHeader->EncapsulationFormat.Encapsulation != UNSPECIFIED_Encapsulation ||
+         TaskOffloadHeader->EncapsulationFormat.EncapsulationHeaderSize != sizeof(ETH_HEADER)))
+    {
+        return NDIS_STATUS_NOT_SUPPORTED;
+    }
+    if (TaskOffloadHeader->Version != NDIS_TASK_OFFLOAD_VERSION)
+    {
+        return NDIS_STATUS_NOT_SUPPORTED;
+    }
+
+    TaskOffloadHeader->OffsetFirstTask = sizeof(*TaskOffloadHeader);
+    TaskOffload = (PNDIS_TASK_OFFLOAD)(TaskOffloadHeader + 1);
+    if (Adapter->Flags & E100_FLAG_CSUM_OFFLOAD)
+    {
+        PNDIS_TASK_TCP_IP_CHECKSUM ChecksumTask;
+
+        TaskOffload->Size = sizeof(*TaskOffload);
+        TaskOffload->Version = NDIS_TASK_OFFLOAD_VERSION;
+        TaskOffload->Task = TcpIpChecksumNdisTask;
+        TaskOffload->TaskBufferLength = sizeof(*ChecksumTask);
+        TaskOffload->OffsetNextTask = FIELD_OFFSET(NDIS_TASK_OFFLOAD, TaskBuffer) +
+                                      sizeof(*ChecksumTask);
+
+        ChecksumTask = (PNDIS_TASK_TCP_IP_CHECKSUM)TaskOffload->TaskBuffer;
+        RtlZeroMemory(ChecksumTask, sizeof(*ChecksumTask));
+
+        if (Adapter->Flags & E100_FLAG_82559_RXCSUM)
+        {
+            ChecksumTask->V4Receive.TcpChecksum = 1;
+            ChecksumTask->V4Receive.UdpChecksum = 1;
+        }
+        else
+        {
+            ASSERT(Adapter->Flags & E100_FLAG_EXT_RFA);
+
+            // FIXME: The IP header checksum offload is disabled for now
+            // until it has some more testing on all 82550/82551 steppings.
+            //
+            // fxp(4) says that the 82550 chip rev 0x0C
+            // does not calculate IP header checksum properly
+            // for very small UDP datagrams (fragments containing less than 4 bytes).
+#if 0
+            ChecksumTask->V4Transmit.IpChecksum = 1;
+            ChecksumTask->V4Transmit.IpOptionsSupported = 1;
+#endif
+            ChecksumTask->V4Transmit.TcpOptionsSupported = 1;
+            ChecksumTask->V4Transmit.TcpChecksum = 1;
+            ChecksumTask->V4Transmit.UdpChecksum = 1;
+
+            ChecksumTask->V4Receive.IpChecksum = 1;
+            ChecksumTask->V4Receive.IpOptionsSupported = 1;
+            ChecksumTask->V4Receive.TcpOptionsSupported = 1;
+            ChecksumTask->V4Receive.TcpChecksum = 1;
+            ChecksumTask->V4Receive.UdpChecksum = 1;
+        }
+    }
+    TaskOffload->OffsetNextTask = 0;
+
+    *BytesWritten = InfoLength;
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+static
+NDIS_STATUS
+EeSetTcpTaskOffload(
+    _Inout_ PE100_ADAPTER Adapter,
+    _In_ PNDIS_TASK_OFFLOAD_HEADER TaskOffloadHeader,
+    _In_ PULONG BytesRead)
+{
+    ULONG Offset;
+    PNDIS_TASK_OFFLOAD TaskOffload;
+
+    if (TaskOffloadHeader->Version != NDIS_TASK_OFFLOAD_VERSION)
+    {
+        return NDIS_STATUS_NOT_SUPPORTED;
+    }
+
+    TaskOffload = (PNDIS_TASK_OFFLOAD)TaskOffloadHeader;
+    Offset = TaskOffloadHeader->OffsetFirstTask;
+
+    while (Offset)
+    {
+        *BytesRead += FIELD_OFFSET(NDIS_TASK_OFFLOAD, TaskBuffer);
+
+        TaskOffload = (PNDIS_TASK_OFFLOAD)((PUCHAR)TaskOffload + Offset);
+        switch (TaskOffload->Task)
+        {
+            case TcpIpChecksumNdisTask:
+            {
+                PNDIS_TASK_TCP_IP_CHECKSUM Task;
+
+                *BytesRead += sizeof(*Task);
+
+                if (!(Adapter->Flags & E100_FLAG_CSUM_OFFLOAD))
+                {
+                    return NDIS_STATUS_NOT_SUPPORTED;
+                }
+
+                ASSERT((Adapter->Flags & E100_FLAG_82559_RXCSUM) ||
+                       (Adapter->Flags & E100_FLAG_EXT_RFA));
+
+                NdisAcquireSpinLock(&Adapter->ReceiveLock);
+                NdisDprAcquireSpinLock(&Adapter->SendLock);
+
+                Task = (PNDIS_TASK_TCP_IP_CHECKSUM)TaskOffload->TaskBuffer;
+
+                Adapter->Offload.SendTcpChecksum = Task->V4Transmit.TcpChecksum;
+                Adapter->Offload.SendUdpChecksum = Task->V4Transmit.UdpChecksum;
+                Adapter->Offload.SendIpChecksum = Task->V4Transmit.IpChecksum;
+
+                Adapter->Offload.ReceiveTcpChecksum = Task->V4Receive.TcpChecksum;
+                Adapter->Offload.ReceiveUdpChecksum = Task->V4Receive.UdpChecksum;
+                Adapter->Offload.ReceiveIpChecksum = Task->V4Receive.IpChecksum;
+
+                if (Adapter->Flags & E100_FLAG_82559_RXCSUM)
+                {
+                    EeEnableRxChecksumOffload82559(Adapter,
+                                                   Task->V4Receive.TcpChecksum ||
+                                                   Task->V4Receive.UdpChecksum);
+                }
+
+                NdisDprReleaseSpinLock(&Adapter->SendLock);
+                NdisReleaseSpinLock(&Adapter->ReceiveLock);
+                break;
+            }
+
+            // TODO: LSO support is not implemented yet
+            // case TcpLargeSendNdisTask:
+            // E100_FLAG_LARGE_SEND_OFFLOAD
+
+            default:
+                break;
+        }
+
+        Offset = TaskOffload->OffsetNextTask;
+    }
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+NDIS_STATUS
+NTAPI
+MiniportQueryInformation(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ NDIS_OID Oid,
+    _In_ PVOID InformationBuffer,
+    _In_ ULONG InformationBufferLength,
+    _Out_ PULONG BytesWritten,
+    _Out_ PULONG BytesNeeded)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    NDIS_STATUS Status = NDIS_STATUS_SUCCESS;
+    ULONG InfoLength;
+    PVOID InfoPtr;
+    union _GENERIC_INFORMATION
+    {
+        USHORT Ushort;
+        ULONG Ulong;
+        ULONG64 Ulong64;
+        NDIS_MEDIUM Medium;
+        NDIS_HARDWARE_STATUS Status;
+        NDIS_DEVICE_POWER_STATE PowerState;
+    } GenericInfo;
+
+    InfoLength = sizeof(ULONG);
+    InfoPtr = &GenericInfo;
+
+    switch (Oid)
+    {
+        case OID_GEN_SUPPORTED_LIST:
+            InfoPtr = (PVOID)&E100SupportedOidList;
+            InfoLength = sizeof(E100SupportedOidList);
+            break;
+
+        case OID_GEN_CURRENT_PACKET_FILTER:
+            GenericInfo.Ulong = Adapter->PacketFilter;
+            break;
+
+        case OID_802_3_MULTICAST_LIST:
+            InfoPtr = Adapter->MulticastList;
+            InfoLength = Adapter->MulticastListSize;
+            break;
+
+        case OID_802_3_MAXIMUM_LIST_SIZE:
+            GenericInfo.Ulong = E100_MULTICAST_LIST_SIZE;
+            break;
+
+        case OID_GEN_MEDIA_SUPPORTED:
+        case OID_GEN_MEDIA_IN_USE:
+        {
+            GenericInfo.Medium = NdisMedium802_3;
+            InfoLength = sizeof(NDIS_MEDIUM);
+            break;
+        }
+
+        case OID_GEN_HARDWARE_STATUS:
+        {
+            /* The card has been physically ejected */
+            if (CSR_READ_8(Adapter, FXP_CSR_SCB_STATACK) == 0xFF)
+                GenericInfo.Status = NdisHardwareStatusNotReady;
+            else
+                GenericInfo.Status = NdisHardwareStatusReady;
+
+            InfoLength = sizeof(NDIS_HARDWARE_STATUS);
+            break;
+        }
+
+        case OID_GEN_MAXIMUM_FRAME_SIZE:
+        case OID_GEN_MAXIMUM_LOOKAHEAD:
+        case OID_GEN_CURRENT_LOOKAHEAD:
+            GenericInfo.Ulong = E100_MAXIMUM_FRAME_SIZE - E100_ETHERNET_HEADER_SIZE;
+            break;
+
+        case OID_GEN_MAXIMUM_TOTAL_SIZE:
+            GenericInfo.Ulong = E100_MAXIMUM_FRAME_SIZE;
+            break;
+
+        case OID_GEN_TRANSMIT_BLOCK_SIZE:
+            GenericInfo.Ulong = E100_TRANSMIT_BLOCK_SIZE;
+            break;
+
+        case OID_GEN_TRANSMIT_BUFFER_SPACE:
+            GenericInfo.Ulong = E100_TRANSMIT_BLOCK_SIZE * Adapter->TcbCount;
+            break;
+
+        case OID_GEN_RECEIVE_BLOCK_SIZE:
+            GenericInfo.Ulong = E100_RECEIVE_BLOCK_SIZE;
+            break;
+
+        case OID_GEN_RECEIVE_BUFFER_SPACE:
+            GenericInfo.Ulong = E100_RECEIVE_BLOCK_SIZE * Adapter->RfdCount;
+            break;
+
+        case OID_GEN_LINK_SPEED:
+            if (Adapter->CurrentMedia & E100_MEDIA_100T)
+                GenericInfo.Ulong = 100 * 10000;
+            else
+                GenericInfo.Ulong = 10 * 10000;
+            break;
+
+        case OID_GEN_VENDOR_ID:
+            GenericInfo.Ulong = 0;
+            GenericInfo.Ulong |= (Adapter->PermanentMacAddress[0] << 16);
+            GenericInfo.Ulong |= (Adapter->PermanentMacAddress[1] << 8);
+            GenericInfo.Ulong |= (Adapter->PermanentMacAddress[2] & 0xFF);
+            break;
+
+        case OID_GEN_VENDOR_DESCRIPTION:
+        {
+            static const CHAR VendorDesc[] = "i8255x compatible Ethernet Controller";
+            InfoPtr = (PVOID)&VendorDesc;
+            InfoLength = sizeof(VendorDesc);
+            break;
+        }
+
+        case OID_GEN_VENDOR_DRIVER_VERSION:
+            /* 1.0.0 */
+            GenericInfo.Ulong = 0x100;
+            break;
+
+        case OID_GEN_DRIVER_VERSION:
+        {
+            InfoLength = sizeof(USHORT);
+            GenericInfo.Ushort = (NDIS_MINIPORT_MAJOR_VERSION << 8) | NDIS_MINIPORT_MINOR_VERSION;
+            break;
+        }
+
+        case OID_GEN_MAXIMUM_SEND_PACKETS:
+            GenericInfo.Ulong = Adapter->TcbCount;
+            break;
+
+        case OID_GEN_MAC_OPTIONS:
+            GenericInfo.Ulong = NDIS_MAC_OPTION_COPY_LOOKAHEAD_DATA |
+                                NDIS_MAC_OPTION_TRANSFERS_NOT_PEND |
+                                NDIS_MAC_OPTION_NO_LOOPBACK;
+
+            if (Adapter->Flags & E100_FLAG_PACKET_PRIORITY)
+                GenericInfo.Ulong |= NDIS_MAC_OPTION_8021P_PRIORITY;
+            if (Adapter->Flags & E100_FLAG_VLAN_TAGGING)
+                GenericInfo.Ulong |= NDIS_MAC_OPTION_8021Q_VLAN;
+            break;
+
+        case OID_GEN_MEDIA_CONNECT_STATUS:
+            if (Adapter->CurrentMedia == E100_MEDIA_NONE)
+                GenericInfo.Ulong = NdisMediaStateDisconnected;
+            else
+                GenericInfo.Ulong = NdisMediaStateConnected;
+            break;
+
+        case OID_802_3_PERMANENT_ADDRESS:
+            InfoPtr = Adapter->PermanentMacAddress;
+            InfoLength = ETH_LENGTH_OF_ADDRESS;
+            break;
+
+        case OID_802_3_CURRENT_ADDRESS:
+            InfoPtr = Adapter->CurrentMacAddress;
+            InfoLength = ETH_LENGTH_OF_ADDRESS;
+            break;
+
+        // FIXME: HACK for ReactOS, to be removed
+        case OID_GEN_PHYSICAL_MEDIUM:
+            GenericInfo.Ulong = NdisPhysicalMedium802_3;
+            break;
+
+        case OID_GEN_XMIT_OK:
+        case OID_GEN_RCV_OK:
+        case OID_GEN_XMIT_ERROR:
+        case OID_GEN_RCV_ERROR:
+        case OID_GEN_RCV_NO_BUFFER:
+        case OID_GEN_RCV_CRC_ERROR:
+        case OID_802_3_RCV_ERROR_ALIGNMENT:
+        case OID_802_3_XMIT_ONE_COLLISION:
+        case OID_802_3_XMIT_MORE_COLLISIONS:
+        case OID_802_3_XMIT_DEFERRED:
+        case OID_802_3_XMIT_MAX_COLLISIONS:
+        case OID_802_3_RCV_OVERRUN:
+        case OID_802_3_XMIT_UNDERRUN:
+        case OID_802_3_XMIT_HEARTBEAT_FAILURE:
+        case OID_802_3_XMIT_TIMES_CRS_LOST:
+        case OID_802_3_XMIT_LATE_COLLISIONS:
+        {
+            EeQueryStatisticCounter(Adapter, Oid, &GenericInfo.Ulong64);
+
+            *BytesNeeded = sizeof(ULONG64);
+            if (InformationBufferLength < sizeof(ULONG))
+            {
+                *BytesWritten = 0;
+                return NDIS_STATUS_BUFFER_TOO_SHORT;
+            }
+            if (InformationBufferLength >= sizeof(ULONG64))
+            {
+                *BytesWritten = sizeof(ULONG64);
+                RtlCopyMemory(InformationBuffer, InfoPtr, sizeof(ULONG64));
+            }
+            else
+            {
+                *BytesWritten = sizeof(ULONG);
+                RtlCopyMemory(InformationBuffer, InfoPtr, sizeof(ULONG));
+            }
+
+            return NDIS_STATUS_SUCCESS;
+        }
+
+        case OID_GEN_TRANSMIT_QUEUE_LENGTH:
+            NdisAcquireSpinLock(&Adapter->SendLock);
+            GenericInfo.Ulong = Adapter->TcbCount - Adapter->TxPending;
+            NdisReleaseSpinLock(&Adapter->SendLock);
+            break;
+
+        case OID_GEN_VLAN_ID:
+        {
+            if (!(Adapter->Flags & E100_FLAG_VLAN_TAGGING))
+            {
+                Status = NDIS_STATUS_NOT_SUPPORTED;
+                break;
+            }
+
+            GenericInfo.Ulong = Adapter->VlanId;
+            break;
+        }
+
+        case OID_TCP_TASK_OFFLOAD:
+        {
+            return EeGetTcpTaskOffload(Adapter,
+                                       InformationBuffer,
+                                       InformationBufferLength,
+                                       BytesWritten,
+                                       BytesWritten);
+        }
+
+        case OID_PNP_CAPABILITIES:
+        {
+            PNDIS_PNP_CAPABILITIES Capabilities = InformationBuffer;
+
+            InfoLength = sizeof(*Capabilities);
+
+            if (InformationBufferLength < InfoLength)
+            {
+                *BytesWritten = 0;
+                *BytesNeeded = InfoLength;
+                return NDIS_STATUS_BUFFER_TOO_SHORT;
+            }
+
+            *BytesWritten = InfoLength;
+            *BytesNeeded = 0;
+
+            return EeGetPowerManagementCapabilities(Adapter, Capabilities);
+        }
+
+        case OID_PNP_QUERY_POWER:
+            return NDIS_STATUS_SUCCESS;
+
+        case OID_PNP_ENABLE_WAKE_UP:
+            GenericInfo.Ulong = Adapter->WakeUpFlags;
+            break;
+
+        default:
+            Status = NDIS_STATUS_INVALID_OID;
+            break;
+    }
+
+    if (Status == NDIS_STATUS_SUCCESS)
+    {
+        if (InfoLength > InformationBufferLength)
+        {
+            *BytesWritten = 0;
+            *BytesNeeded = InfoLength;
+            Status = NDIS_STATUS_BUFFER_TOO_SHORT;
+        }
+        else
+        {
+            RtlCopyMemory(InformationBuffer, InfoPtr, InfoLength);
+            *BytesWritten = InfoLength;
+            *BytesNeeded = 0;
+        }
+    }
+    else
+    {
+        *BytesWritten = 0;
+        *BytesNeeded = 0;
+    }
+
+    return Status;
+}
+
+NDIS_STATUS
+NTAPI
+MiniportSetInformation(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ NDIS_OID Oid,
+    _In_ PVOID InformationBuffer,
+    _In_ ULONG InformationBufferLength,
+    _Out_ PULONG BytesRead,
+    _Out_ PULONG BytesNeeded)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    NDIS_STATUS Status = NDIS_STATUS_SUCCESS;
+    ULONG GenericUlong;
+
+    *BytesRead = 0;
+    *BytesNeeded = 0;
+
+    switch (Oid)
+    {
+        case OID_GEN_CURRENT_PACKET_FILTER:
+        {
+            if (InformationBufferLength < sizeof(ULONG))
+            {
+                *BytesNeeded = sizeof(ULONG);
+                Status = NDIS_STATUS_INVALID_LENGTH;
+                break;
+            }
+
+            *BytesRead = sizeof(ULONG);
+            RtlCopyMemory(&GenericUlong, InformationBuffer, sizeof(ULONG));
+
+            if (GenericUlong & ~E100_PACKET_FILTERS)
+            {
+                Status = NDIS_STATUS_NOT_SUPPORTED;
+                break;
+            }
+
+            if (Adapter->PacketFilter == GenericUlong)
+            {
+                break;
+            }
+
+            Adapter->PacketFilter = GenericUlong;
+
+            EeApplyPacketFilter(Adapter);
+            break;
+        }
+
+        case OID_802_3_MULTICAST_LIST:
+        {
+            ULONG Size;
+
+            if (InformationBufferLength % ETH_LENGTH_OF_ADDRESS)
+            {
+                *BytesNeeded = (InformationBufferLength / ETH_LENGTH_OF_ADDRESS) *
+                               ETH_LENGTH_OF_ADDRESS;
+                Status = NDIS_STATUS_INVALID_LENGTH;
+                break;
+            }
+
+            Size = E100_MULTICAST_LIST_SIZE * ETH_LENGTH_OF_ADDRESS;
+            if (InformationBufferLength > Size)
+            {
+                *BytesNeeded = Size;
+                Status = NDIS_STATUS_MULTICAST_FULL;
+                break;
+            }
+
+            *BytesRead = InformationBufferLength;
+            RtlCopyMemory(Adapter->MulticastList, InformationBuffer, InformationBufferLength);
+
+            Adapter->MulticastListSize = InformationBufferLength;
+
+            EeUpdateMulticastList(Adapter);
+            break;
+        }
+
+        case OID_GEN_CURRENT_LOOKAHEAD:
+        {
+            if (InformationBufferLength < sizeof(ULONG))
+            {
+                *BytesNeeded = sizeof(ULONG);
+                Status = NDIS_STATUS_INVALID_LENGTH;
+                break;
+            }
+
+            /* Nothing to do */
+            *BytesRead = sizeof(ULONG);
+            break;
+        }
+
+        case OID_GEN_VLAN_ID:
+        {
+            if (InformationBufferLength < sizeof(ULONG))
+            {
+                *BytesNeeded = sizeof(ULONG);
+                Status = NDIS_STATUS_INVALID_LENGTH;
+                break;
+            }
+
+            if (!(Adapter->Flags & E100_FLAG_VLAN_TAGGING))
+            {
+                Status = NDIS_STATUS_NOT_SUPPORTED;
+                break;
+            }
+
+            *BytesRead = sizeof(ULONG);
+            RtlCopyMemory(&GenericUlong, InformationBuffer, sizeof(ULONG));
+
+            if (GenericUlong > E100_MAXIMUM_VLAN_ID)
+            {
+                Status = NDIS_STATUS_FAILURE;
+                break;
+            }
+
+            Adapter->VlanId = GenericUlong;
+            break;
+        }
+
+        case OID_TCP_TASK_OFFLOAD:
+        {
+            PNDIS_TASK_OFFLOAD_HEADER TaskOffloadHeader = InformationBuffer;
+
+            if (InformationBufferLength < sizeof(*TaskOffloadHeader))
+            {
+                *BytesNeeded = sizeof(*TaskOffloadHeader);
+                Status = NDIS_STATUS_INVALID_LENGTH;
+                break;
+            }
+
+            *BytesRead = InformationBufferLength;
+
+            Status = EeSetTcpTaskOffload(Adapter, TaskOffloadHeader, BytesRead);
+            break;
+        }
+
+        case OID_PNP_ENABLE_WAKE_UP:
+        {
+            if (InformationBufferLength < sizeof(ULONG))
+            {
+                *BytesNeeded = sizeof(ULONG);
+                Status = NDIS_STATUS_INVALID_LENGTH;
+                break;
+            }
+
+            *BytesRead = sizeof(ULONG);
+            RtlCopyMemory(&GenericUlong, InformationBuffer, sizeof(ULONG));
+
+            Adapter->WakeUpFlags = GenericUlong;
+            break;
+        }
+
+        case OID_PNP_ADD_WAKE_UP_PATTERN:
+        case OID_PNP_REMOVE_WAKE_UP_PATTERN:
+        {
+            PNDIS_PM_PACKET_PATTERN PmPattern = InformationBuffer;
+
+            if (!(Adapter->Flags & E100_FLAG_HAS_WOL))
+            {
+                Status = NDIS_STATUS_NOT_SUPPORTED;
+                break;
+            }
+
+            if (InformationBufferLength < sizeof(*PmPattern))
+            {
+                *BytesNeeded = sizeof(*PmPattern);
+                Status = NDIS_STATUS_INVALID_LENGTH;
+                break;
+            }
+
+            if (Oid == OID_PNP_ADD_WAKE_UP_PATTERN)
+                Status = EeAddWakeUpPattern(Adapter, PmPattern);
+            else
+                Status = EeRemoveWakeUpPattern(Adapter, PmPattern);
+            break;
+        }
+
+        case OID_PNP_SET_POWER:
+        {
+            if (InformationBufferLength < sizeof(NDIS_DEVICE_POWER_STATE))
+            {
+                *BytesNeeded = sizeof(NDIS_DEVICE_POWER_STATE);
+                Status = NDIS_STATUS_INVALID_LENGTH;
+                break;
+            }
+
+            *BytesRead = sizeof(ULONG);
+            RtlCopyMemory(&GenericUlong, InformationBuffer, sizeof(ULONG));
+
+            if (GenericUlong < NdisDeviceStateD0 || GenericUlong > NdisDeviceStateD3)
+            {
+                ASSERT(FALSE);
+                Status = NDIS_STATUS_INVALID_DATA;
+                break;
+            }
+
+            Adapter->PowerState = GenericUlong;
+
+            NdisScheduleWorkItem(&Adapter->PowerWorkItem);
+
+            Status = NDIS_STATUS_PENDING;
+            break;
+        }
+
+        default:
+            Status = NDIS_STATUS_NOT_SUPPORTED;
+            break;
+    }
+
+    return Status;
+}

--- a/drivers/network/dd/e100/send.c
+++ b/drivers/network/dd/e100/send.c
@@ -1,0 +1,398 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Packet sending
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* FUNCTIONS ******************************************************************/
+
+static
+VOID
+EeStartTransmit(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PE100_TX_CONTEXT TxContext)
+{
+    if (Adapter->CommandUnitActive)
+    {
+        TRACE("Resume CU %02X\n", FXP_SCB_CUS(CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS)));
+
+        /* Errata: LAN Microcontroller PCI Protocol Violation with 10Mbps half-duplex link */
+        if (!(Adapter->CurrentMedia & E100_MEDIA_100T) &&
+            !(Adapter->CurrentMedia & E100_MEDIA_FD) &&
+            (Adapter->Flags & E100_FLAG_IS_ICH))
+        {
+            /* Issue a CU_NOP command before CU_RESUME and wait */
+            EeCommandUnitExecuteCommand(Adapter, FXP_SCB_COMMAND_CU_NOP);
+            NdisStallExecution(1);
+        }
+
+        EeCommandUnitExecuteCommand(Adapter, FXP_SCB_COMMAND_CU_RESUME);
+    }
+    else
+    {
+        TRACE("Starting CU %02X\n", FXP_SCB_CUS(CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS)));
+
+        Adapter->CommandUnitActive = TRUE;
+
+        EeCommandUnitExecuteCommandAddr(Adapter, FXP_SCB_COMMAND_CU_START, TxContext->TcbPhys);
+    }
+}
+
+static
+VOID
+EeInsertVlanTag(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PNDIS_PACKET Packet,
+    _In_ PFXP_CB_TRANSMIT Tcb)
+{
+    NDIS_PACKET_8021Q_INFO VlanTag;
+
+    VlanTag.Value = NDIS_PER_PACKET_INFO_FROM_PACKET(Packet, Ieee8021QInfo);
+
+    if (Adapter->Flags & E100_FLAG_VLAN_TAGGING)
+    {
+        if (!VlanTag.TagHeader.VlanId)
+            VlanTag.TagHeader.VlanId = Adapter->VlanId;
+    }
+    else
+    {
+        VlanTag.TagHeader.VlanId = 0;
+    }
+
+    if (!(Adapter->Flags & E100_FLAG_PACKET_PRIORITY))
+    {
+        VlanTag.TagHeader.UserPriority = 0;
+    }
+
+    if (VlanTag.TagHeader.VlanId || VlanTag.TagHeader.UserPriority)
+    {
+        USHORT Control;
+
+        Control = VlanTag.TagHeader.VlanId;
+        Control |= VlanTag.TagHeader.CanonicalFormatId << 12;
+        Control |= VlanTag.TagHeader.UserPriority << 13;
+
+        Tcb->Ipcb.VlanId = htons(Control);
+        Tcb->Ipcb.IpActivationHigh |= FXP_IPCB_INSERTVLAN_ENABLE;
+    }
+}
+
+static
+VOID
+EeSetChecksumOperation(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PNDIS_PACKET Packet,
+    _In_ PFXP_CB_TRANSMIT Tcb)
+{
+    NDIS_TCP_IP_CHECKSUM_PACKET_INFO CsInfo;
+
+    CsInfo.Value = PtrToUlong(NDIS_PER_PACKET_INFO_FROM_PACKET(Packet, TcpIpChecksumPacketInfo));
+
+    if (CsInfo.Transmit.NdisPacketChecksumV4)
+    {
+        if (CsInfo.Transmit.NdisPacketIpChecksum && Adapter->Offload.SendIpChecksum)
+        {
+            Tcb->Ipcb.IpSchedule |= FXP_IPCB_IP_CHECKSUM_ENABLE;
+        }
+
+        if ((CsInfo.Transmit.NdisPacketTcpChecksum && Adapter->Offload.SendTcpChecksum) ||
+            (CsInfo.Transmit.NdisPacketUdpChecksum && Adapter->Offload.SendUdpChecksum))
+        {
+            Tcb->Ipcb.IpSchedule |= FXP_IPCB_TCPUDP_CHECKSUM_ENABLE;
+        }
+    }
+}
+
+static
+VOID
+EeTransmitPacket(
+    _In_ E100_ADAPTER* __restrict Adapter,
+    _In_ NDIS_PACKET* __restrict Packet,
+    _In_ FXP_CB_TRANSMIT* __restrict Tcb,
+    _In_ SCATTER_GATHER_LIST* __restrict SgList)
+{
+    PFXP_TBD Tbd;
+    ULONG i;
+
+    Tbd = Tcb->Tbd;
+
+    if (Adapter->Flags & E100_FLAG_EXT_RFA)
+    {
+        Tcb->Ipcb.IpActivationHigh = FXP_IPCB_HARDWAREPARSING_ENABLE;
+
+        if ((Adapter->Flags & E100_FLAG_VLAN_TAGGING) ||
+            (Adapter->Flags & E100_FLAG_PACKET_PRIORITY))
+        {
+            EeInsertVlanTag(Adapter, Packet, Tcb);
+        }
+
+        EeSetChecksumOperation(Adapter, Packet, Tcb);
+
+        /* Skip IPCB block */
+        Tbd++;
+    }
+
+    for (i = 0; i < SgList->NumberOfElements; ++i)
+    {
+        /* 32-bit DMA */
+        ASSERT(SgList->Elements[i].Address.HighPart == 0);
+
+        Tbd[i].Address = htole32(SgList->Elements[i].Address.LowPart);
+        Tbd[i].Size = htole32(SgList->Elements[i].Length);
+    }
+
+    if (Adapter->Flags & E100_FLAG_EXT_RFA)
+    {
+        /* Dynamic TBD mode, required in order to use LSO */
+        Tcb->TbdNumber = 0xFF;
+        Tcb->Tbd[i].Size |= htole32(FXP_TBD_DYNTBD_EL);
+    }
+    else
+    {
+        Tcb->TbdNumber = i;
+    }
+
+    Tcb->ByteCount = 0;
+    Tcb->Header.Status = 0;
+    Tcb->Header.Command = Adapter->TransmitCommand;
+    Tcb->TxThreshold = Adapter->TransmitThreshold;
+}
+
+static
+BOOLEAN
+EeCopyPacket(
+    _In_ PNDIS_PACKET Packet,
+    _In_ PE100_COALESCE_BUFFER Buffer)
+{
+    PNDIS_BUFFER CurrentBuffer;
+    PVOID Address;
+    UINT CurrentLength, PacketLength;
+    PUCHAR Destination;
+
+    NdisGetFirstBufferFromPacketSafe(Packet,
+                                     &CurrentBuffer,
+                                     &Address,
+                                     &CurrentLength,
+                                     &PacketLength,
+                                     HighPagePriority);
+    if (!Address)
+        return FALSE;
+
+    Destination = Buffer->VirtualAddress;
+
+    while (TRUE)
+    {
+        RtlCopyMemory(Destination, Address, CurrentLength);
+        Destination += CurrentLength;
+
+        NdisGetNextBuffer(CurrentBuffer, &CurrentBuffer);
+        if (!CurrentBuffer)
+            break;
+
+        NdisQueryBufferSafe(CurrentBuffer,
+                            &Address,
+                            &CurrentLength,
+                            HighPagePriority);
+        if (!Address)
+            return FALSE;
+    }
+
+    return TRUE;
+}
+
+static
+NDIS_STATUS
+EeSendPacket(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PNDIS_PACKET Packet)
+{
+    PSCATTER_GATHER_LIST SgList;
+    PE100_TX_CONTEXT TxContext;
+
+    if (Adapter->TxPending >= Adapter->TcbCount)
+        return NDIS_STATUS_RESOURCES;
+
+    TxContext = Adapter->TxLast->Next;
+
+    SgList = NDIS_PER_PACKET_INFO_FROM_PACKET(Packet, ScatterGatherListPacketInfo);
+    if (SgList->NumberOfElements > Adapter->MaxTbdCount)
+    {
+        PE100_COALESCE_BUFFER CoalesceBuffer;
+        UINT PacketLength;
+        PSINGLE_LIST_ENTRY Entry;
+
+        Entry = Adapter->SendBufferList.Next;
+        if (!Entry)
+            return NDIS_STATUS_RESOURCES;
+
+        CoalesceBuffer = CONTAINING_RECORD(Entry, E100_COALESCE_BUFFER, ListEntry);
+
+        NdisQueryPacketLength(Packet, &PacketLength);
+        if (!EeCopyPacket(Packet, CoalesceBuffer))
+            return NDIS_STATUS_RESOURCES;
+
+        NT_VERIFY(PopEntryList(&Adapter->SendBufferList) != NULL);
+
+        SgList = &Adapter->LocalSgList;
+        SgList->Elements[0].Address.LowPart = CoalesceBuffer->PhysicalAddress;
+        SgList->Elements[0].Length = PacketLength;
+        SgList->NumberOfElements = 1;
+
+        TxContext->Buffer = CoalesceBuffer;
+    }
+
+    ASSERT(Adapter->TxPending < Adapter->TcbCount);
+    ++Adapter->TxPending;
+
+    TxContext->Packet = Packet;
+
+    EeTransmitPacket(Adapter, Packet, TxContext->Tcb, SgList);
+
+    /* Reset suspend bit in the previous TCB */
+    EE_WRITE_BARRIER();
+    Adapter->TxLast->Tcb->Header.Command &= htole16(~FXP_CB_COMMAND_S);
+    Adapter->TxLast = TxContext;
+
+    return NDIS_STATUS_PENDING;
+}
+
+VOID
+EeSendPackets(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PPNDIS_PACKET PacketArray,
+    _In_ UINT NumberOfPackets)
+{
+    PE100_TX_CONTEXT FirstTxContext;
+    ULONG i, PrevTxPending;
+    PLIST_ENTRY Entry;
+    NDIS_STATUS Status;
+    PNDIS_PACKET Packet;
+
+    TRACE("Send packets %lu\n", NumberOfPackets);
+
+    FirstTxContext = Adapter->TxLast->Next;
+    PrevTxPending = Adapter->TxPending;
+
+    if (NumberOfPackets == 0)
+    {
+        ASSERT(!IsListEmpty(&Adapter->SendQueueList));
+
+        /* Try to start more packets transmitting */
+        do
+        {
+            Entry = RemoveHeadList(&Adapter->SendQueueList);
+
+            Packet = E100_PACKET_FROM_LIST_ENTRY(Entry);
+
+            Status = EeSendPacket(Adapter, Packet);
+            if (Status == NDIS_STATUS_RESOURCES)
+            {
+                InsertHeadList(&Adapter->SendQueueList, E100_LIST_ENTRY_FROM_PACKET(Packet));
+                break;
+            }
+        }
+        while (!IsListEmpty(&Adapter->SendQueueList));
+    }
+    else
+    {
+        for (i = 0; i < NumberOfPackets; ++i)
+        {
+            Packet = PacketArray[i];
+
+            Status = EeSendPacket(Adapter, Packet);
+            if (Status == NDIS_STATUS_RESOURCES)
+            {
+                InsertTailList(&Adapter->SendQueueList, E100_LIST_ENTRY_FROM_PACKET(Packet));
+            }
+        }
+    }
+
+    /* Issue a CU_RESUME command in case the CU was suspended */
+    if (Adapter->TxPending != PrevTxPending)
+    {
+        Adapter->TxTimeOut = 3;
+
+        EeStartTransmit(Adapter, FirstTxContext);
+    }
+}
+
+VOID
+NTAPI
+MiniportSendPackets(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ PPNDIS_PACKET PacketArray,
+    _In_ UINT NumberOfPackets)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    ULONG i;
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    if (!Adapter->AdapterActive)
+    {
+        NdisReleaseSpinLock(&Adapter->SendLock);
+
+        for (i = 0; i < NumberOfPackets; ++i)
+        {
+            NdisMSendComplete(Adapter->AdapterHandle, PacketArray[i], NDIS_STATUS_NOT_ACCEPTED);
+        }
+        return;
+    }
+
+    EeSendPackets(Adapter, PacketArray, NumberOfPackets);
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+}
+
+VOID
+NTAPI
+MiniportCancelSendPackets(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ PVOID CancelId)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    LIST_ENTRY DoneList;
+    PLIST_ENTRY Entry, NextEntry;
+
+    TRACE("Called\n");
+
+    InitializeListHead(&DoneList);
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    NextEntry = Adapter->SendQueueList.Flink;
+    while (NextEntry != &Adapter->SendQueueList)
+    {
+        PNDIS_PACKET Packet;
+
+        Entry = NextEntry;
+        NextEntry = NextEntry->Flink;
+
+        Packet = E100_PACKET_FROM_LIST_ENTRY(Entry);
+
+        if (NDIS_GET_PACKET_CANCEL_ID(Packet) == CancelId)
+        {
+            RemoveEntryList(E100_LIST_ENTRY_FROM_PACKET(Packet));
+
+            InsertTailList(&DoneList, E100_LIST_ENTRY_FROM_PACKET(Packet));
+        }
+    }
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+
+    while (!IsListEmpty(&DoneList))
+    {
+        Entry = RemoveHeadList(&DoneList);
+
+        NdisMSendComplete(Adapter->AdapterHandle,
+                          E100_PACKET_FROM_LIST_ENTRY(Entry),
+                          NDIS_STATUS_REQUEST_ABORTED);
+    }
+}

--- a/drivers/network/dd/e100/send.c
+++ b/drivers/network/dd/e100/send.c
@@ -1,0 +1,367 @@
+/*
+ * PROJECT:     Intel PRO/100 Ethernet Controller Driver
+ * LICENSE:     BSD-2-Clause (https://spdx.org/licenses/BSD-2-Clause)
+ * PURPOSE:     Packet sending
+ * COPYRIGHT:   Copyright 2026 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "e100.h"
+
+#include <debug.h>
+
+/* FUNCTIONS ******************************************************************/
+
+static
+VOID
+EeStartTransmit(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PE100_TX_CONTEXT TxContext)
+{
+    if (Adapter->CommandUnitActive)
+    {
+        TRACE("Resume CU %02X\n", FXP_SCB_CUS(CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS)));
+
+        /* Errata: LAN Microcontroller PCI Protocol Violation with 10Mbps half-duplex link */
+        if (!(Adapter->CurrentMedia & E100_MEDIA_100T) &&
+            !(Adapter->CurrentMedia & E100_MEDIA_FD) &&
+            (Adapter->Flags & E100_FLAG_IS_ICH))
+        {
+            /* Issue a CU_NOP command before CU_RESUME and wait */
+            EeScbWaitForCommandClear(Adapter);
+            CSR_WRITE_8(Adapter, FXP_CSR_SCB_COMMAND, FXP_SCB_COMMAND_CU_NOP);
+            NdisStallExecution(1);
+        }
+
+        EeScbWaitForCommandClear(Adapter);
+        CSR_WRITE_8(Adapter, FXP_CSR_SCB_COMMAND, FXP_SCB_COMMAND_CU_RESUME);
+    }
+    else
+    {
+        TRACE("Starting CU %02X\n", FXP_SCB_CUS(CSR_READ_8(Adapter, FXP_CSR_SCB_RUSCUS)));
+
+        Adapter->CommandUnitActive = TRUE;
+
+        EeScbWaitForCommandClear(Adapter);
+        CSR_WRITE_32(Adapter, FXP_CSR_SCB_GENERAL, TxContext->TcbPhys);
+        CSR_WRITE_8(Adapter, FXP_CSR_SCB_COMMAND, FXP_SCB_COMMAND_CU_START);
+    }
+}
+
+static
+VOID
+EeInsertVlanTag(
+    _In_ E100_ADAPTER* __restrict Adapter,
+    _In_ E100_TX_CONTEXT* __restrict TxContext,
+    _In_ FXP_CB_TRANSMIT* __restrict Tcb)
+{
+    NDIS_PACKET_8021Q_INFO VlanPriInfo;
+
+    if (!(Adapter->Flags & E100_FLAG_VLAN_TAGGING) &&
+        !(Adapter->Flags & E100_FLAG_PACKET_PRIORITY))
+    {
+        return;
+    }
+
+    VlanPriInfo.Value = NDIS_PER_PACKET_INFO_FROM_PACKET(TxContext->Packet, Ieee8021QInfo);
+
+    if (Adapter->Flags & E100_FLAG_VLAN_TAGGING)
+    {
+        if (!VlanPriInfo.TagHeader.VlanId)
+            VlanPriInfo.TagHeader.VlanId = Adapter->VlanId;
+    }
+    else
+    {
+        VlanPriInfo.TagHeader.VlanId = 0;
+    }
+
+    if (!(Adapter->Flags & E100_FLAG_PACKET_PRIORITY))
+    {
+        VlanPriInfo.TagHeader.UserPriority = 0;
+    }
+
+    if (VlanPriInfo.TagHeader.VlanId || VlanPriInfo.TagHeader.UserPriority)
+    {
+        Tcb->Ipcb.VlanId = FXP_IPCB_PACK_8021Q_INFO(VlanPriInfo.TagHeader.UserPriority,
+                                                    VlanPriInfo.TagHeader.CanonicalFormatId,
+                                                    VlanPriInfo.TagHeader.VlanId);
+        Tcb->Ipcb.IpActivationHigh |= FXP_IPCB_INSERTVLAN_ENABLE;
+    }
+}
+
+static
+VOID
+EeTransmitPacket(
+    _In_ E100_ADAPTER* __restrict Adapter,
+    _In_ E100_TX_CONTEXT* __restrict TxContext,
+    _In_ FXP_CB_TRANSMIT* __restrict Tcb,
+    _In_ SCATTER_GATHER_LIST* __restrict SgList)
+{
+    PFXP_TBD Tbd;
+    ULONG i;
+
+    Tbd = Tcb->Tbd;
+
+    if (Adapter->Flags & E100_FLAG_EXT_RFA)
+    {
+        Tcb->Ipcb.IpActivationHigh = FXP_IPCB_HARDWAREPARSING_ENABLE;
+
+        EeInsertVlanTag(Adapter, TxContext, Tcb);
+
+        Tbd++;
+    }
+
+    for (i = 0; i < SgList->NumberOfElements; ++i)
+    {
+        /* 32-bit DMA */
+        ASSERT(SgList->Elements[i].Address.HighPart == 0);
+
+        Tbd[i].Address = htole32(SgList->Elements[i].Address.LowPart);
+        Tbd[i].Size = htole32(SgList->Elements[i].Length);
+    }
+
+    if (Adapter->Flags & E100_FLAG_EXT_RFA)
+    {
+        Tcb->TbdNumber = 0xFF;
+        Tcb->Tbd[i].Size |= htole32(0x8000);
+    }
+    else
+    {
+        Tcb->TbdNumber = i;
+    }
+
+    Tcb->ByteCount = 0;
+    Tcb->TxThreshold = Adapter->TransmitThreshold;
+    Tcb->Header.Status = 0;
+    Tcb->Header.Command = Adapter->TransmitCommand;
+}
+
+static
+BOOLEAN
+EeCopyPacket(
+    _In_ PNDIS_PACKET Packet,
+    _In_ PE100_COALESCE_BUFFER Buffer)
+{
+    PNDIS_BUFFER CurrentBuffer;
+    PVOID Address;
+    UINT CurrentLength, PacketLength;
+    PUCHAR Destination;
+
+    NdisGetFirstBufferFromPacketSafe(Packet,
+                                     &CurrentBuffer,
+                                     &Address,
+                                     &CurrentLength,
+                                     &PacketLength,
+                                     HighPagePriority);
+    if (!Address)
+        return FALSE;
+
+    Destination = Buffer->VirtualAddress;
+
+    while (TRUE)
+    {
+        NdisMoveMemory(Destination, Address, CurrentLength);
+        Destination += CurrentLength;
+
+        NdisGetNextBuffer(CurrentBuffer, &CurrentBuffer);
+        if (!CurrentBuffer)
+            break;
+
+        NdisQueryBufferSafe(CurrentBuffer,
+                            &Address,
+                            &CurrentLength,
+                            HighPagePriority);
+        if (!Address)
+            return FALSE;
+    }
+
+    return TRUE;
+}
+
+static
+NDIS_STATUS
+EeSendPacket(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PNDIS_PACKET Packet)
+{
+    PSCATTER_GATHER_LIST SgList;
+    PE100_TX_CONTEXT TxContext;
+
+    if (Adapter->TxPending >= Adapter->TcbCount)
+        return NDIS_STATUS_RESOURCES;
+
+    TxContext = Adapter->TxLast->Next;
+
+    SgList = NDIS_PER_PACKET_INFO_FROM_PACKET(Packet, ScatterGatherListPacketInfo);
+    if (SgList->NumberOfElements > Adapter->TbdCount)
+    {
+        PE100_COALESCE_BUFFER CoalesceBuffer;
+        UINT PacketLength;
+        PSINGLE_LIST_ENTRY Entry;
+
+        Entry = Adapter->SendBufferList.Next;
+        if (!Entry)
+            return NDIS_STATUS_RESOURCES;
+
+        CoalesceBuffer = CONTAINING_RECORD(Entry, E100_COALESCE_BUFFER, ListEntry);
+
+        NdisQueryPacketLength(Packet, &PacketLength);
+        if (!EeCopyPacket(Packet, CoalesceBuffer))
+            return NDIS_STATUS_RESOURCES;
+
+        NT_VERIFY(PopEntryList(&Adapter->SendBufferList) != NULL);
+
+        SgList = &Adapter->LocalSgList;
+        SgList->Elements[0].Address.LowPart = CoalesceBuffer->PhysicalAddress;
+        SgList->Elements[0].Length = PacketLength;
+        SgList->NumberOfElements = 1;
+
+        TxContext->Buffer = CoalesceBuffer;
+    }
+
+    ASSERT(Adapter->TxPending < Adapter->TcbCount);
+    ++Adapter->TxPending;
+
+    TxContext->Packet = Packet;
+
+    EeTransmitPacket(Adapter, TxContext, TxContext->Tcb, SgList);
+
+    EE_WRITE_BARRIER();
+    Adapter->TxLast->Tcb->Header.Command &= htole16(~FXP_CB_COMMAND_S);
+    Adapter->TxLast = TxContext;
+
+    return NDIS_STATUS_PENDING;
+}
+
+VOID
+EeSendPackets(
+    _In_ PE100_ADAPTER Adapter,
+    _In_ PPNDIS_PACKET PacketArray,
+    _In_ UINT NumberOfPackets)
+{
+    PE100_TX_CONTEXT FirstTxContext;
+    ULONG i, PrevTxPending;
+    PLIST_ENTRY Entry;
+    NDIS_STATUS Status;
+    PNDIS_PACKET Packet;
+
+    TRACE("Send packets %lu\n", NumberOfPackets);
+
+    FirstTxContext = Adapter->TxLast->Next;
+    PrevTxPending = Adapter->TxPending;
+
+    if (NumberOfPackets == 0)
+    {
+        ASSERT(!IsListEmpty(&Adapter->SendQueueList));
+
+        /* Try to start more packets transmitting */
+        do
+        {
+            Entry = RemoveHeadList(&Adapter->SendQueueList);
+
+            Packet = E100_PACKET_FROM_LIST_ENTRY(Entry);
+
+            Status = EeSendPacket(Adapter, Packet);
+            if (Status == NDIS_STATUS_RESOURCES)
+            {
+                InsertHeadList(&Adapter->SendQueueList, E100_LIST_ENTRY_FROM_PACKET(Packet));
+                break;
+            }
+        }
+        while (!IsListEmpty(&Adapter->SendQueueList));
+    }
+    else
+    {
+        for (i = 0; i < NumberOfPackets; ++i)
+        {
+            Packet = PacketArray[i];
+
+            Status = EeSendPacket(Adapter, Packet);
+            if (Status == NDIS_STATUS_RESOURCES)
+            {
+                InsertTailList(&Adapter->SendQueueList, E100_LIST_ENTRY_FROM_PACKET(Packet));
+            }
+        }
+    }
+
+    /* Issue a CU_RESUME command in case the CU was suspended */
+    if (Adapter->TxPending != PrevTxPending)
+    {
+        EeStartTransmit(Adapter, FirstTxContext);
+    }
+}
+
+VOID
+NTAPI
+MiniportSendPackets(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ PPNDIS_PACKET PacketArray,
+    _In_ UINT NumberOfPackets)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    ULONG i;
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    if (!Adapter->AdapterActive)
+    {
+        NdisReleaseSpinLock(&Adapter->SendLock);
+
+        for (i = 0; i < NumberOfPackets; ++i)
+        {
+            NdisMSendComplete(Adapter->AdapterHandle, PacketArray[i], NDIS_STATUS_NOT_ACCEPTED);
+        }
+        return;
+    }
+
+    EeSendPackets(Adapter, PacketArray, NumberOfPackets);
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+}
+
+VOID
+NTAPI
+MiniportCancelSendPackets(
+    _In_ NDIS_HANDLE MiniportAdapterContext,
+    _In_ PVOID CancelId)
+{
+    PE100_ADAPTER Adapter = MiniportAdapterContext;
+    LIST_ENTRY DoneList;
+    PLIST_ENTRY Entry, NextEntry;
+
+    TRACE("Called\n");
+
+    InitializeListHead(&DoneList);
+
+    NdisAcquireSpinLock(&Adapter->SendLock);
+
+    NextEntry = Adapter->SendQueueList.Flink;
+    while (NextEntry != &Adapter->SendQueueList)
+    {
+        PNDIS_PACKET Packet;
+
+        Entry = NextEntry;
+        NextEntry = NextEntry->Flink;
+
+        Packet = E100_PACKET_FROM_LIST_ENTRY(Entry);
+
+        if (NDIS_GET_PACKET_CANCEL_ID(Packet) == CancelId)
+        {
+            RemoveEntryList(E100_LIST_ENTRY_FROM_PACKET(Packet));
+
+            InsertTailList(&DoneList, E100_LIST_ENTRY_FROM_PACKET(Packet));
+        }
+    }
+
+    NdisReleaseSpinLock(&Adapter->SendLock);
+
+    while (!IsListEmpty(&DoneList))
+    {
+        Entry = RemoveHeadList(&DoneList);
+
+        NdisMSendComplete(Adapter->AdapterHandle,
+                          E100_PACKET_FROM_LIST_ENTRY(Entry),
+                          NDIS_STATUS_REQUEST_ABORTED);
+    }
+}


### PR DESCRIPTION
## Purpose

Tested with
- Intel PILA8460B (8086:1229 rev 08)
- ICH3-based laptop (8086:1038 rev 42)
- QEMU model=i82557a (8086:1229 rev 01)

It appears that QEMU does not emulate some e100 devices correctly (the driver fails to start with model=i82550).

JIRA issue: [CORE-20648](https://jira.reactos.org/browse/CORE-20648)

<details>
  <summary>Testing</summary>
  <img width="1150" height="854" alt="pro100" src="https://github.com/user-attachments/assets/9446e702-271c-49d3-9ae0-24d466838308" />
  <img width="1055" height="810" alt="pila" src="https://github.com/user-attachments/assets/1aa3f913-a8a8-44cf-a3ff-a08fd6512dda" />
</details>

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: