### PR TITLE
[VBEMP] Return NO_ERROR in VBESetPowerState

### DIFF
--- a/win32ss/drivers/miniport/vbe/vbemp.c
+++ b/win32ss/drivers/miniport/vbe/vbemp.c
@@ -650,9 +650,9 @@ VBEGetPowerState(
 
 VP_STATUS NTAPI
 VBESetPowerState(
-   PVOID HwDeviceExtension,
-   ULONG HwId,
-   PVIDEO_POWER_MANAGEMENT VideoPowerControl)
+   _In_ PVOID HwDeviceExtension,
+   _In_ ULONG HwId,
+   _In_ PVIDEO_POWER_MANAGEMENT VideoPowerControl)
 {
    INT10_BIOS_ARGUMENTS BiosRegisters;
    PVBE_DEVICE_EXTENSION VBEDeviceExtension =
@@ -692,7 +692,7 @@ VBESetPowerState(
    if (VBE_GETRETURNCODE(BiosRegisters.Eax) != VBE_SUCCESS)
       return ERROR_INVALID_FUNCTION;
 
-   return VBE_SUCCESS;
+   return NO_ERROR;
 }
 
 /*

--- a/win32ss/drivers/miniport/vbe/vbemp.h
+++ b/win32ss/drivers/miniport/vbe/vbemp.h
@@ -252,9 +252,9 @@ VBEGetPowerState(
 
 VP_STATUS NTAPI
 VBESetPowerState(
-   PVOID HwDeviceExtension,
-   ULONG HwId,
-   PVIDEO_POWER_MANAGEMENT VideoPowerControl);
+   _In_ PVOID HwDeviceExtension,
+   _In_ ULONG HwId,
+   _In_ PVIDEO_POWER_MANAGEMENT VideoPowerControl);
 
 BOOLEAN FASTCALL
 VBESetCurrentMode(


### PR DESCRIPTION
## Purpose
Fix incorrect status code returned by `VBESetPowerState` in the VBE miniport driver.

JIRA issue: None

## Proposed changes
- `VBESetPowerState` returned `VBE_SUCCESS` (`0x4F`, raw VESA BIOS AL success code) instead of `NO_ERROR` on success, so callers checking for `NO_ERROR` would treat every successful DPMS power-state change as a failure. Change it to `NO_ERROR`.
- Change annotations to SAL2.

## Testbot runs (Filled in by Devs)
- [ ] KVM x86:
- [ ] KVM x64: