### PR TITLE
[NTOS:MM] Allow contiguous-memory frees at DISPATCH_LEVEL

### DIFF
--- a/ntoskrnl/mm/ARM3/contmem.c
+++ b/ntoskrnl/mm/ARM3/contmem.c
@@ -464,7 +464,7 @@ MiFreeContiguousMemory(IN PVOID BaseAddress)
     PFN_NUMBER PageFrameIndex, LastPage, PageCount;
     PMMPFN Pfn1, StartPfn;
     PMMPTE PointerPte;
-    PAGED_CODE();
+    ASSERT(KeGetCurrentIrql() <= DISPATCH_LEVEL);
 
     //
     // First, check if the memory came from initial nonpaged pool, or expansion

--- a/ntoskrnl/mm/ARM3/contmem.c
+++ b/ntoskrnl/mm/ARM3/contmem.c
@@ -464,7 +464,7 @@ MiFreeContiguousMemory(IN PVOID BaseAddress)
     PFN_NUMBER PageFrameIndex, LastPage, PageCount;
     PMMPFN Pfn1, StartPfn;
     PMMPTE PointerPte;
-    ASSERT(KeGetCurrentIrql() <= DISPATCH_LEVEL);
+    ASSERT_IRQL_LESS_OR_EQUAL(DISPATCH_LEVEL);
 
     //
     // First, check if the memory came from initial nonpaged pool, or expansion


### PR DESCRIPTION
`MmFreeContiguousMemory` is callable at up to `DISPATCH_LEVEL`, but `MiFreeContiguousMemory` uses `PAGED_CODE()`, which incorrectly asserts above `APC_LEVEL` in checked builds.

Replace it with an assertion that enforces the exported IRQL contract.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109165,109167
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109166,109168