### PR TITLE
[CONSRV] Add virtual terminal processing

### DIFF
--- a/dll/win32/kernel32/client/console/vista.c
+++ b/dll/win32/kernel32/client/console/vista.c
@@ -119,7 +119,7 @@ GetConsoleOriginalTitleA(OUT LPSTR lpConsoleTitle,
 
 
 /*
- * @unimplemented
+ * @implemented
  */
 BOOL
 WINAPI
@@ -127,14 +127,45 @@ DECLSPEC_HOTPATCH
 GetConsoleScreenBufferInfoEx(IN HANDLE hConsoleOutput,
                              OUT PCONSOLE_SCREEN_BUFFER_INFOEX lpConsoleScreenBufferInfoEx)
 {
-    DPRINT1("GetConsoleScreenBufferInfoEx(0x%p, 0x%p) UNIMPLEMENTED!\n", hConsoleOutput, lpConsoleScreenBufferInfoEx);
-    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-    return FALSE;
+    CONSOLE_API_MESSAGE ApiMessage;
+    PCONSOLE_GETSCREENBUFFERINFOEX ScreenBufferInfoExRequest = &ApiMessage.Data.ScreenBufferInfoExRequest;
+
+    if (lpConsoleScreenBufferInfoEx == NULL ||
+        lpConsoleScreenBufferInfoEx->cbSize != sizeof(CONSOLE_SCREEN_BUFFER_INFOEX))
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    ScreenBufferInfoExRequest->ConsoleHandle = NtCurrentPeb()->ProcessParameters->ConsoleHandle;
+    ScreenBufferInfoExRequest->OutputHandle  = hConsoleOutput;
+
+    CsrClientCallServer((PCSR_API_MESSAGE)&ApiMessage, NULL, CSR_CREATE_API_NUMBER(CONSRV_SERVERDLL_INDEX, ConsolepGetScreenBufferInfoEx), sizeof(*ScreenBufferInfoExRequest));
+    if (!NT_SUCCESS(ApiMessage.Status))
+    {
+        BaseSetLastNTError(ApiMessage.Status);
+        return FALSE;
+    }
+
+    lpConsoleScreenBufferInfoEx->dwSize              = ScreenBufferInfoExRequest->ScreenBufferSize;
+    lpConsoleScreenBufferInfoEx->dwCursorPosition    = ScreenBufferInfoExRequest->CursorPosition;
+    lpConsoleScreenBufferInfoEx->wAttributes         = ScreenBufferInfoExRequest->Attributes;
+    lpConsoleScreenBufferInfoEx->srWindow.Left       = ScreenBufferInfoExRequest->ViewOrigin.X;
+    lpConsoleScreenBufferInfoEx->srWindow.Top        = ScreenBufferInfoExRequest->ViewOrigin.Y;
+    lpConsoleScreenBufferInfoEx->srWindow.Right      = ScreenBufferInfoExRequest->ViewOrigin.X + ScreenBufferInfoExRequest->ViewSize.X - 1;
+    lpConsoleScreenBufferInfoEx->srWindow.Bottom     = ScreenBufferInfoExRequest->ViewOrigin.Y + ScreenBufferInfoExRequest->ViewSize.Y - 1;
+    lpConsoleScreenBufferInfoEx->dwMaximumWindowSize = ScreenBufferInfoExRequest->MaximumViewSize;
+    lpConsoleScreenBufferInfoEx->wPopupAttributes    = ScreenBufferInfoExRequest->PopupAttributes;
+    lpConsoleScreenBufferInfoEx->bFullscreenSupported = ScreenBufferInfoExRequest->FullscreenSupported;
+
+    RtlCopyMemory(lpConsoleScreenBufferInfoEx->ColorTable, ScreenBufferInfoExRequest->ColorTable, sizeof(ScreenBufferInfoExRequest->ColorTable));
+
+    return TRUE;
 }
 
 
 /*
- * @unimplemented
+ * @implemented
  */
 BOOL
 WINAPI
@@ -142,9 +173,40 @@ DECLSPEC_HOTPATCH
 SetConsoleScreenBufferInfoEx(IN HANDLE hConsoleOutput,
                              IN PCONSOLE_SCREEN_BUFFER_INFOEX lpConsoleScreenBufferInfoEx)
 {
-    DPRINT1("SetConsoleScreenBufferInfoEx(0x%p, 0x%p) UNIMPLEMENTED!\n", hConsoleOutput, lpConsoleScreenBufferInfoEx);
-    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-    return FALSE;
+    CONSOLE_API_MESSAGE ApiMessage;
+    PCONSOLE_GETSCREENBUFFERINFOEX ScreenBufferInfoExRequest = &ApiMessage.Data.ScreenBufferInfoExRequest;
+
+    if (lpConsoleScreenBufferInfoEx == NULL ||
+        lpConsoleScreenBufferInfoEx->cbSize != sizeof(CONSOLE_SCREEN_BUFFER_INFOEX))
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    ScreenBufferInfoExRequest->ConsoleHandle = NtCurrentPeb()->ProcessParameters->ConsoleHandle;
+    ScreenBufferInfoExRequest->OutputHandle  = hConsoleOutput;
+
+    ScreenBufferInfoExRequest->ScreenBufferSize = lpConsoleScreenBufferInfoEx->dwSize;
+    ScreenBufferInfoExRequest->CursorPosition   = lpConsoleScreenBufferInfoEx->dwCursorPosition;
+    ScreenBufferInfoExRequest->Attributes       = lpConsoleScreenBufferInfoEx->wAttributes;
+    ScreenBufferInfoExRequest->ViewOrigin.X     = lpConsoleScreenBufferInfoEx->srWindow.Left;
+    ScreenBufferInfoExRequest->ViewOrigin.Y     = lpConsoleScreenBufferInfoEx->srWindow.Top;
+    ScreenBufferInfoExRequest->ViewSize.X       = lpConsoleScreenBufferInfoEx->srWindow.Right - lpConsoleScreenBufferInfoEx->srWindow.Left + 1;
+    ScreenBufferInfoExRequest->ViewSize.Y       = lpConsoleScreenBufferInfoEx->srWindow.Bottom - lpConsoleScreenBufferInfoEx->srWindow.Top + 1;
+    ScreenBufferInfoExRequest->MaximumViewSize  = lpConsoleScreenBufferInfoEx->dwMaximumWindowSize;
+    ScreenBufferInfoExRequest->PopupAttributes  = lpConsoleScreenBufferInfoEx->wPopupAttributes;
+    ScreenBufferInfoExRequest->FullscreenSupported = lpConsoleScreenBufferInfoEx->bFullscreenSupported;
+
+    RtlCopyMemory(ScreenBufferInfoExRequest->ColorTable, lpConsoleScreenBufferInfoEx->ColorTable, sizeof(ScreenBufferInfoExRequest->ColorTable));
+
+    CsrClientCallServer((PCSR_API_MESSAGE)&ApiMessage, NULL, CSR_CREATE_API_NUMBER(CONSRV_SERVERDLL_INDEX, ConsolepSetScreenBufferInfoEx), sizeof(*ScreenBufferInfoExRequest));
+    if (!NT_SUCCESS(ApiMessage.Status))
+    {
+        BaseSetLastNTError(ApiMessage.Status);
+        return FALSE;
+    }
+
+    return TRUE;
 }
 
 

--- a/modules/rostests/apitests/kernel32/CMakeLists.txt
+++ b/modules/rostests/apitests/kernel32/CMakeLists.txt
@@ -5,6 +5,7 @@ add_message_headers(ANSI FormatMessage.mc)
 
 list(APPEND SOURCE
     ConsoleCP.c
+    ConsoleVirtualTerminal.c
     CreateProcess.c
     DefaultActCtx.c
     DeviceIoControl.c
@@ -61,7 +62,7 @@ add_executable(kernel32_apitest
 target_link_libraries(kernel32_apitest wine ${PSEH_LIB})
 set_module_type(kernel32_apitest win32cui)
 add_delay_importlibs(kernel32_apitest advapi32 shlwapi)
-add_importlibs(kernel32_apitest netapi32 msvcrt kernel32 ntdll)
+add_importlibs(kernel32_apitest netapi32 user32 msvcrt kernel32 ntdll)
 add_dependencies(kernel32_apitest FormatMessage)
 add_pch(kernel32_apitest precomp.h "${PCH_SKIP_SOURCE}")
 add_rostests_file(TARGET kernel32_apitest)

--- a/modules/rostests/apitests/kernel32/ConsoleVirtualTerminal.c
+++ b/modules/rostests/apitests/kernel32/ConsoleVirtualTerminal.c
@@ -1,0 +1,811 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     End-to-end tests for the Win32 virtual terminal path
+ */
+
+#include "precomp.h"
+#include <winuser.h>
+
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
+
+#ifndef DISABLE_NEWLINE_AUTO_RETURN
+#define DISABLE_NEWLINE_AUTO_RETURN 0x0008
+#endif
+
+#ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
+#define ENABLE_VIRTUAL_TERMINAL_INPUT 0x0200
+#endif
+
+#ifndef CONSOLE_READ_NOWAIT
+#define CONSOLE_READ_NOWAIT 0x0002
+#endif
+
+#define EDIT_INPUT_MODE \
+    (ENABLE_WINDOW_INPUT | ENABLE_EXTENDED_FLAGS | ENABLE_VIRTUAL_TERMINAL_INPUT)
+
+#define EDIT_OUTPUT_MODE \
+    (ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT | \
+     ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN)
+
+#define INPUT_RECORD_COUNT 4096
+
+typedef BOOL
+(WINAPI *PREAD_CONSOLE_INPUT_EX_W)(
+    HANDLE hConsoleInput,
+    PINPUT_RECORD lpBuffer,
+    DWORD nLength,
+    LPDWORD lpNumberOfEventsRead,
+    WORD wFlags);
+
+static BOOL
+WriteVt(HANDLE Output,
+        const char *Buffer,
+        DWORD Length)
+{
+    BOOL Success;
+    DWORD Written = 0;
+
+    SetLastError(0xdeadbeef);
+    Success = WriteFile(Output, Buffer, Length, &Written, NULL);
+    ok(Success, "WriteFile failed with error %lu\n", GetLastError());
+    ok(Written == Length, "WriteFile wrote %lu of %lu bytes\n", Written, Length);
+    return Success && Written == Length;
+}
+
+#define WRITE_VT(Output, String) WriteVt((Output), (String), sizeof(String) - 1)
+
+static BOOL
+ClearScreen(HANDLE Output,
+            CONSOLE_SCREEN_BUFFER_INFO *Info)
+{
+    COORD Origin = {0, 0};
+    DWORD CellCount;
+    DWORD Written;
+    BOOL Success;
+
+    Success = GetConsoleScreenBufferInfo(Output, Info);
+    ok(Success, "GetConsoleScreenBufferInfo failed with error %lu\n", GetLastError());
+    if (!Success)
+        return FALSE;
+
+    CellCount = (DWORD)Info->dwSize.X * Info->dwSize.Y;
+    Success = FillConsoleOutputCharacterW(Output, L' ', CellCount, Origin, &Written);
+    ok(Success, "FillConsoleOutputCharacterW failed with error %lu\n", GetLastError());
+    ok(Written == CellCount, "Filled %lu of %lu characters\n", Written, CellCount);
+
+    Success = FillConsoleOutputAttribute(Output, Info->wAttributes, CellCount, Origin, &Written);
+    ok(Success, "FillConsoleOutputAttribute failed with error %lu\n", GetLastError());
+    ok(Written == CellCount, "Filled %lu of %lu attributes\n", Written, CellCount);
+
+    Success = SetConsoleCursorPosition(Output, Origin);
+    ok(Success, "SetConsoleCursorPosition failed with error %lu\n", GetLastError());
+    return Success;
+}
+
+static WCHAR
+ReadCell(HANDLE Output,
+         SHORT X,
+         SHORT Y)
+{
+    COORD Position;
+    WCHAR Character = 0;
+    DWORD Read = 0;
+    BOOL Success;
+
+    Position.X = X;
+    Position.Y = Y;
+    Success = ReadConsoleOutputCharacterW(Output, &Character, 1, Position, &Read);
+    ok(Success, "ReadConsoleOutputCharacterW(%d, %d) failed with error %lu\n",
+       X, Y, GetLastError());
+    ok(Read == 1, "ReadConsoleOutputCharacterW(%d, %d) read %lu characters\n",
+       X, Y, Read);
+    return Character;
+}
+
+static WORD
+ReadCellAttribute(HANDLE Output,
+                  SHORT X,
+                  SHORT Y)
+{
+    COORD Position;
+    WORD Attribute = 0;
+    DWORD Read = 0;
+    BOOL Success;
+
+    Position.X = X;
+    Position.Y = Y;
+    Success = ReadConsoleOutputAttribute(Output, &Attribute, 1, Position, &Read);
+    ok(Success, "ReadConsoleOutputAttribute(%d, %d) failed with error %lu\n",
+       X, Y, GetLastError());
+    ok(Read == 1, "ReadConsoleOutputAttribute(%d, %d) read %lu attributes\n",
+       X, Y, Read);
+    return Attribute;
+}
+
+static BOOL
+Contains(const WCHAR *Buffer,
+         DWORD Length,
+         const WCHAR *Needle)
+{
+    DWORD NeedleLength = (DWORD)wcslen(Needle);
+    DWORD Index;
+
+    if (NeedleLength == 0)
+        return TRUE;
+    if (NeedleLength > Length)
+        return FALSE;
+
+    for (Index = 0; Index <= Length - NeedleLength; ++Index)
+    {
+        if (memcmp(Buffer + Index, Needle, NeedleLength * sizeof(WCHAR)) == 0)
+            return TRUE;
+    }
+
+    return FALSE;
+}
+
+static DWORD
+CountOccurrences(const WCHAR *Buffer,
+                 DWORD Length,
+                 const WCHAR *Needle)
+{
+    DWORD NeedleLength = (DWORD)wcslen(Needle);
+    DWORD Count = 0;
+    DWORD Index;
+
+    if (NeedleLength == 0 || NeedleLength > Length)
+        return 0;
+
+    for (Index = 0; Index <= Length - NeedleLength; ++Index)
+    {
+        if (memcmp(Buffer + Index, Needle, NeedleLength * sizeof(WCHAR)) == 0)
+        {
+            ++Count;
+            Index += NeedleLength - 1;
+        }
+    }
+
+    return Count;
+}
+
+static DWORD
+ReadVtCharacters(PREAD_CONSOLE_INPUT_EX_W ReadConsoleInputExW_,
+                 HANDLE Input,
+                 WCHAR *Characters,
+                 DWORD Capacity,
+                 DWORD *RecordCount)
+{
+    PINPUT_RECORD Records;
+    DWORD RecordsRead = 0;
+    DWORD CharacterCount = 0;
+    DWORD StoredCount;
+    DWORD Index;
+    BOOL CallCompleted = FALSE;
+    BOOL Success;
+
+    Records = HeapAlloc(GetProcessHeap(), 0, INPUT_RECORD_COUNT * sizeof(*Records));
+    ok(Records != NULL, "Unable to allocate the input record buffer\n");
+    if (Records == NULL)
+        return 0;
+
+    SetLastError(0xdeadbeef);
+    _SEH2_TRY
+    {
+        Success = ReadConsoleInputExW_(Input,
+                                       Records,
+                                       INPUT_RECORD_COUNT,
+                                       &RecordsRead,
+                                       CONSOLE_READ_NOWAIT);
+        CallCompleted = TRUE;
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        Success = FALSE;
+    }
+    _SEH2_END;
+
+    ok(CallCompleted, "ReadConsoleInputExW raised an exception\n");
+    if (CallCompleted)
+        ok(Success, "ReadConsoleInputExW failed with error %lu\n", GetLastError());
+
+    if (CallCompleted && Success)
+    {
+        for (Index = 0; Index < RecordsRead; ++Index)
+        {
+            if (Records[Index].EventType == KEY_EVENT &&
+                Records[Index].Event.KeyEvent.bKeyDown &&
+                Records[Index].Event.KeyEvent.uChar.UnicodeChar != UNICODE_NULL)
+            {
+                if (CharacterCount < Capacity)
+                    Characters[CharacterCount] = Records[Index].Event.KeyEvent.uChar.UnicodeChar;
+                ++CharacterCount;
+            }
+        }
+    }
+
+    StoredCount = Capacity != 0 ? min(CharacterCount, Capacity - 1) : 0;
+    if (Capacity != 0)
+        Characters[StoredCount] = UNICODE_NULL;
+    ok(CharacterCount < Capacity,
+       "Input returned %lu characters for a %lu-character buffer\n",
+       CharacterCount, Capacity);
+
+    if (RecordCount != NULL)
+        *RecordCount = RecordsRead;
+
+    HeapFree(GetProcessHeap(), 0, Records);
+    return StoredCount;
+}
+
+static VOID
+TestEditStartup(HANDLE Input,
+                HANDLE Output,
+                PREAD_CONSOLE_INPUT_EX_W ReadConsoleInputExW_)
+{
+    static const char EditSetup[] =
+        "\x1b[?1049h\x1b[?1002;1006;2004h\x1b[?1036h"
+        "\x1b]4;0;?;1;?;2;?;3;?;4;?;5;?;6;?;7;?\x07"
+        "\x1b]4;8;?;9;?;10;?;11;?;12;?;13;?;14;?;15;?\x07"
+        "\x1b]10;?\x07\x1b]11;?\x07"
+        "\r" "\xe2\x80\xa6" "\x1b[6n"
+        "\x1b[c";
+    static const char EditRestore[] =
+        "\x1b[0 q\x1b[?25h\x1b]0;\x07"
+        "\x1b[?1002;1006;2004l\x1b[?1049l";
+    CONSOLE_SCREEN_BUFFER_INFO Info;
+    WCHAR Responses[1024];
+    COORD MarkerPosition = {7, 3};
+    DWORD CharacterCount;
+    DWORD RecordsRead;
+    BOOL Success;
+
+    if (!ClearScreen(Output, &Info))
+        return;
+    if (Info.dwSize.X <= MarkerPosition.X || Info.dwSize.Y <= MarkerPosition.Y)
+    {
+        skip("Console screen buffer is too small for the alternate-screen test\n");
+        return;
+    }
+
+    Success = SetConsoleCursorPosition(Output, MarkerPosition);
+    ok(Success, "Unable to position the primary-screen marker, error %lu\n", GetLastError());
+    if (!Success)
+        return;
+    WRITE_VT(Output, "P");
+
+    Success = FlushConsoleInputBuffer(Input);
+    ok(Success, "FlushConsoleInputBuffer failed with error %lu\n", GetLastError());
+
+    WriteVt(Output, EditSetup, sizeof(EditSetup) - 1);
+
+    ok(ReadCell(Output, MarkerPosition.X, MarkerPosition.Y) == L' ',
+       "Primary-screen marker remained visible on the alternate screen\n");
+    ok(ReadCell(Output, 0, 0) == 0x2026,
+       "Expected the UTF-8 ellipsis at the alternate-screen origin\n");
+
+    RecordsRead = 0;
+    CharacterCount = ReadVtCharacters(ReadConsoleInputExW_,
+                                      Input,
+                                      Responses,
+                                      ARRAYSIZE(Responses),
+                                      &RecordsRead);
+    trace("Edit startup returned %lu input records\n", RecordsRead);
+    ok(CountOccurrences(Responses, CharacterCount, L"\x1b]4;") == 16,
+       "Expected 16 OSC 4 palette replies\n");
+    ok(Contains(Responses, CharacterCount, L"\x1b]10;rgb:"),
+       "Missing OSC 10 foreground-colour reply\n");
+    ok(Contains(Responses, CharacterCount, L"\x1b]11;rgb:"),
+       "Missing OSC 11 background-colour reply\n");
+    ok(Contains(Responses, CharacterCount, L"\x1b[1;2R") ||
+       Contains(Responses, CharacterCount, L"\x1b[1;3R"),
+       "Missing cursor-position reply for the ambiguous-width probe\n");
+    ok(Contains(Responses, CharacterCount, L"\x1b[?1;0c"),
+       "Missing primary device-attributes reply\n");
+
+    WriteVt(Output, EditRestore, sizeof(EditRestore) - 1);
+    ok(ReadCell(Output, MarkerPosition.X, MarkerPosition.Y) == L'P',
+       "Primary-screen contents were not restored\n");
+
+    Success = GetConsoleScreenBufferInfo(Output, &Info);
+    ok(Success, "GetConsoleScreenBufferInfo failed with error %lu\n", GetLastError());
+    if (Success)
+    {
+        ok(Info.dwCursorPosition.X == MarkerPosition.X + 1 &&
+           Info.dwCursorPosition.Y == MarkerPosition.Y,
+           "Primary cursor restored to (%d, %d), expected (%d, %d)\n",
+           Info.dwCursorPosition.X,
+           Info.dwCursorPosition.Y,
+           MarkerPosition.X + 1,
+           MarkerPosition.Y);
+    }
+}
+
+static VOID
+TestEditRendering(HANDLE Output)
+{
+    CONSOLE_SCREEN_BUFFER_INFO Info;
+    CONSOLE_CURSOR_INFO DefaultCursor;
+    CONSOLE_CURSOR_INFO Cursor;
+    COORD Position;
+    WCHAR Character;
+    WORD Attribute;
+    BOOL Success;
+
+    if (!ClearScreen(Output, &Info))
+        return;
+    if (Info.dwSize.X < 8 || Info.dwSize.Y < 4)
+    {
+        skip("Console screen buffer is too small for the rendering tests\n");
+        return;
+    }
+
+    WRITE_VT(Output, "\x1b[3;");
+    ok(ReadCell(Output, 0, 0) == L' ',
+       "An incomplete CSI sequence was rendered as text\n");
+
+    WRITE_VT(Output, "5H");
+    WRITE_VT(Output, "Z");
+    ok(ReadCell(Output, 4, 2) == L'Z',
+       "Split CUP sequence did not place text at column 5, row 3\n");
+
+    Success = GetConsoleScreenBufferInfo(Output, &Info);
+    ok(Success, "GetConsoleScreenBufferInfo failed with error %lu\n", GetLastError());
+    if (Success)
+    {
+        ok(Info.dwCursorPosition.X == 5 && Info.dwCursorPosition.Y == 2,
+           "Cursor is at (%d, %d), expected (5, 2)\n",
+           Info.dwCursorPosition.X, Info.dwCursorPosition.Y);
+    }
+
+    WRITE_VT(Output,
+             "\x1b[m\x1b[2;3H"
+             "\x1b[38;2;17;34;51m\x1b[48;2;68;85;102m"
+             "\x1b[3m\x1b[4mE"
+             "\x1b[23m\x1b[24m\x1b[39m\x1b[49mF");
+    ok(ReadCell(Output, 2, 1) == L'E',
+       "True-colour SGR sequence did not render its text at column 3, row 2\n");
+    Attribute = ReadCellAttribute(Output, 2, 1);
+    ok((Attribute & COMMON_LVB_UNDERSCORE) != 0,
+       "SGR 4 did not apply the underline attribute\n");
+    ok(ReadCell(Output, 3, 1) == L'F',
+       "SGR reset sequence did not render the following character\n");
+    Attribute = ReadCellAttribute(Output, 3, 1);
+    ok((Attribute & COMMON_LVB_UNDERSCORE) == 0,
+       "SGR 24 did not clear the underline attribute\n");
+
+    Success = GetConsoleCursorInfo(Output, &DefaultCursor);
+    ok(Success, "GetConsoleCursorInfo failed with error %lu\n", GetLastError());
+    if (Success)
+    {
+        WRITE_VT(Output, "\x1b[1 q");
+        Success = GetConsoleCursorInfo(Output, &Cursor);
+        ok(Success, "GetConsoleCursorInfo failed with error %lu\n", GetLastError());
+        if (Success)
+            ok(Cursor.dwSize == 100, "Block cursor size is %lu, expected 100\n", Cursor.dwSize);
+
+        WRITE_VT(Output, "\x1b[5 q");
+        Success = GetConsoleCursorInfo(Output, &Cursor);
+        ok(Success, "GetConsoleCursorInfo failed with error %lu\n", GetLastError());
+        if (Success)
+            ok(Cursor.dwSize == 25, "Bar cursor size is %lu, expected 25\n", Cursor.dwSize);
+
+        WRITE_VT(Output, "\x1b[?25l");
+        Success = GetConsoleCursorInfo(Output, &Cursor);
+        ok(Success, "GetConsoleCursorInfo failed with error %lu\n", GetLastError());
+        if (Success)
+            ok(!Cursor.bVisible, "DECTCEM did not hide the cursor\n");
+
+        WRITE_VT(Output, "\x1b[0 q\x1b[?25h");
+        Success = GetConsoleCursorInfo(Output, &Cursor);
+        ok(Success, "GetConsoleCursorInfo failed with error %lu\n", GetLastError());
+        if (Success)
+        {
+            ok(Cursor.dwSize == DefaultCursor.dwSize,
+               "Default cursor size is %lu, expected %lu\n",
+               Cursor.dwSize, DefaultCursor.dwSize);
+            ok(Cursor.bVisible, "DECTCEM did not show the cursor\n");
+        }
+    }
+
+    if (!ClearScreen(Output, &Info))
+        return;
+
+    Position.X = Info.dwSize.X - 1;
+    Position.Y = 1;
+    Success = SetConsoleCursorPosition(Output, Position);
+    ok(Success, "SetConsoleCursorPosition failed with error %lu\n", GetLastError());
+    if (!Success)
+        return;
+
+    WRITE_VT(Output, "A");
+    Success = GetConsoleScreenBufferInfo(Output, &Info);
+    ok(Success, "GetConsoleScreenBufferInfo failed with error %lu\n", GetLastError());
+    if (Success)
+    {
+        ok(Info.dwCursorPosition.X == Position.X &&
+           Info.dwCursorPosition.Y == Position.Y,
+           "Delayed wrap moved the cursor to (%d, %d)\n",
+           Info.dwCursorPosition.X, Info.dwCursorPosition.Y);
+    }
+
+    WRITE_VT(Output, "B");
+    Success = GetConsoleScreenBufferInfo(Output, &Info);
+    ok(Success, "GetConsoleScreenBufferInfo failed with error %lu\n", GetLastError());
+    if (Success)
+    {
+        ok(Info.dwCursorPosition.X == 1 &&
+           Info.dwCursorPosition.Y == Position.Y + 1,
+           "Delayed wrap continued at (%d, %d), expected (1, %d)\n",
+           Info.dwCursorPosition.X,
+           Info.dwCursorPosition.Y,
+           Position.Y + 1);
+    }
+
+    Character = ReadCell(Output, Position.X, Position.Y);
+    ok(Character == L'A', "Last-column character is %#x, expected 'A'\n", Character);
+    Character = ReadCell(Output, 0, Position.Y + 1);
+    ok(Character == L'B', "Wrapped character is %#x, expected 'B'\n", Character);
+}
+
+static BOOL
+SendConsoleMessage(HWND Window,
+                   UINT Message,
+                   WPARAM WParam,
+                   LPARAM LParam)
+{
+    DWORD_PTR Result = 0;
+    BOOL Success;
+
+    SetLastError(0xdeadbeef);
+    Success = SendMessageTimeoutW(Window,
+                                  Message,
+                                  WParam,
+                                  LParam,
+                                  SMTO_ABORTIFHUNG,
+                                  2000,
+                                  &Result) != 0;
+    ok(Success, "SendMessageTimeoutW(%#x) failed with error %lu\n",
+       Message, GetLastError());
+    return Success;
+}
+
+static VOID
+TestEditFrontendInput(HANDLE Input,
+                      HANDLE Output,
+                      PREAD_CONSOLE_INPUT_EX_W ReadConsoleInputExW_)
+{
+    WCHAR Characters[128];
+    HWND Window;
+    UINT ScanCode;
+    LPARAM KeyDown;
+    LPARAM KeyUp;
+    RECT Client;
+    LPARAM MousePosition;
+    DWORD CharacterCount;
+    BOOL Success;
+
+    Window = GetConsoleWindow();
+    if (Window == NULL || !IsWindow(Window))
+    {
+        skip("No GUI console window is available for frontend input tests\n");
+        return;
+    }
+
+    WRITE_VT(Output, "\x1b[?1002;1006;2004h\x1b[?1036h");
+
+    Success = FlushConsoleInputBuffer(Input);
+    ok(Success, "FlushConsoleInputBuffer failed with error %lu\n", GetLastError());
+
+    ScanCode = MapVirtualKeyW(VK_UP, MAPVK_VK_TO_VSC);
+    KeyDown = 1 | ((LPARAM)ScanCode << 16) | ((LPARAM)1 << 24);
+    KeyUp = KeyDown | ((LPARAM)1 << 30) | ((LPARAM)1 << 31);
+
+    if (SendConsoleMessage(Window, WM_KEYDOWN, VK_UP, KeyDown) &&
+        SendConsoleMessage(Window, WM_KEYUP, VK_UP, KeyUp))
+    {
+        CharacterCount = ReadVtCharacters(ReadConsoleInputExW_,
+                                          Input,
+                                          Characters,
+                                          ARRAYSIZE(Characters),
+                                          NULL);
+        ok(CharacterCount == 3,
+           "Up arrow produced %lu VT characters, expected 3\n", CharacterCount);
+        ok(CharacterCount >= 3 &&
+           Characters[0] == L'\x1b' &&
+           Characters[1] == L'[' &&
+           Characters[2] == L'A',
+           "Up arrow did not produce CSI A\n");
+    }
+
+    Success = FlushConsoleInputBuffer(Input);
+    ok(Success, "FlushConsoleInputBuffer failed with error %lu\n", GetLastError());
+
+    Success = GetClientRect(Window, &Client);
+    ok(Success, "GetClientRect failed with error %lu\n", GetLastError());
+    if (Success && Client.right > 2 && Client.bottom > 2)
+    {
+        MousePosition = MAKELPARAM(Client.right / 2, Client.bottom / 2);
+        if (SendConsoleMessage(Window, WM_LBUTTONDOWN, MK_LBUTTON, MousePosition) &&
+            SendConsoleMessage(Window, WM_LBUTTONUP, 0, MousePosition))
+        {
+            CharacterCount = ReadVtCharacters(ReadConsoleInputExW_,
+                                              Input,
+                                              Characters,
+                                              ARRAYSIZE(Characters),
+                                              NULL);
+            ok(CountOccurrences(Characters, CharacterCount, L"\x1b[<0;") == 2,
+               "Mouse press/release did not produce two SGR mouse sequences\n");
+            ok(CharacterCount != 0 && Characters[CharacterCount - 1] == L'm',
+               "Mouse release did not end in the SGR release marker\n");
+        }
+    }
+
+    WRITE_VT(Output, "\x1b[?1002;1006;2004l");
+    FlushConsoleInputBuffer(Input);
+}
+
+START_TEST(ConsoleVirtualTerminal)
+{
+    PREAD_CONSOLE_INPUT_EX_W ReadConsoleInputExW_;
+    CONSOLE_SCREEN_BUFFER_INFOEX InfoEx;
+    HANDLE OriginalOutput = INVALID_HANDLE_VALUE;
+    HANDLE Input = INVALID_HANDLE_VALUE;
+    HANDLE Output = INVALID_HANDLE_VALUE;
+    DWORD OriginalInputMode = 0;
+    DWORD OriginalOutputMode = 0;
+    DWORD Mode;
+    DWORD Error;
+    UINT OriginalInputCodePage = 0;
+    UINT OriginalOutputCodePage = 0;
+    WCHAR OriginalTitle[256];
+    BOOL HaveInputMode = FALSE;
+    BOOL HaveTitle = FALSE;
+    BOOL AllocatedConsole = FALSE;
+    BOOL TestBufferActive = FALSE;
+    BOOL RunningOnReactOS;
+    BOOL NativeNt63;
+    BOOL Success;
+    ULONG NtVersion;
+
+    NtVersion = GetNTVersion();
+    RunningOnReactOS = is_reactos();
+    NativeNt63 = !RunningOnReactOS && NtVersion == _WIN32_WINNT_WINBLUE;
+    trace("Running Edit VT tests on NT %lu.%lu\n", NtVersion >> 8, NtVersion & 0xff);
+    /* ReactOS exposes this VT path independently of its reported NT version. */
+    if (!RunningOnReactOS && NtVersion < _WIN32_WINNT_WINBLUE)
+    {
+        skip("The Edit VT baseline requires native NT 6.3 or newer\n");
+        return;
+    }
+
+    ReadConsoleInputExW_ = (PREAD_CONSOLE_INPUT_EX_W)GetProcAddress(
+        GetModuleHandleW(L"kernel32.dll"), "ReadConsoleInputExW");
+    ok(ReadConsoleInputExW_ != NULL, "ReadConsoleInputExW is not exported\n");
+
+    OriginalOutput = CreateFileW(L"CONOUT$",
+                                 GENERIC_READ | GENERIC_WRITE,
+                                 FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                 NULL,
+                                 OPEN_EXISTING,
+                                 0,
+                                 NULL);
+    if (OriginalOutput == INVALID_HANDLE_VALUE && AllocConsole())
+    {
+        AllocatedConsole = TRUE;
+        OriginalOutput = CreateFileW(L"CONOUT$",
+                                     GENERIC_READ | GENERIC_WRITE,
+                                     FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                     NULL,
+                                     OPEN_EXISTING,
+                                     0,
+                                     NULL);
+    }
+    ok(OriginalOutput != INVALID_HANDLE_VALUE,
+       "Opening CONOUT$ failed with error %lu\n", GetLastError());
+    if (OriginalOutput == INVALID_HANDLE_VALUE)
+        goto Cleanup;
+
+    Input = CreateFileW(L"CONIN$",
+                        GENERIC_READ | GENERIC_WRITE,
+                        FILE_SHARE_READ | FILE_SHARE_WRITE,
+                        NULL,
+                        OPEN_EXISTING,
+                        0,
+                        NULL);
+    ok(Input != INVALID_HANDLE_VALUE,
+       "Opening CONIN$ failed with error %lu\n", GetLastError());
+    if (Input == INVALID_HANDLE_VALUE)
+        goto Cleanup;
+
+    Output = CreateConsoleScreenBuffer(GENERIC_READ | GENERIC_WRITE,
+                                       FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                       NULL,
+                                       CONSOLE_TEXTMODE_BUFFER,
+                                       NULL);
+    ok(Output != INVALID_HANDLE_VALUE,
+       "CreateConsoleScreenBuffer failed with error %lu\n", GetLastError());
+    if (Output == INVALID_HANDLE_VALUE)
+        goto Cleanup;
+
+    Success = GetConsoleMode(Input, &OriginalInputMode);
+    ok(Success, "GetConsoleMode(CONIN$) failed with error %lu\n", GetLastError());
+    if (!Success)
+        goto Cleanup;
+    HaveInputMode = TRUE;
+
+    OriginalInputCodePage = GetConsoleCP();
+    OriginalOutputCodePage = GetConsoleOutputCP();
+    OriginalTitle[0] = UNICODE_NULL;
+    GetConsoleTitleW(OriginalTitle, ARRAYSIZE(OriginalTitle));
+    HaveTitle = TRUE;
+
+    Success = SetConsoleActiveScreenBuffer(Output);
+    ok(Success, "SetConsoleActiveScreenBuffer failed with error %lu\n", GetLastError());
+    if (!Success)
+        goto Cleanup;
+    TestBufferActive = TRUE;
+
+    Success = SetConsoleCP(CP_UTF8);
+    ok(Success, "SetConsoleCP(CP_UTF8) failed with error %lu\n", GetLastError());
+    Success = SetConsoleOutputCP(CP_UTF8);
+    ok(Success, "SetConsoleOutputCP(CP_UTF8) failed with error %lu\n", GetLastError());
+
+    Success = GetConsoleMode(Output, &OriginalOutputMode);
+    ok(Success, "GetConsoleMode(CONOUT$) failed with error %lu\n", GetLastError());
+    if (!Success)
+        goto Cleanup;
+
+    SetLastError(0xdeadbeef);
+    Success = SetConsoleMode(Input, EDIT_INPUT_MODE);
+    Error = GetLastError();
+    if (NativeNt63)
+    {
+        ok(!Success, "SetConsoleMode(Edit input mode) unexpectedly succeeded\n");
+        ok(Error == ERROR_INVALID_PARAMETER,
+           "SetConsoleMode(Edit input mode) failed with error %lu, expected %lu\n",
+           Error, (DWORD)ERROR_INVALID_PARAMETER);
+    }
+    else
+    {
+        ok(Success, "SetConsoleMode(Edit input mode) failed with error %lu\n", Error);
+    }
+    Success = GetConsoleMode(Input, &Mode);
+    ok(Success, "GetConsoleMode(CONIN$) failed with error %lu\n", GetLastError());
+    if (Success)
+    {
+        if (NativeNt63)
+        {
+            ok(Mode == OriginalInputMode,
+               "Rejected Edit input mode changed the mode from %#lx to %#lx\n",
+               OriginalInputMode, Mode);
+        }
+        else
+        {
+            /*
+             * ENABLE_EXTENDED_FLAGS controls the Quick Edit setting passed to
+             * SetConsoleMode; it is not an independent input behavior. Console
+             * hosts may omit it when both Quick Edit and Insert mode are disabled.
+             */
+            ok((Mode & ~ENABLE_EXTENDED_FLAGS) == (EDIT_INPUT_MODE & ~ENABLE_EXTENDED_FLAGS),
+               "Input mode is %#lx, expected Edit's operational mode %#lx\n",
+               Mode,
+               (DWORD)(EDIT_INPUT_MODE & ~ENABLE_EXTENDED_FLAGS));
+        }
+    }
+
+    SetLastError(0xdeadbeef);
+    Success = SetConsoleMode(Output, EDIT_OUTPUT_MODE);
+    Error = GetLastError();
+    if (NativeNt63)
+    {
+        ok(!Success, "SetConsoleMode(Edit output mode) unexpectedly succeeded\n");
+        ok(Error == ERROR_INVALID_PARAMETER,
+           "SetConsoleMode(Edit output mode) failed with error %lu, expected %lu\n",
+           Error, (DWORD)ERROR_INVALID_PARAMETER);
+    }
+    else
+    {
+        ok(Success, "SetConsoleMode(Edit output mode) failed with error %lu\n", Error);
+    }
+    Success = GetConsoleMode(Output, &Mode);
+    ok(Success, "GetConsoleMode(CONOUT$) failed with error %lu\n", GetLastError());
+    if (Success)
+    {
+        if (NativeNt63)
+            ok(Mode == OriginalOutputMode,
+               "Rejected Edit output mode changed the mode from %#lx to %#lx\n",
+               OriginalOutputMode, Mode);
+        else
+            ok(Mode == EDIT_OUTPUT_MODE, "Output mode is %#lx, expected %#lx\n", Mode, (DWORD)EDIT_OUTPUT_MODE);
+    }
+
+    ZeroMemory(&InfoEx, sizeof(InfoEx));
+    InfoEx.cbSize = sizeof(InfoEx);
+    Success = GetConsoleScreenBufferInfoEx(Output, &InfoEx);
+    ok(Success, "GetConsoleScreenBufferInfoEx failed with error %lu\n", GetLastError());
+    if (Success)
+    {
+        ok(InfoEx.dwSize.X > 0 && InfoEx.dwSize.Y > 0,
+           "Invalid screen-buffer size %dx%d\n", InfoEx.dwSize.X, InfoEx.dwSize.Y);
+        ok(InfoEx.srWindow.Right >= InfoEx.srWindow.Left &&
+           InfoEx.srWindow.Bottom >= InfoEx.srWindow.Top,
+           "Invalid console window (%d,%d)-(%d,%d)\n",
+           InfoEx.srWindow.Left,
+           InfoEx.srWindow.Top,
+           InfoEx.srWindow.Right,
+           InfoEx.srWindow.Bottom);
+    }
+
+    if (ReadConsoleInputExW_ != NULL)
+    {
+        Success = FlushConsoleInputBuffer(Input);
+        ok(Success, "FlushConsoleInputBuffer failed with error %lu\n", GetLastError());
+        if (Success)
+        {
+            WCHAR Empty[1];
+            DWORD RecordsRead = 0;
+            DWORD CharacterCount;
+
+            CharacterCount = ReadVtCharacters(ReadConsoleInputExW_,
+                                              Input,
+                                              Empty,
+                                              ARRAYSIZE(Empty),
+                                              &RecordsRead);
+            ok(RecordsRead == 0, "Empty nonblocking read returned %lu records\n", RecordsRead);
+            ok(CharacterCount == 0, "Empty nonblocking read returned %lu characters\n",
+               CharacterCount);
+        }
+
+        if (!NativeNt63)
+            TestEditStartup(Input, Output, ReadConsoleInputExW_);
+    }
+    else
+    {
+        skip("ReadConsoleInputExW is unavailable; skipping Edit startup replies\n");
+    }
+    if (NativeNt63)
+    {
+        skip("Native NT 6.3 does not support VT processing; skipping Edit VT parser tests\n");
+    }
+    else
+    {
+        TestEditRendering(Output);
+        if (ReadConsoleInputExW_ != NULL)
+            TestEditFrontendInput(Input, Output, ReadConsoleInputExW_);
+    }
+
+Cleanup:
+    if (!NativeNt63 && Output != INVALID_HANDLE_VALUE)
+        WRITE_VT(Output, "\x1b[?1002;1006;2004l\x1b[?1049l\x1b[0 q\x1b[?25h");
+
+    if (TestBufferActive && OriginalOutput != INVALID_HANDLE_VALUE)
+    {
+        Success = SetConsoleActiveScreenBuffer(OriginalOutput);
+        ok(Success, "Restoring the original screen buffer failed with error %lu\n",
+           GetLastError());
+    }
+
+    if (HaveInputMode)
+        SetConsoleMode(Input, OriginalInputMode);
+    if (Input != INVALID_HANDLE_VALUE)
+        FlushConsoleInputBuffer(Input);
+
+    if (OriginalInputCodePage != 0)
+        SetConsoleCP(OriginalInputCodePage);
+    if (OriginalOutputCodePage != 0)
+        SetConsoleOutputCP(OriginalOutputCodePage);
+    if (HaveTitle)
+        SetConsoleTitleW(OriginalTitle);
+
+    if (Output != INVALID_HANDLE_VALUE)
+        CloseHandle(Output);
+    if (Input != INVALID_HANDLE_VALUE)
+        CloseHandle(Input);
+    if (OriginalOutput != INVALID_HANDLE_VALUE)
+        CloseHandle(OriginalOutput);
+    if (AllocatedConsole)
+        FreeConsole();
+}

--- a/modules/rostests/apitests/kernel32/testlist.c
+++ b/modules/rostests/apitests/kernel32/testlist.c
@@ -4,6 +4,7 @@
 
 extern void func_ActCtxWithXmlNamespaces(void);
 extern void func_ConsoleCP(void);
+extern void func_ConsoleVirtualTerminal(void);
 extern void func_CreateProcess(void);
 extern void func_DefaultActCtx(void);
 extern void func_DeviceIoControl(void);
@@ -50,6 +51,7 @@ const struct test winetest_testlist[] =
 {
     { "ActCtxWithXmlNamespaces",     func_ActCtxWithXmlNamespaces },
     { "ConsoleCP",                   func_ConsoleCP },
+    { "ConsoleVirtualTerminal",      func_ConsoleVirtualTerminal },
     { "CreateProcess",               func_CreateProcess },
     { "DefaultActCtx",               func_DefaultActCtx },
     { "DeviceIoControl",             func_DeviceIoControl },

--- a/sdk/include/reactos/subsys/win/conmsg.h
+++ b/sdk/include/reactos/subsys/win/conmsg.h
@@ -110,6 +110,8 @@ typedef enum _CONSRV_API_NUMBER
     // ConsolepSetCurrentFont,                 // Added in Vista+
     // ConsolepSetScreenBufferInfo,            // Added in Vista+
     // ConsolepClientConnect,                  // Added in Win7
+    ConsolepGetScreenBufferInfoEx,          // Added in Vista+
+    ConsolepSetScreenBufferInfoEx,          // Added in Vista+
 
     ConsolepMaxApiNumber
 } CONSRV_API_NUMBER, *PCONSRV_API_NUMBER;
@@ -316,6 +318,21 @@ typedef struct _CONSOLE_GETSCREENBUFFERINFO
     COORD  ViewSize;
     COORD  MaximumViewSize;
 } CONSOLE_GETSCREENBUFFERINFO, *PCONSOLE_GETSCREENBUFFERINFO;
+
+typedef struct _CONSOLE_GETSCREENBUFFERINFOEX
+{
+    HANDLE ConsoleHandle;
+    HANDLE OutputHandle;
+    COORD  ScreenBufferSize;
+    COORD  CursorPosition;
+    COORD  ViewOrigin;
+    WORD   Attributes;
+    COORD  ViewSize;
+    COORD  MaximumViewSize;
+    WORD   PopupAttributes;
+    BOOL   FullscreenSupported;
+    COLORREF ColorTable[16];
+} CONSOLE_GETSCREENBUFFERINFOEX, *PCONSOLE_GETSCREENBUFFERINFOEX;
 
 typedef struct _CONSOLE_SETCURSORPOSITION
 {
@@ -949,6 +966,7 @@ typedef struct _CONSOLE_API_MESSAGE
         CONSOLE_CREATESCREENBUFFER CreateScreenBufferRequest;
         CONSOLE_SETACTIVESCREENBUFFER SetScreenBufferRequest;
         CONSOLE_GETSCREENBUFFERINFO ScreenBufferInfoRequest;
+        CONSOLE_GETSCREENBUFFERINFOEX ScreenBufferInfoExRequest;
         CONSOLE_SETSCREENBUFFERSIZE SetScreenBufferSizeRequest;
         CONSOLE_SCROLLSCREENBUFFER ScrollScreenBufferRequest;
 

--- a/win32ss/user/winsrv/consrv.cmake
+++ b/win32ss/user/winsrv/consrv.cmake
@@ -26,6 +26,7 @@ list(APPEND CONSRV_SOURCE
     consrv/condrv/dummyterm.c
     consrv/condrv/graphics.c
     consrv/condrv/text.c
+    consrv/condrv/vt.c
     consrv/frontends/input.c
     consrv/frontends/terminal.c
     consrv/frontends/wcwidth.c

--- a/win32ss/user/winsrv/consrv/api.h
+++ b/win32ss/user/winsrv/consrv/api.h
@@ -116,6 +116,8 @@ CSR_API(SrvSetConsoleCursorPosition);
 CSR_API(SrvSetConsoleTextAttribute);
 CSR_API(SrvCreateConsoleScreenBuffer);
 CSR_API(SrvGetConsoleScreenBufferInfo);
+CSR_API(SrvGetConsoleScreenBufferInfoEx);
+CSR_API(SrvSetConsoleScreenBufferInfoEx);
 CSR_API(SrvSetConsoleActiveScreenBuffer);
 CSR_API(SrvSetConsoleScreenBufferSize);
 CSR_API(SrvScrollConsoleScreenBuffer);

--- a/win32ss/user/winsrv/consrv/condrv/conoutput.c
+++ b/win32ss/user/winsrv/consrv/condrv/conoutput.c
@@ -10,6 +10,7 @@
 /* INCLUDES *******************************************************************/
 
 #include <consrv.h>
+#include "../include/vt.h"
 
 #define NDEBUG
 #include <debug.h>
@@ -336,6 +337,7 @@ ConDrvSetConsoleCursorPosition(IN PCONSOLE Console,
     OldCursorX = Buffer->CursorPosition.X;
     OldCursorY = Buffer->CursorPosition.Y;
     Buffer->CursorPosition = *Position;
+    Buffer->VtState.PrivateModes &= ~VT_PRIVMODE_DELAYED_EOL_WRAP;
 
     if ( ((PCONSOLE_SCREEN_BUFFER)Buffer == Console->ActiveBuffer) &&
          (!TermSetScreenInfo(Console, (PCONSOLE_SCREEN_BUFFER)Buffer, OldCursorX, OldCursorY)) )

--- a/win32ss/user/winsrv/consrv/condrv/conoutput.c
+++ b/win32ss/user/winsrv/consrv/condrv/conoutput.c
@@ -224,6 +224,103 @@ ConDrvInvalidateBitMapRect(IN PCONSOLE Console,
 }
 
 NTSTATUS NTAPI
+ConDrvSetConsoleScreenBufferSize(IN PCONSOLE Console, IN PTEXTMODE_SCREEN_BUFFER Buffer, IN PCOORD Size);
+NTSTATUS NTAPI
+ConDrvSetConsoleWindowInfo(IN PCONSOLE Console, IN PTEXTMODE_SCREEN_BUFFER Buffer, IN BOOLEAN Absolute, IN PSMALL_RECT WindowRect);
+NTSTATUS NTAPI
+ConDrvChangeScreenBufferAttributes(IN PCONSOLE Console, IN PTEXTMODE_SCREEN_BUFFER Buffer, IN USHORT NewScreenAttrib, IN USHORT NewPopupAttrib);
+VOID NTAPI
+ConDrvVtRefreshPalette(IN PCONSOLE Console);
+NTSTATUS NTAPI
+ConDrvSetConsoleCursorPosition(IN PCONSOLE Console, IN PTEXTMODE_SCREEN_BUFFER Buffer, IN PCOORD Position);
+
+/*
+ * Apply a whole CONSOLE_SCREEN_BUFFER_INFOEX in one go.
+ *
+ * Everything is validated before anything is applied, so a rejected request
+ * leaves the buffer exactly as it was. The buffer/window ordering rule lives
+ * here rather than in the server: when the backing buffer shrinks, the window
+ * has to be made to fit first, otherwise the resize is rejected for overlapping
+ * a window that is about to move anyway.
+ */
+NTSTATUS NTAPI
+ConDrvSetScreenBufferInfoEx(IN PCONSOLE Console, IN PTEXTMODE_SCREEN_BUFFER Buffer, IN PCOORD ScreenBufferSize, IN PCOORD CursorPosition, IN PSMALL_RECT WindowRect, IN USHORT Attributes, IN USHORT PopupAttributes, IN const COLORREF *ColorTable, IN ULONG ColorCount)
+{
+    NTSTATUS Status;
+    COORD ViewSize;
+    BOOLEAN WindowMoved;
+
+    if (Console == NULL || Buffer == NULL || ScreenBufferSize == NULL ||
+        CursorPosition == NULL || WindowRect == NULL)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    ASSERT(Console == Buffer->Header.Console);
+
+    ViewSize.X = WindowRect->Right - WindowRect->Left + 1;
+    ViewSize.Y = WindowRect->Bottom - WindowRect->Top + 1;
+
+    /* Validate everything up front */
+    if (ScreenBufferSize->X <= 0 || ScreenBufferSize->Y <= 0 ||
+        ViewSize.X <= 0 || ViewSize.Y <= 0 ||
+        ViewSize.X > ScreenBufferSize->X || ViewSize.Y > ScreenBufferSize->Y ||
+        WindowRect->Left < 0 || WindowRect->Top < 0 ||
+        WindowRect->Right >= ScreenBufferSize->X ||
+        WindowRect->Bottom >= ScreenBufferSize->Y ||
+        CursorPosition->X < 0 || CursorPosition->Y < 0 ||
+        CursorPosition->X >= ScreenBufferSize->X ||
+        CursorPosition->Y >= ScreenBufferSize->Y)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    /* The colour table is server-layer state, reached through the TERMINAL vtable */
+    if (ColorTable != NULL && ColorCount != 0 && ColorCount != CONSOLE_COLOR_TABLE_SIZE)
+        return STATUS_INVALID_PARAMETER;
+
+    /* Shrinking: the window must fit the new size before the buffer changes */
+    WindowMoved = FALSE;
+    if (ScreenBufferSize->X < Buffer->ViewSize.X || ScreenBufferSize->Y < Buffer->ViewSize.Y)
+    {
+        Status = ConDrvSetConsoleWindowInfo(Console, Buffer, TRUE, WindowRect);
+        if (!NT_SUCCESS(Status)) return Status;
+        WindowMoved = TRUE;
+    }
+
+    if (Buffer->ScreenBufferSize.X != ScreenBufferSize->X ||
+        Buffer->ScreenBufferSize.Y != ScreenBufferSize->Y)
+    {
+        Status = ConDrvSetConsoleScreenBufferSize(Console, Buffer, ScreenBufferSize);
+        if (!NT_SUCCESS(Status)) return Status;
+    }
+
+    if (!WindowMoved)
+    {
+        Status = ConDrvSetConsoleWindowInfo(Console, Buffer, TRUE, WindowRect);
+        if (!NT_SUCCESS(Status)) return Status;
+    }
+
+    Status = ConDrvSetConsoleCursorPosition(Console, Buffer, CursorPosition);
+    if (!NT_SUCCESS(Status)) return Status;
+
+    if (Buffer->ScreenDefaultAttrib != Attributes ||
+        Buffer->PopupDefaultAttrib != PopupAttributes)
+    {
+        Status = ConDrvChangeScreenBufferAttributes(Console, Buffer, Attributes, PopupAttributes);
+        if (!NT_SUCCESS(Status)) return Status;
+    }
+
+    if (ColorTable != NULL && ColorCount != 0)
+    {
+        if (TermSetColorTable(Console, ColorTable, ColorCount))
+            ConDrvVtRefreshPalette(Console);
+    }
+
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS NTAPI
 ConDrvSetConsolePalette(IN PCONSOLE Console,
                         // IN PGRAPHICS_SCREEN_BUFFER Buffer,
                         IN PCONSOLE_SCREEN_BUFFER Buffer,
@@ -316,9 +413,7 @@ ConDrvSetConsoleCursorInfo(IN PCONSOLE Console,
 }
 
 NTSTATUS NTAPI
-ConDrvSetConsoleCursorPosition(IN PCONSOLE Console,
-                               IN PTEXTMODE_SCREEN_BUFFER Buffer,
-                               IN PCOORD Position)
+ConDrvSetConsoleCursorPosition(IN PCONSOLE Console, IN PTEXTMODE_SCREEN_BUFFER Buffer, IN PCOORD Position)
 {
     SHORT OldCursorX, OldCursorY;
 

--- a/win32ss/user/winsrv/consrv/condrv/console.c
+++ b/win32ss/user/winsrv/consrv/condrv/console.c
@@ -14,6 +14,7 @@
 #include <consrv.h>
 #include <coninput.h>
 #include "../../concfg/font.h"
+#include "../include/vt.h"
 
 #define NDEBUG
 #include <debug.h>
@@ -145,6 +146,14 @@ ConDrvInitConsole(
     /* Make the new screen buffer active */
     Console->ActiveBuffer = NewBuffer;
     Console->ConsolePaused = FALSE;
+    /*
+     * Permissive by default. Reading the user's policy needs client
+     * impersonation, which only the server layer can do, so ConSrvInitConsole
+     * overrides these right after we return.
+     */
+    Console->AllowVtOscClipboard = TRUE;
+    Console->AllowVtOscHyperlinks = TRUE;
+    Console->AllowVtDcsPassthrough = TRUE;
 
     DPRINT("Console initialized\n");
 
@@ -358,10 +367,13 @@ ConDrvSetConsoleMode(IN PCONSOLE Console,
                      IN PCONSOLE_IO_OBJECT Object,
                      IN ULONG ConsoleMode)
 {
-#define CONSOLE_VALID_INPUT_MODES   ( ENABLE_PROCESSED_INPUT  | ENABLE_LINE_INPUT   | \
-                                      ENABLE_ECHO_INPUT       | ENABLE_WINDOW_INPUT | \
-                                      ENABLE_MOUSE_INPUT )
-#define CONSOLE_VALID_OUTPUT_MODES  ( ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT )
+#define CONSOLE_VALID_INPUT_MODES   ( ENABLE_PROCESSED_INPUT          | ENABLE_LINE_INPUT   | \
+                                      ENABLE_ECHO_INPUT               | ENABLE_WINDOW_INPUT | \
+                                      ENABLE_MOUSE_INPUT              | ENABLE_EXTENDED_FLAGS | \
+                                      ENABLE_VIRTUAL_TERMINAL_INPUT )
+#define CONSOLE_VALID_OUTPUT_MODES  ( ENABLE_PROCESSED_OUTPUT             | ENABLE_WRAP_AT_EOL_OUTPUT | \
+                                      ENABLE_VIRTUAL_TERMINAL_PROCESSING  | DISABLE_NEWLINE_AUTO_RETURN | \
+                                      ENABLE_LVB_GRID_WORLDWIDE )
 
     NTSTATUS Status = STATUS_SUCCESS;
 
@@ -396,7 +408,15 @@ ConDrvSetConsoleMode(IN PCONSOLE Console,
         }
         else
         {
+            ULONG OldMode = Buffer->Mode;
             Buffer->Mode = (ConsoleMode & CONSOLE_VALID_OUTPUT_MODES);
+
+            if ((OldMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) &&
+                !(Buffer->Mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) &&
+                GetType(Buffer) == TEXTMODE_BUFFER)
+            {
+                ConDrvVtInvalidateBufferRgb((PTEXTMODE_SCREEN_BUFFER)Buffer);
+            }
         }
     }
     else

--- a/win32ss/user/winsrv/consrv/condrv/dummyterm.c
+++ b/win32ss/user/winsrv/consrv/condrv/dummyterm.c
@@ -140,6 +140,47 @@ DummyShowMouseCursor(IN OUT PTERMINAL This,
     return 0;
 }
 
+static BOOL NTAPI
+DummySetTitle(IN OUT PTERMINAL This,
+              IN PCWSTR Title,
+              IN ULONG Length)
+{
+    return TRUE;
+}
+
+static BOOL NTAPI
+DummyGetColorTable(IN OUT PTERMINAL This,
+                   OUT COLORREF* Colors,
+                   IN ULONG Count)
+{
+    return FALSE;
+}
+
+static BOOL NTAPI
+DummySetColorTable(IN OUT PTERMINAL This,
+                   IN const COLORREF* Colors,
+                   IN ULONG Count)
+{
+    return FALSE;
+}
+
+/* No frontend attached, so there is no window station to reach the clipboard through */
+static BOOL NTAPI
+DummyGetClipboardText(IN OUT PTERMINAL This,
+                      OUT PWCHAR* Text,
+                      OUT PULONG Length)
+{
+    return FALSE;
+}
+
+static BOOL NTAPI
+DummySetClipboardText(IN OUT PTERMINAL This,
+                      IN PCWSTR Text,
+                      IN ULONG Length)
+{
+    return FALSE;
+}
+
 static TERMINAL_VTBL DummyVtbl =
 {
     DummyInitTerminal,
@@ -158,6 +199,11 @@ static TERMINAL_VTBL DummyVtbl =
     DummySetPalette,
     DummySetCodePage,
     DummyShowMouseCursor,
+    DummySetTitle,
+    DummyGetColorTable,
+    DummySetColorTable,
+    DummyGetClipboardText,
+    DummySetClipboardText,
 };
 
 VOID

--- a/win32ss/user/winsrv/consrv/condrv/dummyterm.c
+++ b/win32ss/user/winsrv/consrv/condrv/dummyterm.c
@@ -206,6 +206,16 @@ static TERMINAL_VTBL DummyVtbl =
     DummySetClipboardText,
 };
 
+/*
+ * The dummy terminal pends every operation, so callers that must not perform
+ * side effects before a possible STATUS_PENDING can test for it up front.
+ */
+BOOLEAN
+ConDrvIsTerminalAttached(IN PCONSOLE Console)
+{
+    return (Console != NULL && Console->TermIFace.Vtbl != &DummyVtbl);
+}
+
 VOID
 ResetTerminal(IN PCONSOLE Console)
 {

--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -10,6 +10,7 @@
 /* INCLUDES *******************************************************************/
 
 #include <consrv.h>
+#include "../include/vt.h"
 
 #define NDEBUG
 #include <debug.h>
@@ -88,6 +89,9 @@ TEXTMODE_BUFFER_Initialize(OUT PCONSOLE_SCREEN_BUFFER* Buffer,
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
+    /* The extended colour array stays NULL until a VT sequence needs it */
+    NewBuffer->CellRgb = NULL;
+
     NewBuffer->ScreenBufferSize = TextModeInfo->ScreenBufferSize;
     NewBuffer->OldScreenBufferSize = NewBuffer->ScreenBufferSize;
 
@@ -116,6 +120,8 @@ TEXTMODE_BUFFER_Initialize(OUT PCONSOLE_SCREEN_BUFFER* Buffer,
     }
     NewBuffer->CursorPosition.X = NewBuffer->CursorPosition.Y = 0;
 
+    ConDrvVtInitializeBuffer(NewBuffer);
+
     NewBuffer->Mode = ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT;
 
     *Buffer = (PCONSOLE_SCREEN_BUFFER)NewBuffer;
@@ -134,6 +140,9 @@ TEXTMODE_BUFFER_Destroy(IN OUT PCONSOLE_SCREEN_BUFFER Buffer)
     Buffer->Header.Type = SCREEN_BUFFER;
 
     ConsoleFreeHeap(Buff->Buffer);
+    if (Buff->CellRgb) ConsoleFreeHeap(Buff->CellRgb);
+    if (Buff->VtState.HyperlinkUri.Buffer)
+        ConsoleFreeHeap(Buff->VtState.HyperlinkUri.Buffer);
 
     CONSOLE_SCREEN_BUFFER_Destroy(Buffer);
 }
@@ -142,9 +151,27 @@ TEXTMODE_BUFFER_Destroy(IN OUT PCONSOLE_SCREEN_BUFFER Buffer)
 PCHAR_INFO
 ConioCoordToPointer(PTEXTMODE_SCREEN_BUFFER Buff, ULONG X, ULONG Y)
 {
-    ASSERT(X < Buff->ScreenBufferSize.X);
-    ASSERT(Y < Buff->ScreenBufferSize.Y);
-    return &Buff->Buffer[((Y + Buff->VirtualY) % Buff->ScreenBufferSize.Y) * Buff->ScreenBufferSize.X + X];
+    /* The addressing formula and its bounds checks live in ConioCoordToIndex,
+     * so the character plane and the colour planes cannot drift apart */
+    return &Buff->Buffer[ConioCoordToIndex(Buff, X, Y)];
+}
+
+BOOLEAN
+ConioEnsureCellColors(PTEXTMODE_SCREEN_BUFFER Buff)
+{
+    SIZE_T Size;
+
+    if (Buff->CellRgb) return TRUE;
+
+    Size = (SIZE_T)Buff->ScreenBufferSize.X * Buff->ScreenBufferSize.Y * sizeof(CELL_RGB);
+    if (Size == 0) return FALSE;
+
+    Buff->CellRgb = ConsoleAllocHeap(0, Size);
+    if (!Buff->CellRgb) return FALSE;
+
+    /* CLR_INVALID is all-ones: every cell starts with no extended colour */
+    RtlFillMemory(Buff->CellRgb, Size, 0xFF);
+    return TRUE;
 }
 
 /*static*/ VOID
@@ -159,6 +186,7 @@ ClearLineBuffer(PTEXTMODE_SCREEN_BUFFER Buff)
         Ptr->Char.UnicodeChar = L' ';
         Ptr->Attributes = Buff->ScreenDefaultAttrib;
     }
+    ConioFillCellColors(Buff, 0, Buff->CursorPosition.Y, Buff->ScreenBufferSize.X, CLR_INVALID, CLR_INVALID);
 }
 
 static VOID
@@ -276,12 +304,14 @@ ConioCopyRegion(
         for (j = 0; j < Width; ++j, SX += XDelta, DX += XDelta)
         {
             *PtrDst = *PtrSrc;
+            ConioSetCellColors(ScreenBuffer, DX, DY, ConioGetCellFgColor(ScreenBuffer, SX, SY), ConioGetCellBgColor(ScreenBuffer, SX, SY));
             PtrSrc += XDelta;
             PtrDst += XDelta;
         }
 #else
         /* RtlMoveMemory() takes into account for the direction of the copy */
         RtlMoveMemory(PtrDst, PtrSrc, Width * sizeof(CHAR_INFO));
+        ConioMoveCellColors(ScreenBuffer, DstOrigin->X, DY, SrcRegion->Left, SY, Width);
 #endif
     }
 }
@@ -325,6 +355,8 @@ ConioFillRegion(
     /* Loop through the destination region */
     for (Y = Region->Top; Y <= Region->Bottom; ++Y)
     {
+        SHORT RunStart = -1;
+
         Ptr = ConioCoordToPointer(ScreenBuffer, Region->Left, Y);
         for (X = Region->Left; X <= Region->Right; ++X)
         {
@@ -337,10 +369,20 @@ ConioFillRegion(
                 /* We are outside the excluded region, fill the destination */
                 *Ptr = FillChar;
                 // Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
+                if (RunStart < 0) RunStart = X;
+            }
+            else if (RunStart >= 0)
+            {
+                /* The excluded region interrupts the run: flush the colours so far */
+                ConioFillCellColors(ScreenBuffer, RunStart, Y, X - RunStart, CLR_INVALID, CLR_INVALID);
+                RunStart = -1;
             }
 
             ++Ptr;
         }
+
+        if (RunStart >= 0)
+            ConioFillCellColors(ScreenBuffer, RunStart, Y, Region->Right + 1 - RunStart, CLR_INVALID, CLR_INVALID);
     }
 }
 
@@ -366,6 +408,8 @@ ConioResizeBuffer(PCONSOLE Console,
     WORD CurrentAttribute;
     USHORT CurrentY;
     PCHAR_INFO OldBuffer;
+    PCELL_RGB NewCellRgb;
+    PCELL_RGB OldCellRgb;
     DWORD i;
     DWORD diff;
 
@@ -397,9 +441,26 @@ ConioResizeBuffer(PCONSOLE Console,
     Buffer = ConsoleAllocHeap(HEAP_ZERO_MEMORY, Size.X * Size.Y * sizeof(CHAR_INFO));
     if (!Buffer) return STATUS_NO_MEMORY;
 
+    /* Only carry the colour array across if this buffer actually has one */
+    NewCellRgb = NULL;
+    if (ScreenBuffer->CellRgb)
+    {
+        SIZE_T ColorSize = (SIZE_T)Size.X * Size.Y * sizeof(CELL_RGB);
+
+        NewCellRgb = ConsoleAllocHeap(0, ColorSize);
+        if (!NewCellRgb)
+        {
+            ConsoleFreeHeap(Buffer);
+            return STATUS_NO_MEMORY;
+        }
+
+        RtlFillMemory(NewCellRgb, ColorSize, 0xFF);
+    }
+
     DPRINT("Resizing (%d,%d) to (%d,%d)\n", ScreenBuffer->ScreenBufferSize.X, ScreenBuffer->ScreenBufferSize.Y, Size.X, Size.Y);
 
     OldBuffer = ScreenBuffer->Buffer;
+    OldCellRgb = ScreenBuffer->CellRgb;
 
     for (CurrentY = 0; CurrentY < ScreenBuffer->ScreenBufferSize.Y && CurrentY < Size.Y; CurrentY++)
     {
@@ -409,6 +470,8 @@ ConioResizeBuffer(PCONSOLE Console,
         {
             /* Reduce size */
             RtlCopyMemory(Buffer + Offset, Ptr, Size.X * sizeof(CHAR_INFO));
+            if (NewCellRgb)
+                RtlCopyMemory(NewCellRgb + Offset, ScreenBuffer->CellRgb + ConioCoordToIndex(ScreenBuffer, 0, CurrentY), Size.X * sizeof(CELL_RGB));
             Offset += Size.X;
 
             /* If we have cut a trailing full-width character in half, remove it completely */
@@ -418,12 +481,15 @@ ConioResizeBuffer(PCONSOLE Console,
                 Ptr->Char.UnicodeChar = L' ';
                 /* Keep all the other original attributes intact */
                 Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
+                if (NewCellRgb) NewCellRgb[Offset - 1].Fg = NewCellRgb[Offset - 1].Bg = CLR_INVALID;
             }
         }
         else
         {
             /* Enlarge size */
             RtlCopyMemory(Buffer + Offset, Ptr, ScreenBuffer->ScreenBufferSize.X * sizeof(CHAR_INFO));
+            if (NewCellRgb)
+                RtlCopyMemory(NewCellRgb + Offset, ScreenBuffer->CellRgb + ConioCoordToIndex(ScreenBuffer, 0, CurrentY), ScreenBuffer->ScreenBufferSize.X * sizeof(CELL_RGB));
             Offset += ScreenBuffer->ScreenBufferSize.X;
 
             /* The attribute to be used is the one of the last cell of the current line */
@@ -460,9 +526,17 @@ ConioResizeBuffer(PCONSOLE Console,
     }
 
     (void)InterlockedExchangePointer((PVOID volatile*)&ScreenBuffer->Buffer, Buffer);
-    ConsoleFreeHeap(OldBuffer);
+    (void)InterlockedExchangePointer((PVOID volatile*)&ScreenBuffer->CellRgb, NewCellRgb);
+    if (OldBuffer) ConsoleFreeHeap(OldBuffer);
+    if (OldCellRgb) ConsoleFreeHeap(OldCellRgb);
     ScreenBuffer->ScreenBufferSize = ScreenBuffer->OldScreenBufferSize = Size;
     ScreenBuffer->VirtualY = 0;
+
+    /* Keep the VT scrolling margins inside the resized buffer (Size.Y is non-zero here) */
+    if (ScreenBuffer->VtState.ScrollTop < 0 || ScreenBuffer->VtState.ScrollTop >= Size.Y)
+        ScreenBuffer->VtState.ScrollTop = 0;
+    if (ScreenBuffer->VtState.ScrollBottom < ScreenBuffer->VtState.ScrollTop || ScreenBuffer->VtState.ScrollBottom >= Size.Y)
+        ScreenBuffer->VtState.ScrollBottom = Size.Y - 1;
 
     /* Ensure the cursor and the view are within the buffer */
     ScreenBuffer->CursorPosition.X = min(ScreenBuffer->CursorPosition.X, Size.X - 1);
@@ -690,6 +764,7 @@ ConDrvWriteConsoleOutput(IN PCONSOLE Console,
             ++Ptr;
             ++CurCharInfo;
         }
+        ConioFillCellColors(Buffer, CapturedWriteRegion.Left, Y, ConioRectWidth(&CapturedWriteRegion), CLR_INVALID, CLR_INVALID);
     }
 
     TermDrawRegion(Console, &CapturedWriteRegion);
@@ -754,6 +829,7 @@ ConDrvWriteConsoleOutputVDM(IN PCONSOLE Console,
             ++Ptr;
             ++CurCharInfo;
         }
+        ConioFillCellColors(Buffer, CapturedWriteRegion.Left, Y, ConioRectWidth(&CapturedWriteRegion), CLR_INVALID, CLR_INVALID);
     }
 
     return STATUS_SUCCESS;
@@ -786,6 +862,7 @@ ConDrvWriteConsole(IN PCONSOLE Console,
     if (Unicode)
     {
         Buffer = StringBuffer;
+        Length = NumCharsToWrite;
     }
     else
     {
@@ -812,15 +889,17 @@ ConDrvWriteConsole(IN PCONSOLE Console,
     {
         if (NT_SUCCESS(Status))
         {
-            Status = TermWriteStream(Console,
-                                     ScreenBuffer,
-                                     Buffer,
-                                     NumCharsToWrite,
-                                     TRUE);
-            if (NT_SUCCESS(Status))
-            {
-                Written = NumCharsToWrite;
-            }
+            if (ScreenBuffer->Mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+                Status = ConDrvVtWriteConsole(Console, ScreenBuffer, Buffer, Length, &Written, NULL);
+            else
+                Status = TermWriteStream(Console, ScreenBuffer, Buffer, Length, TRUE);
+
+            /*
+             * Report the count in the caller's units: it asked us to write
+             * NumCharsToWrite of its own characters, which may differ from the
+             * number of UNICODE characters we actually pushed.
+             */
+            if (NT_SUCCESS(Status)) Written = NumCharsToWrite;
         }
 
         if (!Unicode) ConsoleFreeHeap(Buffer);

--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -141,6 +141,10 @@ TEXTMODE_BUFFER_Destroy(IN OUT PCONSOLE_SCREEN_BUFFER Buffer)
 
     ConsoleFreeHeap(Buff->Buffer);
     if (Buff->CellRgb) ConsoleFreeHeap(Buff->CellRgb);
+
+    /* The primary screen is parked here while the alternate screen is shown */
+    if (Buff->VtState.SavedBuffer) ConsoleFreeHeap(Buff->VtState.SavedBuffer);
+    if (Buff->VtState.SavedCellRgb) ConsoleFreeHeap(Buff->VtState.SavedCellRgb);
     if (Buff->VtState.HyperlinkUri.Buffer)
         ConsoleFreeHeap(Buff->VtState.HyperlinkUri.Buffer);
 
@@ -857,6 +861,16 @@ ConDrvWriteConsole(IN PCONSOLE Console,
 
     /* Stop here if the console is paused */
     if (Console->ConsolePaused) return STATUS_PENDING;
+
+    /*
+     * With no terminal attached every write pends, and WriteConsoleThread
+     * replays the entire original request once one is plugged in. The VT parser
+     * is not restartable - sequences it has already executed (erases, scrolls,
+     * cursor moves, an alternate-buffer switch) would be applied a second time -
+     * so pend here, before parsing, exactly as the paused case does. Nothing has
+     * happened yet, which is what makes the replay safe.
+     */
+    if (!ConDrvIsTerminalAttached(Console)) return STATUS_PENDING;
 
     /* Convert the string to UNICODE */
     if (Unicode)

--- a/win32ss/user/winsrv/consrv/condrv/vt.c
+++ b/win32ss/user/winsrv/consrv/condrv/vt.c
@@ -1,0 +1,5525 @@
+/*
+ * COPYRIGHT:       See COPYING in the top level directory
+ * PROJECT:         ReactOS Console Server DLL
+ * FILE:            win32ss/user/winsrv/consrv/condrv/vt.c
+ * PURPOSE:         Virtual Terminal processing (phase 1 implementation)
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include <consrv.h>
+#include <debug.h>
+#include "../conoutput.h"
+#include "../coninput.h"
+#include "../include/vt.h"
+
+#include <limits.h>
+
+NTSTATUS NTAPI ConDrvScrollConsoleScreenBuffer(PCONSOLE Console,
+                                             PTEXTMODE_SCREEN_BUFFER Buffer,
+                                             BOOLEAN Unicode,
+                                             PSMALL_RECT ScrollRectangle,
+                                             BOOLEAN UseClipRectangle,
+                                             PSMALL_RECT ClipRectangle OPTIONAL,
+                                             PCOORD DestinationOrigin,
+                                             CHAR_INFO FillChar);
+
+NTSTATUS NTAPI ConDrvWriteConsoleInput(PCONSOLE Console,
+                                       PCONSOLE_INPUT_BUFFER InputBuffer,
+                                       BOOLEAN AppendToEnd,
+                                       PINPUT_RECORD InputRecord,
+                                       ULONG NumEventsToWrite,
+                                       PULONG NumEventsWritten OPTIONAL);
+
+NTSTATUS NTAPI ConDrvSetConsoleActiveScreenBuffer(PCONSOLE Console,
+                                                  PCONSOLE_SCREEN_BUFFER Buffer);
+NTSTATUS NTAPI ConDrvSetConsoleCursorInfo(PCONSOLE Console,
+                                          PTEXTMODE_SCREEN_BUFFER Buffer,
+                                          PCONSOLE_CURSOR_INFO CursorInfo);
+NTSTATUS NTAPI ConDrvSetConsoleCursorPosition(PCONSOLE Console,
+                                              PTEXTMODE_SCREEN_BUFFER Buffer,
+                                              PCOORD Position);
+NTSTATUS NTAPI ConDrvSetConsoleScreenBufferSize(PCONSOLE Console,
+                                                PTEXTMODE_SCREEN_BUFFER Buffer,
+                                                PCOORD Size);
+NTSTATUS NTAPI ConDrvSetConsoleWindowInfo(PCONSOLE Console,
+                                          PTEXTMODE_SCREEN_BUFFER Buffer,
+                                          BOOLEAN Absolute,
+                                          PSMALL_RECT WindowRect);
+
+static UCHAR
+VtXtermToConsoleIndex(UCHAR Index);
+
+static VOID
+VtFillKeyEvent(PINPUT_RECORD Destination, WCHAR Character, BOOLEAN KeyDown);
+
+#define VT_MAX_PARAMS 16
+#define VT_MAX_INPUT_SEQUENCE_CHARS 32
+
+#define FG_ATTR_MASK (FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY)
+#define BG_ATTR_MASK (BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY)
+
+#define VT_DEFAULT_TAB_WIDTH 8
+
+
+#define VT_CHARSET_SLOT_G0                   0
+#define VT_CHARSET_SLOT_G1                   1
+#define VT_CHARSET_SLOT_G2                   2
+#define VT_CHARSET_SLOT_G3                   3
+#define VT_CHARSET_SLOT_INVALID              0xFF
+
+typedef enum _VT_CHARSET_ID
+{
+    VtCharsetAscii = 0,
+    VtCharsetDecSpecial,
+    VtCharsetUnitedKingdom,
+    VtCharsetDutch,
+    VtCharsetFinnish,
+    VtCharsetFrench,
+    VtCharsetFrenchCanadian,
+    VtCharsetGerman,
+    VtCharsetItalian,
+    VtCharsetNorwegianDanish,
+    VtCharsetSpanish,
+    VtCharsetSwedish,
+    VtCharsetSwiss,
+    VtCharsetPortuguese,
+    VtCharsetDecTechnical
+} VT_CHARSET_ID;
+
+#define VT_DEC_SPECIAL_START 0x20
+#define VT_DEC_SPECIAL_COUNT 0x60
+
+static const WCHAR VtDecSpecialMap[VT_DEC_SPECIAL_COUNT] =
+{
+    0x0020, 0x0021, 0x0022, 0x0023, 0x0024, 0x0025, 0x0026, 0x0027,
+    0x0028, 0x0029, 0x002A, 0x2192, 0x2190, 0x2191, 0x2193, 0x002F,
+    0x2588, 0x0031, 0x0032, 0x0033, 0x0034, 0x0035, 0x0036, 0x0037,
+    0x0038, 0x0039, 0x003A, 0x003B, 0x003C, 0x003D, 0x003E, 0x003F,
+    0x0040, 0x0041, 0x0042, 0x0043, 0x0044, 0x0045, 0x0046, 0x0047,
+    0x0048, 0x0049, 0x004A, 0x004B, 0x004C, 0x004D, 0x004E, 0x004F,
+    0x0050, 0x0051, 0x0052, 0x0053, 0x0054, 0x0055, 0x0056, 0x0057,
+    0x0058, 0x0059, 0x005A, 0x005B, 0x005C, 0x005D, 0x005E, 0x00A0,
+    0x25C6, 0x2592, 0x2409, 0x240C, 0x240D, 0x240A, 0x00B0, 0x00B1,
+    0x2591, 0x240B, 0x2518, 0x2510, 0x250C, 0x2514, 0x253C, 0x23BA,
+    0x23BB, 0x2500, 0x23BC, 0x23BD, 0x251C, 0x2524, 0x2534, 0x252C,
+    0x2502, 0x2264, 0x2265, 0x03C0, 0x2260, 0x00A3, 0x00B7, 0x007F,
+};
+
+typedef struct _VT_CHARSET_OVERRIDE
+{
+    WCHAR Source;
+    WCHAR Target;
+} VT_CHARSET_OVERRIDE;
+
+static const VT_CHARSET_OVERRIDE VtNrcsBritishOverrides[] =
+{
+    { L'#', 0x00A3 }
+};
+
+static const VT_CHARSET_OVERRIDE VtNrcsDutchOverrides[] =
+{
+    { L'#', 0x00A3 },
+    { L'@', 0x00BE },
+    { L'[', 0x0133 },
+    { L'\\', 0x00BD },
+    { L']', 0x007C },
+    { L'{', 0x00A8 },
+    { L'|', 0x0192 },
+    { L'}', 0x00BC },
+    { L'~', 0x00B4 }
+};
+
+static const VT_CHARSET_OVERRIDE VtNrcsFinnishOverrides[] =
+{
+    { L'[', 0x00C4 },
+    { L'\\', 0x00D6 },
+    { L']', 0x00C5 },
+    { L'^', 0x00DC },
+    { L'`', 0x00E9 },
+    { L'{', 0x00E4 },
+    { L'|', 0x00F6 },
+    { L'}', 0x00E5 },
+    { L'~', 0x00FC }
+};
+
+static const VT_CHARSET_OVERRIDE VtNrcsFrenchOverrides[] =
+{
+    { L'#', 0x00A3 },
+    { L'@', 0x00E0 },
+    { L'[', 0x00B0 },
+    { L'\\', 0x00E7 },
+    { L']', 0x00A7 },
+    { L'{', 0x00E9 },
+    { L'|', 0x00F9 },
+    { L'}', 0x00E8 },
+    { L'~', 0x00A8 }
+};
+
+static const VT_CHARSET_OVERRIDE VtNrcsFrenchCanadianOverrides[] =
+{
+    { L'@', 0x00E0 },
+    { L'[', 0x00E2 },
+    { L'\\', 0x00E7 },
+    { L']', 0x00EA },
+    { L'^', 0x00EE },
+    { L'`', 0x00F4 },
+    { L'{', 0x00E9 },
+    { L'|', 0x00F9 },
+    { L'}', 0x00E8 },
+    { L'~', 0x00FB }
+};
+
+static const VT_CHARSET_OVERRIDE VtNrcsGermanOverrides[] =
+{
+    { L'@', 0x00A7 },
+    { L'[', 0x00C4 },
+    { L'\\', 0x00D6 },
+    { L']', 0x00DC },
+    { L'{', 0x00E4 },
+    { L'|', 0x00F6 },
+    { L'}', 0x00FC },
+    { L'~', 0x00DF }
+};
+
+static const VT_CHARSET_OVERRIDE VtNrcsItalianOverrides[] =
+{
+    { L'#', 0x00A3 },
+    { L'@', 0x00A7 },
+    { L'[', 0x00B0 },
+    { L'\\', 0x00E7 },
+    { L']', 0x00E9 },
+    { L'`', 0x00F9 },
+    { L'{', 0x00E0 },
+    { L'|', 0x00F2 },
+    { L'}', 0x00E8 },
+    { L'~', 0x00EC }
+};
+
+static const VT_CHARSET_OVERRIDE VtNrcsNorwegianDanishOverrides[] =
+{
+    { L'@', 0x00C4 },
+    { L'[', 0x00C6 },
+    { L'\\', 0x00D8 },
+    { L']', 0x00C5 },
+    { L'^', 0x00DC },
+    { L'`', 0x00E4 },
+    { L'{', 0x00E6 },
+    { L'|', 0x00F8 },
+    { L'}', 0x00E5 },
+    { L'~', 0x00FC }
+};
+
+static const VT_CHARSET_OVERRIDE VtNrcsSpanishOverrides[] =
+{
+    { L'#', 0x00A3 },
+    { L'@', 0x00A7 },
+    { L'[', 0x00A1 },
+    { L'\\', 0x00D1 },
+    { L']', 0x00BF },
+    { L'{', 0x00B0 },
+    { L'|', 0x00F1 },
+    { L'}', 0x00E7 }
+};
+
+static const VT_CHARSET_OVERRIDE VtNrcsSwedishOverrides[] =
+{
+    { L'@', 0x00C9 },
+    { L'[', 0x00C4 },
+    { L'\\', 0x00D6 },
+    { L']', 0x00C5 },
+    { L'^', 0x00DC },
+    { L'`', 0x00E9 },
+    { L'{', 0x00E4 },
+    { L'|', 0x00F6 },
+    { L'}', 0x00E5 },
+    { L'~', 0x00FC }
+};
+
+static const VT_CHARSET_OVERRIDE VtNrcsSwissOverrides[] =
+{
+    { L'#', 0x00F9 },
+    { L'@', 0x00E0 },
+    { L'[', 0x00E9 },
+    { L'\\', 0x00E7 },
+    { L']', 0x00EA },
+    { L'^', 0x00EE },
+    { L'_', 0x00E8 },
+    { L'`', 0x00F4 },
+    { L'{', 0x00E4 },
+    { L'|', 0x00F6 },
+    { L'}', 0x00FC },
+    { L'~', 0x00FB }
+};
+
+static const VT_CHARSET_OVERRIDE VtNrcsPortugueseOverrides[] =
+{
+    { L'[', 0x00C3 },
+    { L'\\', 0x00C7 },
+    { L']', 0x00D5 },
+    { L'{', 0x00E3 },
+    { L'|', 0x00E7 },
+    { L'}', 0x00F5 }
+};
+
+static const VT_CHARSET_OVERRIDE VtDecTechnicalOverrides[] =
+{
+    { L'!', 0x23B7 },
+    { L'"', 0x250C },
+    { L'#', 0x2500 },
+    { L'$', 0x2320 },
+    { L'%', 0x2321 },
+    { L'&', 0x2502 },
+    { L'\'', 0x23A1 },
+    { L'(', 0x23A3 },
+    { L')', 0x23A4 },
+    { L'*', 0x23A6 },
+    { L'+', 0x239B },
+    { L',', 0x239D },
+    { L'-', 0x239E },
+    { L'.', 0x23A0 },
+    { L'/', 0x23A8 }
+};
+
+
+#ifdef DBG
+
+#define VT_TRACE_PARAM_LIMIT 6
+#define VT_TRACE_LIMIT       64
+
+static VOID
+VtTraceUnhandledCsi(WCHAR PrivateIndicator,
+                    WCHAR Intermediate,
+                    WCHAR Final,
+                    const ULONG *Params,
+                    ULONG Count)
+{
+    static ULONG Logged;
+
+    if (Logged >= VT_TRACE_LIMIT)
+        return;
+
+    Logged++;
+
+    DPRINT1("VT: Unhandled CSI sequence (priv='%lc', inter='%lc', final='%lc', count=%lu)\n",
+            PrivateIndicator ? PrivateIndicator : L' ',
+            Intermediate ? Intermediate : L' ',
+            Final, Count);
+
+    if (Count > 0 && Params)
+    {
+        ULONG i;
+        ULONG Limit = (Count < VT_TRACE_PARAM_LIMIT) ? Count : VT_TRACE_PARAM_LIMIT;
+
+        for (i = 0; i < Limit; ++i)
+            DPRINT1("    param[%lu] = %lu\n", i, Params[i]);
+
+        if (Count > Limit)
+            DPRINT1("    ... %lu more params omitted\n", Count - Limit);
+    }
+}
+
+static VOID
+VtTraceUnhandledEscape(WCHAR Indicator)
+{
+    static ULONG Logged;
+
+    if (Logged >= VT_TRACE_LIMIT)
+        return;
+
+    Logged++;
+
+    DPRINT1("VT: Unhandled ESC sequence (indicator='%lc', code=0x%04x)\n",
+            (Indicator >= L' ' && Indicator <= L'~') ? Indicator : L' ',
+            Indicator);
+}
+
+static VOID
+VtTraceUnhandledOsc(ULONG Parameter)
+{
+    static ULONG Logged;
+
+    if (Logged >= VT_TRACE_LIMIT)
+        return;
+
+    Logged++;
+
+    DPRINT1("VT: Unhandled OSC %lu\n", Parameter);
+}
+
+static VOID
+VtTraceUnhandledDcs(VOID)
+{
+    static ULONG Logged;
+
+    if (Logged >= VT_TRACE_LIMIT)
+        return;
+
+    Logged++;
+
+    DPRINT1("VT: Unhandled DCS sequence\n");
+}
+
+static VOID
+VtTracePolicyBlocked(const char *Feature)
+{
+    static ULONG Logged;
+
+    if (Logged >= VT_TRACE_LIMIT)
+        return;
+
+    Logged++;
+    DPRINT1("VT: %s suppressed by policy\n", Feature);
+}
+
+static VOID
+VtTraceDcsReplayFailure(NTSTATUS Status)
+{
+    static ULONG Logged;
+
+    if (Logged >= VT_TRACE_LIMIT)
+        return;
+
+    Logged++;
+    DPRINT1("VT: DCS passthrough replay failed (Status 0x%08lx)\n", Status);
+}
+
+#else
+
+#define VtTraceUnhandledCsi(Private, Intermediate, Final, Params, Count) ((void)0)
+#define VtTraceUnhandledEscape(Indicator) ((void)0)
+#define VtTraceUnhandledOsc(Parameter) ((void)0)
+#define VtTraceUnhandledDcs()          ((void)0)
+#define VtTracePolicyBlocked(Feature)  ((void)0)
+#define VtTraceDcsReplayFailure(Status) ((void)0)
+
+#endif
+
+static BOOLEAN
+VtEnsureTabStops(PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    USHORT Width;
+    PUCHAR NewStops;
+    USHORT CopyLength;
+
+    if (!ScreenBuffer)
+        return FALSE;
+
+    Width = (ScreenBuffer->ScreenBufferSize.X > 0)
+                ? (USHORT)ScreenBuffer->ScreenBufferSize.X
+                : 1;
+
+    if (ScreenBuffer->VtState.TabStops && ScreenBuffer->VtState.TabStopLength == Width)
+        return TRUE;
+
+    NewStops = (PUCHAR)ConsoleAllocHeap(0, Width * sizeof(UCHAR));
+    if (!NewStops)
+        return FALSE;
+
+    RtlZeroMemory(NewStops, Width * sizeof(UCHAR));
+
+    if (ScreenBuffer->VtState.TabStops && ScreenBuffer->VtState.TabStopLength > 0)
+    {
+        CopyLength = min(ScreenBuffer->VtState.TabStopLength, Width);
+        RtlCopyMemory(NewStops,
+                      ScreenBuffer->VtState.TabStops,
+                      CopyLength * sizeof(UCHAR));
+        ConsoleFreeHeap(ScreenBuffer->VtState.TabStops);
+
+        if (Width > CopyLength)
+        {
+            for (USHORT Column = CopyLength; Column < Width; ++Column)
+            {
+                if ((Column % VT_DEFAULT_TAB_WIDTH) == 0 && Column != 0)
+                    NewStops[Column] = 1;
+            }
+        }
+    }
+    else
+    {
+        for (USHORT Column = VT_DEFAULT_TAB_WIDTH; Column < Width; Column += VT_DEFAULT_TAB_WIDTH)
+            NewStops[Column] = 1;
+    }
+
+    ScreenBuffer->VtState.TabStops = NewStops;
+    ScreenBuffer->VtState.TabStopLength = Width;
+    return TRUE;
+}
+
+VOID
+NTAPI
+VtResetTabStops(PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    if (!VtEnsureTabStops(ScreenBuffer))
+        return;
+
+    RtlZeroMemory(ScreenBuffer->VtState.TabStops,
+                  ScreenBuffer->VtState.TabStopLength * sizeof(UCHAR));
+
+    for (USHORT Column = VT_DEFAULT_TAB_WIDTH;
+         Column < ScreenBuffer->VtState.TabStopLength;
+         Column += VT_DEFAULT_TAB_WIDTH)
+    {
+        ScreenBuffer->VtState.TabStops[Column] = 1;
+    }
+}
+
+VOID
+NTAPI
+VtSetTabStopAtCursor(PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    if (!ScreenBuffer)
+        return;
+
+    if (!VtEnsureTabStops(ScreenBuffer))
+        return;
+
+    if (ScreenBuffer->CursorPosition.X >= 0 &&
+        ScreenBuffer->CursorPosition.X < ScreenBuffer->VtState.TabStopLength)
+    {
+        ScreenBuffer->VtState.TabStops[ScreenBuffer->CursorPosition.X] = 1;
+    }
+}
+
+VOID
+NTAPI
+VtHandleTabClear(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                 ULONG Mode)
+{
+    if (!ScreenBuffer)
+        return;
+
+    if (!VtEnsureTabStops(ScreenBuffer))
+        return;
+
+    switch (Mode)
+    {
+        case 0:
+        case 2:
+        default:
+            if (ScreenBuffer->CursorPosition.X >= 0 &&
+                ScreenBuffer->CursorPosition.X < ScreenBuffer->VtState.TabStopLength)
+            {
+                ScreenBuffer->VtState.TabStops[ScreenBuffer->CursorPosition.X] = 0;
+            }
+            break;
+
+        case 3:
+            RtlZeroMemory(ScreenBuffer->VtState.TabStops,
+                          ScreenBuffer->VtState.TabStopLength * sizeof(UCHAR));
+            break;
+    }
+}
+
+SHORT
+NTAPI
+VtFindNextTabStop(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                  SHORT StartColumn)
+{
+    SHORT Width;
+    SHORT Column;
+
+    if (!ScreenBuffer || ScreenBuffer->ScreenBufferSize.X <= 0)
+        return 0;
+
+    Width = ScreenBuffer->ScreenBufferSize.X;
+
+    if (!VtEnsureTabStops(ScreenBuffer))
+    {
+        SHORT Fallback = ((StartColumn + 1 + (VT_DEFAULT_TAB_WIDTH - 1)) / VT_DEFAULT_TAB_WIDTH) * VT_DEFAULT_TAB_WIDTH;
+        if (Fallback <= StartColumn)
+            Fallback = StartColumn + 1;
+        return (Fallback < Width) ? Fallback : Width;
+    }
+
+    if (StartColumn < -1)
+        StartColumn = -1;
+
+    for (Column = StartColumn + 1; Column < ScreenBuffer->VtState.TabStopLength; ++Column)
+    {
+        if (ScreenBuffer->VtState.TabStops[Column])
+            return Column;
+    }
+
+    /* No configured tab stop found, fall back to the next multiple of the default width. */
+    Column = ((StartColumn + 1 + (VT_DEFAULT_TAB_WIDTH - 1)) / VT_DEFAULT_TAB_WIDTH) * VT_DEFAULT_TAB_WIDTH;
+    if (Column <= StartColumn)
+        Column = StartColumn + 1;
+    return (Column < Width) ? Column : Width;
+}
+
+static BOOLEAN
+VtHandleDcsSequence(PCONSOLE Console,
+                    PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                    const WCHAR *Sequence,
+                    ULONG Length)
+{
+    PTEXTMODE_SCREEN_BUFFER Target;
+
+    if (!Console)
+        return TRUE;
+
+    if (!Console->AllowVtDcsPassthrough)
+    {
+        VtTracePolicyBlocked("VT DCS passthrough");
+        return TRUE;
+    }
+
+    if (!Sequence || Length == 0)
+        return TRUE;
+
+    /* tmux multiplexes escape sequences via DCS "tmux;" wrappers. */
+    if (Length >= 5 &&
+        Sequence[0] == L't' && Sequence[1] == L'm' &&
+        Sequence[2] == L'u' && Sequence[3] == L'x' &&
+        Sequence[4] == L';')
+    {
+        const WCHAR *Payload = Sequence + 5;
+        ULONG PayloadLength = Length - 5;
+        ULONG Processed = 0;
+        BOOLEAN Handled = FALSE;
+        NTSTATUS Status;
+
+        if (PayloadLength == 0)
+            return TRUE;
+
+        Target = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
+        if (!Target)
+            Target = ScreenBuffer;
+
+        if (!Target)
+            return TRUE;
+
+        Status = ConDrvVtWriteConsole(Console,
+                                      Target,
+                                      Payload,
+                                      PayloadLength,
+                                      &Processed,
+                                      &Handled);
+        if (!NT_SUCCESS(Status))
+            VtTraceDcsReplayFailure(Status);
+        return TRUE;
+    }
+
+    VtTraceUnhandledDcs();
+    return TRUE;
+}
+
+static WCHAR
+VtTranslateUsingTable(WCHAR Ch,
+                      const VT_CHARSET_OVERRIDE *Table,
+                      size_t Count)
+{
+    if (Ch < 0x20 || Ch > 0x7F || Table == NULL || Count == 0)
+        return Ch;
+
+    for (size_t i = 0; i < Count; ++i)
+    {
+        if (Table[i].Source == Ch)
+            return Table[i].Target;
+    }
+
+    return Ch;
+}
+
+static VT_CHARSET_ID
+VtGetCharsetSlot(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                 UCHAR Slot)
+{
+    if (Slot >= ARRAYSIZE(ScreenBuffer->VtState.Charsets))
+        return VtCharsetAscii;
+
+    return (VT_CHARSET_ID)ScreenBuffer->VtState.Charsets[Slot];
+}
+
+static VT_CHARSET_ID
+VtGetActiveCharset(PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    return VtGetCharsetSlot(ScreenBuffer, ScreenBuffer->VtState.ActiveCharset);
+}
+
+static VOID
+VtSetActiveCharset(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                   UCHAR Slot)
+{
+    if (Slot > VT_CHARSET_SLOT_G3)
+        Slot = VT_CHARSET_SLOT_G0;
+
+    ScreenBuffer->VtState.ActiveCharset = Slot;
+}
+
+static BOOLEAN
+VtDesignateCharset(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                   UCHAR Slot,
+                   WCHAR Intermediate,
+                   WCHAR Designator)
+{
+    VT_CHARSET_ID Charset = VtCharsetAscii;
+    BOOLEAN Logged = FALSE;
+
+    if (Intermediate == L'%')
+    {
+        switch (Designator)
+        {
+            case L'6':
+                Charset = VtCharsetPortuguese;
+                break;
+
+            default:
+                Logged = TRUE;
+                Charset = VtCharsetAscii;
+                break;
+        }
+    }
+    else
+    {
+        switch (Designator)
+        {
+            case L'0':
+                Charset = VtCharsetDecSpecial;
+                break;
+
+            case L'A':
+                Charset = VtCharsetUnitedKingdom;
+                break;
+
+            case L'4':
+                Charset = VtCharsetDutch;
+                break;
+
+            case L'5':
+            case L'C':
+                Charset = VtCharsetFinnish;
+                break;
+
+            case L'R':
+            case L'f':
+                Charset = VtCharsetFrench;
+                break;
+
+            case L'Q':
+            case L'9':
+                Charset = VtCharsetFrenchCanadian;
+                break;
+
+            case L'K':
+                Charset = VtCharsetGerman;
+                break;
+
+            case L'Y':
+                Charset = VtCharsetItalian;
+                break;
+
+            case L'E':
+            case L'6':
+            case 0x0060: /* ` */
+                Charset = VtCharsetNorwegianDanish;
+                break;
+
+            case L'Z':
+                Charset = VtCharsetSpanish;
+                break;
+
+            case L'7':
+            case L'H':
+                Charset = VtCharsetSwedish;
+                break;
+
+            case L'=':
+                Charset = VtCharsetSwiss;
+                break;
+
+            case L'>':
+                Charset = VtCharsetDecTechnical;
+                break;
+
+            case L'B':
+            case L'U':
+            default:
+                if (Designator != L'B' && Designator != L'U')
+                    Logged = TRUE;
+                Charset = VtCharsetAscii;
+                break;
+        }
+    }
+
+#ifdef DBG
+    if (Logged)
+    {
+        static ULONG LoggedCount;
+        if (LoggedCount < VT_TRACE_LIMIT)
+        {
+            LoggedCount++;
+            DPRINT1("VT: Unsupported charset designator ESC %c %lc (slot %u)\n",
+                    (Intermediate ? Intermediate : L'(' + Slot), Designator, Slot);
+        }
+    }
+#endif
+
+    if (Slot >= ARRAYSIZE(ScreenBuffer->VtState.Charsets))
+        return FALSE;
+
+    ScreenBuffer->VtState.Charsets[Slot] = (UCHAR)Charset;
+    return TRUE;
+}
+
+static WCHAR
+VtTranslateGlyphSlot(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                     UCHAR Slot,
+                     WCHAR Ch)
+{
+    VT_CHARSET_ID Charset = VtGetCharsetSlot(ScreenBuffer, Slot);
+
+    if (Charset == VtCharsetDecSpecial)
+    {
+        if (Ch < VT_DEC_SPECIAL_START ||
+            Ch >= (VT_DEC_SPECIAL_START + VT_DEC_SPECIAL_COUNT))
+        {
+            return Ch;
+        }
+
+        return VtDecSpecialMap[Ch - VT_DEC_SPECIAL_START];
+    }
+
+    if (Ch < 0x20 || Ch > 0x7F)
+        return Ch;
+
+    /*
+     * The NRCS tables are indexed by VT_CHARSET_ID, so adding a character set
+     * means adding its table to this one array - not editing a switch as well.
+     */
+    static const struct
+    {
+        const VT_CHARSET_OVERRIDE *Table;
+        USHORT Count;
+    } NrcsTables[] =
+    {
+        {NULL, 0},                                                                  /* VtCharsetAscii */
+        {NULL, 0},                                                                  /* VtCharsetDecSpecial, handled above */
+        {VtNrcsBritishOverrides, RTL_NUMBER_OF_V1(VtNrcsBritishOverrides)},
+        {VtNrcsDutchOverrides, RTL_NUMBER_OF_V1(VtNrcsDutchOverrides)},
+        {VtNrcsFinnishOverrides, RTL_NUMBER_OF_V1(VtNrcsFinnishOverrides)},
+        {VtNrcsFrenchOverrides, RTL_NUMBER_OF_V1(VtNrcsFrenchOverrides)},
+        {VtNrcsFrenchCanadianOverrides, RTL_NUMBER_OF_V1(VtNrcsFrenchCanadianOverrides)},
+        {VtNrcsGermanOverrides, RTL_NUMBER_OF_V1(VtNrcsGermanOverrides)},
+        {VtNrcsItalianOverrides, RTL_NUMBER_OF_V1(VtNrcsItalianOverrides)},
+        {VtNrcsNorwegianDanishOverrides, RTL_NUMBER_OF_V1(VtNrcsNorwegianDanishOverrides)},
+        {VtNrcsSpanishOverrides, RTL_NUMBER_OF_V1(VtNrcsSpanishOverrides)},
+        {VtNrcsSwedishOverrides, RTL_NUMBER_OF_V1(VtNrcsSwedishOverrides)},
+        {VtNrcsSwissOverrides, RTL_NUMBER_OF_V1(VtNrcsSwissOverrides)},
+        {VtNrcsPortugueseOverrides, RTL_NUMBER_OF_V1(VtNrcsPortugueseOverrides)},
+        {VtDecTechnicalOverrides, RTL_NUMBER_OF_V1(VtDecTechnicalOverrides)},
+    };
+
+    if ((ULONG)Charset >= ARRAYSIZE(NrcsTables) || NrcsTables[Charset].Table == NULL)
+        return Ch;
+
+    return VtTranslateUsingTable(Ch, NrcsTables[Charset].Table, NrcsTables[Charset].Count);
+}
+
+static VOID
+VtSaveCursorState(PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    ScreenBuffer->VtState.SavedCursorPos = ScreenBuffer->CursorPosition;
+    ScreenBuffer->VtState.SavedAttributes = ScreenBuffer->VtState.CurrentAttributes;
+    ScreenBuffer->VtState.SavedFgColor = ScreenBuffer->VtState.CurrentFgColor;
+    ScreenBuffer->VtState.SavedBgColor = ScreenBuffer->VtState.CurrentBgColor;
+    ScreenBuffer->VtState.SavedUseRgbForeground = ScreenBuffer->VtState.UseRgbForeground;
+    ScreenBuffer->VtState.SavedUseRgbBackground = ScreenBuffer->VtState.UseRgbBackground;
+    RtlCopyMemory(ScreenBuffer->VtState.SavedCharsets, ScreenBuffer->VtState.Charsets, sizeof(ScreenBuffer->VtState.Charsets));
+    ScreenBuffer->VtState.SavedActiveCharset = ScreenBuffer->VtState.ActiveCharset;
+    ScreenBuffer->VtState.LastCharValid = FALSE;
+    ScreenBuffer->VtState.LastWrittenChar = L' ';
+    ScreenBuffer->VtState.CursorSaved = TRUE;
+}
+
+static VOID
+VtRestoreCursorState(PCONSOLE Console,
+                     PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    if (!ScreenBuffer->VtState.CursorSaved)
+        return;
+
+    ConDrvSetConsoleCursorPosition(Console,
+                                   ScreenBuffer,
+                                   &ScreenBuffer->VtState.SavedCursorPos);
+    ScreenBuffer->VtState.CurrentAttributes = ScreenBuffer->VtState.SavedAttributes;
+    ScreenBuffer->VtState.CurrentFgColor = ScreenBuffer->VtState.SavedFgColor;
+    ScreenBuffer->VtState.CurrentBgColor = ScreenBuffer->VtState.SavedBgColor;
+    ScreenBuffer->VtState.UseRgbForeground = ScreenBuffer->VtState.SavedUseRgbForeground;
+    ScreenBuffer->VtState.UseRgbBackground = ScreenBuffer->VtState.SavedUseRgbBackground;
+    RtlCopyMemory(ScreenBuffer->VtState.Charsets, ScreenBuffer->VtState.SavedCharsets, sizeof(ScreenBuffer->VtState.Charsets));
+    VtSetActiveCharset(ScreenBuffer, ScreenBuffer->VtState.SavedActiveCharset);
+    ScreenBuffer->VtState.PendingSingleShift = VT_CHARSET_SLOT_INVALID;
+}
+
+static BOOLEAN
+VtEnableAlternateScreen(PCONSOLE Console,
+                        PTEXTMODE_SCREEN_BUFFER PrimaryBuffer)
+{
+    TEXTMODE_BUFFER_INFO AltInfo;
+    PCONSOLE_SCREEN_BUFFER NewBuffer = NULL;
+    PTEXTMODE_SCREEN_BUFFER AltBuffer;
+    NTSTATUS Status;
+
+    if (PrimaryBuffer->VtState.AlternateBuffer != NULL)
+    {
+        /* Already active, ensure the console is pointing at it. */
+        if (Console->ActiveBuffer != (PCONSOLE_SCREEN_BUFFER)PrimaryBuffer->VtState.AlternateBuffer)
+        {
+            ConDrvSetConsoleActiveScreenBuffer(Console,
+                                               (PCONSOLE_SCREEN_BUFFER)PrimaryBuffer->VtState.AlternateBuffer);
+        }
+        return TRUE;
+    }
+
+    PrimaryBuffer->VtState.PrimaryCursorInfo = PrimaryBuffer->CursorInfo;
+    PrimaryBuffer->VtState.PrimaryCursorPos = PrimaryBuffer->CursorPosition;
+    PrimaryBuffer->VtState.PrimaryViewOrigin = PrimaryBuffer->ViewOrigin;
+    PrimaryBuffer->VtState.PrimaryVirtualY = PrimaryBuffer->VirtualY;
+    AltInfo.ScreenBufferSize = PrimaryBuffer->ViewSize;
+    AltInfo.ScreenBufferSize.X = max(AltInfo.ScreenBufferSize.X, 1);
+    AltInfo.ScreenBufferSize.Y = max(AltInfo.ScreenBufferSize.Y, 1);
+    AltInfo.ViewSize         = AltInfo.ScreenBufferSize;
+    AltInfo.ScreenAttrib     = PrimaryBuffer->ScreenDefaultAttrib;
+    AltInfo.PopupAttrib      = PrimaryBuffer->PopupDefaultAttrib;
+    AltInfo.CursorSize       = PrimaryBuffer->CursorInfo.dwSize;
+    AltInfo.IsCursorVisible  = PrimaryBuffer->CursorInfo.bVisible;
+
+    Status = ConDrvCreateScreenBuffer(&NewBuffer,
+                                      Console,
+                                      NULL,
+                                      CONSOLE_TEXTMODE_BUFFER,
+                                      &AltInfo);
+    if (!NT_SUCCESS(Status) || NewBuffer == NULL)
+    {
+        PrimaryBuffer->VtState.PrimaryBuffer = NULL;
+        return FALSE;
+    }
+
+    AltBuffer = (PTEXTMODE_SCREEN_BUFFER)NewBuffer;
+    AltBuffer->Mode = PrimaryBuffer->Mode;
+
+    /*
+     * The alternate screen inherits the primary's VT state wholesale, so copy
+     * the struct rather than enumerating fields - an enumerated list silently
+     * stops covering every field that gets added later.
+     *
+     * Everything the alternate buffer must NOT share is then reset explicitly.
+     * Clearing the owning pointers first matters: TabStops and HyperlinkUri.Buffer
+     * are heap-owned per buffer, and leaving the copied values in place would
+     * alias the primary's allocations and double-free them.
+     */
+    AltBuffer->VtState = PrimaryBuffer->VtState;
+
+    AltBuffer->VtState.PrimaryBuffer = PrimaryBuffer;
+    AltBuffer->VtState.AlternateBuffer = NULL;
+    AltBuffer->VtState.PrivateModes |= VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER;
+
+    AltBuffer->VtState.TabStops = NULL;
+    AltBuffer->VtState.TabStopLength = 0;
+
+    AltBuffer->VtState.HyperlinkUri.Buffer = NULL;
+    AltBuffer->VtState.HyperlinkUri.Length = 0;
+    AltBuffer->VtState.HyperlinkUri.MaximumLength = 0;
+
+    AltBuffer->VtState.PendingSequenceLength = 0;
+
+    /*
+     * The DECSC slot and the REP / mouse-tracking scratch are per screen, not
+     * inherited - the alternate screen starts with none of them set, matching
+     * xterm and the previous field-by-field behaviour.
+     */
+    AltBuffer->VtState.CursorSaved = FALSE;
+    AltBuffer->VtState.SavedCursorPos.X = AltBuffer->VtState.SavedCursorPos.Y = 0;
+    AltBuffer->VtState.LastWrittenChar = 0;
+    AltBuffer->VtState.LastCharValid = FALSE;
+    AltBuffer->VtState.MouseButtonState = 0;
+
+    /* The alternate screen starts unscrolled, with its own margins */
+    AltBuffer->VtState.ScrollTop = min(PrimaryBuffer->VtState.ScrollTop, (SHORT)max(0, AltBuffer->ScreenBufferSize.Y - 1));
+    if (PrimaryBuffer->VtState.HyperlinkActive &&
+        PrimaryBuffer->VtState.HyperlinkUri.Buffer &&
+        PrimaryBuffer->VtState.HyperlinkUri.Length > 0)
+    {
+        ULONG Bytes = PrimaryBuffer->VtState.HyperlinkUri.Length + sizeof(WCHAR);
+        PWCHAR Copy = ConsoleAllocHeap(0, Bytes);
+        if (Copy)
+        {
+            RtlCopyMemory(Copy, PrimaryBuffer->VtState.HyperlinkUri.Buffer,
+                          PrimaryBuffer->VtState.HyperlinkUri.Length);
+            Copy[PrimaryBuffer->VtState.HyperlinkUri.Length / sizeof(WCHAR)] = UNICODE_NULL;
+            AltBuffer->VtState.HyperlinkUri.Buffer = Copy;
+            AltBuffer->VtState.HyperlinkUri.Length = PrimaryBuffer->VtState.HyperlinkUri.Length;
+            AltBuffer->VtState.HyperlinkUri.MaximumLength = (USHORT)Bytes;
+        }
+        else
+        {
+            AltBuffer->VtState.HyperlinkActive = FALSE;
+        }
+    }
+
+    VtResetTabStops(AltBuffer);
+
+    AltBuffer->VtState.ScrollBottom = min(PrimaryBuffer->VtState.ScrollBottom,
+                                          (SHORT)max(0, AltBuffer->ScreenBufferSize.Y - 1));
+    if (AltBuffer->VtState.ScrollBottom < AltBuffer->VtState.ScrollTop)
+    {
+        AltBuffer->VtState.ScrollTop = 0;
+        AltBuffer->VtState.ScrollBottom = max(0, AltBuffer->ScreenBufferSize.Y - 1);
+    }
+
+    PrimaryBuffer->VtState.AlternateBuffer = AltBuffer;
+    PrimaryBuffer->VtState.PrivateModes |= VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER;
+
+    ConDrvSetConsoleActiveScreenBuffer(Console, NewBuffer);
+    ConDrvSetConsoleCursorInfo(Console, AltBuffer, &AltBuffer->CursorInfo);
+    return TRUE;
+}
+
+static BOOLEAN
+VtDisableAlternateScreen(PCONSOLE Console,
+                         PTEXTMODE_SCREEN_BUFFER ActiveBuffer)
+{
+    PTEXTMODE_SCREEN_BUFFER PrimaryBuffer;
+
+    if (ActiveBuffer->VtState.PrimaryBuffer == NULL)
+    {
+        /* No alternate screen in use. */
+        if (ActiveBuffer->VtState.AlternateBuffer != NULL)
+        {
+            PTEXTMODE_SCREEN_BUFFER AltBuffer = ActiveBuffer->VtState.AlternateBuffer;
+            ActiveBuffer->VtState.AlternateBuffer = NULL;
+            AltBuffer->VtState.PrimaryBuffer = NULL;
+            ActiveBuffer->VtState.PrivateModes &= ~VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER;
+            ConDrvDeleteScreenBuffer((PCONSOLE_SCREEN_BUFFER)AltBuffer);
+        }
+        return TRUE;
+    }
+
+    PrimaryBuffer = ActiveBuffer->VtState.PrimaryBuffer;
+
+    /* Restore the saved attributes on the primary buffer before switching back. */
+    PrimaryBuffer->CursorInfo = PrimaryBuffer->VtState.PrimaryCursorInfo;
+    PrimaryBuffer->CursorPosition = PrimaryBuffer->VtState.PrimaryCursorPos;
+    PrimaryBuffer->ViewOrigin = PrimaryBuffer->VtState.PrimaryViewOrigin;
+    PrimaryBuffer->VirtualY = PrimaryBuffer->VtState.PrimaryVirtualY;
+
+    PrimaryBuffer->VtState.PrivateModes &= ~VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER;
+    PrimaryBuffer->VtState.AlternateBuffer = NULL;
+
+    ActiveBuffer->VtState.PrimaryBuffer = NULL;
+    ActiveBuffer->VtState.PrivateModes &= ~VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER;
+
+    ConDrvVtInvalidateBufferRgb(ActiveBuffer);
+
+    ConDrvSetConsoleActiveScreenBuffer(Console, (PCONSOLE_SCREEN_BUFFER)PrimaryBuffer);
+    ConDrvSetConsoleCursorInfo(Console, PrimaryBuffer, &PrimaryBuffer->CursorInfo);
+    ConDrvSetConsoleCursorPosition(Console, PrimaryBuffer, &PrimaryBuffer->CursorPosition);
+
+    return TRUE;
+}
+
+/*
+ * The 16-colour table belongs to the server layer, so reach it through the
+ * TERMINAL vtable rather than casting Console to PCONSRV_CONSOLE.
+ */
+#define VT_PALETTE_SIZE 16
+
+static BOOLEAN
+VtReadPalette(PCONSOLE Console, COLORREF *Colors)
+{
+    if (!Console) return FALSE;
+    return !!TermGetColorTable(Console, Colors, VT_PALETTE_SIZE);
+}
+
+static COLORREF
+VtGetPaletteColor(PCONSOLE Console, UCHAR Index)
+{
+    COLORREF Colors[VT_PALETTE_SIZE];
+
+    if (!VtReadPalette(Console, Colors)) return 0;
+    return Colors[Index & 0x0F];
+}
+
+static VOID
+VtClearHyperlink(PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    if (!ScreenBuffer)
+        return;
+
+    if (ScreenBuffer->VtState.HyperlinkUri.Buffer)
+    {
+        ConsoleFreeHeap(ScreenBuffer->VtState.HyperlinkUri.Buffer);
+        ScreenBuffer->VtState.HyperlinkUri.Buffer = NULL;
+    }
+
+    ScreenBuffer->VtState.HyperlinkUri.Length = 0;
+    ScreenBuffer->VtState.HyperlinkUri.MaximumLength = 0;
+    ScreenBuffer->VtState.HyperlinkActive = FALSE;
+}
+
+VOID
+NTAPI
+ConDrvVtInvalidateBufferRgb(PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    SIZE_T CellCount;
+    PCONSOLE Console;
+
+    if (!ScreenBuffer)
+        return;
+
+    CellCount = (SIZE_T)ScreenBuffer->ScreenBufferSize.X * ScreenBuffer->ScreenBufferSize.Y;
+
+    if (ScreenBuffer->CellRgb)
+        RtlFillMemory(ScreenBuffer->CellRgb, CellCount * sizeof(CELL_RGB), 0xFF);
+
+    ScreenBuffer->VtState.CursorSaved = FALSE;
+    ScreenBuffer->VtState.UseRgbForeground = FALSE;
+    ScreenBuffer->VtState.UseRgbBackground = FALSE;
+    ScreenBuffer->VtState.SavedUseRgbForeground = FALSE;
+    ScreenBuffer->VtState.SavedUseRgbBackground = FALSE;
+    ScreenBuffer->VtState.PrivateModes = 0;
+    ScreenBuffer->VtState.ScrollTop = 0;
+    ScreenBuffer->VtState.ScrollBottom = max(0, ScreenBuffer->ScreenBufferSize.Y - 1);
+    ScreenBuffer->VtState.PendingSequenceLength = 0;
+    VtClearHyperlink(ScreenBuffer);
+
+    Console = ScreenBuffer->Header.Console;
+    if (Console)
+    {
+        COLORREF fg = VtGetPaletteColor(Console, ScreenBuffer->VtState.CurrentAttributes & 0x0F);
+        COLORREF bg = VtGetPaletteColor(Console, (ScreenBuffer->VtState.CurrentAttributes >> 4) & 0x0F);
+        ScreenBuffer->VtState.CurrentFgColor = fg;
+        ScreenBuffer->VtState.CurrentBgColor = bg;
+        ScreenBuffer->VtState.SavedFgColor = fg;
+        ScreenBuffer->VtState.SavedBgColor = bg;
+    }
+}
+
+static UCHAR
+VtFindNearestPaletteIndex(PCONSOLE Console, COLORREF Color)
+{
+    COLORREF Colors[VT_PALETTE_SIZE];
+    UCHAR best = 0;
+    ULONG bestDiff = ULONG_MAX;
+
+    if (!VtReadPalette(Console, Colors)) return 0;
+    for (UCHAR idx = 0; idx < VT_PALETTE_SIZE; ++idx)
+    {
+        COLORREF ref = Colors[idx];
+        LONG dr = (LONG)GetRValue(Color) - (LONG)GetRValue(ref);
+        LONG dg = (LONG)GetGValue(Color) - (LONG)GetGValue(ref);
+        LONG db = (LONG)GetBValue(Color) - (LONG)GetBValue(ref);
+        ULONG diff = (ULONG)(dr * dr + dg * dg + db * db);
+        if (diff < bestDiff)
+        {
+            bestDiff = diff;
+            best = idx;
+        }
+    }
+    return best;
+}
+
+static COLORREF
+VtColorFromXtermIndex(ULONG Index)
+{
+    /* Indices below 16 are palette entries and never reach here - the caller
+     * resolves those through the console attribute directly */
+    if (Index >= 16 && Index <= 231)
+    {
+        Index -= 16;
+        ULONG r = (Index / 36) % 6;
+        ULONG g = (Index / 6) % 6;
+        ULONG b = Index % 6;
+        r = r ? r * 40 + 55 : 0;
+        g = g ? g * 40 + 55 : 0;
+        b = b ? b * 40 + 55 : 0;
+        return RGB((BYTE)r, (BYTE)g, (BYTE)b);
+    }
+
+    if (Index >= 232 && Index <= 255)
+    {
+        BYTE shade = (BYTE)((Index - 232) * 10 + 8);
+        return RGB(shade, shade, shade);
+    }
+
+    return 0;
+}
+
+static SIZE_T
+VtAppendNumber(WCHAR *Buffer, SIZE_T BufferLength, ULONG Number)
+{
+    WCHAR Temp[12];
+    SIZE_T Count = 0;
+    SIZE_T Written = 0;
+
+    if (BufferLength == 0)
+        return 0;
+
+    do
+    {
+        Temp[Count++] = (WCHAR)(L'0' + (Number % 10));
+        Number /= 10;
+    } while (Number != 0 && Count < ARRAYSIZE(Temp));
+
+    while (Count > 0 && Written < BufferLength)
+    {
+        Buffer[Written++] = Temp[--Count];
+    }
+
+    return Written;
+}
+
+static USHORT
+VtGetModifierParameter(const KEY_EVENT_RECORD *KeyEvent)
+{
+    USHORT Parameter = 1;
+
+    if (KeyEvent->dwControlKeyState & SHIFT_PRESSED)
+        Parameter += 1;
+    if (KeyEvent->dwControlKeyState & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED))
+        Parameter += 2;
+    if (KeyEvent->dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED))
+        Parameter += 4;
+
+    return Parameter;
+}
+
+static BOOLEAN
+VtComposeCsiTildeSequence(ULONG Parameter,
+                          USHORT ModifierParam,
+                          WCHAR Final,
+                          WCHAR *Buffer,
+                          SIZE_T Capacity,
+                          SIZE_T *Length)
+{
+    SIZE_T Written = 0;
+
+    if (Capacity < 3)
+        return FALSE;
+
+    Buffer[Written++] = L'\x1b';
+    Buffer[Written++] = L'[';
+    Written += VtAppendNumber(Buffer + Written,
+                              Capacity - Written,
+                              Parameter);
+
+    if (ModifierParam > 1)
+    {
+        if (Written >= Capacity)
+            return FALSE;
+        Buffer[Written++] = L';';
+        Written += VtAppendNumber(Buffer + Written,
+                                  Capacity - Written,
+                                  ModifierParam);
+    }
+
+    if (Written >= Capacity)
+        return FALSE;
+
+    Buffer[Written++] = Final;
+    *Length = Written;
+    return TRUE;
+}
+
+static BOOLEAN
+VtComposeCursorKeySequence(BOOLEAN ApplicationMode,
+                           const KEY_EVENT_RECORD *KeyEvent,
+                           WCHAR Final,
+                           WCHAR *Buffer,
+                           SIZE_T Capacity,
+                           SIZE_T *Length)
+{
+    SIZE_T Written = 0;
+    USHORT ModifierParam = VtGetModifierParameter(KeyEvent);
+
+    if (ApplicationMode && ModifierParam == 1)
+    {
+        if (Capacity < 3)
+            return FALSE;
+        Buffer[Written++] = L'\x1b';
+        Buffer[Written++] = L'O';
+        Buffer[Written++] = Final;
+        *Length = Written;
+        return TRUE;
+    }
+
+    if (Capacity < 3)
+        return FALSE;
+
+    Buffer[Written++] = L'\x1b';
+    Buffer[Written++] = L'[';
+
+    if (ModifierParam > 1)
+    {
+        Written += VtAppendNumber(Buffer + Written,
+                                  Capacity - Written,
+                                  1);
+        if (Written >= Capacity)
+            return FALSE;
+        Buffer[Written++] = L';';
+        Written += VtAppendNumber(Buffer + Written,
+                                  Capacity - Written,
+                                  ModifierParam);
+    }
+
+    if (Written >= Capacity)
+        return FALSE;
+
+    Buffer[Written++] = Final;
+    *Length = Written;
+    return TRUE;
+}
+
+static USHORT
+VtMouseModifierBits(DWORD ControlKeyState)
+{
+    USHORT Bits = 0;
+
+    if (ControlKeyState & SHIFT_PRESSED)
+        Bits |= 4;
+    if (ControlKeyState & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED))
+        Bits |= 8;
+    if (ControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED))
+        Bits |= 16;
+
+    return Bits;
+}
+
+static INT
+VtFirstMouseButton(ULONG Mask)
+{
+    if (Mask & FROM_LEFT_1ST_BUTTON_PRESSED) return 0;
+    if (Mask & FROM_LEFT_2ND_BUTTON_PRESSED) return 1;
+    if (Mask & RIGHTMOST_BUTTON_PRESSED) return 2;
+    if (Mask & FROM_LEFT_3RD_BUTTON_PRESSED) return 3;
+    if (Mask & FROM_LEFT_4TH_BUTTON_PRESSED) return 4;
+    return -1;
+}
+
+static BOOLEAN
+VtComposeMouseSgrSequence(ULONG ButtonCode,
+                          ULONG X,
+                          ULONG Y,
+                          BOOLEAN Released,
+                          WCHAR *Buffer,
+                          SIZE_T Capacity,
+                          SIZE_T *Length)
+{
+    SIZE_T Written = 0;
+
+    if (Capacity < 7)
+        return FALSE;
+
+    if (X == 0) X = 1;
+    if (Y == 0) Y = 1;
+
+    Buffer[Written++] = L'\x1b';
+    Buffer[Written++] = L'[';
+    Buffer[Written++] = L'<';
+    Written += VtAppendNumber(Buffer + Written,
+                              Capacity - Written,
+                              ButtonCode);
+    if (Written >= Capacity)
+        return FALSE;
+    Buffer[Written++] = L';';
+    Written += VtAppendNumber(Buffer + Written,
+                              Capacity - Written,
+                              X);
+    if (Written >= Capacity)
+        return FALSE;
+    Buffer[Written++] = L';';
+    Written += VtAppendNumber(Buffer + Written,
+                              Capacity - Written,
+                              Y);
+    if (Written >= Capacity)
+        return FALSE;
+    Buffer[Written++] = Released ? L'm' : L'M';
+    *Length = Written;
+    return TRUE;
+}
+
+static BOOLEAN
+VtComposeMouseLegacySequence(ULONG ButtonCode,
+                             ULONG X,
+                             ULONG Y,
+                             WCHAR *Buffer,
+                             SIZE_T Capacity,
+                             SIZE_T *Length)
+{
+    ULONG AdjustedX;
+    ULONG AdjustedY;
+
+    if (Capacity < 6)
+        return FALSE;
+
+    if (X < 1) X = 1;
+    if (Y < 1) Y = 1;
+
+    AdjustedX = min(223u, X);
+    AdjustedY = min(223u, Y);
+
+    Buffer[0] = L'\x1b';
+    Buffer[1] = L'[';
+    Buffer[2] = L'M';
+    Buffer[3] = (WCHAR)((min(ButtonCode, 255u)) + 32u);
+    Buffer[4] = (WCHAR)(AdjustedX + 32u);
+    Buffer[5] = (WCHAR)(AdjustedY + 32u);
+    *Length = 6;
+    return TRUE;
+}
+
+static VOID
+VtSendInputResponse(PCONSOLE Console,
+                    const WCHAR *Response,
+                    SIZE_T Length)
+{
+    /* Every caller replies out of a WCHAR[VT_MAX_INPUT_SEQUENCE_CHARS], so the
+     * stack covers all of them and the heap path is only a safety net */
+    INPUT_RECORD Stack[VT_MAX_INPUT_SEQUENCE_CHARS * 2];
+    PINPUT_RECORD Records = Stack;
+    SIZE_T Index;
+    ULONG Total;
+
+    if (Console == NULL || Response == NULL || Length == 0)
+        return;
+
+    Total = (ULONG)(Length * 2);
+    if (Total > ARRAYSIZE(Stack))
+    {
+        Records = ConsoleAllocHeap(0, Total * sizeof(INPUT_RECORD));
+        if (!Records)
+            return;
+    }
+
+    for (Index = 0; Index < Length; ++Index)
+    {
+        VtFillKeyEvent(&Records[Index * 2], Response[Index], TRUE);
+        VtFillKeyEvent(&Records[Index * 2 + 1], Response[Index], FALSE);
+    }
+
+    ConDrvWriteConsoleInput(Console,
+                            &Console->InputBuffer,
+                            TRUE,
+                            Records,
+                            Total,
+                            NULL);
+
+    if (Records != Stack) ConsoleFreeHeap(Records);
+}
+
+static BOOLEAN
+VtStorePendingSequence(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                       const WCHAR *Sequence,
+                       ULONG Length)
+{
+    if (!ScreenBuffer)
+        return FALSE;
+
+    if (!Sequence || Length == 0)
+    {
+        ScreenBuffer->VtState.PendingSequenceLength = 0;
+        return TRUE;
+    }
+
+    if (Length > ARRAYSIZE(ScreenBuffer->VtState.PendingSequence))
+        return FALSE;
+
+    RtlCopyMemory(ScreenBuffer->VtState.PendingSequence,
+                  Sequence,
+                  Length * sizeof(WCHAR));
+    ScreenBuffer->VtState.PendingSequenceLength = (USHORT)Length;
+    return TRUE;
+}
+
+static SIZE_T
+VtAppendHex(WCHAR *Buffer, SIZE_T BufferLength, ULONG Value, ULONG Digits)
+{
+    SIZE_T Written = 0;
+    LONG Shift;
+
+    if (Digits == 0 || BufferLength == 0)
+        return 0;
+
+    for (Shift = (LONG)(Digits - 1); Shift >= 0 && Written < BufferLength; --Shift)
+    {
+        ULONG Nibble = (Value >> (Shift * 4)) & 0xF;
+        Buffer[Written++] = (WCHAR)(Nibble < 10 ? (L'0' + Nibble) : (L'A' + (Nibble - 10)));
+    }
+
+    return Written;
+}
+
+static SIZE_T
+VtAppendOscRgb(WCHAR *Buffer, SIZE_T BufferLength, COLORREF Color)
+{
+    SIZE_T Written = 0;
+    ULONG Components[3];
+    ULONG Index;
+
+    if (BufferLength < 4)
+        return 0;
+
+    Buffer[Written++] = L'r';
+    Buffer[Written++] = L'g';
+    Buffer[Written++] = L'b';
+    Buffer[Written++] = L':';
+
+    Components[0] = (ULONG)GetRValue(Color) * 257u;
+    Components[1] = (ULONG)GetGValue(Color) * 257u;
+    Components[2] = (ULONG)GetBValue(Color) * 257u;
+
+    for (Index = 0; Index < ARRAYSIZE(Components) && Written < BufferLength; ++Index)
+    {
+        Written += VtAppendHex(Buffer + Written,
+                               BufferLength - Written,
+                               Components[Index],
+                               4);
+
+        if (Index + 1 < ARRAYSIZE(Components) && Written < BufferLength)
+            Buffer[Written++] = L'/';
+    }
+
+    return Written;
+}
+
+static INT
+VtBase64Value(WCHAR Ch)
+{
+    if (Ch >= L'A' && Ch <= L'Z') return (INT)(Ch - L'A');
+    if (Ch >= L'a' && Ch <= L'z') return (INT)(Ch - L'a') + 26;
+    if (Ch >= L'0' && Ch <= L'9') return (INT)(Ch - L'0') + 52;
+    if (Ch == L'+') return 62;
+    if (Ch == L'/') return 63;
+    return -1;
+}
+
+static BOOLEAN
+VtDecodeBase64(const WCHAR *Input,
+               ULONG Length,
+               PBYTE *Output,
+               PULONG OutputSize)
+{
+    ULONG Estimate;
+    PBYTE Buffer;
+    ULONG OutIndex = 0;
+    ULONG Quad[4];
+    ULONG QuadCount = 0;
+    ULONG PadCount = 0;
+
+    if (!Output || !OutputSize)
+        return FALSE;
+
+    Estimate = ((Length + 3) / 4) * 3;
+    Buffer = ConsoleAllocHeap(0, Estimate ? Estimate : 1);
+    if (!Buffer)
+        return FALSE;
+
+    for (ULONG i = 0; i < Length; ++i)
+    {
+        WCHAR Ch = Input[i];
+
+        if (Ch == L'\r' || Ch == L'\n' || Ch == L'	' || Ch == L' ')
+            continue;
+
+        if (Ch == L'=')
+        {
+            Quad[QuadCount++] = 0;
+            PadCount++;
+        }
+        else
+        {
+            INT Value = VtBase64Value(Ch);
+            if (Value < 0)
+            {
+                ConsoleFreeHeap(Buffer);
+                return FALSE;
+            }
+
+            Quad[QuadCount++] = (ULONG)Value;
+        }
+
+        if (QuadCount == 4)
+        {
+            Buffer[OutIndex++] = (BYTE)((Quad[0] << 2) | (Quad[1] >> 4));
+            if (PadCount < 2)
+                Buffer[OutIndex++] = (BYTE)(((Quad[1] & 0x0F) << 4) | (Quad[2] >> 2));
+            if (PadCount < 1)
+                Buffer[OutIndex++] = (BYTE)(((Quad[2] & 0x03) << 6) | Quad[3]);
+
+            QuadCount = 0;
+            PadCount = 0;
+        }
+    }
+
+    if (QuadCount != 0)
+    {
+        ConsoleFreeHeap(Buffer);
+        return FALSE;
+    }
+
+    *Output = Buffer;
+    *OutputSize = OutIndex;
+    return TRUE;
+}
+
+static BOOLEAN
+VtEncodeBase64(const BYTE *Input,
+               ULONG Length,
+               PWSTR *Output,
+               PULONG OutputChars)
+{
+    static const WCHAR Table[] =
+        L"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    ULONG OutLen;
+    PWSTR Buffer;
+    ULONG Index = 0;
+
+    if (!Output || !OutputChars)
+        return FALSE;
+
+    OutLen = ((Length + 2) / 3) * 4;
+    Buffer = ConsoleAllocHeap(0, (OutLen + 1) * sizeof(WCHAR));
+    if (!Buffer)
+        return FALSE;
+
+    for (ULONG i = 0; i < Length; i += 3)
+    {
+        BYTE b0 = Input[i];
+        BYTE b1 = (i + 1 < Length) ? Input[i + 1] : 0;
+        BYTE b2 = (i + 2 < Length) ? Input[i + 2] : 0;
+
+        Buffer[Index++] = Table[(b0 >> 2) & 0x3F];
+        Buffer[Index++] = Table[((b0 & 0x03) << 4) | ((b1 >> 4) & 0x0F)];
+        Buffer[Index++] = (i + 1 < Length) ? Table[((b1 & 0x0F) << 2) | ((b2 >> 6) & 0x03)] : L'=';
+        Buffer[Index++] = (i + 2 < Length) ? Table[b2 & 0x3F] : L'=';
+    }
+
+    Buffer[Index] = UNICODE_NULL;
+    *Output = Buffer;
+    *OutputChars = Index;
+    return TRUE;
+}
+
+static VOID
+VtSendOscClipboardResponse(PCONSOLE Console,
+                           const WCHAR *TargetStart,
+                           SIZE_T TargetLength,
+                           const WCHAR *Payload)
+{
+    WCHAR StaticTarget = L'c';
+    const WCHAR *Target = TargetStart;
+    SIZE_T Length = TargetLength;
+    SIZE_T PayloadLength = Payload ? wcslen(Payload) : 0;
+    PWSTR Response;
+    SIZE_T Pos = 0;
+
+    if (!Target || Length == 0)
+    {
+        Target = &StaticTarget;
+        Length = 1;
+    }
+
+    Response = ConsoleAllocHeap(0, (5 + Length + PayloadLength + 2) * sizeof(WCHAR));
+    if (!Response)
+        return;
+
+    Response[Pos++] = L'';
+    Response[Pos++] = L']';
+    Response[Pos++] = L'5';
+    Response[Pos++] = L'2';
+    Response[Pos++] = L';';
+
+    for (SIZE_T i = 0; i < Length; ++i)
+        Response[Pos++] = Target[i];
+
+    Response[Pos++] = L';';
+
+    for (SIZE_T i = 0; i < PayloadLength; ++i)
+        Response[Pos++] = Payload[i];
+
+    Response[Pos++] = L'';
+
+    VtSendInputResponse(Console, Response, Pos);
+
+    ConsoleFreeHeap(Response);
+}
+
+
+static VOID
+VtSendOscColorResponse(PCONSOLE Console,
+                       ULONG Parameter,
+                       COLORREF Color)
+{
+    WCHAR Response[64];
+    SIZE_T Len = 0;
+
+    Response[Len++] = L'\x1b';
+    Response[Len++] = L']';
+    Len += VtAppendNumber(Response + Len, ARRAYSIZE(Response) - Len, Parameter);
+    if (Len < ARRAYSIZE(Response))
+        Response[Len++] = L';';
+    Len += VtAppendOscRgb(Response + Len, ARRAYSIZE(Response) - Len, Color);
+    if (Len < ARRAYSIZE(Response))
+        Response[Len++] = L'\x07';
+
+    VtSendInputResponse(Console, Response, Len);
+}
+
+static VOID
+VtSendOscPaletteResponse(PCONSOLE Console,
+                         ULONG Index,
+                         COLORREF Color)
+{
+    WCHAR Response[80];
+    SIZE_T Len = 0;
+
+    Response[Len++] = L'\x1b';
+    Response[Len++] = L']';
+    Response[Len++] = L'4';
+    Response[Len++] = L';';
+    Len += VtAppendNumber(Response + Len, ARRAYSIZE(Response) - Len, Index);
+    if (Len < ARRAYSIZE(Response))
+        Response[Len++] = L';';
+    Len += VtAppendOscRgb(Response + Len, ARRAYSIZE(Response) - Len, Color);
+    if (Len < ARRAYSIZE(Response))
+        Response[Len++] = L'\x07';
+
+    VtSendInputResponse(Console, Response, Len);
+}
+
+/*
+ * Apply the current SGR state to a rectangle, clipped to the buffer.
+ *
+ * FillChar == 0 refreshes only the extended colours, leaving the characters and
+ * attributes alone - that is what the scrolling paths need after cells have been
+ * moved about. Any other value also overwrites every cell's glyph and attribute.
+ */
+static VOID
+VtFillRect(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+           SHORT Left,
+           SHORT Top,
+           SHORT Right,
+           SHORT Bottom,
+           WCHAR FillChar)
+{
+    SHORT Width = ScreenBuffer->ScreenBufferSize.X;
+    SHORT Height = ScreenBuffer->ScreenBufferSize.Y;
+    SHORT X, Y;
+    USHORT Attr = ScreenBuffer->VtState.CurrentAttributes;
+    COLORREF Fg = ScreenBuffer->VtState.UseRgbForeground ? ScreenBuffer->VtState.CurrentFgColor : CLR_INVALID;
+    COLORREF Bg = ScreenBuffer->VtState.UseRgbBackground ? ScreenBuffer->VtState.CurrentBgColor : CLR_INVALID;
+
+    if (Width <= 0 || Height <= 0)
+        return;
+
+    Left = max(Left, 0);
+    Top = max(Top, 0);
+    Right = min(Right, (SHORT)(Width - 1));
+    Bottom = min(Bottom, (SHORT)(Height - 1));
+
+    if (Left > Right || Top > Bottom)
+        return;
+
+    if (Fg != CLR_INVALID || Bg != CLR_INVALID)
+        ConioEnsureCellColors(ScreenBuffer);
+
+    for (Y = Top; Y <= Bottom; ++Y)
+    {
+        if (FillChar)
+        {
+            PCHAR_INFO Ptr = ConioCoordToPointer(ScreenBuffer, Left, Y);
+            for (X = Left; X <= Right; ++X, ++Ptr)
+            {
+                Ptr->Char.UnicodeChar = FillChar;
+                Ptr->Attributes = Attr;
+            }
+        }
+        ConioFillCellColors(ScreenBuffer, Left, Y, Right + 1 - Left, Fg, Bg);
+    }
+}
+
+static VOID
+VtInsertCharacters(PCONSOLE Console,
+                   PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                   ULONG Count)
+{
+    SHORT Width = ScreenBuffer->ScreenBufferSize.X;
+    SHORT Y = ScreenBuffer->CursorPosition.Y;
+    SHORT X = ScreenBuffer->CursorPosition.X;
+    ULONG Available;
+    ULONG CellsToMove;
+    ULONG RowIndex;
+    SHORT FillCount;
+
+    if (Count == 0)
+        Count = 1;
+
+    if (Width <= 0)
+        return;
+
+    if (Y < 0 || Y >= ScreenBuffer->ScreenBufferSize.Y)
+        return;
+
+    if (X < 0 || X >= Width)
+        return;
+
+    Available = (ULONG)(Width - X);
+    if (Available == 0)
+        return;
+
+    if (Count > Available)
+        Count = Available;
+
+    FillCount = (SHORT)Count;
+
+    CellsToMove = Available - Count;
+    if (CellsToMove > 0)
+    {
+        PCHAR_INFO Row = ConioCoordToPointer(ScreenBuffer, 0, Y);
+        RowIndex = ConioCoordToIndex(ScreenBuffer, 0, Y);
+        RtlMoveMemory(Row + X + Count,
+                      Row + X,
+                      CellsToMove * sizeof(CHAR_INFO));
+
+        ConioMoveCellColorsByIndex(ScreenBuffer, RowIndex + X + Count, RowIndex + X, CellsToMove);
+    }
+
+    VtFillRect(ScreenBuffer, X, Y, (SHORT)(X + FillCount - 1), Y, L' ');
+
+    {
+        SMALL_RECT Region;
+        Region.Left = X;
+        Region.Top = Y;
+        Region.Right = Width > 0 ? Width - 1 : 0;
+        Region.Bottom = Y;
+        TermDrawRegion(Console, &Region);
+    }
+}
+
+static VOID
+VtDeleteCharacters(PCONSOLE Console,
+                   PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                   ULONG Count)
+{
+    SHORT Width = ScreenBuffer->ScreenBufferSize.X;
+    SHORT Y = ScreenBuffer->CursorPosition.Y;
+    SHORT X = ScreenBuffer->CursorPosition.X;
+    ULONG Available;
+    ULONG CellsToMove;
+    ULONG RowIndex;
+    SHORT TailStart;
+    SHORT DeleteCount;
+
+    if (Count == 0)
+        Count = 1;
+
+    if (Width <= 0)
+        return;
+
+    if (Y < 0 || Y >= ScreenBuffer->ScreenBufferSize.Y)
+        return;
+
+    if (X < 0 || X >= Width)
+        return;
+
+    Available = (ULONG)(Width - X);
+    if (Available == 0)
+        return;
+
+    if (Count > Available)
+        Count = Available;
+
+    DeleteCount = (SHORT)Count;
+
+    CellsToMove = Available - Count;
+    if (CellsToMove > 0)
+    {
+        PCHAR_INFO Row = ConioCoordToPointer(ScreenBuffer, 0, Y);
+        RowIndex = ConioCoordToIndex(ScreenBuffer, 0, Y);
+        RtlMoveMemory(Row + X,
+                      Row + X + Count,
+                      CellsToMove * sizeof(CHAR_INFO));
+
+        ConioMoveCellColorsByIndex(ScreenBuffer, RowIndex + X, RowIndex + X + Count, CellsToMove);
+    }
+
+    TailStart = (SHORT)(Width - DeleteCount);
+    VtFillRect(ScreenBuffer, TailStart, Y, Width > 0 ? Width - 1 : 0, Y, L' ');
+
+    {
+        SMALL_RECT Region;
+        Region.Left = X;
+        Region.Top = Y;
+        Region.Right = Width > 0 ? Width - 1 : 0;
+        Region.Bottom = Y;
+        TermDrawRegion(Console, &Region);
+    }
+}
+
+static VOID
+VtEraseCharacters(PCONSOLE Console,
+                  PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                  ULONG Count)
+{
+    SHORT Width = ScreenBuffer->ScreenBufferSize.X;
+    SHORT Y = ScreenBuffer->CursorPosition.Y;
+    SHORT X = ScreenBuffer->CursorPosition.X;
+
+    if (Count == 0)
+        Count = 1;
+
+    if (Width <= 0)
+        return;
+
+    if (Y < 0 || Y >= ScreenBuffer->ScreenBufferSize.Y)
+        return;
+
+    if (X < 0 || X >= Width)
+        return;
+
+    if ((ULONG)(Width - X) < Count)
+        Count = (ULONG)(Width - X);
+
+    if (Count == 0)
+        return;
+
+    {
+        SHORT EraseCount = (SHORT)Count;
+        VtFillRect(ScreenBuffer, X, Y, (SHORT)(X + EraseCount - 1), Y, L' ');
+
+        {
+            SMALL_RECT Region;
+            Region.Left = X;
+            Region.Top = Y;
+            Region.Right = (SHORT)(X + EraseCount - 1);
+            Region.Bottom = Y;
+            TermDrawRegion(Console, &Region);
+        }
+    }
+}
+
+static NTSTATUS
+VtFlushText(PCONSOLE Console,
+           PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+           PCWSTR Text,
+           ULONG Length);
+
+static VOID
+VtRepeatCharacter(PCONSOLE Console,
+                  PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                  ULONG Count)
+{
+    WCHAR Chunk[64];
+    ULONG Remaining;
+
+    if (!Console || !ScreenBuffer)
+        return;
+
+    if (!ScreenBuffer->VtState.LastCharValid)
+        return;
+
+    if (Count == 0)
+        Count = 1;
+
+    Remaining = Count;
+
+    while (Remaining > 0)
+    {
+        ULONG Emit = (Remaining > ARRAYSIZE(Chunk)) ? ARRAYSIZE(Chunk) : Remaining;
+        ULONG i;
+
+        for (i = 0; i < Emit; ++i)
+            Chunk[i] = ScreenBuffer->VtState.LastWrittenChar;
+
+        if (!NT_SUCCESS(VtFlushText(Console, ScreenBuffer, Chunk, Emit)))
+            break;
+
+        Remaining -= Emit;
+    }
+}
+
+static VOID
+VtInsertLines(PCONSOLE Console,
+              PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+              ULONG Count)
+{
+    SHORT Width = ScreenBuffer->ScreenBufferSize.X;
+    SHORT CursorY = ScreenBuffer->CursorPosition.Y;
+    SHORT Top = ScreenBuffer->VtState.ScrollTop;
+    SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
+    SHORT LinesAvailable;
+    SHORT Line;
+
+    if (Count == 0)
+        Count = 1;
+
+    if (Width <= 0)
+        return;
+
+    if (Top < 0)
+        Top = 0;
+    if (Bottom >= ScreenBuffer->ScreenBufferSize.Y)
+        Bottom = ScreenBuffer->ScreenBufferSize.Y - 1;
+
+    if (CursorY < Top || CursorY > Bottom)
+        return;
+
+    LinesAvailable = Bottom - CursorY + 1;
+    if (LinesAvailable <= 0)
+        return;
+
+    if ((ULONG)LinesAvailable < Count)
+        Count = LinesAvailable;
+
+    {
+        SHORT InsertCount = (SHORT)Count;
+
+        if (InsertCount <= 0)
+            return;
+
+        if (InsertCount < LinesAvailable)
+        {
+            for (Line = Bottom - InsertCount; Line >= CursorY; --Line)
+            {
+                PCHAR_INFO Src = ConioCoordToPointer(ScreenBuffer, 0, Line);
+                PCHAR_INFO Dst = ConioCoordToPointer(ScreenBuffer, 0, Line + InsertCount);
+                RtlMoveMemory(Dst, Src, Width * sizeof(CHAR_INFO));
+                ConioMoveCellColors(ScreenBuffer, 0, Line + InsertCount, 0, Line, Width);
+            }
+        }
+
+        VtFillRect(ScreenBuffer, 0, CursorY, Width > 0 ? Width - 1 : 0, (SHORT)(CursorY + InsertCount - 1), L' ');
+
+        {
+            SMALL_RECT Region;
+            Region.Left = 0;
+            Region.Right = Width > 0 ? Width - 1 : 0;
+            Region.Top = CursorY;
+            Region.Bottom = Bottom;
+            TermDrawRegion(Console, &Region);
+        }
+    }
+}
+
+static VOID
+VtDeleteLines(PCONSOLE Console,
+              PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+              ULONG Count)
+{
+    SHORT Width = ScreenBuffer->ScreenBufferSize.X;
+    SHORT CursorY = ScreenBuffer->CursorPosition.Y;
+    SHORT Top = ScreenBuffer->VtState.ScrollTop;
+    SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
+    SHORT LinesAvailable;
+    SHORT Line;
+
+    if (Count == 0)
+        Count = 1;
+
+    if (Width <= 0)
+        return;
+
+    if (Top < 0)
+        Top = 0;
+    if (Bottom >= ScreenBuffer->ScreenBufferSize.Y)
+        Bottom = ScreenBuffer->ScreenBufferSize.Y - 1;
+
+    if (CursorY < Top || CursorY > Bottom)
+        return;
+
+    LinesAvailable = Bottom - CursorY + 1;
+    if (LinesAvailable <= 0)
+        return;
+
+    if ((ULONG)LinesAvailable < Count)
+        Count = LinesAvailable;
+
+    {
+        SHORT DeleteCount = (SHORT)Count;
+
+        if (DeleteCount <= 0)
+            return;
+
+        if (DeleteCount < LinesAvailable)
+        {
+            for (Line = CursorY; Line <= Bottom - DeleteCount; ++Line)
+            {
+                PCHAR_INFO Src = ConioCoordToPointer(ScreenBuffer, 0, Line + DeleteCount);
+                PCHAR_INFO Dst = ConioCoordToPointer(ScreenBuffer, 0, Line);
+                RtlMoveMemory(Dst, Src, Width * sizeof(CHAR_INFO));
+                ConioMoveCellColors(ScreenBuffer, 0, Line, 0, Line + DeleteCount, Width);
+            }
+        }
+
+        VtFillRect(ScreenBuffer, 0, (SHORT)(Bottom - DeleteCount + 1), Width > 0 ? Width - 1 : 0, Bottom, L' ');
+
+        {
+            SMALL_RECT Region;
+            Region.Left = 0;
+            Region.Right = Width > 0 ? Width - 1 : 0;
+            Region.Top = CursorY;
+            Region.Bottom = Bottom;
+            TermDrawRegion(Console, &Region);
+        }
+    }
+}
+
+static VOID
+VtScrollRegionUp(PCONSOLE Console,
+                 PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                 ULONG Lines)
+{
+    SHORT Top = ScreenBuffer->VtState.ScrollTop;
+    SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
+    SHORT Height = Bottom - Top + 1;
+    SMALL_RECT ScrollRect;
+    COORD DestOrigin;
+    CHAR_INFO FillChar;
+
+    if (Height <= 0)
+        return;
+
+    if (Lines == 0)
+        Lines = 1;
+    if (Lines > (ULONG)Height)
+        Lines = Height;
+
+    ScrollRect.Left = 0;
+    ScrollRect.Top = Top;
+    ScrollRect.Right = ScreenBuffer->ScreenBufferSize.X - 1;
+    ScrollRect.Bottom = Bottom;
+
+    DestOrigin.X = 0;
+    DestOrigin.Y = (SHORT)(Top - (SHORT)Lines);
+
+    FillChar.Char.UnicodeChar = L' ';
+    FillChar.Attributes = ScreenBuffer->VtState.CurrentAttributes;
+
+    if (!NT_SUCCESS(ConDrvScrollConsoleScreenBuffer(Console,
+                                                    ScreenBuffer,
+                                                    TRUE,
+                                                    &ScrollRect,
+                                                    FALSE,
+                                                    NULL,
+                                                    &DestOrigin,
+                                                    FillChar)))
+    {
+        return;
+    }
+
+    VtFillRect(ScreenBuffer, 0, Bottom - (SHORT)Lines + 1, ScreenBuffer->ScreenBufferSize.X - 1, Bottom, 0);
+}
+
+static VOID
+VtScrollRegionDown(PCONSOLE Console,
+                 PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                 ULONG Lines)
+{
+    SHORT Top = ScreenBuffer->VtState.ScrollTop;
+    SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
+    SHORT Height = Bottom - Top + 1;
+    SMALL_RECT ScrollRect;
+    COORD DestOrigin;
+    CHAR_INFO FillChar;
+
+    if (Height <= 0)
+        return;
+
+    if (Lines == 0)
+        Lines = 1;
+    if (Lines > (ULONG)Height)
+        Lines = Height;
+
+    ScrollRect.Left = 0;
+    ScrollRect.Top = Top;
+    ScrollRect.Right = ScreenBuffer->ScreenBufferSize.X - 1;
+    ScrollRect.Bottom = Bottom;
+
+    DestOrigin.X = 0;
+    DestOrigin.Y = (SHORT)(Top + (SHORT)Lines);
+
+    FillChar.Char.UnicodeChar = L' ';
+    FillChar.Attributes = ScreenBuffer->VtState.CurrentAttributes;
+
+    if (!NT_SUCCESS(ConDrvScrollConsoleScreenBuffer(Console,
+                                                    ScreenBuffer,
+                                                    TRUE,
+                                                    &ScrollRect,
+                                                    FALSE,
+                                                    NULL,
+                                                    &DestOrigin,
+                                                    FillChar)))
+    {
+        return;
+    }
+
+    VtFillRect(ScreenBuffer, 0, Top, ScreenBuffer->ScreenBufferSize.X - 1, Top + (SHORT)Lines - 1, 0);
+}
+
+VOID
+NTAPI
+ConDrvVtAdvanceLine(PCONSOLE Console,
+                    PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    SHORT Bottom;
+
+    if (!Console || !ScreenBuffer || ScreenBuffer->ScreenBufferSize.Y <= 0)
+        return;
+
+    Bottom = ScreenBuffer->ScreenBufferSize.Y - 1;
+
+    if (ScreenBuffer->VtState.ScrollTop >= 0 &&
+        ScreenBuffer->VtState.ScrollBottom >= ScreenBuffer->VtState.ScrollTop)
+    {
+        Bottom = min(Bottom, ScreenBuffer->VtState.ScrollBottom);
+    }
+
+    if (ScreenBuffer->CursorPosition.Y >= ScreenBuffer->VtState.ScrollTop &&
+        ScreenBuffer->CursorPosition.Y == Bottom)
+    {
+        VtScrollRegionUp(Console, ScreenBuffer, 1);
+        return;
+    }
+
+    if (ScreenBuffer->CursorPosition.Y < ScreenBuffer->ScreenBufferSize.Y - 1)
+        ScreenBuffer->CursorPosition.Y++;
+}
+
+static VOID
+VtScrollLeft(PCONSOLE Console,
+             PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+             ULONG Count)
+{
+    SHORT Top = ScreenBuffer->VtState.ScrollTop;
+    SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
+    SHORT Width = ScreenBuffer->ScreenBufferSize.X;
+    SHORT Line;
+
+    if (!Console || !ScreenBuffer)
+        return;
+
+    if (Width <= 0)
+        return;
+
+    if (Count == 0)
+        Count = 1;
+    if (Count > (ULONG)Width)
+        Count = Width;
+
+    if (Top < 0)
+        Top = 0;
+    if (Bottom >= ScreenBuffer->ScreenBufferSize.Y)
+        Bottom = ScreenBuffer->ScreenBufferSize.Y - 1;
+    if (Bottom < Top)
+        return;
+
+    for (Line = Top; Line <= Bottom; ++Line)
+    {
+        PCHAR_INFO Row = ConioCoordToPointer(ScreenBuffer, 0, Line);
+        ULONG RowIndex = ConioCoordToIndex(ScreenBuffer, 0, Line);
+        SHORT Shift = (SHORT)Count;
+
+        if (Shift >= Width)
+        {
+            VtFillRect(ScreenBuffer, 0, Line, Width > 0 ? Width - 1 : 0, Line, L' ');
+            continue;
+        }
+
+        RtlMoveMemory(Row, Row + Shift, (Width - Shift) * sizeof(CHAR_INFO));
+
+        ConioMoveCellColorsByIndex(ScreenBuffer, RowIndex, RowIndex + Shift, (Width - Shift));
+
+        /* The columns vacated at the right edge take the current SGR state */
+        VtFillRect(ScreenBuffer, (SHORT)(Width - Shift), Line, (SHORT)(Width - 1), Line, L' ');
+    }
+
+    if (Width > 0)
+    {
+        SMALL_RECT Region;
+        Region.Left = 0;
+        Region.Right = Width - 1;
+        Region.Top = Top;
+        Region.Bottom = Bottom;
+        TermDrawRegion(Console, &Region);
+    }
+}
+
+static VOID
+VtScrollRight(PCONSOLE Console,
+              PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+              ULONG Count)
+{
+    SHORT Top = ScreenBuffer->VtState.ScrollTop;
+    SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
+    SHORT Width = ScreenBuffer->ScreenBufferSize.X;
+    SHORT Line;
+
+    if (!Console || !ScreenBuffer)
+        return;
+
+    if (Width <= 0)
+        return;
+
+    if (Count == 0)
+        Count = 1;
+    if (Count > (ULONG)Width)
+        Count = Width;
+
+    if (Top < 0)
+        Top = 0;
+    if (Bottom >= ScreenBuffer->ScreenBufferSize.Y)
+        Bottom = ScreenBuffer->ScreenBufferSize.Y - 1;
+    if (Bottom < Top)
+        return;
+
+    for (Line = Top; Line <= Bottom; ++Line)
+    {
+        PCHAR_INFO Row = ConioCoordToPointer(ScreenBuffer, 0, Line);
+        ULONG RowIndex = ConioCoordToIndex(ScreenBuffer, 0, Line);
+        SHORT Shift = (SHORT)Count;
+
+        if (Shift >= Width)
+        {
+            VtFillRect(ScreenBuffer, 0, Line, Width > 0 ? Width - 1 : 0, Line, L' ');
+            continue;
+        }
+
+        RtlMoveMemory(Row + Shift, Row, (Width - Shift) * sizeof(CHAR_INFO));
+
+        ConioMoveCellColorsByIndex(ScreenBuffer, RowIndex + Shift, RowIndex, (Width - Shift));
+
+        /* The columns vacated at the left edge take the current SGR state */
+        VtFillRect(ScreenBuffer, 0, Line, (SHORT)(Shift - 1), Line, L' ');
+    }
+
+    if (Width > 0)
+    {
+        SMALL_RECT Region;
+        Region.Left = 0;
+        Region.Right = Width - 1;
+        Region.Top = Top;
+        Region.Bottom = Bottom;
+        TermDrawRegion(Console, &Region);
+    }
+}
+
+static BOOLEAN
+VtSetConsoleTitle(PCONSOLE Console,
+                  const WCHAR *Title,
+                  ULONG Length)
+{
+    if (!Console || !Title)
+        return FALSE;
+
+    /* Clamp to what the UNICODE_STRING behind the title can represent */
+    if (Length > (ULONG)((MAXUSHORT / sizeof(WCHAR)) - 1))
+        Length = (ULONG)((MAXUSHORT / sizeof(WCHAR)) - 1);
+
+    /* The title is server-layer state, including who frees the old buffer */
+    return !!TermSetTitle(Console, Title, Length * sizeof(WCHAR));
+}
+
+static BOOLEAN
+VtReportWindowSize(PCONSOLE Console,
+                   PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                   ULONG ReplyPrefix)
+{
+    WCHAR Response[32];
+    SIZE_T Len = 0;
+    SHORT Rows;
+    SHORT Cols;
+
+    if (!Console || !ScreenBuffer)
+        return FALSE;
+
+    Rows = ScreenBuffer->ViewSize.Y;
+    Cols = ScreenBuffer->ViewSize.X;
+    if (Rows <= 0)
+        Rows = ScreenBuffer->ScreenBufferSize.Y;
+    if (Cols <= 0)
+        Cols = ScreenBuffer->ScreenBufferSize.X;
+    if (Rows <= 0) Rows = 1;
+    if (Cols <= 0) Cols = 1;
+
+    Response[Len++] = L'\x1b';
+    Response[Len++] = L'[';
+    Len += VtAppendNumber(Response + Len,
+                          ARRAYSIZE(Response) - Len,
+                          ReplyPrefix);
+    if (Len < ARRAYSIZE(Response))
+        Response[Len++] = L';';
+    Len += VtAppendNumber(Response + Len,
+                          ARRAYSIZE(Response) - Len,
+                          (ULONG)Rows);
+    if (Len < ARRAYSIZE(Response))
+        Response[Len++] = L';';
+    Len += VtAppendNumber(Response + Len,
+                          ARRAYSIZE(Response) - Len,
+                          (ULONG)Cols);
+    if (Len < ARRAYSIZE(Response))
+        Response[Len++] = L't';
+
+    VtSendInputResponse(Console, Response, Len);
+    return TRUE;
+}
+
+static BOOLEAN
+VtResizeWindow(PCONSOLE Console,
+               PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+               ULONG Rows,
+               ULONG Cols)
+{
+    SMALL_RECT WindowRect;
+    COORD Size;
+    NTSTATUS Status;
+
+    if (!Console || !ScreenBuffer)
+        return FALSE;
+
+    if (Rows == 0 || Cols == 0)
+        return TRUE;
+
+    if (Rows > SHRT_MAX) Rows = SHRT_MAX;
+    if (Cols > SHRT_MAX) Cols = SHRT_MAX;
+
+    Size.X = (SHORT)max(1UL, Cols);
+    Size.Y = (SHORT)max(1UL, Rows);
+
+    if (Size.X != ScreenBuffer->ScreenBufferSize.X ||
+        Size.Y != ScreenBuffer->ScreenBufferSize.Y)
+    {
+        Status = ConDrvSetConsoleScreenBufferSize(Console, ScreenBuffer, &Size);
+        if (!NT_SUCCESS(Status))
+            return FALSE;
+    }
+
+    WindowRect.Left = 0;
+    WindowRect.Top = 0;
+    WindowRect.Right = (SHORT)(Size.X - 1);
+    WindowRect.Bottom = (SHORT)(Size.Y - 1);
+
+    Status = ConDrvSetConsoleWindowInfo(Console, ScreenBuffer, TRUE, &WindowRect);
+    return NT_SUCCESS(Status);
+}
+
+static BOOLEAN
+VtParseHexComponent(const WCHAR *Start,
+                    const WCHAR *End,
+                    ULONG *Value,
+                    ULONG *Digits)
+{
+    ULONG Result = 0;
+    ULONG Count = 0;
+
+    if (!Value || !Digits)
+        return FALSE;
+
+    while (Start < End)
+    {
+        WCHAR Ch = *Start++;
+        ULONG Nibble;
+
+        if (Ch >= L'0' && Ch <= L'9')
+            Nibble = Ch - L'0';
+        else if (Ch >= L'a' && Ch <= L'f')
+            Nibble = Ch - L'a' + 10;
+        else if (Ch >= L'A' && Ch <= L'F')
+            Nibble = Ch - L'A' + 10;
+        else
+            return FALSE;
+
+        Result = (Result << 4) | Nibble;
+        if (++Count > 4)
+            return FALSE;
+    }
+
+    if (Count == 0)
+        return FALSE;
+
+    *Value = Result;
+    *Digits = Count;
+    return TRUE;
+}
+
+static BYTE
+VtScaleComponent(ULONG Value, ULONG Digits)
+{
+    ULONG MaxValue;
+
+    if (Digits == 0)
+        return 0;
+
+    MaxValue = (1u << (Digits * 4)) - 1u;
+    if (MaxValue == 0)
+        return 0;
+
+    return (BYTE)((Value * 255u + MaxValue / 2u) / MaxValue);
+}
+
+static BOOLEAN
+VtOscParseRgb(const WCHAR *Value,
+              ULONG Length,
+              COLORREF *Color)
+{
+    const WCHAR *Start = Value;
+    const WCHAR *End = Value + Length;
+
+    if (!Value || !Color)
+        return FALSE;
+
+    /* Trim surrounding whitespace */
+    while (Start < End && (*Start == L' ' || *Start == L'\t'))
+        ++Start;
+    while (Start < End && (End[-1] == L' ' || End[-1] == L'\t'))
+        --End;
+
+    if (Start >= End)
+        return FALSE;
+
+    if (*Start == L'#')
+    {
+        ULONG DigitsPerComponent;
+        ULONG ComponentLength = (ULONG)(End - Start - 1);
+        ULONG RValue, GValue, BValue;
+        ULONG Digits;
+        const WCHAR *Ptr;
+
+        if (ComponentLength == 0 || (ComponentLength % 3) != 0)
+            return FALSE;
+
+        DigitsPerComponent = ComponentLength / 3;
+        Ptr = Start + 1;
+
+        if (!VtParseHexComponent(Ptr, Ptr + DigitsPerComponent, &RValue, &Digits))
+            return FALSE;
+        Ptr += DigitsPerComponent;
+
+        if (!VtParseHexComponent(Ptr, Ptr + DigitsPerComponent, &GValue, &Digits))
+            return FALSE;
+        Ptr += DigitsPerComponent;
+
+        if (!VtParseHexComponent(Ptr, Ptr + DigitsPerComponent, &BValue, &Digits))
+            return FALSE;
+
+        *Color = RGB(VtScaleComponent(RValue, DigitsPerComponent),
+                     VtScaleComponent(GValue, DigitsPerComponent),
+                     VtScaleComponent(BValue, DigitsPerComponent));
+        return TRUE;
+    }
+
+    if ((End - Start) > 4 && Start[0] == L'r' && Start[1] == L'g' && Start[2] == L'b' && Start[3] == L':')
+    {
+        const WCHAR *Ptr = Start + 4;
+        ULONG Values[3];
+        ULONG Digits;
+        ULONG Index = 0;
+        const WCHAR *SegmentStart;
+
+        while (Index < 3 && Ptr <= End)
+        {
+            SegmentStart = Ptr;
+            while (Ptr < End && *Ptr != L'/')
+                ++Ptr;
+
+            if (!VtParseHexComponent(SegmentStart, Ptr, &Values[Index], &Digits))
+                return FALSE;
+
+            Values[Index] = VtScaleComponent(Values[Index], Digits);
+            ++Index;
+
+            if (Ptr < End)
+                ++Ptr; /* Skip '/' */
+        }
+
+        if (Index != 3)
+            return FALSE;
+
+        *Color = RGB((BYTE)Values[0], (BYTE)Values[1], (BYTE)Values[2]);
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+static VOID
+VtUpdatePaletteHandle(PCONSOLE Console,
+                      PTEXTMODE_SCREEN_BUFFER Buffer)
+{
+    COLORREF Colors[VT_PALETTE_SIZE];
+    PALETTEENTRY Entries[VT_PALETTE_SIZE];
+    UINT Index;
+
+    if (!Buffer || !Buffer->PaletteHandle)
+        return;
+    if (!VtReadPalette(Console, Colors))
+        return;
+
+    for (Index = 0; Index < ARRAYSIZE(Entries); ++Index)
+    {
+        COLORREF Color = Colors[Index];
+        Entries[Index].peRed   = GetRValue(Color);
+        Entries[Index].peGreen = GetGValue(Color);
+        Entries[Index].peBlue  = GetBValue(Color);
+        Entries[Index].peFlags = 0;
+    }
+
+    SetPaletteEntries(Buffer->PaletteHandle, 0, ARRAYSIZE(Entries), Entries);
+}
+
+static VOID
+VtRefreshPaletteForBuffer(PCONSOLE Console,
+                          PTEXTMODE_SCREEN_BUFFER Buffer)
+{
+    if (!Console || !Buffer)
+        return;
+
+    if (!Buffer->VtState.UseRgbForeground)
+    {
+        Buffer->VtState.CurrentFgColor = VtGetPaletteColor(Console, Buffer->VtState.CurrentAttributes & 0x0F);
+    }
+
+    if (!Buffer->VtState.UseRgbBackground)
+    {
+        Buffer->VtState.CurrentBgColor = VtGetPaletteColor(Console, (Buffer->VtState.CurrentAttributes >> 4) & 0x0F);
+    }
+
+    if (!Buffer->VtState.SavedUseRgbForeground)
+    {
+        Buffer->VtState.SavedFgColor = VtGetPaletteColor(Console, Buffer->VtState.SavedAttributes & 0x0F);
+    }
+
+    if (!Buffer->VtState.SavedUseRgbBackground)
+    {
+        Buffer->VtState.SavedBgColor = VtGetPaletteColor(Console, (Buffer->VtState.SavedAttributes >> 4) & 0x0F);
+    }
+
+    VtUpdatePaletteHandle(Console, Buffer);
+}
+
+static VOID
+VtApplyPaletteChange(PCONSOLE Console)
+{
+    PCONSOLE_SCREEN_BUFFER Active;
+
+    if (!Console)
+        return;
+
+    Active = Console->ActiveBuffer;
+    if (Active && GetType(Active) == TEXTMODE_BUFFER)
+    {
+        PTEXTMODE_SCREEN_BUFFER TextActive = (PTEXTMODE_SCREEN_BUFFER)Active;
+        SMALL_RECT Region;
+
+        TermSetPalette(Console, TextActive->PaletteHandle, TextActive->PaletteUsage);
+
+        if (TextActive->ScreenBufferSize.X > 0 && TextActive->ScreenBufferSize.Y > 0)
+        {
+            Region.Left = 0;
+            Region.Top = 0;
+            Region.Right = TextActive->ScreenBufferSize.X - 1;
+            Region.Bottom = TextActive->ScreenBufferSize.Y - 1;
+            TermDrawRegion(Console, &Region);
+        }
+    }
+}
+
+static BOOLEAN
+VtHandleOscPalette(PCONSOLE Console,
+                   PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                   const WCHAR *Parameters,
+                   ULONG Length)
+{
+    const WCHAR *Ptr = Parameters;
+    const WCHAR *End = Parameters + Length;
+    BOOLEAN Handled = FALSE;
+    BOOLEAN Updated = FALSE;
+    COLORREF Colors[VT_PALETTE_SIZE];
+
+    if (!VtReadPalette(Console, Colors))
+        return TRUE;
+
+    while (Ptr < End)
+    {
+        ULONG Index = 0;
+        BOOLEAN HaveDigits = FALSE;
+
+        while (Ptr < End && (*Ptr == L';' || *Ptr == L' ' || *Ptr == L'\t'))
+            ++Ptr;
+
+        if (Ptr >= End)
+            break;
+
+        while (Ptr < End && *Ptr != L';')
+        {
+            if (*Ptr >= L'0' && *Ptr <= L'9')
+            {
+                Index = Index * 10 + (ULONG)(*Ptr - L'0');
+                HaveDigits = TRUE;
+            }
+            else if (*Ptr != L' ' && *Ptr != L'\t')
+            {
+                HaveDigits = FALSE;
+            }
+            ++Ptr;
+        }
+
+        if (!HaveDigits)
+        {
+            if (Ptr < End)
+                ++Ptr;
+            continue;
+        }
+
+        if (Ptr >= End)
+            break;
+
+        ++Ptr; /* Skip ';' */
+        const WCHAR *ColorStart = Ptr;
+        while (Ptr < End && *Ptr != L';')
+            ++Ptr;
+
+        if (ColorStart < Ptr && Index < 16)
+        {
+            COLORREF Parsed;
+            ULONG ColorLength = (ULONG)(Ptr - ColorStart);
+            UCHAR PaletteIndex = VtXtermToConsoleIndex((UCHAR)Index);
+
+            if (ColorLength == 1 && *ColorStart == L'?')
+            {
+                VtSendOscPaletteResponse(Console, Index, Colors[PaletteIndex]);
+                Handled = TRUE;
+            }
+            else if (VtOscParseRgb(ColorStart, ColorLength, &Parsed))
+            {
+                Colors[PaletteIndex] = Parsed;
+                Handled = TRUE;
+                Updated = TRUE;
+            }
+        }
+    }
+
+    if (Updated)
+    {
+        TermSetColorTable(Console, Colors, VT_PALETTE_SIZE);
+
+        VtRefreshPaletteForBuffer(Console, ScreenBuffer);
+        if (ScreenBuffer && ScreenBuffer->VtState.PrimaryBuffer)
+            VtRefreshPaletteForBuffer(Console, ScreenBuffer->VtState.PrimaryBuffer);
+        if (ScreenBuffer && ScreenBuffer->VtState.AlternateBuffer)
+            VtRefreshPaletteForBuffer(Console, ScreenBuffer->VtState.AlternateBuffer);
+
+        VtApplyPaletteChange(Console);
+    }
+
+    return Handled;
+}
+
+static BOOLEAN
+VtHandleOscDefaultColor(PCONSOLE Console,
+                        PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                        ULONG Parameter,
+                        const WCHAR *Value,
+                        ULONG Length)
+{
+    COLORREF Colors[VT_PALETTE_SIZE];
+    UCHAR Index;
+    COLORREF Parsed;
+
+    if (!ScreenBuffer || !Value)
+        return FALSE;
+    if (!VtReadPalette(Console, Colors))
+        return FALSE;
+
+    while (Length > 0 && (*Value == L' ' || *Value == L'\t'))
+    {
+        ++Value;
+        --Length;
+    }
+
+    if (Parameter == 10)
+        Index = (UCHAR)(ScreenBuffer->ScreenDefaultAttrib & 0x0F);
+    else if (Parameter == 11)
+        Index = (UCHAR)((ScreenBuffer->ScreenDefaultAttrib >> 4) & 0x0F);
+    else
+        return FALSE;
+
+    if (Length > 0 && *Value == L'?')
+    {
+        VtSendOscColorResponse(Console, Parameter, Colors[Index]);
+        return TRUE;
+    }
+
+    if (!VtOscParseRgb(Value, Length, &Parsed))
+        return FALSE;
+
+    Colors[Index] = Parsed;
+    return !!TermSetColorTable(Console, Colors, VT_PALETTE_SIZE);
+}
+
+static BOOLEAN
+VtHandleOscHyperlink(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                     const WCHAR *Parameters,
+                     ULONG Length)
+{
+    PCONSOLE Console = ScreenBuffer ? ScreenBuffer->Header.Console : NULL;
+    const WCHAR *Ptr = Parameters;
+    const WCHAR *End = Parameters + Length;
+    const WCHAR *UriStart;
+    ULONG UriLength = 0;
+
+    if (!ScreenBuffer)
+        return TRUE;
+
+    if (Console && !Console->AllowVtOscHyperlinks)
+    {
+        VtTracePolicyBlocked("OSC 8 hyperlink");
+        VtClearHyperlink(ScreenBuffer);
+        return TRUE;
+    }
+
+    while (Ptr < End && *Ptr != L';')
+        ++Ptr;
+
+    if (Ptr < End)
+        ++Ptr;
+    else
+        Ptr = End;
+
+    UriStart = Ptr;
+    if (UriStart < End)
+        UriLength = (ULONG)(End - UriStart);
+
+    VtClearHyperlink(ScreenBuffer);
+
+    if (UriLength == 0)
+        return TRUE;
+
+    if (UriLength >= (ULONG)((USHRT_MAX / sizeof(WCHAR)) - 1))
+        return TRUE;
+
+    PWCHAR Buffer = ConsoleAllocHeap(0, (UriLength + 1) * sizeof(WCHAR));
+    if (!Buffer)
+        return TRUE;
+
+    RtlCopyMemory(Buffer, UriStart, UriLength * sizeof(WCHAR));
+    Buffer[UriLength] = UNICODE_NULL;
+
+    ScreenBuffer->VtState.HyperlinkUri.Buffer = Buffer;
+    ScreenBuffer->VtState.HyperlinkUri.Length = (USHORT)(UriLength * sizeof(WCHAR));
+    ScreenBuffer->VtState.HyperlinkUri.MaximumLength = (USHORT)((UriLength + 1) * sizeof(WCHAR));
+    ScreenBuffer->VtState.HyperlinkActive = TRUE;
+    return TRUE;
+}
+
+
+static BOOLEAN
+VtHandleOscClipboard(PCONSOLE Console,
+                     const WCHAR *Parameters,
+                     ULONG Length)
+{
+    const WCHAR *End = Parameters + Length;
+    const WCHAR *TargetStart = Parameters;
+    const WCHAR *TargetEnd = TargetStart;
+    const WCHAR *DataStart;
+    SIZE_T TargetLength;
+
+    if (!Console)
+        return TRUE;
+
+    while (TargetEnd < End && *TargetEnd != L';')
+        ++TargetEnd;
+
+    DataStart = (TargetEnd < End) ? TargetEnd + 1 : End;
+    TargetLength = (SIZE_T)(TargetEnd - TargetStart);
+
+    while (DataStart < End && (*DataStart == L' ' || *DataStart == L'	'))
+        ++DataStart;
+    while (End > DataStart && (End[-1] == L' ' || End[-1] == L'	'))
+        --End;
+
+    if (DataStart >= End)
+        return TRUE;
+
+    if (*DataStart == L'?')
+    {
+        PWSTR Encoded = NULL;
+        BYTE *Utf8Buffer = NULL;
+        PWCHAR ClipText = NULL;
+        ULONG ClipChars = 0;
+        BOOL Success = FALSE;
+
+        if (!Console->AllowVtOscClipboard)
+        {
+            VtSendOscClipboardResponse(Console, TargetStart, TargetLength, L"");
+            return TRUE;
+        }
+
+        /* The clipboard belongs to the frontend's window station, not to us */
+        if (TermGetClipboardText(Console, &ClipText, &ClipChars) && ClipChars > 0)
+        {
+            int Required = WideCharToMultiByte(CP_UTF8, 0, ClipText, (int)ClipChars, NULL, 0, NULL, NULL);
+            if (Required > 0)
+            {
+                Utf8Buffer = ConsoleAllocHeap(0, (ULONG)Required);
+                if (Utf8Buffer)
+                {
+                    if (WideCharToMultiByte(CP_UTF8, 0, ClipText, (int)ClipChars, (LPSTR)Utf8Buffer, Required, NULL, NULL) == Required)
+                    {
+                        ULONG EncodedChars = 0;
+                        if (VtEncodeBase64(Utf8Buffer, (ULONG)Required, &Encoded, &EncodedChars))
+                            Success = TRUE;
+                    }
+                    ConsoleFreeHeap(Utf8Buffer);
+                }
+            }
+        }
+        if (ClipText) ConsoleFreeHeap(ClipText);
+
+        if (Success && Encoded)
+        {
+            VtSendOscClipboardResponse(Console, TargetStart, TargetLength, Encoded);
+            ConsoleFreeHeap(Encoded);
+        }
+        else
+        {
+            VtSendOscClipboardResponse(Console, TargetStart, TargetLength, L"");
+            ConsoleFreeHeap(Encoded);
+        }
+
+        return TRUE;
+    }
+
+    if (!Console->AllowVtOscClipboard)
+        return TRUE;
+
+    {
+        ULONG DataLength = (ULONG)(End - DataStart);
+        BYTE *Decoded = NULL;
+        ULONG DecodedLength = 0;
+
+        if (!VtDecodeBase64(DataStart, DataLength, &Decoded, &DecodedLength))
+            return TRUE;
+
+        if (DecodedLength > 0)
+        {
+            int WideChars = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, (LPCSTR)Decoded, (int)DecodedLength, NULL, 0);
+            if (WideChars > 0)
+            {
+                PWCHAR Wide = ConsoleAllocHeap(0, ((ULONG)WideChars + 1) * sizeof(WCHAR));
+                if (Wide)
+                {
+                    if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, (LPCSTR)Decoded, (int)DecodedLength, Wide, WideChars) == WideChars)
+                    {
+                        Wide[WideChars] = UNICODE_NULL;
+                        /* Publishing to the clipboard is the frontend's job */
+                        TermSetClipboardText(Console, Wide, (ULONG)WideChars);
+                    }
+                    ConsoleFreeHeap(Wide);
+                }
+            }
+        }
+
+        ConsoleFreeHeap(Decoded);
+    }
+
+    return TRUE;
+}
+
+static BOOLEAN
+VtHandleOscSequence(PCONSOLE Console,
+                    PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                    const WCHAR *Sequence,
+                    ULONG Length)
+{
+    const WCHAR *End = Sequence + Length;
+    const WCHAR *ParamEnd = Sequence;
+    ULONG Parameter = 0;
+    BOOLEAN HaveParameter = FALSE;
+
+    while (ParamEnd < End && *ParamEnd != L';')
+        ++ParamEnd;
+
+    for (const WCHAR *Ptr = Sequence; Ptr < ParamEnd; ++Ptr)
+    {
+        if (*Ptr >= L'0' && *Ptr <= L'9')
+        {
+            Parameter = Parameter * 10 + (ULONG)(*Ptr - L'0');
+            HaveParameter = TRUE;
+        }
+        else if (*Ptr != L' ' && *Ptr != L'\t')
+        {
+            return TRUE;
+        }
+    }
+
+    if (!HaveParameter)
+        Parameter = 0;
+
+    if (ParamEnd < End)
+        ++ParamEnd;
+
+    switch (Parameter)
+    {
+        case 0:
+        case 1:
+        case 2:
+            if (ParamEnd <= End)
+            {
+                VtSetConsoleTitle(Console, ParamEnd, (ULONG)(End - ParamEnd));
+            }
+            return TRUE;
+
+        case 4:
+            VtHandleOscPalette(Console, ScreenBuffer, ParamEnd, (ULONG)(End - ParamEnd));
+            return TRUE;
+
+        case 10:
+        case 11:
+        {
+            BOOLEAN Updated = FALSE;
+
+            if (ParamEnd <= End)
+            {
+                Updated = VtHandleOscDefaultColor(Console,
+                                                   ScreenBuffer,
+                                                   Parameter,
+                                                   ParamEnd,
+                                                   (ULONG)(End - ParamEnd));
+            }
+
+            if (Updated)
+            {
+                VtRefreshPaletteForBuffer(Console, ScreenBuffer);
+                if (ScreenBuffer && ScreenBuffer->VtState.PrimaryBuffer)
+                    VtRefreshPaletteForBuffer(Console, ScreenBuffer->VtState.PrimaryBuffer);
+                if (ScreenBuffer && ScreenBuffer->VtState.AlternateBuffer)
+                    VtRefreshPaletteForBuffer(Console, ScreenBuffer->VtState.AlternateBuffer);
+
+                VtApplyPaletteChange(Console);
+            }
+
+            return TRUE;
+        }
+
+        case 8:
+            return VtHandleOscHyperlink(ScreenBuffer, ParamEnd, (ULONG)(End - ParamEnd));
+
+        case 52:
+            return VtHandleOscClipboard(Console, ParamEnd, (ULONG)(End - ParamEnd));
+
+        case 133: /* iTerm2 prompt markers */
+        case 134:
+        case 633:
+            return TRUE;
+
+        default:
+            VtTraceUnhandledOsc(Parameter);
+            return TRUE;
+    }
+
+    return TRUE;
+}
+
+static VOID
+VtUpdateLastWrittenChar(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                        PCWSTR Text,
+                        ULONG Length)
+{
+    ULONG i;
+
+    if (!ScreenBuffer || !Text || Length == 0)
+        return;
+
+    for (i = Length; i > 0; --i)
+    {
+        WCHAR Ch = Text[i - 1];
+        if (Ch >= L' ' && Ch != 0x7F)
+        {
+            ScreenBuffer->VtState.LastWrittenChar = Ch;
+            ScreenBuffer->VtState.LastCharValid = TRUE;
+            break;
+        }
+    }
+}
+
+static NTSTATUS
+VtFlushText(PCONSOLE Console,
+           PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+           PCWSTR Text,
+           ULONG Length)
+{
+    NTSTATUS Status;
+    USHORT OriginalAttrib;
+    WCHAR StackBuffer[128];
+    WCHAR *Translated;
+    UCHAR pending;
+
+    if (Length == 0) return STATUS_SUCCESS;
+
+    OriginalAttrib = ScreenBuffer->ScreenDefaultAttrib;
+    ScreenBuffer->ScreenDefaultAttrib = ScreenBuffer->VtState.CurrentAttributes;
+
+    VT_CHARSET_ID ActiveCharset = VtGetActiveCharset(ScreenBuffer);
+
+    if ((ScreenBuffer->VtState.PendingSingleShift == VT_CHARSET_SLOT_INVALID) &&
+        (ActiveCharset == VtCharsetAscii))
+    {
+        Status = TermWriteStream(Console,
+                                 ScreenBuffer,
+                                 (PWCHAR)Text,
+                                 Length,
+                                 TRUE);
+        if (NT_SUCCESS(Status))
+            VtUpdateLastWrittenChar(ScreenBuffer, Text, Length);
+        ScreenBuffer->ScreenDefaultAttrib = OriginalAttrib;
+        return Status;
+    }
+
+    Translated = StackBuffer;
+
+    if (Length > ARRAYSIZE(StackBuffer))
+    {
+        Translated = ConsoleAllocHeap(0, Length * sizeof(WCHAR));
+        if (!Translated)
+        {
+            ScreenBuffer->ScreenDefaultAttrib = OriginalAttrib;
+            return STATUS_INSUFFICIENT_RESOURCES;
+        }
+    }
+
+    pending = ScreenBuffer->VtState.PendingSingleShift;
+
+    for (ULONG i = 0; i < Length; ++i)
+    {
+        UCHAR slot = (pending != VT_CHARSET_SLOT_INVALID) ? pending
+                                                          : ScreenBuffer->VtState.ActiveCharset;
+        Translated[i] = VtTranslateGlyphSlot(ScreenBuffer, slot, Text[i]);
+
+        if (pending != VT_CHARSET_SLOT_INVALID)
+            pending = VT_CHARSET_SLOT_INVALID;
+    }
+
+    ScreenBuffer->VtState.PendingSingleShift = pending;
+
+    Status = TermWriteStream(Console,
+                             ScreenBuffer,
+                             Translated,
+                             Length,
+                             TRUE);
+
+    if (NT_SUCCESS(Status))
+        VtUpdateLastWrittenChar(ScreenBuffer, Translated, Length);
+
+    if (Translated != StackBuffer)
+        ConsoleFreeHeap(Translated);
+
+    ScreenBuffer->ScreenDefaultAttrib = OriginalAttrib;
+    return Status;
+}
+
+static UCHAR
+VtXtermToConsoleIndex(UCHAR Index)
+{
+    Index &= 0x0F;
+    return (UCHAR)((Index & 0x8) |
+                   ((Index & 0x1) << 2) |
+                   (Index & 0x2) |
+                   ((Index & 0x4) >> 2));
+}
+
+static VOID
+VtApplySgr(PCONSOLE Console,
+           PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+           const ULONG *Params,
+           ULONG Count)
+{
+    USHORT Attr = ScreenBuffer->VtState.CurrentAttributes;
+    const USHORT DefaultAttr = ScreenBuffer->VtState.SavedAttributes;
+
+    if (Count == 0)
+    {
+        Attr = DefaultAttr;
+        ScreenBuffer->VtState.UseRgbForeground = FALSE;
+        ScreenBuffer->VtState.UseRgbBackground = FALSE;
+        ScreenBuffer->VtState.CurrentFgColor = VtGetPaletteColor(Console, Attr & 0x0F);
+        ScreenBuffer->VtState.CurrentBgColor = VtGetPaletteColor(Console, (Attr >> 4) & 0x0F);
+        ScreenBuffer->VtState.CurrentAttributes = Attr;
+        return;
+    }
+
+    for (ULONG i = 0; i < Count; ++i)
+    {
+        ULONG Code = Params[i];
+        switch (Code)
+        {
+            case 0:
+                Attr = DefaultAttr;
+                ScreenBuffer->VtState.UseRgbForeground = FALSE;
+                ScreenBuffer->VtState.UseRgbBackground = FALSE;
+                break;
+
+            case 1:
+                Attr |= FOREGROUND_INTENSITY;
+                break;
+
+            case 2:
+                /* SGR 2 (Dim/Faint): Not supported by the console subsystem;
+                 * recognized to avoid unknown-sequence warnings. */
+                break;
+
+            case 3:
+                /* SGR 3 (Italic): Not supported by the console subsystem;
+                 * recognized to avoid unknown-sequence warnings. */
+                break;
+
+            case 4:
+                Attr |= COMMON_LVB_UNDERSCORE;
+                break;
+
+            case 7:
+                Attr |= COMMON_LVB_REVERSE_VIDEO;
+                break;
+
+            case 9:
+                /* SGR 9 (Strikethrough): Not supported by the console subsystem;
+                 * recognized to avoid unknown-sequence warnings. */
+                break;
+
+            case 22:
+                Attr &= ~FOREGROUND_INTENSITY;
+                break;
+
+            case 23:
+                /* SGR 23 (Italic off): Not supported by the console subsystem;
+                 * recognized to avoid unknown-sequence warnings. */
+                break;
+
+            case 24:
+                Attr &= ~COMMON_LVB_UNDERSCORE;
+                break;
+
+            case 27:
+                Attr &= ~COMMON_LVB_REVERSE_VIDEO;
+                break;
+
+            case 29:
+                /* SGR 29 (Strikethrough off): Not supported by the console subsystem;
+                 * recognized to avoid unknown-sequence warnings. */
+                break;
+
+            case 30: case 31: case 32: case 33:
+            case 34: case 35: case 36: case 37:
+            {
+                UCHAR idx = (UCHAR)(Code - 30);
+                Attr &= ~FG_ATTR_MASK;
+                Attr |= VtXtermToConsoleIndex(idx);
+                ScreenBuffer->VtState.UseRgbForeground = FALSE;
+                break;
+            }
+
+            case 39:
+                Attr &= ~FG_ATTR_MASK;
+                Attr |= (DefaultAttr & FG_ATTR_MASK);
+                ScreenBuffer->VtState.UseRgbForeground = FALSE;
+                break;
+
+            case 40: case 41: case 42: case 43:
+            case 44: case 45: case 46: case 47:
+            {
+                UCHAR idx = (UCHAR)(Code - 40);
+                Attr &= ~BG_ATTR_MASK;
+                Attr |= (USHORT)(VtXtermToConsoleIndex(idx) << 4);
+                ScreenBuffer->VtState.UseRgbBackground = FALSE;
+                break;
+            }
+
+            case 49:
+                Attr &= ~BG_ATTR_MASK;
+                Attr |= (DefaultAttr & BG_ATTR_MASK);
+                ScreenBuffer->VtState.UseRgbBackground = FALSE;
+                break;
+
+            case 90: case 91: case 92: case 93:
+            case 94: case 95: case 96: case 97:
+            {
+                UCHAR idx = (UCHAR)((Code - 90) | 0x08);
+                Attr &= ~FG_ATTR_MASK;
+                Attr |= VtXtermToConsoleIndex(idx);
+                ScreenBuffer->VtState.UseRgbForeground = FALSE;
+                break;
+            }
+
+            case 100: case 101: case 102: case 103:
+            case 104: case 105: case 106: case 107:
+            {
+                UCHAR idx = (UCHAR)((Code - 100) | 0x08);
+                Attr &= ~BG_ATTR_MASK;
+                Attr |= (USHORT)(VtXtermToConsoleIndex(idx) << 4);
+                ScreenBuffer->VtState.UseRgbBackground = FALSE;
+                break;
+            }
+
+            case 38:
+            case 48:
+            {
+                BOOL Foreground = (Code == 38);
+                if (i + 1 < Count)
+                {
+                    ULONG mode = Params[++i];
+                    if (mode == 2 && (i + 3) < Count)
+                    {
+                        ULONG r = Params[++i] & 0xFF;
+                        ULONG g = Params[++i] & 0xFF;
+                        ULONG b = Params[++i] & 0xFF;
+                        COLORREF color = RGB((BYTE)r, (BYTE)g, (BYTE)b);
+                        UCHAR nearest = VtFindNearestPaletteIndex(Console, color);
+                        if (Foreground)
+                        {
+                            Attr &= ~FG_ATTR_MASK;
+                            Attr |= (USHORT)(nearest & 0x0F);
+                            ScreenBuffer->VtState.UseRgbForeground = TRUE;
+                            ScreenBuffer->VtState.CurrentFgColor = color;
+                        }
+                        else
+                        {
+                            Attr &= ~BG_ATTR_MASK;
+                            Attr |= (USHORT)((nearest & 0x0F) << 4);
+                            ScreenBuffer->VtState.UseRgbBackground = TRUE;
+                            ScreenBuffer->VtState.CurrentBgColor = color;
+                        }
+                        continue;
+                    }
+                    else if (mode == 5 && (i + 1) < Count)
+                    {
+                        ULONG idx = Params[++i];
+                        if (idx < 16)
+                        {
+                            if (Foreground)
+                            {
+                                Attr &= ~FG_ATTR_MASK;
+                                Attr |= VtXtermToConsoleIndex((UCHAR)idx);
+                                ScreenBuffer->VtState.UseRgbForeground = FALSE;
+                            }
+                            else
+                            {
+                                Attr &= ~BG_ATTR_MASK;
+                                Attr |= (USHORT)(VtXtermToConsoleIndex((UCHAR)idx) << 4);
+                                ScreenBuffer->VtState.UseRgbBackground = FALSE;
+                            }
+                        }
+                        else
+                        {
+                            /* Only the 6x6x6 cube and the greyscale ramp need an RGB value */
+                            COLORREF color = VtColorFromXtermIndex(idx);
+                            UCHAR nearest = VtFindNearestPaletteIndex(Console, color);
+                            if (Foreground)
+                            {
+                                Attr &= ~FG_ATTR_MASK;
+                                Attr |= (USHORT)(nearest & 0x0F);
+                                ScreenBuffer->VtState.UseRgbForeground = TRUE;
+                                ScreenBuffer->VtState.CurrentFgColor = color;
+                            }
+                            else
+                            {
+                                Attr &= ~BG_ATTR_MASK;
+                                Attr |= (USHORT)((nearest & 0x0F) << 4);
+                                ScreenBuffer->VtState.UseRgbBackground = TRUE;
+                                ScreenBuffer->VtState.CurrentBgColor = color;
+                            }
+                        }
+                        continue;
+                    }
+                }
+
+                if (Foreground)
+                    ScreenBuffer->VtState.UseRgbForeground = FALSE;
+                else
+                    ScreenBuffer->VtState.UseRgbBackground = FALSE;
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+
+    ScreenBuffer->VtState.CurrentAttributes = Attr;
+
+    if (!ScreenBuffer->VtState.UseRgbForeground)
+        ScreenBuffer->VtState.CurrentFgColor = VtGetPaletteColor(Console, Attr & 0x0F);
+    if (!ScreenBuffer->VtState.UseRgbBackground)
+        ScreenBuffer->VtState.CurrentBgColor = VtGetPaletteColor(Console, (Attr >> 4) & 0x0F);
+}
+
+
+static VOID
+VtEraseLine(PCONSOLE Console,
+            PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+            ULONG Mode)
+{
+    SHORT Y = ScreenBuffer->CursorPosition.Y;
+    SMALL_RECT Region;
+    SHORT StartX, EndX;
+
+    if (Y < 0 || Y >= ScreenBuffer->ScreenBufferSize.Y)
+        return;
+
+    switch (Mode)
+    {
+        case 1:
+            StartX = 0;
+            EndX = ScreenBuffer->CursorPosition.X;
+            break;
+
+        case 2:
+            StartX = 0;
+            EndX = ScreenBuffer->ScreenBufferSize.X - 1;
+            break;
+
+        case 0:
+        default:
+            StartX = ScreenBuffer->CursorPosition.X;
+            EndX = ScreenBuffer->ScreenBufferSize.X - 1;
+            break;
+    }
+
+    StartX = max(StartX, 0);
+    EndX = min(EndX, (SHORT)(ScreenBuffer->ScreenBufferSize.X - 1));
+    if (EndX < StartX)
+        return;
+
+    VtFillRect(ScreenBuffer, StartX, Y, EndX, Y, L' ');
+
+    Region.Left   = StartX;
+    Region.Right  = EndX;
+    Region.Top    = Y;
+    Region.Bottom = Y;
+    TermDrawRegion(Console, &Region);
+}
+
+static VOID
+VtDecaln(PCONSOLE Console,
+         PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    SMALL_RECT Region;
+    COORD Origin;
+
+    if (!Console || !ScreenBuffer)
+        return;
+
+    /* DECALN fills the whole screen with 'E' using the current attributes */
+    VtFillRect(ScreenBuffer, 0, 0, (SHORT)(ScreenBuffer->ScreenBufferSize.X - 1), (SHORT)(ScreenBuffer->ScreenBufferSize.Y - 1), L'E');
+
+    Region.Left   = 0;
+    Region.Top    = 0;
+    Region.Right  = ScreenBuffer->ScreenBufferSize.X > 0 ? ScreenBuffer->ScreenBufferSize.X - 1 : 0;
+    Region.Bottom = ScreenBuffer->ScreenBufferSize.Y > 0 ? ScreenBuffer->ScreenBufferSize.Y - 1 : 0;
+    TermDrawRegion(Console, &Region);
+
+    Origin.X = 0;
+    Origin.Y = 0;
+    ConDrvSetConsoleCursorPosition(Console, ScreenBuffer, &Origin);
+}
+
+static VOID
+VtEraseDisplay(PCONSOLE Console,
+               PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+               ULONG Mode)
+{
+    SHORT Y;
+    SMALL_RECT Region;
+    COORD Origin;
+
+    switch (Mode)
+    {
+        case 1:
+        case 0:
+        {
+            SHORT StartY, EndY;
+            SHORT StartX = 0;
+            SHORT EndX = ScreenBuffer->ScreenBufferSize.X - 1;
+
+            if (Mode == 0)
+            {
+                StartY = ScreenBuffer->CursorPosition.Y;
+                EndY = ScreenBuffer->ScreenBufferSize.Y - 1;
+            }
+            else
+            {
+                StartY = 0;
+                EndY = ScreenBuffer->CursorPosition.Y;
+            }
+
+            StartY = max(StartY, 0);
+            EndY = min(EndY, (SHORT)(ScreenBuffer->ScreenBufferSize.Y - 1));
+            if (EndY < StartY)
+                return;
+
+            for (Y = StartY; Y <= EndY; ++Y)
+            {
+                SHORT LocalStartX = StartX;
+                SHORT LocalEndX = EndX;
+
+                if (Mode == 0 && Y == StartY)
+                    LocalStartX = max(ScreenBuffer->CursorPosition.X, 0);
+                else if (Mode == 1 && Y == EndY)
+                    LocalEndX = min(ScreenBuffer->CursorPosition.X, (SHORT)(ScreenBuffer->ScreenBufferSize.X - 1));
+
+                VtFillRect(ScreenBuffer, LocalStartX, Y, LocalEndX, Y, L' ');
+            }
+
+            Region.Left   = 0;
+            Region.Right  = ScreenBuffer->ScreenBufferSize.X - 1;
+            Region.Top    = StartY;
+            Region.Bottom = EndY;
+            TermDrawRegion(Console, &Region);
+            break;
+        }
+
+        case 2:
+        case 3:
+            VtFillRect(ScreenBuffer, 0, 0, (SHORT)(ScreenBuffer->ScreenBufferSize.X - 1), (SHORT)(ScreenBuffer->ScreenBufferSize.Y - 1), L' ');
+
+            Region.Left   = 0;
+            Region.Top    = 0;
+            Region.Right  = ScreenBuffer->ScreenBufferSize.X - 1;
+            Region.Bottom = ScreenBuffer->ScreenBufferSize.Y - 1;
+            TermDrawRegion(Console, &Region);
+
+            Origin.X = Origin.Y = 0;
+            ConDrvSetConsoleCursorPosition(Console, ScreenBuffer, &Origin);
+
+            if (Mode == 3)
+            {
+                ScreenBuffer->VirtualY = 0;
+                ScreenBuffer->ViewOrigin.Y = 0;
+            }
+            break;
+    }
+}
+
+static VOID
+VtSoftReset(PCONSOLE Console,
+            PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    PTEXTMODE_SCREEN_BUFFER Target;
+    COORD Origin;
+
+    if (!Console || !ScreenBuffer)
+        return;
+
+    if (ScreenBuffer->VtState.PrimaryBuffer != NULL ||
+        ScreenBuffer->VtState.AlternateBuffer != NULL)
+    {
+        VtDisableAlternateScreen(Console, ScreenBuffer);
+        Target = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
+    }
+    else
+    {
+        Target = ScreenBuffer;
+    }
+
+    if (!Target)
+        return;
+
+    VtClearHyperlink(Target);
+    ConDrvVtInitializeBuffer(Target);
+
+    VtEraseDisplay(Console, Target, 2);
+
+    Origin.X = 0;
+    Origin.Y = 0;
+    ConDrvSetConsoleCursorPosition(Console, Target, &Origin);
+    ConDrvSetConsoleCursorInfo(Console, Target, &Target->CursorInfo);
+    Target->VtState.LastCharValid = FALSE;
+}
+
+VOID
+NTAPI
+ConDrvVtInitializeBuffer(PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    COORD Zero = {0, 0};
+
+    if (!ScreenBuffer) return;
+
+    ScreenBuffer->VtState.CursorSaved = FALSE;
+    ScreenBuffer->VtState.SavedCursorPos = Zero;
+    ScreenBuffer->VtState.SavedAttributes = ScreenBuffer->ScreenDefaultAttrib;
+    ScreenBuffer->VtState.CurrentAttributes = ScreenBuffer->ScreenDefaultAttrib;
+    ScreenBuffer->VtState.UseRgbForeground = FALSE;
+    ScreenBuffer->VtState.UseRgbBackground = FALSE;
+    ScreenBuffer->VtState.CurrentFgColor = VtGetPaletteColor(ScreenBuffer->Header.Console, ScreenBuffer->ScreenDefaultAttrib & 0x0F);
+    ScreenBuffer->VtState.CurrentBgColor = VtGetPaletteColor(ScreenBuffer->Header.Console, (ScreenBuffer->ScreenDefaultAttrib >> 4) & 0x0F);
+    ScreenBuffer->VtState.SavedFgColor = ScreenBuffer->VtState.CurrentFgColor;
+    ScreenBuffer->VtState.SavedBgColor = ScreenBuffer->VtState.CurrentBgColor;
+    ScreenBuffer->VtState.SavedUseRgbForeground = FALSE;
+    ScreenBuffer->VtState.SavedUseRgbBackground = FALSE;
+    ScreenBuffer->VtState.PrivateModes = 0;
+    ScreenBuffer->VtState.AlternateBuffer = NULL;
+    ScreenBuffer->VtState.ScrollTop = 0;
+    ScreenBuffer->VtState.ScrollBottom = max(0, ScreenBuffer->ScreenBufferSize.Y - 1);
+    ScreenBuffer->VtState.PrimaryBuffer = NULL;
+    ScreenBuffer->VtState.PrimaryCursorInfo = ScreenBuffer->CursorInfo;
+    ScreenBuffer->VtState.PrimaryCursorPos = Zero;
+    ScreenBuffer->VtState.PrimaryViewOrigin = Zero;
+    ScreenBuffer->VtState.PrimaryVirtualY = 0;
+    ScreenBuffer->VtState.DefaultCursorInfo = ScreenBuffer->CursorInfo;
+    ScreenBuffer->VtState.HyperlinkActive = FALSE;
+    ScreenBuffer->VtState.HyperlinkUri.Buffer = NULL;
+    ScreenBuffer->VtState.HyperlinkUri.Length = 0;
+    ScreenBuffer->VtState.HyperlinkUri.MaximumLength = 0;
+    ScreenBuffer->VtState.Charsets[VT_CHARSET_SLOT_G0] = VtCharsetAscii;
+    ScreenBuffer->VtState.Charsets[VT_CHARSET_SLOT_G1] = VtCharsetDecSpecial;
+    ScreenBuffer->VtState.Charsets[VT_CHARSET_SLOT_G2] = VtCharsetAscii;
+    ScreenBuffer->VtState.Charsets[VT_CHARSET_SLOT_G3] = VtCharsetAscii;
+    ScreenBuffer->VtState.ActiveCharset = VT_CHARSET_SLOT_G0;
+    ScreenBuffer->VtState.PendingSingleShift = VT_CHARSET_SLOT_INVALID;
+    RtlCopyMemory(ScreenBuffer->VtState.SavedCharsets, ScreenBuffer->VtState.Charsets, sizeof(ScreenBuffer->VtState.Charsets));
+    ScreenBuffer->VtState.SavedActiveCharset = ScreenBuffer->VtState.ActiveCharset;
+    ScreenBuffer->VtState.MouseButtonState = 0;
+    ScreenBuffer->VtState.PendingSequenceLength = 0;
+
+    /* VtEnsureTabStops reuses an existing bitmap of the right width, so there is
+     * no need to free and immediately re-allocate one here */
+    VtResetTabStops(ScreenBuffer);
+}
+
+static VOID
+VtHandleCursorPosition(PCONSOLE Console,
+                       PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                       const ULONG *Params,
+                       ULONG Count)
+{
+    COORD Position;
+    SHORT Row, Col;
+
+    Row = (Count >= 1) ? (SHORT)max(1UL, Params[0]) : 1;
+    Col = (Count >= 2) ? (SHORT)max(1UL, Params[1]) : 1;
+
+    if (ScreenBuffer->VtState.PrivateModes & VT_PRIVMODE_ORIGIN_MODE)
+    {
+        SHORT Top = ScreenBuffer->VtState.ScrollTop;
+        SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
+        SHORT Height = Bottom - Top + 1;
+
+        if (Height <= 0 || Height > ScreenBuffer->ScreenBufferSize.Y)
+            Height = ScreenBuffer->ScreenBufferSize.Y;
+        if (Height <= 0)
+            Height = 1;
+
+        if (Row > Height)
+            Row = Height;
+
+        Position.Y = Top + Row - 1;
+    }
+    else
+    {
+        if (Row > ScreenBuffer->ScreenBufferSize.Y)
+            Row = ScreenBuffer->ScreenBufferSize.Y;
+
+        Position.Y = Row - 1;
+    }
+
+    if (Col > ScreenBuffer->ScreenBufferSize.X)
+        Col = ScreenBuffer->ScreenBufferSize.X;
+
+    Position.X = Col - 1;
+
+    ConDrvSetConsoleCursorPosition(Console, ScreenBuffer, &Position);
+}
+
+static VOID
+VtMoveCursorRelative(PCONSOLE Console,
+                     PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                     LONG DeltaX,
+                     LONG DeltaY)
+{
+    COORD Position;
+    LONG MinY = 0;
+    LONG MaxY;
+    LONG MaxX;
+
+    if (!Console || !ScreenBuffer)
+        return;
+
+    if (ScreenBuffer->ScreenBufferSize.X <= 0 || ScreenBuffer->ScreenBufferSize.Y <= 0)
+        return;
+
+    Position = ScreenBuffer->CursorPosition;
+    MaxX = ScreenBuffer->ScreenBufferSize.X - 1;
+    MaxY = ScreenBuffer->ScreenBufferSize.Y - 1;
+
+    if (ScreenBuffer->VtState.PrivateModes & VT_PRIVMODE_ORIGIN_MODE)
+    {
+        MinY = max(0, ScreenBuffer->VtState.ScrollTop);
+        MaxY = min(MaxY, ScreenBuffer->VtState.ScrollBottom);
+        if (MaxY < MinY)
+        {
+            MinY = 0;
+            MaxY = ScreenBuffer->ScreenBufferSize.Y - 1;
+        }
+    }
+
+    Position.X = (SHORT)min(max((LONG)Position.X + DeltaX, 0), MaxX);
+    Position.Y = (SHORT)min(max((LONG)Position.Y + DeltaY, MinY), MaxY);
+    ConDrvSetConsoleCursorPosition(Console, ScreenBuffer, &Position);
+}
+
+static BOOLEAN
+VtApplyCursorStyle(PCONSOLE Console,
+                   PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                   ULONG Style)
+{
+    CONSOLE_CURSOR_INFO CursorInfo;
+
+    if (Style == 0)
+    {
+        CursorInfo = ScreenBuffer->VtState.DefaultCursorInfo;
+    }
+    else
+    {
+        CursorInfo = ScreenBuffer->CursorInfo;
+
+        switch (Style)
+        {
+            case 1: /* blinking block (default) */
+            case 2: /* steady block */
+                CursorInfo.dwSize = 100;
+                break;
+
+            case 3: /* blinking underline */
+            case 4: /* steady underline */
+                CursorInfo.dwSize = 15;
+                break;
+
+            case 5: /* blinking bar */
+            case 6: /* steady bar */
+                CursorInfo.dwSize = 25;
+                break;
+
+            default:
+                return FALSE;
+        }
+    }
+
+    if (!NT_SUCCESS(ConDrvSetConsoleCursorInfo(Console,
+                                               ScreenBuffer,
+                                               &CursorInfo)))
+    {
+        return FALSE;
+    }
+
+
+    return TRUE;
+}
+
+static BOOLEAN
+VtHandleDecPrivateMode(PCONSOLE Console,
+                       PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                       ULONG Mode,
+                       BOOLEAN Enable)
+{
+    ULONG Mask = 0;
+    BOOLEAN RequiresWindowResize = FALSE;
+    ULONG NewColumns = 0;
+    BOOLEAN Handled = FALSE;
+
+    switch (Mode)
+    {
+        case 25: /* DECTCEM – show/hide the text cursor */
+        {
+            CONSOLE_CURSOR_INFO CursorInfo = ScreenBuffer->CursorInfo;
+            CursorInfo.bVisible = Enable ? TRUE : FALSE;
+
+            return NT_SUCCESS(ConDrvSetConsoleCursorInfo(Console,
+                                                         ScreenBuffer,
+                                                         &CursorInfo));
+        }
+
+        case 1:  /* DECCKM – cursor keys send application sequences */
+            Mask = VT_PRIVMODE_CURSOR_KEYS_APPLICATION;
+            Handled = TRUE;
+            break;
+
+        case 3:  /* DECCOLM – 80/132 column mode */
+            Mask = VT_PRIVMODE_COLUMN_132;
+            Handled = TRUE;
+            RequiresWindowResize = TRUE;
+            NewColumns = Enable ? 132 : 80;
+            break;
+
+        case 6:  /* DECOM – origin mode */
+        {
+            if (Enable)
+                ScreenBuffer->VtState.PrivateModes |= VT_PRIVMODE_ORIGIN_MODE;
+            else
+                ScreenBuffer->VtState.PrivateModes &= ~VT_PRIVMODE_ORIGIN_MODE;
+
+            {
+                COORD Home;
+                Home.X = 0;
+                Home.Y = Enable ? ScreenBuffer->VtState.ScrollTop : 0;
+                ConDrvSetConsoleCursorPosition(Console, ScreenBuffer, &Home);
+            }
+
+            return TRUE;
+        }
+
+        case 1000:
+            Mask = VT_PRIVMODE_MOUSE_X10;
+            break;
+
+        case 1003:
+            Mask = VT_PRIVMODE_MOUSE_ANY_EVENT;
+            break;
+
+        case 1002:
+            Mask = VT_PRIVMODE_MOUSE_BUTTON_TRACKING;
+            break;
+
+        case 1006:
+            Mask = VT_PRIVMODE_MOUSE_SGR_EXTENDED;
+            break;
+
+        case 1004:
+            Mask = VT_PRIVMODE_FOCUS_EVENT;
+            break;
+
+        case 2004:
+            Mask = VT_PRIVMODE_BRACKETED_PASTE;
+            break;
+
+        case 1036:
+            Mask = VT_PRIVMODE_META_SENDS_ESCAPE;
+            break;
+
+        case 66: /* DECNKM – keypad application mode */
+            Mask = VT_PRIVMODE_KEYPAD_APPLICATION;
+            Handled = TRUE;
+            break;
+
+        case 1049:
+            if (Enable)
+                return VtEnableAlternateScreen(Console, ScreenBuffer);
+            return VtDisableAlternateScreen(Console, ScreenBuffer);
+
+        default:
+            return FALSE;
+    }
+
+    if (RequiresWindowResize)
+    {
+        if (NewColumns == 0)
+            NewColumns = ScreenBuffer->ScreenBufferSize.X;
+
+        if (NewColumns < 1)
+            NewColumns = 1;
+
+        if (ScreenBuffer->ScreenBufferSize.X != (SHORT)NewColumns)
+        {
+            ULONG Rows = (ULONG)max(1, ScreenBuffer->ScreenBufferSize.Y);
+            if (!VtResizeWindow(Console, ScreenBuffer, Rows, NewColumns))
+                DPRINT1("VT: Failed to resize console to %lu columns for DECCOLM\n", NewColumns);
+        }
+
+        ScreenBuffer->VtState.ScrollTop = 0;
+        ScreenBuffer->VtState.ScrollBottom = max(0, ScreenBuffer->ScreenBufferSize.Y - 1);
+        VtEraseDisplay(Console, ScreenBuffer, 2);
+        VtResetTabStops(ScreenBuffer);
+
+        {
+            COORD Home = {0, 0};
+            ConDrvSetConsoleCursorPosition(Console, ScreenBuffer, &Home);
+        }
+    }
+
+    if (Enable)
+        ScreenBuffer->VtState.PrivateModes |= Mask;
+    else
+        ScreenBuffer->VtState.PrivateModes &= ~Mask;
+
+    return Handled || (Mask != 0);
+}
+
+static BOOLEAN
+VtHandleDeviceAttributes(PCONSOLE Console,
+                         WCHAR PrivateIndicator)
+{
+    WCHAR Response[32];
+    SIZE_T Len = 0;
+
+    if (!Console)
+        return FALSE;
+
+    Response[Len++] = L'\x1b';
+    Response[Len++] = L'[';
+
+    switch (PrivateIndicator)
+    {
+        case 0:
+            if (Len >= ARRAYSIZE(Response))
+                return FALSE;
+            Response[Len++] = L'?';
+            Len += VtAppendNumber(Response + Len,
+                                  ARRAYSIZE(Response) - Len,
+                                  1);
+            if (Len >= ARRAYSIZE(Response))
+                return FALSE;
+            Response[Len++] = L';';
+            Len += VtAppendNumber(Response + Len,
+                                  ARRAYSIZE(Response) - Len,
+                                  0);
+            break;
+
+        case L'>':
+            if (Len >= ARRAYSIZE(Response))
+                return FALSE;
+            Response[Len++] = L'>';
+            Len += VtAppendNumber(Response + Len,
+                                  ARRAYSIZE(Response) - Len,
+                                  0);
+            if (Len >= ARRAYSIZE(Response))
+                return FALSE;
+            Response[Len++] = L';';
+            Len += VtAppendNumber(Response + Len,
+                                  ARRAYSIZE(Response) - Len,
+                                  136);
+            if (Len >= ARRAYSIZE(Response))
+                return FALSE;
+            Response[Len++] = L';';
+            Len += VtAppendNumber(Response + Len,
+                                  ARRAYSIZE(Response) - Len,
+                                  0);
+            break;
+
+        case L'?':
+            if (Len >= ARRAYSIZE(Response))
+                return FALSE;
+            Response[Len++] = L'>';
+            Len += VtAppendNumber(Response + Len,
+                                  ARRAYSIZE(Response) - Len,
+                                  83);
+            if (Len >= ARRAYSIZE(Response))
+                return FALSE;
+            Response[Len++] = L';';
+            Len += VtAppendNumber(Response + Len,
+                                  ARRAYSIZE(Response) - Len,
+                                  40003);
+            if (Len >= ARRAYSIZE(Response))
+                return FALSE;
+            Response[Len++] = L';';
+            Len += VtAppendNumber(Response + Len,
+                                  ARRAYSIZE(Response) - Len,
+                                  0);
+            break;
+
+        default:
+            return FALSE;
+    }
+
+    if (Len >= ARRAYSIZE(Response))
+        return FALSE;
+
+    Response[Len++] = L'c';
+
+    VtSendInputResponse(Console, Response, Len);
+    return TRUE;
+}
+
+static BOOLEAN
+VtHandlePrivateCsiSequence(PCONSOLE Console,
+                           PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                           WCHAR PrivateIndicator,
+                           WCHAR Final,
+                           WCHAR Intermediate,
+                           const ULONG *Params,
+                           ULONG Count)
+{
+    UNREFERENCED_PARAMETER(Intermediate);
+
+    switch (Final)
+    {
+        case L'h':
+        case L'l':
+        {
+            BOOLEAN Enable = (Final == L'h');
+            BOOLEAN Handled = FALSE;
+            ULONG i;
+
+            for (i = 0; i < Count; ++i)
+            {
+                if (VtHandleDecPrivateMode(Console, ScreenBuffer, Params[i], Enable))
+                    Handled = TRUE;
+            }
+
+            return Handled;
+        }
+
+        case L'c':
+            return VtHandleDeviceAttributes(Console, PrivateIndicator);
+
+        default:
+            return FALSE;
+    }
+}
+
+static BOOLEAN
+VtHandleCsiSequence(PCONSOLE Console,
+                    PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                    WCHAR PrivateIndicator,
+                    WCHAR Final,
+                    WCHAR Intermediate,
+                    const ULONG *Params,
+                    ULONG Count)
+{
+    switch (Final)
+    {
+        case L'm':
+            VtApplySgr(Console, ScreenBuffer, Params, Count);
+            return TRUE;
+
+        case L'p':
+            if (Intermediate == L'!')
+            {
+                VtSoftReset(Console, ScreenBuffer);
+                return TRUE;
+            }
+            VtTraceUnhandledCsi(PrivateIndicator, Intermediate, Final, Params, Count);
+            return FALSE;
+
+        case L'H':
+        case L'f':
+            VtHandleCursorPosition(Console, ScreenBuffer, Params, Count);
+            return TRUE;
+
+        case L'J':
+            VtEraseDisplay(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 0);
+            return TRUE;
+
+        case L'K':
+            VtEraseLine(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 0);
+            return TRUE;
+
+        case L'@':
+            if (Intermediate == L' ')
+            {
+                ULONG Columns = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
+                VtScrollLeft(Console, ScreenBuffer, Columns);
+                return TRUE;
+            }
+            VtInsertCharacters(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 1);
+            return TRUE;
+        case L'A':
+            if (Intermediate == L' ')
+            {
+                ULONG Columns = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
+                VtScrollRight(Console, ScreenBuffer, Columns);
+                return TRUE;
+            }
+            {
+                ULONG Raw = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
+                LONG Distance = (LONG)min(Raw, (ULONG)LONG_MAX);
+                VtMoveCursorRelative(Console, ScreenBuffer, 0, -Distance);
+            }
+            return TRUE;
+
+        case L'B':
+        {
+            ULONG Raw = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
+            LONG Distance = (LONG)min(Raw, (ULONG)LONG_MAX);
+            VtMoveCursorRelative(Console, ScreenBuffer, 0, Distance);
+        }
+            return TRUE;
+
+        case L'C':
+        {
+            ULONG Raw = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
+            LONG Distance = (LONG)min(Raw, (ULONG)LONG_MAX);
+            VtMoveCursorRelative(Console, ScreenBuffer, Distance, 0);
+        }
+            return TRUE;
+
+        case L'D':
+        {
+            ULONG Raw = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
+            LONG Distance = (LONG)min(Raw, (ULONG)LONG_MAX);
+            VtMoveCursorRelative(Console, ScreenBuffer, -Distance, 0);
+        }
+            return TRUE;
+
+        case L'P':
+            VtDeleteCharacters(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 1);
+            return TRUE;
+
+        case L'X':
+            VtEraseCharacters(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 1);
+            return TRUE;
+
+        case L'b':
+        {
+            ULONG Repeat = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
+            VtRepeatCharacter(Console, ScreenBuffer, Repeat);
+            return TRUE;
+        }
+
+        case L'L':
+            VtInsertLines(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 1);
+            return TRUE;
+
+        case L'M':
+            VtDeleteLines(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 1);
+            return TRUE;
+
+        case L'c':
+            if (Intermediate == 0)
+                return VtHandleDeviceAttributes(Console, 0);
+            VtTraceUnhandledCsi(PrivateIndicator, Intermediate, Final, Params, Count);
+            return FALSE;
+
+        case L't':
+        {
+            ULONG Action = (Count >= 1) ? Params[0] : 0;
+
+            switch (Action)
+            {
+                case 8:
+                    if (Count >= 3)
+                    {
+                        ULONG Rows = Params[1];
+                        ULONG Cols = Params[2];
+                        VtResizeWindow(Console, ScreenBuffer, Rows, Cols);
+                        return TRUE;
+                    }
+                    return TRUE;
+
+                case 18:
+                    return VtReportWindowSize(Console, ScreenBuffer, 8);
+
+                case 19:
+                    return VtReportWindowSize(Console, ScreenBuffer, 4);
+
+                default:
+                    VtTraceUnhandledCsi(PrivateIndicator, Intermediate, Final, Params, Count);
+                    return FALSE;
+            }
+        }
+
+        case L'n':
+        {
+            ULONG Query = (Count >= 1) ? Params[0] : 0;
+            WCHAR Response[32];
+            SIZE_T Len = 0;
+
+            switch (Query)
+            {
+                case 5:
+                    Response[Len++] = L'\x1b';
+                    Response[Len++] = L'[';
+                    Response[Len++] = L'0';
+                    Response[Len++] = L'n';
+                    break;
+
+                case 6:
+                {
+                    SHORT Row = ScreenBuffer->CursorPosition.Y - ScreenBuffer->ViewOrigin.Y;
+                    SHORT Col = ScreenBuffer->CursorPosition.X - ScreenBuffer->ViewOrigin.X;
+
+                    if (Row < 0) Row = 0;
+                    if (Col < 0) Col = 0;
+
+                    Response[Len++] = L'\x1b';
+                    Response[Len++] = L'[';
+                    Len += VtAppendNumber(Response + Len,
+                                          ARRAYSIZE(Response) - Len,
+                                          (ULONG)Row + 1);
+                    if (Len < ARRAYSIZE(Response))
+                        Response[Len++] = L';';
+                    Len += VtAppendNumber(Response + Len,
+                                          ARRAYSIZE(Response) - Len,
+                                          (ULONG)Col + 1);
+                    if (Len < ARRAYSIZE(Response))
+                        Response[Len++] = L'R';
+                    break;
+                }
+
+                default:
+                    VtTraceUnhandledCsi(PrivateIndicator, Intermediate, Final, Params, Count);
+                    return FALSE;
+            }
+
+            VtSendInputResponse(Console, Response, Len);
+            return TRUE;
+        }
+
+        case L'S':
+        {
+            ULONG Lines = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
+            VtScrollRegionUp(Console, ScreenBuffer, Lines);
+            return TRUE;
+        }
+
+        case L'T':
+        {
+            ULONG Lines = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
+            VtScrollRegionDown(Console, ScreenBuffer, Lines);
+            return TRUE;
+        }
+
+        case L'r':
+        {
+            SHORT Top = 0;
+            SHORT Bottom = ScreenBuffer->ScreenBufferSize.Y > 0 ? ScreenBuffer->ScreenBufferSize.Y - 1 : 0;
+
+            if (Count >= 1 && Params[0] != 0)
+                Top = (SHORT)max(0L, (LONG)Params[0] - 1);
+            if (Count >= 2 && Params[1] != 0)
+                Bottom = (SHORT)min((LONG)Bottom, (LONG)Params[1] - 1);
+
+            if (Top < 0)
+                Top = 0;
+            if (Bottom >= ScreenBuffer->ScreenBufferSize.Y)
+                Bottom = ScreenBuffer->ScreenBufferSize.Y - 1;
+
+            if (Bottom < Top)
+            {
+                Top = 0;
+                Bottom = ScreenBuffer->ScreenBufferSize.Y > 0 ? ScreenBuffer->ScreenBufferSize.Y - 1 : 0;
+            }
+
+            ScreenBuffer->VtState.ScrollTop = Top;
+            ScreenBuffer->VtState.ScrollBottom = Bottom;
+
+            {
+                COORD Home;
+                Home.X = 0;
+                Home.Y = Top;
+                ConDrvSetConsoleCursorPosition(Console, ScreenBuffer, &Home);
+            }
+            return TRUE;
+        }
+
+        case L'q':
+            if (Intermediate == L' ')
+            {
+                ULONG Style = (Count >= 1) ? Params[0] : 0;
+                if (VtApplyCursorStyle(Console, ScreenBuffer, Style))
+                    return TRUE;
+            }
+            VtTraceUnhandledCsi(PrivateIndicator, Intermediate, Final, Params, Count);
+            return FALSE;
+
+        default:
+            VtTraceUnhandledCsi(PrivateIndicator, Intermediate, Final, Params, Count);
+            return FALSE;
+    }
+}
+
+static BOOLEAN
+VtHandleEscapeSequence(PCONSOLE Console,
+                       PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                       WCHAR Indicator,
+                       PCWSTR Buffer,
+                       ULONG Length,
+                       PULONG Position)
+{
+    switch (Indicator)
+    {
+        case L's':
+        case L'7':
+            VtSaveCursorState(ScreenBuffer);
+            return TRUE;
+
+        case L'u':
+        case L'8':
+            VtRestoreCursorState(Console, ScreenBuffer);
+            return TRUE;
+
+        case L'c':
+            VtSoftReset(Console, ScreenBuffer);
+            return TRUE;
+
+        case L'#':
+        {
+            WCHAR Selector;
+
+            if (!Position || *Position >= Length)
+                return FALSE;
+
+            Selector = Buffer[*Position];
+            if (Selector == L'8')
+            {
+                (*Position)++;
+                VtDecaln(Console, ScreenBuffer);
+                return TRUE;
+            }
+
+            return FALSE;
+        }
+
+        case L'(':
+        case L')':
+        case L'*':
+        case L'+':
+        case L'-':
+        case L'.':
+        case L'/':
+        {
+            UCHAR Slot;
+            WCHAR Intermediate;
+            WCHAR Final;
+
+            if (!Position || *Position >= Length)
+                return FALSE;
+
+            switch (Indicator)
+            {
+                case L'(': Slot = VT_CHARSET_SLOT_G0; break;
+                case L')':
+                case L'-': Slot = VT_CHARSET_SLOT_G1; break;
+                case L'*':
+                case L'.': Slot = VT_CHARSET_SLOT_G2; break;
+                case L'+':
+                case L'/': Slot = VT_CHARSET_SLOT_G3; break;
+                default: return FALSE;
+            }
+
+            Final = Buffer[*Position];
+            Intermediate = 0;
+
+            while (Final >= L' ' && Final <= L'/')
+            {
+                Intermediate = Final;
+                (*Position)++;
+                if (!Position || *Position >= Length)
+                    return FALSE;
+                Final = Buffer[*Position];
+            }
+
+            if (VtDesignateCharset(ScreenBuffer, Slot, Intermediate, Final))
+            {
+                (*Position)++;
+                return TRUE;
+            }
+
+            VtTraceUnhandledEscape(Indicator);
+            return FALSE;
+        }
+
+        case L'N':
+            ScreenBuffer->VtState.PendingSingleShift = VT_CHARSET_SLOT_G2;
+            return TRUE;
+
+        case L'O':
+            ScreenBuffer->VtState.PendingSingleShift = VT_CHARSET_SLOT_G3;
+            return TRUE;
+
+        case L'n':
+            VtSetActiveCharset(ScreenBuffer, VT_CHARSET_SLOT_G2);
+            return TRUE;
+
+        case L'o':
+            VtSetActiveCharset(ScreenBuffer, VT_CHARSET_SLOT_G3);
+            return TRUE;
+
+        default:
+            return FALSE;
+    }
+}
+
+NTSTATUS
+NTAPI
+ConDrvVtWriteConsole(PCONSOLE Console,
+                     PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                     PCWSTR Buffer,
+                     ULONG Length,
+                     PULONG NumCharsProcessed,
+                     PBOOLEAN Handled)
+{
+    PWSTR ExpandedBuffer = NULL;
+    PWSTR CombinedBuffer = NULL;
+    PCWSTR WorkingBuffer = Buffer;
+    ULONG WorkingLength = Length;
+    ULONG OriginalInputLength = Length;
+    ULONG Pos = 0;
+    ULONG SegmentStart = 0;
+    ULONG Processed = 0;
+    ULONG Params[VT_MAX_PARAMS];
+    NTSTATUS Status = STATUS_SUCCESS;
+    BOOLEAN AnyHandled = FALSE;
+    BOOLEAN HoldTail = FALSE;
+    ULONG TailStart = 0;
+
+    if (!Console || !ScreenBuffer || !Buffer)
+    {
+        if (NumCharsProcessed) *NumCharsProcessed = 0;
+        if (Handled) *Handled = FALSE;
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    if (WorkingLength > 0)
+    {
+        BOOLEAN NeedsExpansion = FALSE;
+        ULONG i;
+
+        for (i = 0; i < WorkingLength; ++i)
+        {
+            WCHAR C = WorkingBuffer[i];
+            if (C >= 0x80 && C <= 0x9F)
+            {
+                NeedsExpansion = TRUE;
+                break;
+            }
+        }
+
+        if (NeedsExpansion)
+        {
+            PWSTR Temp = ConsoleAllocHeap(0, (WorkingLength * 2 + 1) * sizeof(WCHAR));
+            if (Temp)
+            {
+                ULONG Out = 0;
+
+                for (i = 0; i < WorkingLength; ++i)
+                {
+                    WCHAR C = WorkingBuffer[i];
+
+                    switch (C)
+                    {
+                        case 0x90: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'P'; break;
+                        case 0x91: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'Q'; break;
+                        case 0x92: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'R'; break;
+                        case 0x93: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'S'; break;
+                        case 0x94: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'T'; break;
+                        case 0x95: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'U'; break;
+                        case 0x96: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'V'; break;
+                        case 0x97: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'W'; break;
+                        case 0x98: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'X'; break;
+                        case 0x99: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'Y'; break;
+                        case 0x9A: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'Z'; break;
+                        case 0x9B: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'['; break;
+                        case 0x9C: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = (WCHAR)0x5C; break;
+                        case 0x9D: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L']'; break;
+                        case 0x9E: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'^'; break;
+                        case 0x9F: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'_'; break;
+                        default: Temp[Out++] = C; break;
+                    }
+                }
+
+                WorkingBuffer = Temp;
+                WorkingLength = Out;
+                Temp[Out] = UNICODE_NULL;
+                ExpandedBuffer = Temp;
+            }
+        }
+    }
+
+    if (ScreenBuffer->VtState.PendingSequenceLength > 0)
+    {
+        ULONG PendingLength = ScreenBuffer->VtState.PendingSequenceLength;
+        ULONGLONG TotalLength64 = (ULONGLONG)PendingLength + (ULONGLONG)WorkingLength;
+
+        if (TotalLength64 > ULONG_MAX)
+        {
+            Status = STATUS_INTEGER_OVERFLOW;
+            goto Cleanup;
+        }
+
+        CombinedBuffer = ConsoleAllocHeap(0, ((ULONG)TotalLength64 + 1) * sizeof(WCHAR));
+        if (!CombinedBuffer)
+        {
+            Status = VtFlushText(Console,
+                                 ScreenBuffer,
+                                 ScreenBuffer->VtState.PendingSequence,
+                                 PendingLength);
+            ScreenBuffer->VtState.PendingSequenceLength = 0;
+            if (!NT_SUCCESS(Status))
+                goto Cleanup;
+        }
+        else
+        {
+            if (PendingLength > 0)
+            {
+                RtlCopyMemory(CombinedBuffer,
+                              ScreenBuffer->VtState.PendingSequence,
+                              PendingLength * sizeof(WCHAR));
+            }
+
+            if (WorkingLength > 0)
+            {
+                RtlCopyMemory(CombinedBuffer + PendingLength,
+                              WorkingBuffer,
+                              WorkingLength * sizeof(WCHAR));
+            }
+
+            CombinedBuffer[(ULONG)TotalLength64] = UNICODE_NULL;
+            WorkingBuffer = CombinedBuffer;
+            WorkingLength = (ULONG)TotalLength64;
+            ScreenBuffer->VtState.PendingSequenceLength = 0;
+        }
+    }
+
+    while (Pos < WorkingLength && NT_SUCCESS(Status))
+    {
+        WCHAR Ch = WorkingBuffer[Pos];
+
+        if (Ch == L'' || Ch == L'')
+        {
+            Status = VtFlushText(Console,
+                                 ScreenBuffer,
+                                 WorkingBuffer + SegmentStart,
+                                 Pos - SegmentStart);
+            if (!NT_SUCCESS(Status))
+                break;
+
+            VtSetActiveCharset(ScreenBuffer,
+                               (Ch == L'\x0e') ? VT_CHARSET_SLOT_G1
+                                                 : VT_CHARSET_SLOT_G0);
+            Pos++;
+            SegmentStart = Pos;
+            AnyHandled = TRUE;
+            continue;
+        }
+
+        if (Ch == L'')
+        {
+            ULONG EscStart = Pos;
+
+            if (Pos + 1 >= WorkingLength)
+            {
+                HoldTail = TRUE;
+                TailStart = EscStart;
+                break;
+            }
+
+            Status = VtFlushText(Console,
+                                 ScreenBuffer,
+                                 WorkingBuffer + SegmentStart,
+                                 EscStart - SegmentStart);
+            if (!NT_SUCCESS(Status))
+                break;
+
+            Pos++;
+            Ch = WorkingBuffer[Pos++];
+
+            if (Ch == L'[')
+            {
+                WCHAR Final = 0;
+                ULONG Count = 0;
+                ULONG Current = 0;
+                BOOLEAN HaveCurrent = FALSE;
+                WCHAR PrivateIndicator = 0;
+                WCHAR Intermediate = 0;
+
+                if (Pos < WorkingLength &&
+                    (WorkingBuffer[Pos] == L'?' || WorkingBuffer[Pos] == L'>' ||
+                     WorkingBuffer[Pos] == L'<' || WorkingBuffer[Pos] == L'='))
+                {
+                    PrivateIndicator = WorkingBuffer[Pos];
+                    Pos++;
+                }
+
+                while (Pos < WorkingLength)
+                {
+                    WCHAR C = WorkingBuffer[Pos];
+                    if (C >= L'0' && C <= L'9')
+                    {
+                        ULONG Digit = (ULONG)(C - L'0');
+                        HaveCurrent = TRUE;
+                        if (Current > (ULONG_MAX - Digit) / 10)
+                            Current = ULONG_MAX;
+                        else
+                            Current = Current * 10 + Digit;
+                        Pos++;
+                        continue;
+                    }
+                    if (C == L';')
+                    {
+                        if (Count < VT_MAX_PARAMS)
+                            Params[Count++] = HaveCurrent ? Current : 0;
+                        Current = 0;
+                        HaveCurrent = FALSE;
+                        Pos++;
+                        continue;
+                    }
+
+                    if (C >= L' ' && C <= L'/')
+                    {
+                        Intermediate = C;
+                        Pos++;
+                        continue;
+                    }
+
+                    Final = C;
+                    Pos++;
+                    break;
+                }
+
+                if (Final == 0)
+                {
+                    HoldTail = TRUE;
+                    TailStart = EscStart;
+                    break;
+                }
+
+                if (HaveCurrent || Count == 0)
+                {
+                    if (Count < VT_MAX_PARAMS)
+                        Params[Count++] = HaveCurrent ? Current : 0;
+                }
+
+                if (Count == 0)
+                    Params[Count++] = 0;
+
+                if ((PrivateIndicator != 0 &&
+                     VtHandlePrivateCsiSequence(Console, ScreenBuffer, PrivateIndicator, Final, Intermediate, Params, Count)) ||
+                    (PrivateIndicator == 0 &&
+                     VtHandleCsiSequence(Console, ScreenBuffer, PrivateIndicator, Final, Intermediate, Params, Count)))
+                {
+                    AnyHandled = TRUE;
+                    ScreenBuffer = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
+                    SegmentStart = Pos;
+                    continue;
+                }
+
+                /* Unsupported CSI sequence, emit literally */
+                Status = VtFlushText(Console,
+                                     ScreenBuffer,
+                                     WorkingBuffer + EscStart,
+                                     Pos - EscStart);
+                SegmentStart = Pos;
+                continue;
+            }
+            else if (Ch == L']')
+            {
+                ULONG OscStart = Pos;
+                ULONG SearchPos = Pos;
+                ULONG TerminatorLen = 0;
+
+                while (SearchPos < WorkingLength)
+                {
+                    WCHAR C = WorkingBuffer[SearchPos];
+                    if (C == L'\a')
+                    {
+                        TerminatorLen = 1;
+                        break;
+                    }
+                    if (C == L'\x1b' && (SearchPos + 1) < WorkingLength && WorkingBuffer[SearchPos + 1] == L'\\')
+                    {
+                        TerminatorLen = 2;
+                        break;
+                    }
+                    SearchPos++;
+                }
+
+                if (TerminatorLen == 0)
+                {
+                    HoldTail = TRUE;
+                    TailStart = EscStart;
+                    break;
+                }
+
+                if (VtHandleOscSequence(Console,
+                                        ScreenBuffer,
+                                        WorkingBuffer + OscStart,
+                                        SearchPos - OscStart))
+                {
+                    AnyHandled = TRUE;
+                    Pos = SearchPos + TerminatorLen;
+                    ScreenBuffer = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
+                    SegmentStart = Pos;
+                    continue;
+                }
+
+                Status = VtFlushText(Console,
+                                     ScreenBuffer,
+                                     WorkingBuffer + EscStart,
+                                     (SearchPos + TerminatorLen) - EscStart);
+                Pos = SearchPos + TerminatorLen;
+                SegmentStart = Pos;
+                continue;
+            }
+            else if (Ch == L'P')
+            {
+                ULONG SearchPos = Pos;
+                ULONG TerminatorLen = 0;
+
+                while (SearchPos < WorkingLength)
+                {
+                    WCHAR C = WorkingBuffer[SearchPos];
+                    if (C == L'\x1b' && (SearchPos + 1) < WorkingLength && WorkingBuffer[SearchPos + 1] == L'\\')
+                    {
+                        TerminatorLen = 2;
+                        break;
+                    }
+                    SearchPos++;
+                }
+
+                if (TerminatorLen == 0)
+                {
+                    HoldTail = TRUE;
+                    TailStart = EscStart;
+                    break;
+                }
+
+                if (VtHandleDcsSequence(Console,
+                                        ScreenBuffer,
+                                        WorkingBuffer + Pos,
+                                        SearchPos - Pos))
+                {
+                    AnyHandled = TRUE;
+                    Pos = SearchPos + TerminatorLen;
+                    ScreenBuffer = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
+                    SegmentStart = Pos;
+                    continue;
+                }
+
+                VtTraceUnhandledDcs();
+            }
+            else
+            {
+                ULONG NewPos = Pos;
+                if (VtHandleEscapeSequence(Console,
+                                           ScreenBuffer,
+                                           Ch,
+                                           WorkingBuffer,
+                                           WorkingLength,
+                                           &NewPos))
+                {
+                    AnyHandled = TRUE;
+                    Pos = NewPos;
+                    ScreenBuffer = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
+                    SegmentStart = Pos;
+                    continue;
+                }
+
+                if ((Ch == L'#' ||
+                     Ch == L'(' || Ch == L')' || Ch == L'*' || Ch == L'+' ||
+                     Ch == L'-' || Ch == L'.' || Ch == L'/') &&
+                    Pos >= WorkingLength)
+                {
+                    HoldTail = TRUE;
+                    TailStart = EscStart;
+                    break;
+                }
+
+                /* Unsupported ESC sequence, emit literally */
+                Status = VtFlushText(Console,
+                                     ScreenBuffer,
+                                     WorkingBuffer + EscStart,
+                                     Pos - EscStart);
+                SegmentStart = Pos;
+                continue;
+            }
+        }
+
+        Pos++;
+    }
+
+    if (NT_SUCCESS(Status))
+    {
+        if (HoldTail)
+        {
+            if (TailStart > SegmentStart)
+            {
+                Status = VtFlushText(Console,
+                                     ScreenBuffer,
+                                     WorkingBuffer + SegmentStart,
+                                     TailStart - SegmentStart);
+            }
+
+            if (NT_SUCCESS(Status))
+            {
+                ULONG TailLength = WorkingLength - TailStart;
+
+                if (!VtStorePendingSequence(ScreenBuffer,
+                                            WorkingBuffer + TailStart,
+                                            TailLength))
+                {
+                    Status = VtFlushText(Console,
+                                         ScreenBuffer,
+                                         WorkingBuffer + TailStart,
+                                         TailLength);
+                    ScreenBuffer->VtState.PendingSequenceLength = 0;
+                }
+            }
+        }
+        else
+        {
+            Status = VtFlushText(Console,
+                                 ScreenBuffer,
+                                 WorkingBuffer + SegmentStart,
+                                 WorkingLength - SegmentStart);
+        }
+
+        if (NT_SUCCESS(Status))
+        {
+            Processed = OriginalInputLength;
+            AnyHandled = TRUE;
+        }
+    }
+
+    if (!NT_SUCCESS(Status))
+        AnyHandled = FALSE;
+
+Cleanup:
+    if (ExpandedBuffer)
+        ConsoleFreeHeap(ExpandedBuffer);
+    if (CombinedBuffer)
+        ConsoleFreeHeap(CombinedBuffer);
+
+    if (NumCharsProcessed) *NumCharsProcessed = Processed;
+    if (Handled) *Handled = AnyHandled;
+
+    return Status;
+}
+
+typedef enum _VT_INPUT_ACTION
+{
+    VtInputPassThrough = 0,
+    VtInputGenerateSequence,
+    VtInputDrop
+} VT_INPUT_ACTION;
+
+typedef struct _VT_INPUT_TRANSLATION
+{
+    VT_INPUT_ACTION Action;
+    USHORT RepeatCount;
+    SIZE_T SequenceLength;
+    WCHAR Sequence[VT_MAX_INPUT_SEQUENCE_CHARS];
+} VT_INPUT_TRANSLATION, *PVT_INPUT_TRANSLATION;
+
+static BOOLEAN
+VtShouldHandleKeyUp(USHORT VirtualKey)
+{
+    switch (VirtualKey)
+    {
+        case VK_UP:
+        case VK_DOWN:
+        case VK_LEFT:
+        case VK_RIGHT:
+        case VK_HOME:
+        case VK_END:
+        case VK_INSERT:
+        case VK_DELETE:
+        case VK_PRIOR:
+        case VK_NEXT:
+        case VK_F1:
+        case VK_F2:
+        case VK_F3:
+        case VK_F4:
+        case VK_F5:
+        case VK_F6:
+        case VK_F7:
+        case VK_F8:
+        case VK_F9:
+        case VK_F10:
+        case VK_F11:
+        case VK_F12:
+            return TRUE;
+    }
+
+    return FALSE;
+}
+
+static BOOLEAN
+VtTranslateKeyEvent(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                    const KEY_EVENT_RECORD *KeyEvent,
+                    PVT_INPUT_TRANSLATION Translation)
+{
+    ULONG PrivateModes = ScreenBuffer ? ScreenBuffer->VtState.PrivateModes : 0;
+    SIZE_T Length = 0;
+    USHORT Repeat = (KeyEvent->wRepeatCount != 0) ? KeyEvent->wRepeatCount : 1;
+
+    if (!KeyEvent->bKeyDown)
+    {
+        if (VtShouldHandleKeyUp(KeyEvent->wVirtualKeyCode))
+        {
+            Translation->Action = VtInputDrop;
+            Translation->RepeatCount = 0;
+            Translation->SequenceLength = 0;
+            return TRUE;
+        }
+
+        return FALSE;
+    }
+
+    if (KeyEvent->wVirtualKeyCode == 0 && KeyEvent->uChar.UnicodeChar != 0)
+        return FALSE;
+
+    /* Shift+Tab generates CSI Z (backtab) */
+    if (KeyEvent->wVirtualKeyCode == VK_TAB &&
+        (KeyEvent->dwControlKeyState & SHIFT_PRESSED))
+    {
+        Translation->Action = VtInputGenerateSequence;
+        Translation->RepeatCount = Repeat;
+        Translation->Sequence[0] = L'\x1b';
+        Translation->Sequence[1] = L'[';
+        Translation->Sequence[2] = L'Z';
+        Translation->SequenceLength = 3;
+        return TRUE;
+    }
+
+    /* VT terminals send DEL (0x7f) for Backspace */
+    if (KeyEvent->wVirtualKeyCode == VK_BACK)
+    {
+        if ((PrivateModes & VT_PRIVMODE_META_SENDS_ESCAPE) &&
+            (KeyEvent->dwControlKeyState & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED)))
+        {
+            Translation->Action = VtInputGenerateSequence;
+            Translation->RepeatCount = Repeat;
+            Translation->Sequence[0] = L'\x1b';
+            Translation->Sequence[1] = L'\x7f';
+            Translation->SequenceLength = 2;
+            return TRUE;
+        }
+
+        Translation->Action = VtInputGenerateSequence;
+        Translation->RepeatCount = Repeat;
+        Translation->Sequence[0] = L'\x7f';
+        Translation->SequenceLength = 1;
+        return TRUE;
+    }
+
+    if ((PrivateModes & VT_PRIVMODE_META_SENDS_ESCAPE) &&
+        (KeyEvent->dwControlKeyState & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED)) &&
+        KeyEvent->uChar.UnicodeChar != 0)
+    {
+        Translation->Action = VtInputGenerateSequence;
+        Translation->RepeatCount = Repeat;
+        Translation->Sequence[0] = L'\x1b';
+        Translation->Sequence[1] = KeyEvent->uChar.UnicodeChar;
+        Translation->SequenceLength = 2;
+        return TRUE;
+    }
+
+    if (KeyEvent->uChar.UnicodeChar != 0)
+        return FALSE;
+
+    switch (KeyEvent->wVirtualKeyCode)
+    {
+        case VK_UP:
+            if (!VtComposeCursorKeySequence((PrivateModes & VT_PRIVMODE_CURSOR_KEYS_APPLICATION) != 0,
+                                            KeyEvent,
+                                            L'A',
+                                            Translation->Sequence,
+                                            ARRAYSIZE(Translation->Sequence),
+                                            &Length))
+                return FALSE;
+            break;
+
+        case VK_DOWN:
+            if (!VtComposeCursorKeySequence((PrivateModes & VT_PRIVMODE_CURSOR_KEYS_APPLICATION) != 0,
+                                            KeyEvent,
+                                            L'B',
+                                            Translation->Sequence,
+                                            ARRAYSIZE(Translation->Sequence),
+                                            &Length))
+                return FALSE;
+            break;
+
+        case VK_RIGHT:
+            if (!VtComposeCursorKeySequence((PrivateModes & VT_PRIVMODE_CURSOR_KEYS_APPLICATION) != 0,
+                                            KeyEvent,
+                                            L'C',
+                                            Translation->Sequence,
+                                            ARRAYSIZE(Translation->Sequence),
+                                            &Length))
+                return FALSE;
+            break;
+
+        case VK_LEFT:
+            if (!VtComposeCursorKeySequence((PrivateModes & VT_PRIVMODE_CURSOR_KEYS_APPLICATION) != 0,
+                                            KeyEvent,
+                                            L'D',
+                                            Translation->Sequence,
+                                            ARRAYSIZE(Translation->Sequence),
+                                            &Length))
+                return FALSE;
+            break;
+
+        case VK_HOME:
+        {
+            BOOLEAN AppMode = (PrivateModes & VT_PRIVMODE_KEYPAD_APPLICATION) != 0;
+
+            if (!VtComposeCursorKeySequence(AppMode,
+                                            KeyEvent,
+                                            L'H',
+                                            Translation->Sequence,
+                                            ARRAYSIZE(Translation->Sequence),
+                                            &Length))
+                return FALSE;
+            break;
+        }
+
+        case VK_END:
+        {
+            BOOLEAN AppMode = (PrivateModes & VT_PRIVMODE_KEYPAD_APPLICATION) != 0;
+
+            if (!VtComposeCursorKeySequence(AppMode,
+                                            KeyEvent,
+                                            L'F',
+                                            Translation->Sequence,
+                                            ARRAYSIZE(Translation->Sequence),
+                                            &Length))
+                return FALSE;
+            break;
+        }
+
+        case VK_INSERT:
+            if (!VtComposeCsiTildeSequence(2,
+                                           VtGetModifierParameter(KeyEvent),
+                                           L'~',
+                                           Translation->Sequence,
+                                           ARRAYSIZE(Translation->Sequence),
+                                           &Length))
+                return FALSE;
+            break;
+
+        case VK_DELETE:
+            if (!VtComposeCsiTildeSequence(3,
+                                           VtGetModifierParameter(KeyEvent),
+                                           L'~',
+                                           Translation->Sequence,
+                                           ARRAYSIZE(Translation->Sequence),
+                                           &Length))
+                return FALSE;
+            break;
+
+        case VK_PRIOR: /* Page Up */
+            if (!VtComposeCsiTildeSequence(5,
+                                           VtGetModifierParameter(KeyEvent),
+                                           L'~',
+                                           Translation->Sequence,
+                                           ARRAYSIZE(Translation->Sequence),
+                                           &Length))
+                return FALSE;
+            break;
+
+        case VK_NEXT: /* Page Down */
+            if (!VtComposeCsiTildeSequence(6,
+                                           VtGetModifierParameter(KeyEvent),
+                                           L'~',
+                                           Translation->Sequence,
+                                           ARRAYSIZE(Translation->Sequence),
+                                           &Length))
+                return FALSE;
+            break;
+
+        case VK_F1:
+        case VK_F2:
+        case VK_F3:
+        case VK_F4:
+        {
+            static const WCHAR Finals[] = { L'P', L'Q', L'R', L'S' };
+            ULONG Index = KeyEvent->wVirtualKeyCode - VK_F1;
+
+            /* F1-F4 use the same SS3 / xterm-modifier encoding as the cursor keys */
+            if (!VtComposeCursorKeySequence(TRUE, KeyEvent, Finals[Index], Translation->Sequence, ARRAYSIZE(Translation->Sequence), &Length))
+                return FALSE;
+            break;
+        }
+
+        case VK_F5:
+        case VK_F6:
+        case VK_F7:
+        case VK_F8:
+        case VK_F9:
+        case VK_F10:
+        case VK_F11:
+        case VK_F12:
+        {
+            static const ULONG Parameters[] = { 15, 17, 18, 19, 20, 21, 23, 24 };
+            ULONG Index = KeyEvent->wVirtualKeyCode - VK_F5;
+
+            if (!VtComposeCsiTildeSequence(Parameters[Index],
+                                           VtGetModifierParameter(KeyEvent),
+                                           L'~',
+                                           Translation->Sequence,
+                                           ARRAYSIZE(Translation->Sequence),
+                                           &Length))
+                return FALSE;
+            break;
+        }
+
+        case VK_NUMPAD0:
+        case VK_NUMPAD1:
+        case VK_NUMPAD2:
+        case VK_NUMPAD3:
+        case VK_NUMPAD4:
+        case VK_NUMPAD5:
+        case VK_NUMPAD6:
+        case VK_NUMPAD7:
+        case VK_NUMPAD8:
+        case VK_NUMPAD9:
+        case VK_DECIMAL:
+        case VK_ADD:
+        case VK_SUBTRACT:
+        case VK_MULTIPLY:
+        case VK_DIVIDE:
+        case VK_RETURN:
+        {
+            if (!(PrivateModes & VT_PRIVMODE_KEYPAD_APPLICATION))
+                return FALSE;
+
+            if (VtGetModifierParameter(KeyEvent) != 1)
+                return FALSE;
+
+            if (KeyEvent->wVirtualKeyCode == VK_RETURN &&
+                !(KeyEvent->dwControlKeyState & ENHANCED_KEY))
+            {
+                return FALSE;
+            }
+
+            {
+                WCHAR Final;
+
+                switch (KeyEvent->wVirtualKeyCode)
+                {
+                    case VK_NUMPAD0: Final = L'p'; break;
+                    case VK_NUMPAD1: Final = L'q'; break;
+                    case VK_NUMPAD2: Final = L'r'; break;
+                    case VK_NUMPAD3: Final = L's'; break;
+                    case VK_NUMPAD4: Final = L't'; break;
+                    case VK_NUMPAD5: Final = L'u'; break;
+                    case VK_NUMPAD6: Final = L'v'; break;
+                    case VK_NUMPAD7: Final = L'w'; break;
+                    case VK_NUMPAD8: Final = L'x'; break;
+                    case VK_NUMPAD9: Final = L'y'; break;
+                    case VK_DECIMAL: Final = L'n'; break;
+                    case VK_ADD:     Final = L'k'; break;
+                    case VK_SUBTRACT:Final = L'm'; break;
+                    case VK_MULTIPLY:Final = L'j'; break;
+                    case VK_DIVIDE:  Final = L'o'; break;
+                    case VK_RETURN:  Final = L'M'; break;
+                    default:
+                        return FALSE;
+                }
+
+                if (ARRAYSIZE(Translation->Sequence) < 3)
+                    return FALSE;
+
+                Translation->Sequence[0] = L'\x1b';
+                Translation->Sequence[1] = L'O';
+                Translation->Sequence[2] = Final;
+                Length = 3;
+            }
+            break;
+        }
+
+        default:
+            return FALSE;
+    }
+
+    Translation->Action = VtInputGenerateSequence;
+    Translation->RepeatCount = Repeat;
+    Translation->SequenceLength = Length;
+    return TRUE;
+}
+
+static BOOLEAN
+VtTranslateMouseEvent(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                      const MOUSE_EVENT_RECORD *MouseEvent,
+                      PVT_INPUT_TRANSLATION Translation)
+{
+    ULONG PrivateModes;
+    ULONG PreviousState;
+    ULONG CurrentState;
+    ULONG ButtonCode = 0;
+    ULONG X;
+    ULONG Y;
+    SIZE_T Length = 0;
+    BOOLEAN Released = FALSE;
+    BOOLEAN UseSgr;
+    ULONG Modifiers;
+    BOOLEAN TrackX10;
+    BOOLEAN TrackButtons;
+    BOOLEAN TrackAny;
+
+    if (!ScreenBuffer)
+        return FALSE;
+
+    PrivateModes = ScreenBuffer->VtState.PrivateModes;
+    TrackX10 = (PrivateModes & VT_PRIVMODE_MOUSE_X10) != 0;
+    TrackButtons = (PrivateModes & VT_PRIVMODE_MOUSE_BUTTON_TRACKING) != 0;
+    TrackAny = (PrivateModes & VT_PRIVMODE_MOUSE_ANY_EVENT) != 0;
+
+    if (!TrackX10 && !TrackButtons && !TrackAny)
+        return FALSE;
+
+    PreviousState = ScreenBuffer->VtState.MouseButtonState;
+    CurrentState = MouseEvent->dwButtonState & 0xFFFF;
+    X = (ULONG)MouseEvent->dwMousePosition.X + 1; /* Convert to 1-based */
+    Y = (ULONG)MouseEvent->dwMousePosition.Y + 1;
+    UseSgr = (PrivateModes & VT_PRIVMODE_MOUSE_SGR_EXTENDED) != 0;
+    Modifiers = VtMouseModifierBits(MouseEvent->dwControlKeyState);
+
+    if (MouseEvent->dwEventFlags == MOUSE_WHEELED ||
+        MouseEvent->dwEventFlags == MOUSE_HWHEELED)
+    {
+        SHORT Delta = (SHORT)HIWORD(MouseEvent->dwButtonState);
+
+        if (Delta == 0)
+            return FALSE;
+
+        if (MouseEvent->dwEventFlags == MOUSE_WHEELED)
+            ButtonCode = (Delta > 0) ? 64 : 65;
+        else
+            ButtonCode = (Delta > 0) ? 66 : 67;
+
+        ButtonCode += Modifiers;
+
+        if (UseSgr)
+        {
+            if (!VtComposeMouseSgrSequence(ButtonCode, X, Y, FALSE,
+                                           Translation->Sequence,
+                                           ARRAYSIZE(Translation->Sequence),
+                                           &Length))
+                return FALSE;
+        }
+        else
+        {
+            if (!VtComposeMouseLegacySequence(ButtonCode, X, Y,
+                                              Translation->Sequence,
+                                              ARRAYSIZE(Translation->Sequence),
+                                              &Length))
+                return FALSE;
+        }
+
+        Translation->Action = VtInputGenerateSequence;
+        Translation->RepeatCount = 1;
+        Translation->SequenceLength = Length;
+        ScreenBuffer->VtState.MouseButtonState = CurrentState;
+        return TRUE;
+    }
+
+    if (MouseEvent->dwEventFlags == MOUSE_MOVED)
+    {
+        if (!TrackAny && !(TrackButtons && CurrentState != 0))
+            return FALSE;
+
+        if (CurrentState != 0)
+        {
+            INT ButtonIndex = VtFirstMouseButton(CurrentState);
+            if (ButtonIndex < 0)
+                return FALSE;
+
+            ButtonCode = (ULONG)ButtonIndex;
+        }
+        else
+        {
+            ButtonCode = 3; /* Motion with no buttons */
+        }
+    }
+    else
+    {
+        ULONG Changed = PreviousState ^ CurrentState;
+        ULONG Pressed = Changed & CurrentState;
+        ULONG ReleasedMask = Changed & ~CurrentState;
+
+        if (Pressed != 0)
+        {
+            INT ButtonIndex = VtFirstMouseButton(Pressed);
+            if (ButtonIndex < 0)
+                ButtonIndex = VtFirstMouseButton(CurrentState);
+            if (ButtonIndex < 0)
+                return FALSE;
+
+            ButtonCode = (ULONG)ButtonIndex;
+        }
+        else if (ReleasedMask != 0)
+        {
+            INT ButtonIndex = VtFirstMouseButton(ReleasedMask);
+            if (ButtonIndex < 0)
+                ButtonIndex = VtFirstMouseButton(PreviousState);
+            if (ButtonIndex < 0)
+                return FALSE;
+
+            ButtonCode = (ULONG)ButtonIndex;
+            Released = TRUE;
+        }
+        else
+        {
+            if (MouseEvent->dwEventFlags == DOUBLE_CLICK)
+            {
+                INT ButtonIndex = VtFirstMouseButton(CurrentState);
+                if (ButtonIndex < 0)
+                    return FALSE;
+
+                ButtonCode = (ULONG)ButtonIndex;
+            }
+            else
+            {
+                return FALSE;
+            }
+        }
+    }
+
+    ButtonCode += Modifiers;
+
+    if (UseSgr)
+    {
+        ULONG Code = ButtonCode;
+
+        if (MouseEvent->dwEventFlags == MOUSE_MOVED)
+            Code |= 32;
+
+        if (!VtComposeMouseSgrSequence(Code, X, Y, Released,
+                                       Translation->Sequence,
+                                       ARRAYSIZE(Translation->Sequence),
+                                       &Length))
+            return FALSE;
+    }
+    else
+    {
+        ULONG Code = ButtonCode;
+
+        if (Released)
+            Code = 3 + Modifiers;
+        else if (MouseEvent->dwEventFlags == MOUSE_MOVED)
+            Code += 32;
+
+        if (!VtComposeMouseLegacySequence(Code, X, Y,
+                                          Translation->Sequence,
+                                          ARRAYSIZE(Translation->Sequence),
+                                          &Length))
+            return FALSE;
+    }
+
+    ScreenBuffer->VtState.MouseButtonState = CurrentState;
+
+    Translation->Action = VtInputGenerateSequence;
+    Translation->RepeatCount = 1;
+    Translation->SequenceLength = Length;
+    return TRUE;
+}
+
+static BOOLEAN
+VtTranslateFocusEvent(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                      const FOCUS_EVENT_RECORD *FocusEvent,
+                      PVT_INPUT_TRANSLATION Translation)
+{
+    if (!ScreenBuffer)
+        return FALSE;
+
+    if (!(ScreenBuffer->VtState.PrivateModes & VT_PRIVMODE_FOCUS_EVENT))
+        return FALSE;
+
+    if (ARRAYSIZE(Translation->Sequence) < 3)
+        return FALSE;
+
+    Translation->Sequence[0] = L'\x1b';
+    Translation->Sequence[1] = L'[';
+    Translation->Sequence[2] = FocusEvent->bSetFocus ? L'I' : L'O';
+    Translation->Action = VtInputGenerateSequence;
+    Translation->RepeatCount = 1;
+    Translation->SequenceLength = 3;
+    return TRUE;
+}
+
+static VOID
+VtFillKeyEvent(PINPUT_RECORD Destination,
+               WCHAR Character,
+               BOOLEAN KeyDown)
+{
+    RtlZeroMemory(Destination, sizeof(*Destination));
+    Destination->EventType = KEY_EVENT;
+    Destination->Event.KeyEvent.bKeyDown = KeyDown;
+    Destination->Event.KeyEvent.wRepeatCount = 1;
+    Destination->Event.KeyEvent.uChar.UnicodeChar = Character;
+}
+
+NTSTATUS
+NTAPI
+ConDrvVtTranslateInput(PCONSOLE Console,
+                       PINPUT_RECORD InputRecords,
+                       ULONG NumRecords,
+                       PINPUT_RECORD *TranslatedRecords,
+                       PULONG TranslatedCount,
+                       PBOOLEAN AllocatedBuffer)
+{
+    PTEXTMODE_SCREEN_BUFFER ScreenBuffer;
+    PVT_INPUT_TRANSLATION TranslationInfo = NULL;
+    PINPUT_RECORD OutputRecords = NULL;
+    ULONGLONG OutputCount64 = 0;
+    ULONG Index;
+    BOOLEAN AnyTranslated = FALSE;
+
+    if (!TranslatedRecords || !TranslatedCount || !AllocatedBuffer)
+        return STATUS_INVALID_PARAMETER;
+
+    *TranslatedRecords = InputRecords;
+    *TranslatedCount = NumRecords;
+    *AllocatedBuffer = FALSE;
+
+    if (Console == NULL || InputRecords == NULL || NumRecords == 0)
+        return STATUS_SUCCESS;
+
+    if (!(Console->InputBuffer.Mode & ENABLE_VIRTUAL_TERMINAL_INPUT))
+        return STATUS_SUCCESS;
+
+    ScreenBuffer = (Console->ActiveBuffer &&
+                    GetType(Console->ActiveBuffer) == TEXTMODE_BUFFER)
+                       ? (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer
+                       : NULL;
+
+    TranslationInfo = ConsoleAllocHeap(0, sizeof(VT_INPUT_TRANSLATION) * NumRecords);
+    if (!TranslationInfo)
+        return STATUS_NO_MEMORY;
+
+    for (Index = 0; Index < NumRecords; ++Index)
+    {
+        const INPUT_RECORD *Record = &InputRecords[Index];
+        PVT_INPUT_TRANSLATION Info = &TranslationInfo[Index];
+
+        Info->Action = VtInputPassThrough;
+        Info->RepeatCount = 0;
+        Info->SequenceLength = 0;
+
+        switch (Record->EventType)
+        {
+            case KEY_EVENT:
+                if (VtTranslateKeyEvent(ScreenBuffer, &Record->Event.KeyEvent, Info))
+                {
+                    AnyTranslated = TRUE;
+
+                    if (Info->Action == VtInputGenerateSequence)
+                    {
+                        ULONGLONG Repeat = Info->RepeatCount ? Info->RepeatCount : 1;
+                        ULONGLONG SequenceLength = Info->SequenceLength;
+                        OutputCount64 += SequenceLength * 2ull * Repeat;
+                    }
+                    else if (Info->Action == VtInputPassThrough)
+                    {
+                        OutputCount64 += 1;
+                    }
+                    /* Drop case contributes nothing */
+                }
+                else
+                {
+                    OutputCount64 += 1;
+                }
+                break;
+
+            case MOUSE_EVENT:
+                if (VtTranslateMouseEvent(ScreenBuffer, &Record->Event.MouseEvent, Info))
+                {
+                    AnyTranslated = TRUE;
+
+                    if (Info->Action == VtInputGenerateSequence)
+                    {
+                        ULONGLONG SequenceLength = Info->SequenceLength;
+                        OutputCount64 += SequenceLength * 2ull;
+                    }
+                    else if (Info->Action == VtInputPassThrough)
+                    {
+                        OutputCount64 += 1;
+                    }
+                }
+                else
+                {
+                    OutputCount64 += 1;
+                }
+                break;
+
+            case FOCUS_EVENT:
+                if (VtTranslateFocusEvent(ScreenBuffer, &Record->Event.FocusEvent, Info))
+                {
+                    AnyTranslated = TRUE;
+
+                    if (Info->Action == VtInputGenerateSequence)
+                    {
+                        ULONGLONG SequenceLength = Info->SequenceLength;
+                        OutputCount64 += SequenceLength * 2ull;
+                    }
+                    else if (Info->Action == VtInputPassThrough)
+                    {
+                        OutputCount64 += 1;
+                    }
+                }
+                else
+                {
+                    OutputCount64 += 1;
+                }
+                break;
+
+            default:
+                OutputCount64 += 1;
+                break;
+        }
+    }
+
+    if (!AnyTranslated)
+    {
+        ConsoleFreeHeap(TranslationInfo);
+        return STATUS_SUCCESS;
+    }
+
+    if (OutputCount64 > ULONG_MAX)
+    {
+        ConsoleFreeHeap(TranslationInfo);
+        return STATUS_INTEGER_OVERFLOW;
+    }
+
+    if (OutputCount64 == 0)
+    {
+        ConsoleFreeHeap(TranslationInfo);
+        *TranslatedRecords = NULL;
+        *TranslatedCount = 0;
+        *AllocatedBuffer = FALSE;
+        return STATUS_SUCCESS;
+    }
+
+    OutputRecords = ConsoleAllocHeap(0, sizeof(INPUT_RECORD) * (ULONG)OutputCount64);
+    if (!OutputRecords)
+    {
+        ConsoleFreeHeap(TranslationInfo);
+        return STATUS_NO_MEMORY;
+    }
+
+    {
+        ULONG OutIndex = 0;
+
+        for (Index = 0; Index < NumRecords; ++Index)
+        {
+            const INPUT_RECORD *Record = &InputRecords[Index];
+            PVT_INPUT_TRANSLATION Info = &TranslationInfo[Index];
+
+            if (Info->Action == VtInputPassThrough)
+            {
+                OutputRecords[OutIndex++] = *Record;
+                continue;
+            }
+
+            if (Info->Action == VtInputDrop)
+                continue;
+
+            if (Info->Action == VtInputGenerateSequence && Info->SequenceLength > 0)
+            {
+                ULONG Repeat;
+
+                for (Repeat = 0; Repeat < (Info->RepeatCount ? Info->RepeatCount : 1); ++Repeat)
+                {
+                    SIZE_T SeqIndex;
+
+                    for (SeqIndex = 0; SeqIndex < Info->SequenceLength; ++SeqIndex)
+                    {
+                        WCHAR Ch = Info->Sequence[SeqIndex];
+                        VtFillKeyEvent(&OutputRecords[OutIndex++], Ch, TRUE);
+                        VtFillKeyEvent(&OutputRecords[OutIndex++], Ch, FALSE);
+                    }
+                }
+                continue;
+            }
+
+            OutputRecords[OutIndex++] = *Record;
+        }
+    }
+
+    ConsoleFreeHeap(TranslationInfo);
+
+    *TranslatedRecords = OutputRecords;
+    *TranslatedCount = (ULONG)OutputCount64;
+    *AllocatedBuffer = TRUE;
+    return STATUS_SUCCESS;
+}

--- a/win32ss/user/winsrv/consrv/condrv/vt.c
+++ b/win32ss/user/winsrv/consrv/condrv/vt.c
@@ -5095,6 +5095,28 @@ VtFillKeyEvent(PINPUT_RECORD Destination,
     Destination->Event.KeyEvent.uChar.UnicodeChar = Character;
 }
 
+BOOLEAN
+NTAPI
+ConDrvVtIsMouseTrackingEnabled(PCONSOLE Console)
+{
+    PTEXTMODE_SCREEN_BUFFER ScreenBuffer;
+    ULONG PrivateModes;
+
+    if (!Console ||
+        !(Console->InputBuffer.Mode & ENABLE_VIRTUAL_TERMINAL_INPUT) ||
+        !Console->ActiveBuffer ||
+        GetType(Console->ActiveBuffer) != TEXTMODE_BUFFER)
+    {
+        return FALSE;
+    }
+
+    ScreenBuffer = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
+    PrivateModes = ScreenBuffer->VtState.PrivateModes;
+    return !!(PrivateModes & (VT_PRIVMODE_MOUSE_X10 |
+                              VT_PRIVMODE_MOUSE_BUTTON_TRACKING |
+                              VT_PRIVMODE_MOUSE_ANY_EVENT));
+}
+
 NTSTATUS
 NTAPI
 ConDrvVtTranslateInput(PCONSOLE Console,

--- a/win32ss/user/winsrv/consrv/condrv/vt.c
+++ b/win32ss/user/winsrv/consrv/condrv/vt.c
@@ -53,6 +53,12 @@ VtXtermToConsoleIndex(UCHAR Index);
 static VOID
 VtFillKeyEvent(PINPUT_RECORD Destination, WCHAR Character, BOOLEAN KeyDown);
 
+static VOID
+VtFlushDirty(PCONSOLE Console, PTEXTMODE_SCREEN_BUFFER ScreenBuffer);
+
+static VOID
+VtMarkDirty(PTEXTMODE_SCREEN_BUFFER ScreenBuffer, SHORT Left, SHORT Top, SHORT Right, SHORT Bottom);
+
 #define VT_MAX_PARAMS 16
 #define VT_MAX_INPUT_SEQUENCE_CHARS 32
 
@@ -548,7 +554,78 @@ VtFindNextTabStop(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
     return (Column < Width) ? Column : Width;
 }
 
-static BOOLEAN
+/* Column of the tab stop at or before StartColumn, or 0 when there is none */
+SHORT
+NTAPI
+VtFindPrevTabStop(PTEXTMODE_SCREEN_BUFFER ScreenBuffer, SHORT StartColumn)
+{
+    SHORT Column;
+
+    if (!ScreenBuffer || ScreenBuffer->ScreenBufferSize.X <= 0 || StartColumn <= 0)
+        return 0;
+
+    if (StartColumn > ScreenBuffer->ScreenBufferSize.X)
+        StartColumn = ScreenBuffer->ScreenBufferSize.X;
+
+    if (VtEnsureTabStops(ScreenBuffer))
+    {
+        for (Column = min(StartColumn, (SHORT)ScreenBuffer->VtState.TabStopLength) - 1; Column > 0; --Column)
+        {
+            if (ScreenBuffer->VtState.TabStops[Column])
+                return Column;
+        }
+        return 0;
+    }
+
+    /* No bitmap available: fall back to the previous multiple of the default width */
+    Column = (SHORT)(((StartColumn - 1) / VT_DEFAULT_TAB_WIDTH) * VT_DEFAULT_TAB_WIDTH);
+    return (Column > 0) ? Column : 0;
+}
+
+/* CHT - move the cursor forward over Count tab stops */
+static VOID
+VtTabForward(PCONSOLE Console, PTEXTMODE_SCREEN_BUFFER ScreenBuffer, ULONG Count)
+{
+    COORD Position;
+    ULONG i;
+
+    if (ScreenBuffer->ScreenBufferSize.X <= 0)
+        return;
+
+    Position = ScreenBuffer->CursorPosition;
+    for (i = 0; i < Count; ++i)
+    {
+        SHORT Next = VtFindNextTabStop(ScreenBuffer, Position.X);
+
+        if (Next >= ScreenBuffer->ScreenBufferSize.X)
+        {
+            Position.X = ScreenBuffer->ScreenBufferSize.X - 1;
+            break;
+        }
+        Position.X = Next;
+    }
+
+    ConDrvSetConsoleCursorPosition(Console, ScreenBuffer, &Position);
+}
+
+/* CBT - move the cursor back over Count tab stops */
+static VOID
+VtTabBackward(PCONSOLE Console, PTEXTMODE_SCREEN_BUFFER ScreenBuffer, ULONG Count)
+{
+    COORD Position;
+    ULONG i;
+
+    if (ScreenBuffer->ScreenBufferSize.X <= 0)
+        return;
+
+    Position = ScreenBuffer->CursorPosition;
+    for (i = 0; i < Count && Position.X > 0; ++i)
+        Position.X = VtFindPrevTabStop(ScreenBuffer, Position.X);
+
+    ConDrvSetConsoleCursorPosition(Console, ScreenBuffer, &Position);
+}
+
+static VOID
 VtHandleDcsSequence(PCONSOLE Console,
                     PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
                     const WCHAR *Sequence,
@@ -557,16 +634,16 @@ VtHandleDcsSequence(PCONSOLE Console,
     PTEXTMODE_SCREEN_BUFFER Target;
 
     if (!Console)
-        return TRUE;
+        return;
 
     if (!Console->AllowVtDcsPassthrough)
     {
         VtTracePolicyBlocked("VT DCS passthrough");
-        return TRUE;
+        return;
     }
 
     if (!Sequence || Length == 0)
-        return TRUE;
+        return;
 
     /* tmux multiplexes escape sequences via DCS "tmux;" wrappers. */
     if (Length >= 5 &&
@@ -581,14 +658,14 @@ VtHandleDcsSequence(PCONSOLE Console,
         NTSTATUS Status;
 
         if (PayloadLength == 0)
-            return TRUE;
+            return;
 
         Target = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
         if (!Target)
             Target = ScreenBuffer;
 
         if (!Target)
-            return TRUE;
+            return;
 
         Status = ConDrvVtWriteConsole(Console,
                                       Target,
@@ -598,11 +675,11 @@ VtHandleDcsSequence(PCONSOLE Console,
                                       &Handled);
         if (!NT_SUCCESS(Status))
             VtTraceDcsReplayFailure(Status);
-        return TRUE;
+        return;
     }
 
     VtTraceUnhandledDcs();
-    return TRUE;
+    return;
 }
 
 static WCHAR
@@ -853,169 +930,110 @@ VtRestoreCursorState(PCONSOLE Console,
     ScreenBuffer->VtState.PendingSingleShift = VT_CHARSET_SLOT_INVALID;
 }
 
+/*
+ * DECSET/DECRST 1047 and 1049 - the alternate screen.
+ *
+ * Implemented as a content swap inside this same screen-buffer object: the
+ * primary's cell array, extended colours, cursor, viewport and margins are
+ * parked in VtState and a blank set is installed in their place. Nothing about
+ * the object's identity changes, so Console->ActiveBuffer, every client handle
+ * and the reference the current write holds all stay valid - which a second
+ * screen-buffer object plus ConDrvSetConsoleActiveScreenBuffer did not.
+ *
+ * The dimensions are deliberately left alone. xterm gives the alternate screen
+ * the visible area only; keeping the buffer size means the rows below the
+ * viewport simply stay blank, and avoids a reallocation that would invalidate
+ * the very pointers being parked.
+ */
 static BOOLEAN
-VtEnableAlternateScreen(PCONSOLE Console,
-                        PTEXTMODE_SCREEN_BUFFER PrimaryBuffer)
+VtEnableAlternateScreen(PCONSOLE Console, PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
 {
-    TEXTMODE_BUFFER_INFO AltInfo;
-    PCONSOLE_SCREEN_BUFFER NewBuffer = NULL;
-    PTEXTMODE_SCREEN_BUFFER AltBuffer;
-    NTSTATUS Status;
+    SIZE_T CellCount;
+    PCHAR_INFO Blank;
+    SHORT X, Y;
 
-    if (PrimaryBuffer->VtState.AlternateBuffer != NULL)
-    {
-        /* Already active, ensure the console is pointing at it. */
-        if (Console->ActiveBuffer != (PCONSOLE_SCREEN_BUFFER)PrimaryBuffer->VtState.AlternateBuffer)
-        {
-            ConDrvSetConsoleActiveScreenBuffer(Console,
-                                               (PCONSOLE_SCREEN_BUFFER)PrimaryBuffer->VtState.AlternateBuffer);
-        }
+    if (ScreenBuffer->VtState.AlternateActive)
         return TRUE;
-    }
 
-    PrimaryBuffer->VtState.PrimaryCursorInfo = PrimaryBuffer->CursorInfo;
-    PrimaryBuffer->VtState.PrimaryCursorPos = PrimaryBuffer->CursorPosition;
-    PrimaryBuffer->VtState.PrimaryViewOrigin = PrimaryBuffer->ViewOrigin;
-    PrimaryBuffer->VtState.PrimaryVirtualY = PrimaryBuffer->VirtualY;
-    AltInfo.ScreenBufferSize = PrimaryBuffer->ViewSize;
-    AltInfo.ScreenBufferSize.X = max(AltInfo.ScreenBufferSize.X, 1);
-    AltInfo.ScreenBufferSize.Y = max(AltInfo.ScreenBufferSize.Y, 1);
-    AltInfo.ViewSize         = AltInfo.ScreenBufferSize;
-    AltInfo.ScreenAttrib     = PrimaryBuffer->ScreenDefaultAttrib;
-    AltInfo.PopupAttrib      = PrimaryBuffer->PopupDefaultAttrib;
-    AltInfo.CursorSize       = PrimaryBuffer->CursorInfo.dwSize;
-    AltInfo.IsCursorVisible  = PrimaryBuffer->CursorInfo.bVisible;
-
-    Status = ConDrvCreateScreenBuffer(&NewBuffer,
-                                      Console,
-                                      NULL,
-                                      CONSOLE_TEXTMODE_BUFFER,
-                                      &AltInfo);
-    if (!NT_SUCCESS(Status) || NewBuffer == NULL)
-    {
-        PrimaryBuffer->VtState.PrimaryBuffer = NULL;
+    CellCount = (SIZE_T)ScreenBuffer->ScreenBufferSize.X * ScreenBuffer->ScreenBufferSize.Y;
+    if (CellCount == 0)
         return FALSE;
-    }
 
-    AltBuffer = (PTEXTMODE_SCREEN_BUFFER)NewBuffer;
-    AltBuffer->Mode = PrimaryBuffer->Mode;
+    Blank = ConsoleAllocHeap(0, CellCount * sizeof(CHAR_INFO));
+    if (!Blank)
+        return FALSE;
 
-    /*
-     * The alternate screen inherits the primary's VT state wholesale, so copy
-     * the struct rather than enumerating fields - an enumerated list silently
-     * stops covering every field that gets added later.
-     *
-     * Everything the alternate buffer must NOT share is then reset explicitly.
-     * Clearing the owning pointers first matters: TabStops and HyperlinkUri.Buffer
-     * are heap-owned per buffer, and leaving the copied values in place would
-     * alias the primary's allocations and double-free them.
-     */
-    AltBuffer->VtState = PrimaryBuffer->VtState;
+    /* Park the primary screen */
+    ScreenBuffer->VtState.SavedBuffer = ScreenBuffer->Buffer;
+    ScreenBuffer->VtState.SavedCellRgb = ScreenBuffer->CellRgb;
+    ScreenBuffer->VtState.SavedVirtualY = ScreenBuffer->VirtualY;
+    ScreenBuffer->VtState.SavedScreenCursorPos = ScreenBuffer->CursorPosition;
+    ScreenBuffer->VtState.SavedScreenCursorInfo = ScreenBuffer->CursorInfo;
+    ScreenBuffer->VtState.SavedViewOrigin = ScreenBuffer->ViewOrigin;
+    ScreenBuffer->VtState.SavedScrollTop = ScreenBuffer->VtState.ScrollTop;
+    ScreenBuffer->VtState.SavedScrollBottom = ScreenBuffer->VtState.ScrollBottom;
 
-    AltBuffer->VtState.PrimaryBuffer = PrimaryBuffer;
-    AltBuffer->VtState.AlternateBuffer = NULL;
-    AltBuffer->VtState.PrivateModes |= VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER;
+    /* Install a blank screen. The colour array is dropped rather than copied:
+     * it is rebuilt lazily the moment a 24-bit colour is written. */
+    ScreenBuffer->Buffer = Blank;
+    ScreenBuffer->CellRgb = NULL;
+    ScreenBuffer->VirtualY = 0;
+    ScreenBuffer->ViewOrigin.X = ScreenBuffer->ViewOrigin.Y = 0;
+    ScreenBuffer->VtState.ScrollTop = 0;
+    ScreenBuffer->VtState.ScrollBottom = max(0, ScreenBuffer->ScreenBufferSize.Y - 1);
 
-    AltBuffer->VtState.TabStops = NULL;
-    AltBuffer->VtState.TabStopLength = 0;
-
-    AltBuffer->VtState.HyperlinkUri.Buffer = NULL;
-    AltBuffer->VtState.HyperlinkUri.Length = 0;
-    AltBuffer->VtState.HyperlinkUri.MaximumLength = 0;
-
-    AltBuffer->VtState.PendingSequenceLength = 0;
-
-    /*
-     * The DECSC slot and the REP / mouse-tracking scratch are per screen, not
-     * inherited - the alternate screen starts with none of them set, matching
-     * xterm and the previous field-by-field behaviour.
-     */
-    AltBuffer->VtState.CursorSaved = FALSE;
-    AltBuffer->VtState.SavedCursorPos.X = AltBuffer->VtState.SavedCursorPos.Y = 0;
-    AltBuffer->VtState.LastWrittenChar = 0;
-    AltBuffer->VtState.LastCharValid = FALSE;
-    AltBuffer->VtState.MouseButtonState = 0;
-
-    /* The alternate screen starts unscrolled, with its own margins */
-    AltBuffer->VtState.ScrollTop = min(PrimaryBuffer->VtState.ScrollTop, (SHORT)max(0, AltBuffer->ScreenBufferSize.Y - 1));
-    if (PrimaryBuffer->VtState.HyperlinkActive &&
-        PrimaryBuffer->VtState.HyperlinkUri.Buffer &&
-        PrimaryBuffer->VtState.HyperlinkUri.Length > 0)
+    for (Y = 0; Y < ScreenBuffer->ScreenBufferSize.Y; ++Y)
     {
-        ULONG Bytes = PrimaryBuffer->VtState.HyperlinkUri.Length + sizeof(WCHAR);
-        PWCHAR Copy = ConsoleAllocHeap(0, Bytes);
-        if (Copy)
+        PCHAR_INFO Row = ConioCoordToPointer(ScreenBuffer, 0, Y);
+
+        for (X = 0; X < ScreenBuffer->ScreenBufferSize.X; ++X, ++Row)
         {
-            RtlCopyMemory(Copy, PrimaryBuffer->VtState.HyperlinkUri.Buffer,
-                          PrimaryBuffer->VtState.HyperlinkUri.Length);
-            Copy[PrimaryBuffer->VtState.HyperlinkUri.Length / sizeof(WCHAR)] = UNICODE_NULL;
-            AltBuffer->VtState.HyperlinkUri.Buffer = Copy;
-            AltBuffer->VtState.HyperlinkUri.Length = PrimaryBuffer->VtState.HyperlinkUri.Length;
-            AltBuffer->VtState.HyperlinkUri.MaximumLength = (USHORT)Bytes;
-        }
-        else
-        {
-            AltBuffer->VtState.HyperlinkActive = FALSE;
+            Row->Char.UnicodeChar = L' ';
+            Row->Attributes = ScreenBuffer->VtState.CurrentAttributes;
         }
     }
 
-    VtResetTabStops(AltBuffer);
+    ScreenBuffer->VtState.AlternateActive = TRUE;
+    ScreenBuffer->VtState.PrivateModes |= VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER;
 
-    AltBuffer->VtState.ScrollBottom = min(PrimaryBuffer->VtState.ScrollBottom,
-                                          (SHORT)max(0, AltBuffer->ScreenBufferSize.Y - 1));
-    if (AltBuffer->VtState.ScrollBottom < AltBuffer->VtState.ScrollTop)
+    VtMarkDirty(ScreenBuffer, 0, 0, (SHORT)(ScreenBuffer->ScreenBufferSize.X - 1), (SHORT)(ScreenBuffer->ScreenBufferSize.Y - 1));
+
     {
-        AltBuffer->VtState.ScrollTop = 0;
-        AltBuffer->VtState.ScrollBottom = max(0, AltBuffer->ScreenBufferSize.Y - 1);
+        COORD Home = {0, 0};
+        ConDrvSetConsoleCursorPosition(Console, ScreenBuffer, &Home);
     }
 
-    PrimaryBuffer->VtState.AlternateBuffer = AltBuffer;
-    PrimaryBuffer->VtState.PrivateModes |= VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER;
-
-    ConDrvSetConsoleActiveScreenBuffer(Console, NewBuffer);
-    ConDrvSetConsoleCursorInfo(Console, AltBuffer, &AltBuffer->CursorInfo);
     return TRUE;
 }
 
 static BOOLEAN
-VtDisableAlternateScreen(PCONSOLE Console,
-                         PTEXTMODE_SCREEN_BUFFER ActiveBuffer)
+VtDisableAlternateScreen(PCONSOLE Console, PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
 {
-    PTEXTMODE_SCREEN_BUFFER PrimaryBuffer;
-
-    if (ActiveBuffer->VtState.PrimaryBuffer == NULL)
-    {
-        /* No alternate screen in use. */
-        if (ActiveBuffer->VtState.AlternateBuffer != NULL)
-        {
-            PTEXTMODE_SCREEN_BUFFER AltBuffer = ActiveBuffer->VtState.AlternateBuffer;
-            ActiveBuffer->VtState.AlternateBuffer = NULL;
-            AltBuffer->VtState.PrimaryBuffer = NULL;
-            ActiveBuffer->VtState.PrivateModes &= ~VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER;
-            ConDrvDeleteScreenBuffer((PCONSOLE_SCREEN_BUFFER)AltBuffer);
-        }
+    if (!ScreenBuffer->VtState.AlternateActive)
         return TRUE;
-    }
 
-    PrimaryBuffer = ActiveBuffer->VtState.PrimaryBuffer;
+    /* Discard the alternate screen and put the primary's contents back */
+    ConsoleFreeHeap(ScreenBuffer->Buffer);
+    if (ScreenBuffer->CellRgb)
+        ConsoleFreeHeap(ScreenBuffer->CellRgb);
 
-    /* Restore the saved attributes on the primary buffer before switching back. */
-    PrimaryBuffer->CursorInfo = PrimaryBuffer->VtState.PrimaryCursorInfo;
-    PrimaryBuffer->CursorPosition = PrimaryBuffer->VtState.PrimaryCursorPos;
-    PrimaryBuffer->ViewOrigin = PrimaryBuffer->VtState.PrimaryViewOrigin;
-    PrimaryBuffer->VirtualY = PrimaryBuffer->VtState.PrimaryVirtualY;
+    ScreenBuffer->Buffer = ScreenBuffer->VtState.SavedBuffer;
+    ScreenBuffer->CellRgb = ScreenBuffer->VtState.SavedCellRgb;
+    ScreenBuffer->VirtualY = ScreenBuffer->VtState.SavedVirtualY;
+    ScreenBuffer->ViewOrigin = ScreenBuffer->VtState.SavedViewOrigin;
+    ScreenBuffer->CursorInfo = ScreenBuffer->VtState.SavedScreenCursorInfo;
+    ScreenBuffer->VtState.ScrollTop = ScreenBuffer->VtState.SavedScrollTop;
+    ScreenBuffer->VtState.ScrollBottom = ScreenBuffer->VtState.SavedScrollBottom;
 
-    PrimaryBuffer->VtState.PrivateModes &= ~VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER;
-    PrimaryBuffer->VtState.AlternateBuffer = NULL;
+    ScreenBuffer->VtState.SavedBuffer = NULL;
+    ScreenBuffer->VtState.SavedCellRgb = NULL;
+    ScreenBuffer->VtState.AlternateActive = FALSE;
+    ScreenBuffer->VtState.PrivateModes &= ~VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER;
 
-    ActiveBuffer->VtState.PrimaryBuffer = NULL;
-    ActiveBuffer->VtState.PrivateModes &= ~VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER;
+    VtMarkDirty(ScreenBuffer, 0, 0, (SHORT)(ScreenBuffer->ScreenBufferSize.X - 1), (SHORT)(ScreenBuffer->ScreenBufferSize.Y - 1));
 
-    ConDrvVtInvalidateBufferRgb(ActiveBuffer);
-
-    ConDrvSetConsoleActiveScreenBuffer(Console, (PCONSOLE_SCREEN_BUFFER)PrimaryBuffer);
-    ConDrvSetConsoleCursorInfo(Console, PrimaryBuffer, &PrimaryBuffer->CursorInfo);
-    ConDrvSetConsoleCursorPosition(Console, PrimaryBuffer, &PrimaryBuffer->CursorPosition);
+    ConDrvSetConsoleCursorInfo(Console, ScreenBuffer, &ScreenBuffer->CursorInfo);
+    ConDrvSetConsoleCursorPosition(Console, ScreenBuffer, &ScreenBuffer->VtState.SavedScreenCursorPos);
 
     return TRUE;
 }
@@ -1647,46 +1665,89 @@ VtSendOscClipboardResponse(PCONSOLE Console,
 }
 
 
+/*
+ * OSC colour report: ESC ] <Ps> [ ; <Index> ] ; <rgb> BEL
+ *
+ * OSC 4 reports a palette entry and carries its index as a second parameter;
+ * OSC 10/11 report the default fore/background and carry none.
+ */
 static VOID
-VtSendOscColorResponse(PCONSOLE Console,
-                       ULONG Parameter,
-                       COLORREF Color)
-{
-    WCHAR Response[64];
-    SIZE_T Len = 0;
-
-    Response[Len++] = L'\x1b';
-    Response[Len++] = L']';
-    Len += VtAppendNumber(Response + Len, ARRAYSIZE(Response) - Len, Parameter);
-    if (Len < ARRAYSIZE(Response))
-        Response[Len++] = L';';
-    Len += VtAppendOscRgb(Response + Len, ARRAYSIZE(Response) - Len, Color);
-    if (Len < ARRAYSIZE(Response))
-        Response[Len++] = L'\x07';
-
-    VtSendInputResponse(Console, Response, Len);
-}
-
-static VOID
-VtSendOscPaletteResponse(PCONSOLE Console,
-                         ULONG Index,
-                         COLORREF Color)
+VtSendOscColorReply(PCONSOLE Console, ULONG Ps, BOOLEAN HasIndex, ULONG Index, COLORREF Color)
 {
     WCHAR Response[80];
     SIZE_T Len = 0;
 
-    Response[Len++] = L'\x1b';
+    Response[Len++] = L'';
     Response[Len++] = L']';
-    Response[Len++] = L'4';
-    Response[Len++] = L';';
-    Len += VtAppendNumber(Response + Len, ARRAYSIZE(Response) - Len, Index);
+    Len += VtAppendNumber(Response + Len, ARRAYSIZE(Response) - Len, Ps);
+
+    if (HasIndex)
+    {
+        if (Len < ARRAYSIZE(Response))
+            Response[Len++] = L';';
+        Len += VtAppendNumber(Response + Len, ARRAYSIZE(Response) - Len, Index);
+    }
+
     if (Len < ARRAYSIZE(Response))
         Response[Len++] = L';';
     Len += VtAppendOscRgb(Response + Len, ARRAYSIZE(Response) - Len, Color);
     if (Len < ARRAYSIZE(Response))
-        Response[Len++] = L'\x07';
+        Response[Len++] = L'';
 
     VtSendInputResponse(Console, Response, Len);
+}
+
+
+/*
+ * Invalidation accumulator.
+ *
+ * Every VT operation used to call TermDrawRegion itself, so a single frame from
+ * a full-screen application cost one win32k InvalidateRect per escape sequence.
+ * Repainting is asynchronous and always reads the buffer as it stands when the
+ * paint happens, so the individual regions can be unioned and issued once.
+ *
+ * The rectangle lives on the screen buffer, so it must be flushed before the
+ * console switches active buffer - otherwise it would be left pending on a
+ * buffer nobody is painting.
+ */
+static VOID
+VtMarkDirty(PTEXTMODE_SCREEN_BUFFER ScreenBuffer, SHORT Left, SHORT Top, SHORT Right, SHORT Bottom)
+{
+    PSMALL_RECT Dirty = &ScreenBuffer->VtState.DirtyRect;
+
+    if (Left > Right || Top > Bottom)
+        return;
+
+    if (!ScreenBuffer->VtState.DirtyValid)
+    {
+        Dirty->Left = Left;
+        Dirty->Top = Top;
+        Dirty->Right = Right;
+        Dirty->Bottom = Bottom;
+        ScreenBuffer->VtState.DirtyValid = TRUE;
+        return;
+    }
+
+    Dirty->Left = min(Dirty->Left, Left);
+    Dirty->Top = min(Dirty->Top, Top);
+    Dirty->Right = max(Dirty->Right, Right);
+    Dirty->Bottom = max(Dirty->Bottom, Bottom);
+}
+
+static VOID
+VtMarkDirtyRect(PTEXTMODE_SCREEN_BUFFER ScreenBuffer, const SMALL_RECT *Region)
+{
+    VtMarkDirty(ScreenBuffer, Region->Left, Region->Top, Region->Right, Region->Bottom);
+}
+
+static VOID
+VtFlushDirty(PCONSOLE Console, PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
+{
+    if (!ScreenBuffer || !ScreenBuffer->VtState.DirtyValid)
+        return;
+
+    ScreenBuffer->VtState.DirtyValid = FALSE;
+    TermDrawRegion(Console, &ScreenBuffer->VtState.DirtyRect);
 }
 
 /*
@@ -1740,23 +1801,28 @@ VtFillRect(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
     }
 }
 
+/*
+ * ICH / DCH - shift the tail of the cursor's row.
+ *
+ * Delta > 0 inserts that many blanks at the cursor, pushing the tail right and
+ * dropping whatever falls off the end. Delta < 0 deletes that many cells,
+ * pulling the tail left and blanking the columns vacated at the right edge.
+ * They are one operation with source and destination swapped and the fill at
+ * the other end.
+ */
 static VOID
-VtInsertCharacters(PCONSOLE Console,
-                   PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
-                   ULONG Count)
+VtShiftRow(PCONSOLE Console, PTEXTMODE_SCREEN_BUFFER ScreenBuffer, LONG Delta)
 {
     SHORT Width = ScreenBuffer->ScreenBufferSize.X;
     SHORT Y = ScreenBuffer->CursorPosition.Y;
     SHORT X = ScreenBuffer->CursorPosition.X;
+    BOOLEAN Insert = (Delta > 0);
     ULONG Available;
+    ULONG Count;
     ULONG CellsToMove;
-    ULONG RowIndex;
-    SHORT FillCount;
+    SMALL_RECT Region;
 
-    if (Count == 0)
-        Count = 1;
-
-    if (Width <= 0)
+    if (Delta == 0 || Width <= 0)
         return;
 
     if (Y < 0 || Y >= ScreenBuffer->ScreenBufferSize.Y)
@@ -1765,97 +1831,34 @@ VtInsertCharacters(PCONSOLE Console,
     if (X < 0 || X >= Width)
         return;
 
+    /* X < Width, so at least one cell is available */
     Available = (ULONG)(Width - X);
-    if (Available == 0)
-        return;
-
+    Count = (ULONG)(Insert ? Delta : -Delta);
     if (Count > Available)
         Count = Available;
-
-    FillCount = (SHORT)Count;
 
     CellsToMove = Available - Count;
     if (CellsToMove > 0)
     {
         PCHAR_INFO Row = ConioCoordToPointer(ScreenBuffer, 0, Y);
-        RowIndex = ConioCoordToIndex(ScreenBuffer, 0, Y);
-        RtlMoveMemory(Row + X + Count,
-                      Row + X,
-                      CellsToMove * sizeof(CHAR_INFO));
+        ULONG RowIndex = ConioCoordToIndex(ScreenBuffer, 0, Y);
+        ULONG Dst = Insert ? (ULONG)X + Count : (ULONG)X;
+        ULONG Src = Insert ? (ULONG)X : (ULONG)X + Count;
 
-        ConioMoveCellColorsByIndex(ScreenBuffer, RowIndex + X + Count, RowIndex + X, CellsToMove);
+        RtlMoveMemory(Row + Dst, Row + Src, CellsToMove * sizeof(CHAR_INFO));
+        ConioMoveCellColorsByIndex(ScreenBuffer, RowIndex + Dst, RowIndex + Src, CellsToMove);
     }
 
-    VtFillRect(ScreenBuffer, X, Y, (SHORT)(X + FillCount - 1), Y, L' ');
+    if (Insert)
+        VtFillRect(ScreenBuffer, X, Y, (SHORT)(X + Count - 1), Y, L' ');
+    else
+        VtFillRect(ScreenBuffer, (SHORT)(Width - Count), Y, (SHORT)(Width - 1), Y, L' ');
 
-    {
-        SMALL_RECT Region;
-        Region.Left = X;
-        Region.Top = Y;
-        Region.Right = Width > 0 ? Width - 1 : 0;
-        Region.Bottom = Y;
-        TermDrawRegion(Console, &Region);
-    }
-}
-
-static VOID
-VtDeleteCharacters(PCONSOLE Console,
-                   PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
-                   ULONG Count)
-{
-    SHORT Width = ScreenBuffer->ScreenBufferSize.X;
-    SHORT Y = ScreenBuffer->CursorPosition.Y;
-    SHORT X = ScreenBuffer->CursorPosition.X;
-    ULONG Available;
-    ULONG CellsToMove;
-    ULONG RowIndex;
-    SHORT TailStart;
-    SHORT DeleteCount;
-
-    if (Count == 0)
-        Count = 1;
-
-    if (Width <= 0)
-        return;
-
-    if (Y < 0 || Y >= ScreenBuffer->ScreenBufferSize.Y)
-        return;
-
-    if (X < 0 || X >= Width)
-        return;
-
-    Available = (ULONG)(Width - X);
-    if (Available == 0)
-        return;
-
-    if (Count > Available)
-        Count = Available;
-
-    DeleteCount = (SHORT)Count;
-
-    CellsToMove = Available - Count;
-    if (CellsToMove > 0)
-    {
-        PCHAR_INFO Row = ConioCoordToPointer(ScreenBuffer, 0, Y);
-        RowIndex = ConioCoordToIndex(ScreenBuffer, 0, Y);
-        RtlMoveMemory(Row + X,
-                      Row + X + Count,
-                      CellsToMove * sizeof(CHAR_INFO));
-
-        ConioMoveCellColorsByIndex(ScreenBuffer, RowIndex + X, RowIndex + X + Count, CellsToMove);
-    }
-
-    TailStart = (SHORT)(Width - DeleteCount);
-    VtFillRect(ScreenBuffer, TailStart, Y, Width > 0 ? Width - 1 : 0, Y, L' ');
-
-    {
-        SMALL_RECT Region;
-        Region.Left = X;
-        Region.Top = Y;
-        Region.Right = Width > 0 ? Width - 1 : 0;
-        Region.Bottom = Y;
-        TermDrawRegion(Console, &Region);
-    }
+    Region.Left = X;
+    Region.Top = Y;
+    Region.Right = Width - 1;
+    Region.Bottom = Y;
+    VtMarkDirtyRect(ScreenBuffer, &Region);
 }
 
 static VOID
@@ -1895,7 +1898,7 @@ VtEraseCharacters(PCONSOLE Console,
             Region.Top = Y;
             Region.Right = (SHORT)(X + EraseCount - 1);
             Region.Bottom = Y;
-            TermDrawRegion(Console, &Region);
+            VtMarkDirtyRect(ScreenBuffer, &Region);
         }
     }
 }
@@ -1940,22 +1943,30 @@ VtRepeatCharacter(PCONSOLE Console,
     }
 }
 
+/*
+ * IL / DL - shift lines within the scrolling region, from the cursor's line to
+ * the bottom margin.
+ *
+ * Delta > 0 opens that many blank lines at the cursor, pushing the rest down and
+ * off the bottom margin. Delta < 0 removes that many lines, pulling the rest up
+ * and blanking the lines vacated at the bottom. One operation, opposite
+ * direction: the copy walks the rows backwards when opening a gap and forwards
+ * when closing one, so overlapping rows are never overwritten before use.
+ */
 static VOID
-VtInsertLines(PCONSOLE Console,
-              PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
-              ULONG Count)
+VtShiftLines(PCONSOLE Console, PTEXTMODE_SCREEN_BUFFER ScreenBuffer, LONG Delta)
 {
     SHORT Width = ScreenBuffer->ScreenBufferSize.X;
     SHORT CursorY = ScreenBuffer->CursorPosition.Y;
     SHORT Top = ScreenBuffer->VtState.ScrollTop;
     SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
+    BOOLEAN Insert = (Delta > 0);
     SHORT LinesAvailable;
+    SHORT Shift;
     SHORT Line;
+    SMALL_RECT Region;
 
-    if (Count == 0)
-        Count = 1;
-
-    if (Width <= 0)
+    if (Delta == 0 || Width <= 0)
         return;
 
     if (Top < 0)
@@ -1970,192 +1981,94 @@ VtInsertLines(PCONSOLE Console,
     if (LinesAvailable <= 0)
         return;
 
-    if ((ULONG)LinesAvailable < Count)
-        Count = LinesAvailable;
+    Shift = (SHORT)(Insert ? Delta : -Delta);
+    if (Shift > LinesAvailable)
+        Shift = LinesAvailable;
 
+    if (Shift < LinesAvailable)
     {
-        SHORT InsertCount = (SHORT)Count;
-
-        if (InsertCount <= 0)
-            return;
-
-        if (InsertCount < LinesAvailable)
+        if (Insert)
         {
-            for (Line = Bottom - InsertCount; Line >= CursorY; --Line)
+            for (Line = Bottom - Shift; Line >= CursorY; --Line)
             {
                 PCHAR_INFO Src = ConioCoordToPointer(ScreenBuffer, 0, Line);
-                PCHAR_INFO Dst = ConioCoordToPointer(ScreenBuffer, 0, Line + InsertCount);
+                PCHAR_INFO Dst = ConioCoordToPointer(ScreenBuffer, 0, Line + Shift);
+
                 RtlMoveMemory(Dst, Src, Width * sizeof(CHAR_INFO));
-                ConioMoveCellColors(ScreenBuffer, 0, Line + InsertCount, 0, Line, Width);
+                ConioMoveCellColors(ScreenBuffer, 0, Line + Shift, 0, Line, Width);
             }
         }
-
-        VtFillRect(ScreenBuffer, 0, CursorY, Width > 0 ? Width - 1 : 0, (SHORT)(CursorY + InsertCount - 1), L' ');
-
+        else
         {
-            SMALL_RECT Region;
-            Region.Left = 0;
-            Region.Right = Width > 0 ? Width - 1 : 0;
-            Region.Top = CursorY;
-            Region.Bottom = Bottom;
-            TermDrawRegion(Console, &Region);
-        }
-    }
-}
-
-static VOID
-VtDeleteLines(PCONSOLE Console,
-              PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
-              ULONG Count)
-{
-    SHORT Width = ScreenBuffer->ScreenBufferSize.X;
-    SHORT CursorY = ScreenBuffer->CursorPosition.Y;
-    SHORT Top = ScreenBuffer->VtState.ScrollTop;
-    SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
-    SHORT LinesAvailable;
-    SHORT Line;
-
-    if (Count == 0)
-        Count = 1;
-
-    if (Width <= 0)
-        return;
-
-    if (Top < 0)
-        Top = 0;
-    if (Bottom >= ScreenBuffer->ScreenBufferSize.Y)
-        Bottom = ScreenBuffer->ScreenBufferSize.Y - 1;
-
-    if (CursorY < Top || CursorY > Bottom)
-        return;
-
-    LinesAvailable = Bottom - CursorY + 1;
-    if (LinesAvailable <= 0)
-        return;
-
-    if ((ULONG)LinesAvailable < Count)
-        Count = LinesAvailable;
-
-    {
-        SHORT DeleteCount = (SHORT)Count;
-
-        if (DeleteCount <= 0)
-            return;
-
-        if (DeleteCount < LinesAvailable)
-        {
-            for (Line = CursorY; Line <= Bottom - DeleteCount; ++Line)
+            for (Line = CursorY; Line <= Bottom - Shift; ++Line)
             {
-                PCHAR_INFO Src = ConioCoordToPointer(ScreenBuffer, 0, Line + DeleteCount);
+                PCHAR_INFO Src = ConioCoordToPointer(ScreenBuffer, 0, Line + Shift);
                 PCHAR_INFO Dst = ConioCoordToPointer(ScreenBuffer, 0, Line);
+
                 RtlMoveMemory(Dst, Src, Width * sizeof(CHAR_INFO));
-                ConioMoveCellColors(ScreenBuffer, 0, Line, 0, Line + DeleteCount, Width);
+                ConioMoveCellColors(ScreenBuffer, 0, Line, 0, Line + Shift, Width);
             }
         }
-
-        VtFillRect(ScreenBuffer, 0, (SHORT)(Bottom - DeleteCount + 1), Width > 0 ? Width - 1 : 0, Bottom, L' ');
-
-        {
-            SMALL_RECT Region;
-            Region.Left = 0;
-            Region.Right = Width > 0 ? Width - 1 : 0;
-            Region.Top = CursorY;
-            Region.Bottom = Bottom;
-            TermDrawRegion(Console, &Region);
-        }
     }
+
+    /* Blank the lines the shift vacated: at the cursor, or at the bottom margin */
+    if (Insert)
+        VtFillRect(ScreenBuffer, 0, CursorY, (SHORT)(Width - 1), (SHORT)(CursorY + Shift - 1), L' ');
+    else
+        VtFillRect(ScreenBuffer, 0, (SHORT)(Bottom - Shift + 1), (SHORT)(Width - 1), Bottom, L' ');
+
+    Region.Left = 0;
+    Region.Right = Width - 1;
+    Region.Top = CursorY;
+    Region.Bottom = Bottom;
+    VtMarkDirtyRect(ScreenBuffer, &Region);
 }
 
+/*
+ * SU / SD - scroll the whole scrolling region. Delta > 0 scrolls content up (the
+ * top lines leave, blanks appear at the bottom margin); Delta < 0 scrolls it
+ * down. ConDrvScrollConsoleScreenBuffer performs the move and the attribute
+ * fill; the shared fill path leaves extended colours at CLR_INVALID, so
+ * VtFillRect then re-applies the current SGR colours to the vacated band.
+ */
 static VOID
-VtScrollRegionUp(PCONSOLE Console,
-                 PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
-                 ULONG Lines)
+VtScrollRegion(PCONSOLE Console, PTEXTMODE_SCREEN_BUFFER ScreenBuffer, LONG Delta)
 {
     SHORT Top = ScreenBuffer->VtState.ScrollTop;
     SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
     SHORT Height = Bottom - Top + 1;
+    SHORT Right = ScreenBuffer->ScreenBufferSize.X - 1;
+    BOOLEAN Up = (Delta > 0);
+    SHORT Lines;
     SMALL_RECT ScrollRect;
     COORD DestOrigin;
     CHAR_INFO FillChar;
 
-    if (Height <= 0)
+    if (Delta == 0 || Height <= 0)
         return;
 
-    if (Lines == 0)
-        Lines = 1;
-    if (Lines > (ULONG)Height)
+    Lines = (SHORT)(Up ? Delta : -Delta);
+    if (Lines > Height)
         Lines = Height;
 
     ScrollRect.Left = 0;
     ScrollRect.Top = Top;
-    ScrollRect.Right = ScreenBuffer->ScreenBufferSize.X - 1;
+    ScrollRect.Right = Right;
     ScrollRect.Bottom = Bottom;
 
     DestOrigin.X = 0;
-    DestOrigin.Y = (SHORT)(Top - (SHORT)Lines);
+    DestOrigin.Y = (SHORT)(Up ? Top - Lines : Top + Lines);
 
     FillChar.Char.UnicodeChar = L' ';
     FillChar.Attributes = ScreenBuffer->VtState.CurrentAttributes;
 
-    if (!NT_SUCCESS(ConDrvScrollConsoleScreenBuffer(Console,
-                                                    ScreenBuffer,
-                                                    TRUE,
-                                                    &ScrollRect,
-                                                    FALSE,
-                                                    NULL,
-                                                    &DestOrigin,
-                                                    FillChar)))
-    {
-        return;
-    }
-
-    VtFillRect(ScreenBuffer, 0, Bottom - (SHORT)Lines + 1, ScreenBuffer->ScreenBufferSize.X - 1, Bottom, 0);
-}
-
-static VOID
-VtScrollRegionDown(PCONSOLE Console,
-                 PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
-                 ULONG Lines)
-{
-    SHORT Top = ScreenBuffer->VtState.ScrollTop;
-    SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
-    SHORT Height = Bottom - Top + 1;
-    SMALL_RECT ScrollRect;
-    COORD DestOrigin;
-    CHAR_INFO FillChar;
-
-    if (Height <= 0)
+    if (!NT_SUCCESS(ConDrvScrollConsoleScreenBuffer(Console, ScreenBuffer, TRUE, &ScrollRect, FALSE, NULL, &DestOrigin, FillChar)))
         return;
 
-    if (Lines == 0)
-        Lines = 1;
-    if (Lines > (ULONG)Height)
-        Lines = Height;
-
-    ScrollRect.Left = 0;
-    ScrollRect.Top = Top;
-    ScrollRect.Right = ScreenBuffer->ScreenBufferSize.X - 1;
-    ScrollRect.Bottom = Bottom;
-
-    DestOrigin.X = 0;
-    DestOrigin.Y = (SHORT)(Top + (SHORT)Lines);
-
-    FillChar.Char.UnicodeChar = L' ';
-    FillChar.Attributes = ScreenBuffer->VtState.CurrentAttributes;
-
-    if (!NT_SUCCESS(ConDrvScrollConsoleScreenBuffer(Console,
-                                                    ScreenBuffer,
-                                                    TRUE,
-                                                    &ScrollRect,
-                                                    FALSE,
-                                                    NULL,
-                                                    &DestOrigin,
-                                                    FillChar)))
-    {
-        return;
-    }
-
-    VtFillRect(ScreenBuffer, 0, Top, ScreenBuffer->ScreenBufferSize.X - 1, Top + (SHORT)Lines - 1, 0);
+    if (Up)
+        VtFillRect(ScreenBuffer, 0, (SHORT)(Bottom - Lines + 1), Right, Bottom, 0);
+    else
+        VtFillRect(ScreenBuffer, 0, Top, Right, (SHORT)(Top + Lines - 1), 0);
 }
 
 VOID
@@ -2179,7 +2092,7 @@ ConDrvVtAdvanceLine(PCONSOLE Console,
     if (ScreenBuffer->CursorPosition.Y >= ScreenBuffer->VtState.ScrollTop &&
         ScreenBuffer->CursorPosition.Y == Bottom)
     {
-        VtScrollRegionUp(Console, ScreenBuffer, 1);
+        VtScrollRegion(Console, ScreenBuffer, 1);
         return;
     }
 
@@ -2187,26 +2100,29 @@ ConDrvVtAdvanceLine(PCONSOLE Console,
         ScreenBuffer->CursorPosition.Y++;
 }
 
+/*
+ * SL / SR - shift every line of the scrolling region sideways. Delta > 0 shifts
+ * content left (columns vacate at the right edge); Delta < 0 shifts it right
+ * (columns vacate at the left edge). A shift at or beyond the buffer width
+ * clears the line outright.
+ */
 static VOID
-VtScrollLeft(PCONSOLE Console,
-             PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
-             ULONG Count)
+VtScrollColumns(PCONSOLE Console, PTEXTMODE_SCREEN_BUFFER ScreenBuffer, LONG Delta)
 {
     SHORT Top = ScreenBuffer->VtState.ScrollTop;
     SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
     SHORT Width = ScreenBuffer->ScreenBufferSize.X;
+    BOOLEAN Left = (Delta > 0);
+    SHORT Shift;
     SHORT Line;
+    SMALL_RECT Region;
 
-    if (!Console || !ScreenBuffer)
+    if (Delta == 0 || Width <= 0)
         return;
 
-    if (Width <= 0)
-        return;
-
-    if (Count == 0)
-        Count = 1;
-    if (Count > (ULONG)Width)
-        Count = Width;
+    Shift = (SHORT)(Left ? Delta : -Delta);
+    if (Shift > Width)
+        Shift = Width;
 
     if (Top < 0)
         Top = 0;
@@ -2219,90 +2135,33 @@ VtScrollLeft(PCONSOLE Console,
     {
         PCHAR_INFO Row = ConioCoordToPointer(ScreenBuffer, 0, Line);
         ULONG RowIndex = ConioCoordToIndex(ScreenBuffer, 0, Line);
-        SHORT Shift = (SHORT)Count;
+        ULONG Keep = (ULONG)(Width - Shift);
 
         if (Shift >= Width)
         {
-            VtFillRect(ScreenBuffer, 0, Line, Width > 0 ? Width - 1 : 0, Line, L' ');
+            VtFillRect(ScreenBuffer, 0, Line, (SHORT)(Width - 1), Line, L' ');
             continue;
         }
 
-        RtlMoveMemory(Row, Row + Shift, (Width - Shift) * sizeof(CHAR_INFO));
-
-        ConioMoveCellColorsByIndex(ScreenBuffer, RowIndex, RowIndex + Shift, (Width - Shift));
-
-        /* The columns vacated at the right edge take the current SGR state */
-        VtFillRect(ScreenBuffer, (SHORT)(Width - Shift), Line, (SHORT)(Width - 1), Line, L' ');
-    }
-
-    if (Width > 0)
-    {
-        SMALL_RECT Region;
-        Region.Left = 0;
-        Region.Right = Width - 1;
-        Region.Top = Top;
-        Region.Bottom = Bottom;
-        TermDrawRegion(Console, &Region);
-    }
-}
-
-static VOID
-VtScrollRight(PCONSOLE Console,
-              PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
-              ULONG Count)
-{
-    SHORT Top = ScreenBuffer->VtState.ScrollTop;
-    SHORT Bottom = ScreenBuffer->VtState.ScrollBottom;
-    SHORT Width = ScreenBuffer->ScreenBufferSize.X;
-    SHORT Line;
-
-    if (!Console || !ScreenBuffer)
-        return;
-
-    if (Width <= 0)
-        return;
-
-    if (Count == 0)
-        Count = 1;
-    if (Count > (ULONG)Width)
-        Count = Width;
-
-    if (Top < 0)
-        Top = 0;
-    if (Bottom >= ScreenBuffer->ScreenBufferSize.Y)
-        Bottom = ScreenBuffer->ScreenBufferSize.Y - 1;
-    if (Bottom < Top)
-        return;
-
-    for (Line = Top; Line <= Bottom; ++Line)
-    {
-        PCHAR_INFO Row = ConioCoordToPointer(ScreenBuffer, 0, Line);
-        ULONG RowIndex = ConioCoordToIndex(ScreenBuffer, 0, Line);
-        SHORT Shift = (SHORT)Count;
-
-        if (Shift >= Width)
+        if (Left)
         {
-            VtFillRect(ScreenBuffer, 0, Line, Width > 0 ? Width - 1 : 0, Line, L' ');
-            continue;
+            RtlMoveMemory(Row, Row + Shift, Keep * sizeof(CHAR_INFO));
+            ConioMoveCellColorsByIndex(ScreenBuffer, RowIndex, RowIndex + Shift, Keep);
+            VtFillRect(ScreenBuffer, (SHORT)(Width - Shift), Line, (SHORT)(Width - 1), Line, L' ');
         }
-
-        RtlMoveMemory(Row + Shift, Row, (Width - Shift) * sizeof(CHAR_INFO));
-
-        ConioMoveCellColorsByIndex(ScreenBuffer, RowIndex + Shift, RowIndex, (Width - Shift));
-
-        /* The columns vacated at the left edge take the current SGR state */
-        VtFillRect(ScreenBuffer, 0, Line, (SHORT)(Shift - 1), Line, L' ');
+        else
+        {
+            RtlMoveMemory(Row + Shift, Row, Keep * sizeof(CHAR_INFO));
+            ConioMoveCellColorsByIndex(ScreenBuffer, RowIndex + Shift, RowIndex, Keep);
+            VtFillRect(ScreenBuffer, 0, Line, (SHORT)(Shift - 1), Line, L' ');
+        }
     }
 
-    if (Width > 0)
-    {
-        SMALL_RECT Region;
-        Region.Left = 0;
-        Region.Right = Width - 1;
-        Region.Top = Top;
-        Region.Bottom = Bottom;
-        TermDrawRegion(Console, &Region);
-    }
+    Region.Left = 0;
+    Region.Right = Width - 1;
+    Region.Top = Top;
+    Region.Bottom = Bottom;
+    VtMarkDirtyRect(ScreenBuffer, &Region);
 }
 
 static BOOLEAN
@@ -2598,13 +2457,32 @@ VtRefreshPaletteForBuffer(PCONSOLE Console,
     VtUpdatePaletteHandle(Console, Buffer);
 }
 
-static VOID
-VtApplyPaletteChange(PCONSOLE Console)
+/*
+ * Make the console's colour table visible on screen.
+ *
+ * This is the one place that knows how a Colors[] change propagates: every
+ * text-mode buffer's cached VT colours and HPALETTE are refreshed, then the
+ * active buffer's palette is handed to the frontend and repainted. Walking
+ * BufferList rather than naming the active/primary/alternate buffers means a
+ * buffer created by some other path is not silently left with a stale palette.
+ */
+VOID
+NTAPI
+ConDrvVtRefreshPalette(PCONSOLE Console)
 {
     PCONSOLE_SCREEN_BUFFER Active;
+    PLIST_ENTRY Entry;
 
     if (!Console)
         return;
+
+    for (Entry = Console->BufferList.Flink; Entry != &Console->BufferList; Entry = Entry->Flink)
+    {
+        PCONSOLE_SCREEN_BUFFER Buffer = CONTAINING_RECORD(Entry, CONSOLE_SCREEN_BUFFER, ListEntry);
+
+        if (GetType(Buffer) == TEXTMODE_BUFFER)
+            VtRefreshPaletteForBuffer(Console, (PTEXTMODE_SCREEN_BUFFER)Buffer);
+    }
 
     Active = Console->ActiveBuffer;
     if (Active && GetType(Active) == TEXTMODE_BUFFER)
@@ -2620,7 +2498,15 @@ VtApplyPaletteChange(PCONSOLE Console)
             Region.Top = 0;
             Region.Right = TextActive->ScreenBufferSize.X - 1;
             Region.Bottom = TextActive->ScreenBufferSize.Y - 1;
-            TermDrawRegion(Console, &Region);
+            /*
+             * Flush straight away rather than accumulating: this marks the
+             * console's active buffer, which need not be the one the current
+             * write is addressed to, so the rectangle could otherwise sit
+             * unpainted until that buffer is next written. A palette change is
+             * a whole-screen repaint and is rare, so there is nothing to save.
+             */
+            VtMarkDirtyRect(TextActive, &Region);
+            VtFlushDirty(Console, TextActive);
         }
     }
 }
@@ -2688,7 +2574,7 @@ VtHandleOscPalette(PCONSOLE Console,
 
             if (ColorLength == 1 && *ColorStart == L'?')
             {
-                VtSendOscPaletteResponse(Console, Index, Colors[PaletteIndex]);
+                VtSendOscColorReply(Console, 4, TRUE, Index, Colors[PaletteIndex]);
                 Handled = TRUE;
             }
             else if (VtOscParseRgb(ColorStart, ColorLength, &Parsed))
@@ -2704,13 +2590,7 @@ VtHandleOscPalette(PCONSOLE Console,
     {
         TermSetColorTable(Console, Colors, VT_PALETTE_SIZE);
 
-        VtRefreshPaletteForBuffer(Console, ScreenBuffer);
-        if (ScreenBuffer && ScreenBuffer->VtState.PrimaryBuffer)
-            VtRefreshPaletteForBuffer(Console, ScreenBuffer->VtState.PrimaryBuffer);
-        if (ScreenBuffer && ScreenBuffer->VtState.AlternateBuffer)
-            VtRefreshPaletteForBuffer(Console, ScreenBuffer->VtState.AlternateBuffer);
-
-        VtApplyPaletteChange(Console);
+        ConDrvVtRefreshPalette(Console);
     }
 
     return Handled;
@@ -2747,7 +2627,7 @@ VtHandleOscDefaultColor(PCONSOLE Console,
 
     if (Length > 0 && *Value == L'?')
     {
-        VtSendOscColorResponse(Console, Parameter, Colors[Index]);
+        VtSendOscColorReply(Console, Parameter, FALSE, 0, Colors[Index]);
         return TRUE;
     }
 
@@ -2758,7 +2638,7 @@ VtHandleOscDefaultColor(PCONSOLE Console,
     return !!TermSetColorTable(Console, Colors, VT_PALETTE_SIZE);
 }
 
-static BOOLEAN
+static VOID
 VtHandleOscHyperlink(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
                      const WCHAR *Parameters,
                      ULONG Length)
@@ -2770,13 +2650,13 @@ VtHandleOscHyperlink(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
     ULONG UriLength = 0;
 
     if (!ScreenBuffer)
-        return TRUE;
+        return;
 
     if (Console && !Console->AllowVtOscHyperlinks)
     {
         VtTracePolicyBlocked("OSC 8 hyperlink");
         VtClearHyperlink(ScreenBuffer);
-        return TRUE;
+        return;
     }
 
     while (Ptr < End && *Ptr != L';')
@@ -2794,14 +2674,14 @@ VtHandleOscHyperlink(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
     VtClearHyperlink(ScreenBuffer);
 
     if (UriLength == 0)
-        return TRUE;
+        return;
 
     if (UriLength >= (ULONG)((USHRT_MAX / sizeof(WCHAR)) - 1))
-        return TRUE;
+        return;
 
     PWCHAR Buffer = ConsoleAllocHeap(0, (UriLength + 1) * sizeof(WCHAR));
     if (!Buffer)
-        return TRUE;
+        return;
 
     RtlCopyMemory(Buffer, UriStart, UriLength * sizeof(WCHAR));
     Buffer[UriLength] = UNICODE_NULL;
@@ -2810,11 +2690,11 @@ VtHandleOscHyperlink(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
     ScreenBuffer->VtState.HyperlinkUri.Length = (USHORT)(UriLength * sizeof(WCHAR));
     ScreenBuffer->VtState.HyperlinkUri.MaximumLength = (USHORT)((UriLength + 1) * sizeof(WCHAR));
     ScreenBuffer->VtState.HyperlinkActive = TRUE;
-    return TRUE;
+    return;
 }
 
 
-static BOOLEAN
+static VOID
 VtHandleOscClipboard(PCONSOLE Console,
                      const WCHAR *Parameters,
                      ULONG Length)
@@ -2826,7 +2706,7 @@ VtHandleOscClipboard(PCONSOLE Console,
     SIZE_T TargetLength;
 
     if (!Console)
-        return TRUE;
+        return;
 
     while (TargetEnd < End && *TargetEnd != L';')
         ++TargetEnd;
@@ -2840,7 +2720,7 @@ VtHandleOscClipboard(PCONSOLE Console,
         --End;
 
     if (DataStart >= End)
-        return TRUE;
+        return;
 
     if (*DataStart == L'?')
     {
@@ -2853,7 +2733,7 @@ VtHandleOscClipboard(PCONSOLE Console,
         if (!Console->AllowVtOscClipboard)
         {
             VtSendOscClipboardResponse(Console, TargetStart, TargetLength, L"");
-            return TRUE;
+            return;
         }
 
         /* The clipboard belongs to the frontend's window station, not to us */
@@ -2888,11 +2768,11 @@ VtHandleOscClipboard(PCONSOLE Console,
             ConsoleFreeHeap(Encoded);
         }
 
-        return TRUE;
+        return;
     }
 
     if (!Console->AllowVtOscClipboard)
-        return TRUE;
+        return;
 
     {
         ULONG DataLength = (ULONG)(End - DataStart);
@@ -2900,7 +2780,7 @@ VtHandleOscClipboard(PCONSOLE Console,
         ULONG DecodedLength = 0;
 
         if (!VtDecodeBase64(DataStart, DataLength, &Decoded, &DecodedLength))
-            return TRUE;
+            return;
 
         if (DecodedLength > 0)
         {
@@ -2924,10 +2804,14 @@ VtHandleOscClipboard(PCONSOLE Console,
         ConsoleFreeHeap(Decoded);
     }
 
-    return TRUE;
+    return;
 }
 
-static BOOLEAN
+/*
+ * An OSC sequence is always consumed, recognised or not: a terminal swallows
+ * what it does not understand rather than printing the raw payload on screen.
+ */
+static VOID
 VtHandleOscSequence(PCONSOLE Console,
                     PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
                     const WCHAR *Sequence,
@@ -2950,7 +2834,8 @@ VtHandleOscSequence(PCONSOLE Console,
         }
         else if (*Ptr != L' ' && *Ptr != L'\t')
         {
-            return TRUE;
+            /* Not a numeric parameter - nothing we can dispatch on */
+            return;
         }
     }
 
@@ -2969,11 +2854,11 @@ VtHandleOscSequence(PCONSOLE Console,
             {
                 VtSetConsoleTitle(Console, ParamEnd, (ULONG)(End - ParamEnd));
             }
-            return TRUE;
+            return;
 
         case 4:
             VtHandleOscPalette(Console, ScreenBuffer, ParamEnd, (ULONG)(End - ParamEnd));
-            return TRUE;
+            return;
 
         case 10:
         case 11:
@@ -2991,35 +2876,29 @@ VtHandleOscSequence(PCONSOLE Console,
 
             if (Updated)
             {
-                VtRefreshPaletteForBuffer(Console, ScreenBuffer);
-                if (ScreenBuffer && ScreenBuffer->VtState.PrimaryBuffer)
-                    VtRefreshPaletteForBuffer(Console, ScreenBuffer->VtState.PrimaryBuffer);
-                if (ScreenBuffer && ScreenBuffer->VtState.AlternateBuffer)
-                    VtRefreshPaletteForBuffer(Console, ScreenBuffer->VtState.AlternateBuffer);
-
-                VtApplyPaletteChange(Console);
+                ConDrvVtRefreshPalette(Console);
             }
 
-            return TRUE;
+            return;
         }
 
         case 8:
-            return VtHandleOscHyperlink(ScreenBuffer, ParamEnd, (ULONG)(End - ParamEnd));
+            VtHandleOscHyperlink(ScreenBuffer, ParamEnd, (ULONG)(End - ParamEnd));
+            return;
 
         case 52:
-            return VtHandleOscClipboard(Console, ParamEnd, (ULONG)(End - ParamEnd));
+            VtHandleOscClipboard(Console, ParamEnd, (ULONG)(End - ParamEnd));
+            return;
 
         case 133: /* iTerm2 prompt markers */
         case 134:
         case 633:
-            return TRUE;
+            return;
 
         default:
             VtTraceUnhandledOsc(Parameter);
-            return TRUE;
+            return;
     }
-
-    return TRUE;
 }
 
 static VOID
@@ -3136,7 +3015,17 @@ VtApplySgr(PCONSOLE Console,
            ULONG Count)
 {
     USHORT Attr = ScreenBuffer->VtState.CurrentAttributes;
-    const USHORT DefaultAttr = ScreenBuffer->VtState.SavedAttributes;
+    /*
+     * What SGR 0 / 39 / 49 reset to is the screen buffer's default attribute,
+     * not whatever DECSC last parked in SavedAttributes - those are unrelated
+     * concepts, and reading the DECSC slot here meant an SGR 0 after a DECSC
+     * reset to the attributes in force at the DECSC rather than to the default.
+     *
+     * Safe to read directly: VtFlushText's temporary override of
+     * ScreenDefaultAttrib is confined to that function and is restored before
+     * any SGR sequence is dispatched.
+     */
+    const USHORT DefaultAttr = ScreenBuffer->ScreenDefaultAttrib;
 
     if (Count == 0)
     {
@@ -3396,7 +3285,7 @@ VtEraseLine(PCONSOLE Console,
     Region.Right  = EndX;
     Region.Top    = Y;
     Region.Bottom = Y;
-    TermDrawRegion(Console, &Region);
+    VtMarkDirtyRect(ScreenBuffer, &Region);
 }
 
 static VOID
@@ -3416,7 +3305,7 @@ VtDecaln(PCONSOLE Console,
     Region.Top    = 0;
     Region.Right  = ScreenBuffer->ScreenBufferSize.X > 0 ? ScreenBuffer->ScreenBufferSize.X - 1 : 0;
     Region.Bottom = ScreenBuffer->ScreenBufferSize.Y > 0 ? ScreenBuffer->ScreenBufferSize.Y - 1 : 0;
-    TermDrawRegion(Console, &Region);
+    VtMarkDirtyRect(ScreenBuffer, &Region);
 
     Origin.X = 0;
     Origin.Y = 0;
@@ -3474,7 +3363,7 @@ VtEraseDisplay(PCONSOLE Console,
             Region.Right  = ScreenBuffer->ScreenBufferSize.X - 1;
             Region.Top    = StartY;
             Region.Bottom = EndY;
-            TermDrawRegion(Console, &Region);
+            VtMarkDirtyRect(ScreenBuffer, &Region);
             break;
         }
 
@@ -3486,7 +3375,7 @@ VtEraseDisplay(PCONSOLE Console,
             Region.Top    = 0;
             Region.Right  = ScreenBuffer->ScreenBufferSize.X - 1;
             Region.Bottom = ScreenBuffer->ScreenBufferSize.Y - 1;
-            TermDrawRegion(Console, &Region);
+            VtMarkDirtyRect(ScreenBuffer, &Region);
 
             Origin.X = Origin.Y = 0;
             ConDrvSetConsoleCursorPosition(Console, ScreenBuffer, &Origin);
@@ -3510,11 +3399,11 @@ VtSoftReset(PCONSOLE Console,
     if (!Console || !ScreenBuffer)
         return;
 
-    if (ScreenBuffer->VtState.PrimaryBuffer != NULL ||
-        ScreenBuffer->VtState.AlternateBuffer != NULL)
+    if (ScreenBuffer->VtState.AlternateActive)
     {
+        /* The swap happens in place, so the target never changes */
         VtDisableAlternateScreen(Console, ScreenBuffer);
-        Target = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
+        Target = ScreenBuffer;
     }
     else
     {
@@ -3546,6 +3435,7 @@ ConDrvVtInitializeBuffer(PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
 
     ScreenBuffer->VtState.CursorSaved = FALSE;
     ScreenBuffer->VtState.SavedCursorPos = Zero;
+    /* DECSC slot: starts out matching the buffer default until a DECSC happens */
     ScreenBuffer->VtState.SavedAttributes = ScreenBuffer->ScreenDefaultAttrib;
     ScreenBuffer->VtState.CurrentAttributes = ScreenBuffer->ScreenDefaultAttrib;
     ScreenBuffer->VtState.UseRgbForeground = FALSE;
@@ -3557,14 +3447,15 @@ ConDrvVtInitializeBuffer(PTEXTMODE_SCREEN_BUFFER ScreenBuffer)
     ScreenBuffer->VtState.SavedUseRgbForeground = FALSE;
     ScreenBuffer->VtState.SavedUseRgbBackground = FALSE;
     ScreenBuffer->VtState.PrivateModes = 0;
-    ScreenBuffer->VtState.AlternateBuffer = NULL;
     ScreenBuffer->VtState.ScrollTop = 0;
     ScreenBuffer->VtState.ScrollBottom = max(0, ScreenBuffer->ScreenBufferSize.Y - 1);
-    ScreenBuffer->VtState.PrimaryBuffer = NULL;
-    ScreenBuffer->VtState.PrimaryCursorInfo = ScreenBuffer->CursorInfo;
-    ScreenBuffer->VtState.PrimaryCursorPos = Zero;
-    ScreenBuffer->VtState.PrimaryViewOrigin = Zero;
-    ScreenBuffer->VtState.PrimaryVirtualY = 0;
+    ScreenBuffer->VtState.AlternateActive = FALSE;
+    ScreenBuffer->VtState.SavedBuffer = NULL;
+    ScreenBuffer->VtState.SavedCellRgb = NULL;
+    ScreenBuffer->VtState.SavedScreenCursorInfo = ScreenBuffer->CursorInfo;
+    ScreenBuffer->VtState.SavedScreenCursorPos = Zero;
+    ScreenBuffer->VtState.SavedViewOrigin = Zero;
+    ScreenBuffer->VtState.SavedVirtualY = 0;
     ScreenBuffer->VtState.DefaultCursorInfo = ScreenBuffer->CursorInfo;
     ScreenBuffer->VtState.HyperlinkActive = FALSE;
     ScreenBuffer->VtState.HyperlinkUri.Buffer = NULL;
@@ -3595,7 +3486,7 @@ VtHandleCursorPosition(PCONSOLE Console,
     COORD Position;
     SHORT Row, Col;
 
-    Row = (Count >= 1) ? (SHORT)max(1UL, Params[0]) : 1;
+    Row = (SHORT)max(1UL, Params[0]);
     Col = (Count >= 2) ? (SHORT)max(1UL, Params[1]) : 1;
 
     if (ScreenBuffer->VtState.PrivateModes & VT_PRIVMODE_ORIGIN_MODE)
@@ -3995,27 +3886,27 @@ VtHandleCsiSequence(PCONSOLE Console,
             return TRUE;
 
         case L'J':
-            VtEraseDisplay(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 0);
+            VtEraseDisplay(Console, ScreenBuffer, Params[0]);
             return TRUE;
 
         case L'K':
-            VtEraseLine(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 0);
+            VtEraseLine(Console, ScreenBuffer, Params[0]);
             return TRUE;
 
         case L'@':
             if (Intermediate == L' ')
             {
                 ULONG Columns = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
-                VtScrollLeft(Console, ScreenBuffer, Columns);
+                VtScrollColumns(Console, ScreenBuffer, (LONG)Columns);
                 return TRUE;
             }
-            VtInsertCharacters(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 1);
+            VtShiftRow(Console, ScreenBuffer, (Count >= 1 && Params[0] != 0) ? (LONG)Params[0] : 1);
             return TRUE;
         case L'A':
             if (Intermediate == L' ')
             {
                 ULONG Columns = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
-                VtScrollRight(Console, ScreenBuffer, Columns);
+                VtScrollColumns(Console, ScreenBuffer, -(LONG)Columns);
                 return TRUE;
             }
             {
@@ -4050,11 +3941,11 @@ VtHandleCsiSequence(PCONSOLE Console,
             return TRUE;
 
         case L'P':
-            VtDeleteCharacters(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 1);
+            VtShiftRow(Console, ScreenBuffer, -((Count >= 1 && Params[0] != 0) ? (LONG)Params[0] : 1));
             return TRUE;
 
         case L'X':
-            VtEraseCharacters(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 1);
+            VtEraseCharacters(Console, ScreenBuffer, Params[0]);
             return TRUE;
 
         case L'b':
@@ -4065,11 +3956,11 @@ VtHandleCsiSequence(PCONSOLE Console,
         }
 
         case L'L':
-            VtInsertLines(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 1);
+            VtShiftLines(Console, ScreenBuffer, (Count >= 1 && Params[0] != 0) ? (LONG)Params[0] : 1);
             return TRUE;
 
         case L'M':
-            VtDeleteLines(Console, ScreenBuffer, (Count >= 1) ? Params[0] : 1);
+            VtShiftLines(Console, ScreenBuffer, -((Count >= 1 && Params[0] != 0) ? (LONG)Params[0] : 1));
             return TRUE;
 
         case L'c':
@@ -4080,7 +3971,7 @@ VtHandleCsiSequence(PCONSOLE Console,
 
         case L't':
         {
-            ULONG Action = (Count >= 1) ? Params[0] : 0;
+            ULONG Action = Params[0];
 
             switch (Action)
             {
@@ -4108,7 +3999,7 @@ VtHandleCsiSequence(PCONSOLE Console,
 
         case L'n':
         {
-            ULONG Query = (Count >= 1) ? Params[0] : 0;
+            ULONG Query = Params[0];
             WCHAR Response[32];
             SIZE_T Len = 0;
 
@@ -4153,17 +4044,40 @@ VtHandleCsiSequence(PCONSOLE Console,
             return TRUE;
         }
 
+        case L'g':
+        {
+            /* TBC - Tab Clear (0 = at cursor, 3 = all) */
+            VtHandleTabClear(ScreenBuffer, Count >= 1 ? Params[0] : 0);
+            return TRUE;
+        }
+
+        case L'I':
+        {
+            /* CHT - Cursor Forward Tabulation */
+            ULONG Count2 = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
+            VtTabForward(Console, ScreenBuffer, Count2);
+            return TRUE;
+        }
+
+        case L'Z':
+        {
+            /* CBT - Cursor Backward Tabulation */
+            ULONG Count2 = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
+            VtTabBackward(Console, ScreenBuffer, Count2);
+            return TRUE;
+        }
+
         case L'S':
         {
             ULONG Lines = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
-            VtScrollRegionUp(Console, ScreenBuffer, Lines);
+            VtScrollRegion(Console, ScreenBuffer, (LONG)Lines);
             return TRUE;
         }
 
         case L'T':
         {
             ULONG Lines = (Count >= 1 && Params[0] != 0) ? Params[0] : 1;
-            VtScrollRegionDown(Console, ScreenBuffer, Lines);
+            VtScrollRegion(Console, ScreenBuffer, -(LONG)Lines);
             return TRUE;
         }
 
@@ -4203,7 +4117,7 @@ VtHandleCsiSequence(PCONSOLE Console,
         case L'q':
             if (Intermediate == L' ')
             {
-                ULONG Style = (Count >= 1) ? Params[0] : 0;
+                ULONG Style = Params[0];
                 if (VtApplyCursorStyle(Console, ScreenBuffer, Style))
                     return TRUE;
             }
@@ -4238,6 +4152,11 @@ VtHandleEscapeSequence(PCONSOLE Console,
 
         case L'c':
             VtSoftReset(Console, ScreenBuffer);
+            return TRUE;
+
+        case L'H':
+            /* HTS - Horizontal Tab Set at the current column */
+            VtSetTabStopAtCursor(ScreenBuffer);
             return TRUE;
 
         case L'#':
@@ -4337,7 +4256,6 @@ ConDrvVtWriteConsole(PCONSOLE Console,
                      PULONG NumCharsProcessed,
                      PBOOLEAN Handled)
 {
-    PWSTR ExpandedBuffer = NULL;
     PWSTR CombinedBuffer = NULL;
     PCWSTR WorkingBuffer = Buffer;
     ULONG WorkingLength = Length;
@@ -4356,62 +4274,6 @@ ConDrvVtWriteConsole(PCONSOLE Console,
         if (NumCharsProcessed) *NumCharsProcessed = 0;
         if (Handled) *Handled = FALSE;
         return STATUS_INVALID_PARAMETER;
-    }
-
-    if (WorkingLength > 0)
-    {
-        BOOLEAN NeedsExpansion = FALSE;
-        ULONG i;
-
-        for (i = 0; i < WorkingLength; ++i)
-        {
-            WCHAR C = WorkingBuffer[i];
-            if (C >= 0x80 && C <= 0x9F)
-            {
-                NeedsExpansion = TRUE;
-                break;
-            }
-        }
-
-        if (NeedsExpansion)
-        {
-            PWSTR Temp = ConsoleAllocHeap(0, (WorkingLength * 2 + 1) * sizeof(WCHAR));
-            if (Temp)
-            {
-                ULONG Out = 0;
-
-                for (i = 0; i < WorkingLength; ++i)
-                {
-                    WCHAR C = WorkingBuffer[i];
-
-                    switch (C)
-                    {
-                        case 0x90: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'P'; break;
-                        case 0x91: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'Q'; break;
-                        case 0x92: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'R'; break;
-                        case 0x93: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'S'; break;
-                        case 0x94: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'T'; break;
-                        case 0x95: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'U'; break;
-                        case 0x96: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'V'; break;
-                        case 0x97: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'W'; break;
-                        case 0x98: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'X'; break;
-                        case 0x99: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'Y'; break;
-                        case 0x9A: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'Z'; break;
-                        case 0x9B: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'['; break;
-                        case 0x9C: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = (WCHAR)0x5C; break;
-                        case 0x9D: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L']'; break;
-                        case 0x9E: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'^'; break;
-                        case 0x9F: Temp[Out++] = (WCHAR)0x1b; Temp[Out++] = L'_'; break;
-                        default: Temp[Out++] = C; break;
-                    }
-                }
-
-                WorkingBuffer = Temp;
-                WorkingLength = Out;
-                Temp[Out] = UNICODE_NULL;
-                ExpandedBuffer = Temp;
-            }
-        }
     }
 
     if (ScreenBuffer->VtState.PendingSequenceLength > 0)
@@ -4481,11 +4343,21 @@ ConDrvVtWriteConsole(PCONSOLE Console,
             continue;
         }
 
-        if (Ch == L'')
+        /*
+         * An escape sequence introducer, either as ESC + a final character or as
+         * the equivalent single C1 control (0x9B == CSI == ESC [, 0x9D == OSC ==
+         * ESC ], 0x90 == DCS == ESC P, ...). A C1 code point is exactly its
+         * two-character form with 0x40 subtracted, so both feed one dispatcher
+         * and no pre-pass has to rewrite the input.
+         */
+        if (Ch == L'' || (Ch >= 0x90 && Ch <= 0x9F))
         {
             ULONG EscStart = Pos;
+            BOOLEAN IsC1 = (Ch != L'');
 
-            if (Pos + 1 >= WorkingLength)
+            /* A bare trailing ESC may still be completed by the next write; a
+             * single C1 code point is already complete. */
+            if (!IsC1 && Pos + 1 >= WorkingLength)
             {
                 HoldTail = TRUE;
                 TailStart = EscStart;
@@ -4499,8 +4371,16 @@ ConDrvVtWriteConsole(PCONSOLE Console,
             if (!NT_SUCCESS(Status))
                 break;
 
-            Pos++;
-            Ch = WorkingBuffer[Pos++];
+            if (IsC1)
+            {
+                Ch = (WCHAR)(Ch - 0x40);
+                Pos++;
+            }
+            else
+            {
+                Pos++;
+                Ch = WorkingBuffer[Pos++];
+            }
 
             if (Ch == L'[')
             {
@@ -4562,14 +4442,16 @@ ConDrvVtWriteConsole(PCONSOLE Console,
                     break;
                 }
 
+                /*
+                 * Always leaves at least one parameter: an empty parameter list
+                 * yields a single 0. Handlers below can therefore read Params[0]
+                 * without testing Count.
+                 */
                 if (HaveCurrent || Count == 0)
                 {
                     if (Count < VT_MAX_PARAMS)
                         Params[Count++] = HaveCurrent ? Current : 0;
                 }
-
-                if (Count == 0)
-                    Params[Count++] = 0;
 
                 if ((PrivateIndicator != 0 &&
                      VtHandlePrivateCsiSequence(Console, ScreenBuffer, PrivateIndicator, Final, Intermediate, Params, Count)) ||
@@ -4577,7 +4459,6 @@ ConDrvVtWriteConsole(PCONSOLE Console,
                      VtHandleCsiSequence(Console, ScreenBuffer, PrivateIndicator, Final, Intermediate, Params, Count)))
                 {
                     AnyHandled = TRUE;
-                    ScreenBuffer = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
                     SegmentStart = Pos;
                     continue;
                 }
@@ -4619,22 +4500,9 @@ ConDrvVtWriteConsole(PCONSOLE Console,
                     break;
                 }
 
-                if (VtHandleOscSequence(Console,
-                                        ScreenBuffer,
-                                        WorkingBuffer + OscStart,
-                                        SearchPos - OscStart))
-                {
-                    AnyHandled = TRUE;
-                    Pos = SearchPos + TerminatorLen;
-                    ScreenBuffer = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
-                    SegmentStart = Pos;
-                    continue;
-                }
+                VtHandleOscSequence(Console, ScreenBuffer, WorkingBuffer + OscStart, SearchPos - OscStart);
 
-                Status = VtFlushText(Console,
-                                     ScreenBuffer,
-                                     WorkingBuffer + EscStart,
-                                     (SearchPos + TerminatorLen) - EscStart);
+                AnyHandled = TRUE;
                 Pos = SearchPos + TerminatorLen;
                 SegmentStart = Pos;
                 continue;
@@ -4662,19 +4530,12 @@ ConDrvVtWriteConsole(PCONSOLE Console,
                     break;
                 }
 
-                if (VtHandleDcsSequence(Console,
-                                        ScreenBuffer,
-                                        WorkingBuffer + Pos,
-                                        SearchPos - Pos))
-                {
-                    AnyHandled = TRUE;
-                    Pos = SearchPos + TerminatorLen;
-                    ScreenBuffer = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
-                    SegmentStart = Pos;
-                    continue;
-                }
+                VtHandleDcsSequence(Console, ScreenBuffer, WorkingBuffer + Pos, SearchPos - Pos);
 
-                VtTraceUnhandledDcs();
+                AnyHandled = TRUE;
+                Pos = SearchPos + TerminatorLen;
+                SegmentStart = Pos;
+                continue;
             }
             else
             {
@@ -4688,7 +4549,6 @@ ConDrvVtWriteConsole(PCONSOLE Console,
                 {
                     AnyHandled = TRUE;
                     Pos = NewPos;
-                    ScreenBuffer = (PTEXTMODE_SCREEN_BUFFER)Console->ActiveBuffer;
                     SegmentStart = Pos;
                     continue;
                 }
@@ -4763,8 +4623,9 @@ ConDrvVtWriteConsole(PCONSOLE Console,
         AnyHandled = FALSE;
 
 Cleanup:
-    if (ExpandedBuffer)
-        ConsoleFreeHeap(ExpandedBuffer);
+    /* One invalidation for everything this write touched */
+    VtFlushDirty(Console, ScreenBuffer);
+
     if (CombinedBuffer)
         ConsoleFreeHeap(CombinedBuffer);
 
@@ -4896,218 +4757,123 @@ VtTranslateKeyEvent(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
     if (KeyEvent->uChar.UnicodeChar != 0)
         return FALSE;
 
-    switch (KeyEvent->wVirtualKeyCode)
+    /*
+     * Every remaining key is a table lookup plus one compose call. The three
+     * groups differ only in which encoding they use:
+     *   - cursor/SS3 keys: ESC O <final> in application mode, CSI <final> otherwise
+     *   - editing and F5-F12 keys: CSI <param> ~
+     *   - the numeric keypad in application mode: ESC O <final>
+     */
     {
-        case VK_UP:
-            if (!VtComposeCursorKeySequence((PrivateModes & VT_PRIVMODE_CURSOR_KEYS_APPLICATION) != 0,
-                                            KeyEvent,
-                                            L'A',
-                                            Translation->Sequence,
-                                            ARRAYSIZE(Translation->Sequence),
-                                            &Length))
-                return FALSE;
-            break;
-
-        case VK_DOWN:
-            if (!VtComposeCursorKeySequence((PrivateModes & VT_PRIVMODE_CURSOR_KEYS_APPLICATION) != 0,
-                                            KeyEvent,
-                                            L'B',
-                                            Translation->Sequence,
-                                            ARRAYSIZE(Translation->Sequence),
-                                            &Length))
-                return FALSE;
-            break;
-
-        case VK_RIGHT:
-            if (!VtComposeCursorKeySequence((PrivateModes & VT_PRIVMODE_CURSOR_KEYS_APPLICATION) != 0,
-                                            KeyEvent,
-                                            L'C',
-                                            Translation->Sequence,
-                                            ARRAYSIZE(Translation->Sequence),
-                                            &Length))
-                return FALSE;
-            break;
-
-        case VK_LEFT:
-            if (!VtComposeCursorKeySequence((PrivateModes & VT_PRIVMODE_CURSOR_KEYS_APPLICATION) != 0,
-                                            KeyEvent,
-                                            L'D',
-                                            Translation->Sequence,
-                                            ARRAYSIZE(Translation->Sequence),
-                                            &Length))
-                return FALSE;
-            break;
-
-        case VK_HOME:
+        static const struct
         {
-            BOOLEAN AppMode = (PrivateModes & VT_PRIVMODE_KEYPAD_APPLICATION) != 0;
+            USHORT Vk;
+            WCHAR Final;
+            ULONG AppModeMask;  /* 0 = always use the application (SS3) form */
+        }
+        CursorKeys[] =
+        {
+            {VK_UP,    L'A', VT_PRIVMODE_CURSOR_KEYS_APPLICATION},
+            {VK_DOWN,  L'B', VT_PRIVMODE_CURSOR_KEYS_APPLICATION},
+            {VK_RIGHT, L'C', VT_PRIVMODE_CURSOR_KEYS_APPLICATION},
+            {VK_LEFT,  L'D', VT_PRIVMODE_CURSOR_KEYS_APPLICATION},
+            {VK_HOME,  L'H', VT_PRIVMODE_KEYPAD_APPLICATION},
+            {VK_END,   L'F', VT_PRIVMODE_KEYPAD_APPLICATION},
+            {VK_F1,    L'P', 0},
+            {VK_F2,    L'Q', 0},
+            {VK_F3,    L'R', 0},
+            {VK_F4,    L'S', 0},
+        };
 
-            if (!VtComposeCursorKeySequence(AppMode,
+        static const struct
+        {
+            USHORT Vk;
+            ULONG Parameter;
+        }
+        TildeKeys[] =
+        {
+            {VK_INSERT, 2},
+            {VK_DELETE, 3},
+            {VK_PRIOR,  5},   /* Page Up */
+            {VK_NEXT,   6},   /* Page Down */
+            {VK_F5,  15}, {VK_F6,  17}, {VK_F7,  18}, {VK_F8,  19},
+            {VK_F9,  20}, {VK_F10, 21}, {VK_F11, 23}, {VK_F12, 24},
+        };
+
+        static const struct
+        {
+            USHORT Vk;
+            WCHAR Final;
+        }
+        KeypadKeys[] =
+        {
+            {VK_NUMPAD0, L'p'}, {VK_NUMPAD1, L'q'}, {VK_NUMPAD2, L'r'},
+            {VK_NUMPAD3, L's'}, {VK_NUMPAD4, L't'}, {VK_NUMPAD5, L'u'},
+            {VK_NUMPAD6, L'v'}, {VK_NUMPAD7, L'w'}, {VK_NUMPAD8, L'x'},
+            {VK_NUMPAD9, L'y'}, {VK_DECIMAL, L'n'}, {VK_ADD,     L'k'},
+            {VK_SUBTRACT, L'm'}, {VK_MULTIPLY, L'j'}, {VK_DIVIDE, L'o'},
+            {VK_RETURN,  L'M'},
+        };
+
+        USHORT Vk = KeyEvent->wVirtualKeyCode;
+        ULONG i;
+        BOOLEAN Matched = FALSE;
+
+        for (i = 0; i < ARRAYSIZE(CursorKeys) && !Matched; ++i)
+        {
+            if (CursorKeys[i].Vk != Vk) continue;
+
+            if (!VtComposeCursorKeySequence(CursorKeys[i].AppModeMask == 0 || (PrivateModes & CursorKeys[i].AppModeMask) != 0,
                                             KeyEvent,
-                                            L'H',
+                                            CursorKeys[i].Final,
                                             Translation->Sequence,
                                             ARRAYSIZE(Translation->Sequence),
                                             &Length))
+            {
                 return FALSE;
-            break;
+            }
+            Matched = TRUE;
         }
 
-        case VK_END:
+        for (i = 0; i < ARRAYSIZE(TildeKeys) && !Matched; ++i)
         {
-            BOOLEAN AppMode = (PrivateModes & VT_PRIVMODE_KEYPAD_APPLICATION) != 0;
+            if (TildeKeys[i].Vk != Vk) continue;
 
-            if (!VtComposeCursorKeySequence(AppMode,
-                                            KeyEvent,
-                                            L'F',
-                                            Translation->Sequence,
-                                            ARRAYSIZE(Translation->Sequence),
-                                            &Length))
+            if (!VtComposeCsiTildeSequence(TildeKeys[i].Parameter,
+                                           VtGetModifierParameter(KeyEvent),
+                                           L'~',
+                                           Translation->Sequence,
+                                           ARRAYSIZE(Translation->Sequence),
+                                           &Length))
+            {
                 return FALSE;
-            break;
+            }
+            Matched = TRUE;
         }
 
-        case VK_INSERT:
-            if (!VtComposeCsiTildeSequence(2,
-                                           VtGetModifierParameter(KeyEvent),
-                                           L'~',
-                                           Translation->Sequence,
-                                           ARRAYSIZE(Translation->Sequence),
-                                           &Length))
-                return FALSE;
-            break;
-
-        case VK_DELETE:
-            if (!VtComposeCsiTildeSequence(3,
-                                           VtGetModifierParameter(KeyEvent),
-                                           L'~',
-                                           Translation->Sequence,
-                                           ARRAYSIZE(Translation->Sequence),
-                                           &Length))
-                return FALSE;
-            break;
-
-        case VK_PRIOR: /* Page Up */
-            if (!VtComposeCsiTildeSequence(5,
-                                           VtGetModifierParameter(KeyEvent),
-                                           L'~',
-                                           Translation->Sequence,
-                                           ARRAYSIZE(Translation->Sequence),
-                                           &Length))
-                return FALSE;
-            break;
-
-        case VK_NEXT: /* Page Down */
-            if (!VtComposeCsiTildeSequence(6,
-                                           VtGetModifierParameter(KeyEvent),
-                                           L'~',
-                                           Translation->Sequence,
-                                           ARRAYSIZE(Translation->Sequence),
-                                           &Length))
-                return FALSE;
-            break;
-
-        case VK_F1:
-        case VK_F2:
-        case VK_F3:
-        case VK_F4:
+        for (i = 0; i < ARRAYSIZE(KeypadKeys) && !Matched; ++i)
         {
-            static const WCHAR Finals[] = { L'P', L'Q', L'R', L'S' };
-            ULONG Index = KeyEvent->wVirtualKeyCode - VK_F1;
+            if (KeypadKeys[i].Vk != Vk) continue;
 
-            /* F1-F4 use the same SS3 / xterm-modifier encoding as the cursor keys */
-            if (!VtComposeCursorKeySequence(TRUE, KeyEvent, Finals[Index], Translation->Sequence, ARRAYSIZE(Translation->Sequence), &Length))
-                return FALSE;
-            break;
-        }
-
-        case VK_F5:
-        case VK_F6:
-        case VK_F7:
-        case VK_F8:
-        case VK_F9:
-        case VK_F10:
-        case VK_F11:
-        case VK_F12:
-        {
-            static const ULONG Parameters[] = { 15, 17, 18, 19, 20, 21, 23, 24 };
-            ULONG Index = KeyEvent->wVirtualKeyCode - VK_F5;
-
-            if (!VtComposeCsiTildeSequence(Parameters[Index],
-                                           VtGetModifierParameter(KeyEvent),
-                                           L'~',
-                                           Translation->Sequence,
-                                           ARRAYSIZE(Translation->Sequence),
-                                           &Length))
-                return FALSE;
-            break;
-        }
-
-        case VK_NUMPAD0:
-        case VK_NUMPAD1:
-        case VK_NUMPAD2:
-        case VK_NUMPAD3:
-        case VK_NUMPAD4:
-        case VK_NUMPAD5:
-        case VK_NUMPAD6:
-        case VK_NUMPAD7:
-        case VK_NUMPAD8:
-        case VK_NUMPAD9:
-        case VK_DECIMAL:
-        case VK_ADD:
-        case VK_SUBTRACT:
-        case VK_MULTIPLY:
-        case VK_DIVIDE:
-        case VK_RETURN:
-        {
+            /* The keypad only differs from ordinary keys in application mode,
+             * carries no modifier encoding, and Enter must be the keypad one */
             if (!(PrivateModes & VT_PRIVMODE_KEYPAD_APPLICATION))
                 return FALSE;
-
             if (VtGetModifierParameter(KeyEvent) != 1)
                 return FALSE;
-
-            if (KeyEvent->wVirtualKeyCode == VK_RETURN &&
-                !(KeyEvent->dwControlKeyState & ENHANCED_KEY))
-            {
+            if (Vk == VK_RETURN && !(KeyEvent->dwControlKeyState & ENHANCED_KEY))
                 return FALSE;
-            }
+            if (ARRAYSIZE(Translation->Sequence) < 3)
+                return FALSE;
 
-            {
-                WCHAR Final;
-
-                switch (KeyEvent->wVirtualKeyCode)
-                {
-                    case VK_NUMPAD0: Final = L'p'; break;
-                    case VK_NUMPAD1: Final = L'q'; break;
-                    case VK_NUMPAD2: Final = L'r'; break;
-                    case VK_NUMPAD3: Final = L's'; break;
-                    case VK_NUMPAD4: Final = L't'; break;
-                    case VK_NUMPAD5: Final = L'u'; break;
-                    case VK_NUMPAD6: Final = L'v'; break;
-                    case VK_NUMPAD7: Final = L'w'; break;
-                    case VK_NUMPAD8: Final = L'x'; break;
-                    case VK_NUMPAD9: Final = L'y'; break;
-                    case VK_DECIMAL: Final = L'n'; break;
-                    case VK_ADD:     Final = L'k'; break;
-                    case VK_SUBTRACT:Final = L'm'; break;
-                    case VK_MULTIPLY:Final = L'j'; break;
-                    case VK_DIVIDE:  Final = L'o'; break;
-                    case VK_RETURN:  Final = L'M'; break;
-                    default:
-                        return FALSE;
-                }
-
-                if (ARRAYSIZE(Translation->Sequence) < 3)
-                    return FALSE;
-
-                Translation->Sequence[0] = L'\x1b';
-                Translation->Sequence[1] = L'O';
-                Translation->Sequence[2] = Final;
-                Length = 3;
-            }
-            break;
+            Translation->Sequence[0] = L'';
+            Translation->Sequence[1] = L'O';
+            Translation->Sequence[2] = KeypadKeys[i].Final;
+            Length = 3;
+            Matched = TRUE;
         }
 
-        default:
+        if (!Matched)
             return FALSE;
     }
 

--- a/win32ss/user/winsrv/consrv/coninput.c
+++ b/win32ss/user/winsrv/consrv/coninput.c
@@ -228,11 +228,43 @@ ConioProcessInputEvent(PCONSRV_CONSOLE Console,
         }
     }
 
-    return ConioAddInputEvents(Console,
-                               InputEvent,
-                               1,
-                               &NumEventsWritten,
-                               TRUE);
+    /*
+     * Translate to VT input sequences here, at enqueue time, so the queue holds
+     * exactly the records every reader will receive. Doing it on the read path
+     * instead made ReadConsoleInput and PeekConsoleInput disagree, hid VT input
+     * from the cooked ReadConsole/ReadFile path entirely, and left
+     * GetNumberOfConsoleInputEvents reporting untranslated counts.
+     *
+     * ConDrvVtTranslateInput pre-sets the out-parameters to pass-through, so a
+     * console without ENABLE_VIRTUAL_TERMINAL_INPUT costs one mode test.
+     */
+    {
+        PINPUT_RECORD Records;
+        ULONG Count;
+        BOOLEAN Allocated;
+        NTSTATUS Status;
+
+        Status = ConDrvVtTranslateInput((PCONSOLE)Console, InputEvent, 1, &Records, &Count, &Allocated);
+        if (!NT_SUCCESS(Status))
+        {
+            /* Best-effort: enqueue the event untranslated rather than losing it */
+            Records = InputEvent;
+            Count = 1;
+            Allocated = FALSE;
+        }
+
+        /* The VT layer drops some events outright (e.g. key-up records) */
+        if (Count == 0)
+        {
+            if (Allocated) ConsoleFreeHeap(Records);
+            return STATUS_SUCCESS;
+        }
+
+        Status = ConioAddInputEvents(Console, Records, Count, &NumEventsWritten, TRUE);
+
+        if (Allocated) ConsoleFreeHeap(Records);
+        return Status;
+    }
 }
 
 
@@ -562,47 +594,6 @@ ReadInputBuffer(IN PGET_INPUT_INFO InputInfo,
 
         if (NT_SUCCESS(Status))
         {
-            /* Translate input records to VT sequences if virtual terminal input is enabled */
-            {
-                PINPUT_RECORD TranslatedRecords;
-                ULONG TranslatedCount;
-                BOOLEAN AllocatedBuffer;
-                NTSTATUS VtStatus;
-
-                VtStatus = ConDrvVtTranslateInput(InputBuffer->Header.Console,
-                                                   InputRecord,
-                                                   NumEventsRead,
-                                                   &TranslatedRecords,
-                                                   &TranslatedCount,
-                                                   &AllocatedBuffer);
-                if (NT_SUCCESS(VtStatus) && AllocatedBuffer)
-                {
-                    ULONG CopyCount = min(TranslatedCount, GetInputRequest->NumRecords);
-                    RtlCopyMemory(InputRecord, TranslatedRecords, CopyCount * sizeof(INPUT_RECORD));
-
-                    /*
-                     * If VT translation expanded input records beyond the client
-                     * buffer capacity, re-enqueue the overflow at the front of
-                     * the input queue so it is returned on the next read.
-                     * Only do this when actually consuming events (not peeking).
-                     */
-                    if (TranslatedCount > CopyCount &&
-                        !(GetInputRequest->Flags & CONSOLE_READ_NOREMOVE))
-                    {
-                        ConDrvWriteConsoleInput(InputBuffer->Header.Console,
-                                               &InputBuffer->Header.Console->InputBuffer,
-                                               FALSE, /* Prepend to front */
-                                               &TranslatedRecords[CopyCount],
-                                               TranslatedCount - CopyCount,
-                                               NULL);
-                    }
-
-                    ConsoleFreeHeap(TranslatedRecords);
-                    NumEventsRead = CopyCount;
-                    GetInputRequest->NumRecords = CopyCount;
-                }
-            }
-
             /* Now translate everything to ANSI */
             if (!GetInputRequest->Unicode)
             {

--- a/win32ss/user/winsrv/consrv/coninput.c
+++ b/win32ss/user/winsrv/consrv/coninput.c
@@ -10,6 +10,7 @@
 /* INCLUDES *******************************************************************/
 
 #include "consrv.h"
+#include "include/vt.h"
 
 #define NDEBUG
 #include <debug.h>
@@ -561,6 +562,47 @@ ReadInputBuffer(IN PGET_INPUT_INFO InputInfo,
 
         if (NT_SUCCESS(Status))
         {
+            /* Translate input records to VT sequences if virtual terminal input is enabled */
+            {
+                PINPUT_RECORD TranslatedRecords;
+                ULONG TranslatedCount;
+                BOOLEAN AllocatedBuffer;
+                NTSTATUS VtStatus;
+
+                VtStatus = ConDrvVtTranslateInput(InputBuffer->Header.Console,
+                                                   InputRecord,
+                                                   NumEventsRead,
+                                                   &TranslatedRecords,
+                                                   &TranslatedCount,
+                                                   &AllocatedBuffer);
+                if (NT_SUCCESS(VtStatus) && AllocatedBuffer)
+                {
+                    ULONG CopyCount = min(TranslatedCount, GetInputRequest->NumRecords);
+                    RtlCopyMemory(InputRecord, TranslatedRecords, CopyCount * sizeof(INPUT_RECORD));
+
+                    /*
+                     * If VT translation expanded input records beyond the client
+                     * buffer capacity, re-enqueue the overflow at the front of
+                     * the input queue so it is returned on the next read.
+                     * Only do this when actually consuming events (not peeking).
+                     */
+                    if (TranslatedCount > CopyCount &&
+                        !(GetInputRequest->Flags & CONSOLE_READ_NOREMOVE))
+                    {
+                        ConDrvWriteConsoleInput(InputBuffer->Header.Console,
+                                               &InputBuffer->Header.Console->InputBuffer,
+                                               FALSE, /* Prepend to front */
+                                               &TranslatedRecords[CopyCount],
+                                               TranslatedCount - CopyCount,
+                                               NULL);
+                    }
+
+                    ConsoleFreeHeap(TranslatedRecords);
+                    NumEventsRead = CopyCount;
+                    GetInputRequest->NumRecords = CopyCount;
+                }
+            }
+
             /* Now translate everything to ANSI */
             if (!GetInputRequest->Unicode)
             {

--- a/win32ss/user/winsrv/consrv/conoutput.c
+++ b/win32ss/user/winsrv/consrv/conoutput.c
@@ -10,6 +10,7 @@
 /* INCLUDES *******************************************************************/
 
 #include "consrv.h"
+#include "include/vt.h"
 
 #define NDEBUG
 #include <debug.h>
@@ -945,6 +946,8 @@ ConDrvSetConsoleWindowInfo(IN PCONSOLE Console,
                            IN PTEXTMODE_SCREEN_BUFFER Buffer,
                            IN BOOLEAN Absolute,
                            IN PSMALL_RECT WindowRect);
+NTSTATUS NTAPI
+ConDrvSetScreenBufferInfoEx(IN PCONSOLE Console, IN PTEXTMODE_SCREEN_BUFFER Buffer, IN PCOORD ScreenBufferSize, IN PCOORD CursorPosition, IN PSMALL_RECT WindowRect, IN USHORT Attributes, IN USHORT PopupAttributes, IN const COLORREF *ColorTable, IN ULONG ColorCount);
 /* API_NUMBER: ConsolepGetScreenBufferInfo */
 CON_API(SrvGetConsoleScreenBufferInfo,
         CONSOLE_GETSCREENBUFFERINFO, ScreenBufferInfoRequest)
@@ -1015,28 +1018,12 @@ CON_API(SrvSetConsoleScreenBufferInfoEx,
 {
     NTSTATUS Status;
     PTEXTMODE_SCREEN_BUFFER Buffer;
-    COORD CurrentScreenBufferSize, CurrentCursorPosition, CurrentViewOrigin;
-    COORD CurrentViewSize, CurrentMaximumViewSize;
-    WORD CurrentAttributes;
     SMALL_RECT WindowRect;
-    BOOLEAN WindowAdjusted = FALSE;
-
-    if (ScreenBufferInfoExRequest->ScreenBufferSize.X <= 0 ||
-        ScreenBufferInfoExRequest->ScreenBufferSize.Y <= 0 ||
-        ScreenBufferInfoExRequest->ViewSize.X <= 0 ||
-        ScreenBufferInfoExRequest->ViewSize.Y <= 0 ||
-        ScreenBufferInfoExRequest->ViewSize.X > ScreenBufferInfoExRequest->ScreenBufferSize.X ||
-        ScreenBufferInfoExRequest->ViewSize.Y > ScreenBufferInfoExRequest->ScreenBufferSize.Y)
-    {
-        return STATUS_INVALID_PARAMETER;
-    }
 
     WindowRect.Left   = ScreenBufferInfoExRequest->ViewOrigin.X;
     WindowRect.Top    = ScreenBufferInfoExRequest->ViewOrigin.Y;
-    WindowRect.Right  = ScreenBufferInfoExRequest->ViewOrigin.X +
-                        ScreenBufferInfoExRequest->ViewSize.X - 1;
-    WindowRect.Bottom = ScreenBufferInfoExRequest->ViewOrigin.Y +
-                        ScreenBufferInfoExRequest->ViewSize.Y - 1;
+    WindowRect.Right  = ScreenBufferInfoExRequest->ViewOrigin.X + ScreenBufferInfoExRequest->ViewSize.X - 1;
+    WindowRect.Bottom = ScreenBufferInfoExRequest->ViewOrigin.Y + ScreenBufferInfoExRequest->ViewSize.Y - 1;
 
     Status = ConSrvGetTextModeBuffer(ProcessData,
                                      ScreenBufferInfoExRequest->OutputHandle,
@@ -1046,91 +1033,21 @@ CON_API(SrvSetConsoleScreenBufferInfoEx,
 
     ASSERT((PCONSOLE)Console == Buffer->Header.Console);
 
-    Status = ConDrvGetConsoleScreenBufferInfo((PCONSOLE)Console,
-                                              Buffer,
-                                              &CurrentScreenBufferSize,
-                                              &CurrentCursorPosition,
-                                              &CurrentViewOrigin,
-                                              &CurrentViewSize,
-                                              &CurrentMaximumViewSize,
-                                              &CurrentAttributes);
-    if (!NT_SUCCESS(Status))
-        goto Quit;
-
     /*
-     * When shrinking the backing buffer, the window must already fit inside
-     * the requested size. Grow operations can resize the buffer first.
+     * The driver owns the buffer/window ordering rule, so hand it the whole
+     * request instead of re-deriving that rule here and applying the pieces one
+     * at a time with no way to tell a partial application from a failed one.
      */
-    if (ScreenBufferInfoExRequest->ScreenBufferSize.X < CurrentViewSize.X ||
-        ScreenBufferInfoExRequest->ScreenBufferSize.Y < CurrentViewSize.Y)
-    {
-        if (CurrentViewOrigin.X != ScreenBufferInfoExRequest->ViewOrigin.X ||
-            CurrentViewOrigin.Y != ScreenBufferInfoExRequest->ViewOrigin.Y ||
-            CurrentViewSize.X   != ScreenBufferInfoExRequest->ViewSize.X   ||
-            CurrentViewSize.Y   != ScreenBufferInfoExRequest->ViewSize.Y)
-        {
-            Status = ConDrvSetConsoleWindowInfo((PCONSOLE)Console,
-                                                Buffer,
-                                                TRUE,
-                                                &WindowRect);
-            if (!NT_SUCCESS(Status))
-                goto Quit;
+    Status = ConDrvSetScreenBufferInfoEx((PCONSOLE)Console,
+                                         Buffer,
+                                         &ScreenBufferInfoExRequest->ScreenBufferSize,
+                                         &ScreenBufferInfoExRequest->CursorPosition,
+                                         &WindowRect,
+                                         ScreenBufferInfoExRequest->Attributes,
+                                         ScreenBufferInfoExRequest->PopupAttributes,
+                                         ScreenBufferInfoExRequest->ColorTable,
+                                         ARRAYSIZE(ScreenBufferInfoExRequest->ColorTable));
 
-            WindowAdjusted = TRUE;
-        }
-    }
-
-    if (CurrentScreenBufferSize.X != ScreenBufferInfoExRequest->ScreenBufferSize.X ||
-        CurrentScreenBufferSize.Y != ScreenBufferInfoExRequest->ScreenBufferSize.Y)
-    {
-        Status = ConDrvSetConsoleScreenBufferSize((PCONSOLE)Console,
-                                                  Buffer,
-                                                  &ScreenBufferInfoExRequest->ScreenBufferSize);
-        if (!NT_SUCCESS(Status))
-            goto Quit;
-    }
-
-    if (!WindowAdjusted &&
-        (CurrentViewOrigin.X != ScreenBufferInfoExRequest->ViewOrigin.X ||
-         CurrentViewOrigin.Y != ScreenBufferInfoExRequest->ViewOrigin.Y ||
-         CurrentViewSize.X   != ScreenBufferInfoExRequest->ViewSize.X   ||
-         CurrentViewSize.Y   != ScreenBufferInfoExRequest->ViewSize.Y))
-    {
-        Status = ConDrvSetConsoleWindowInfo((PCONSOLE)Console,
-                                            Buffer,
-                                            TRUE,
-                                            &WindowRect);
-        if (!NT_SUCCESS(Status))
-            goto Quit;
-    }
-
-    if (CurrentCursorPosition.X != ScreenBufferInfoExRequest->CursorPosition.X ||
-        CurrentCursorPosition.Y != ScreenBufferInfoExRequest->CursorPosition.Y)
-    {
-        Status = ConDrvSetConsoleCursorPosition((PCONSOLE)Console,
-                                                Buffer,
-                                                &ScreenBufferInfoExRequest->CursorPosition);
-        if (!NT_SUCCESS(Status))
-            goto Quit;
-    }
-
-    if (CurrentAttributes != ScreenBufferInfoExRequest->Attributes ||
-        Buffer->PopupDefaultAttrib != ScreenBufferInfoExRequest->PopupAttributes)
-    {
-        Status = ConDrvChangeScreenBufferAttributes((PCONSOLE)Console,
-                                                    Buffer,
-                                                    ScreenBufferInfoExRequest->Attributes,
-                                                    ScreenBufferInfoExRequest->PopupAttributes);
-        if (!NT_SUCCESS(Status))
-            goto Quit;
-    }
-
-    RtlCopyMemory(Console->Colors,
-                  ScreenBufferInfoExRequest->ColorTable,
-                  sizeof(Console->Colors));
-    TermRefreshInternalInfo(Console);
-
-Quit:
     ConSrvReleaseScreenBuffer(Buffer, TRUE);
     return Status;
 }

--- a/win32ss/user/winsrv/consrv/conoutput.c
+++ b/win32ss/user/winsrv/consrv/conoutput.c
@@ -931,6 +931,20 @@ ConDrvGetConsoleScreenBufferInfo(IN  PCONSOLE Console,
                                  OUT PCOORD ViewSize,
                                  OUT PCOORD MaximumViewSize,
                                  OUT PWORD  Attributes);
+NTSTATUS NTAPI
+ConDrvChangeScreenBufferAttributes(IN PCONSOLE Console,
+                                   IN PTEXTMODE_SCREEN_BUFFER Buffer,
+                                   IN USHORT NewScreenAttrib,
+                                   IN USHORT NewPopupAttrib);
+NTSTATUS NTAPI
+ConDrvSetConsoleScreenBufferSize(IN PCONSOLE Console,
+                                 IN PTEXTMODE_SCREEN_BUFFER Buffer,
+                                 IN PCOORD Size);
+NTSTATUS NTAPI
+ConDrvSetConsoleWindowInfo(IN PCONSOLE Console,
+                           IN PTEXTMODE_SCREEN_BUFFER Buffer,
+                           IN BOOLEAN Absolute,
+                           IN PSMALL_RECT WindowRect);
 /* API_NUMBER: ConsolepGetScreenBufferInfo */
 CON_API(SrvGetConsoleScreenBufferInfo,
         CONSOLE_GETSCREENBUFFERINFO, ScreenBufferInfoRequest)
@@ -955,6 +969,168 @@ CON_API(SrvGetConsoleScreenBufferInfo,
                                               &ScreenBufferInfoRequest->MaximumViewSize,
                                               &ScreenBufferInfoRequest->Attributes);
 
+    ConSrvReleaseScreenBuffer(Buffer, TRUE);
+    return Status;
+}
+
+/* API_NUMBER: ConsolepGetScreenBufferInfoEx */
+CON_API(SrvGetConsoleScreenBufferInfoEx,
+        CONSOLE_GETSCREENBUFFERINFOEX, ScreenBufferInfoExRequest)
+{
+    NTSTATUS Status;
+    PTEXTMODE_SCREEN_BUFFER Buffer;
+
+    Status = ConSrvGetTextModeBuffer(ProcessData,
+                                     ScreenBufferInfoExRequest->OutputHandle,
+                                     &Buffer, GENERIC_READ, TRUE);
+    if (!NT_SUCCESS(Status))
+        return Status;
+
+    ASSERT((PCONSOLE)Console == Buffer->Header.Console);
+
+    Status = ConDrvGetConsoleScreenBufferInfo((PCONSOLE)Console,
+                                              Buffer,
+                                              &ScreenBufferInfoExRequest->ScreenBufferSize,
+                                              &ScreenBufferInfoExRequest->CursorPosition,
+                                              &ScreenBufferInfoExRequest->ViewOrigin,
+                                              &ScreenBufferInfoExRequest->ViewSize,
+                                              &ScreenBufferInfoExRequest->MaximumViewSize,
+                                              &ScreenBufferInfoExRequest->Attributes);
+    if (NT_SUCCESS(Status))
+    {
+        ScreenBufferInfoExRequest->PopupAttributes = Buffer->PopupDefaultAttrib;
+        ScreenBufferInfoExRequest->FullscreenSupported = FALSE;
+        RtlCopyMemory(ScreenBufferInfoExRequest->ColorTable,
+                      Console->Colors,
+                      sizeof(ScreenBufferInfoExRequest->ColorTable));
+    }
+
+    ConSrvReleaseScreenBuffer(Buffer, TRUE);
+    return Status;
+}
+
+/* API_NUMBER: ConsolepSetScreenBufferInfoEx */
+CON_API(SrvSetConsoleScreenBufferInfoEx,
+        CONSOLE_GETSCREENBUFFERINFOEX, ScreenBufferInfoExRequest)
+{
+    NTSTATUS Status;
+    PTEXTMODE_SCREEN_BUFFER Buffer;
+    COORD CurrentScreenBufferSize, CurrentCursorPosition, CurrentViewOrigin;
+    COORD CurrentViewSize, CurrentMaximumViewSize;
+    WORD CurrentAttributes;
+    SMALL_RECT WindowRect;
+    BOOLEAN WindowAdjusted = FALSE;
+
+    if (ScreenBufferInfoExRequest->ScreenBufferSize.X <= 0 ||
+        ScreenBufferInfoExRequest->ScreenBufferSize.Y <= 0 ||
+        ScreenBufferInfoExRequest->ViewSize.X <= 0 ||
+        ScreenBufferInfoExRequest->ViewSize.Y <= 0 ||
+        ScreenBufferInfoExRequest->ViewSize.X > ScreenBufferInfoExRequest->ScreenBufferSize.X ||
+        ScreenBufferInfoExRequest->ViewSize.Y > ScreenBufferInfoExRequest->ScreenBufferSize.Y)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    WindowRect.Left   = ScreenBufferInfoExRequest->ViewOrigin.X;
+    WindowRect.Top    = ScreenBufferInfoExRequest->ViewOrigin.Y;
+    WindowRect.Right  = ScreenBufferInfoExRequest->ViewOrigin.X +
+                        ScreenBufferInfoExRequest->ViewSize.X - 1;
+    WindowRect.Bottom = ScreenBufferInfoExRequest->ViewOrigin.Y +
+                        ScreenBufferInfoExRequest->ViewSize.Y - 1;
+
+    Status = ConSrvGetTextModeBuffer(ProcessData,
+                                     ScreenBufferInfoExRequest->OutputHandle,
+                                     &Buffer, GENERIC_READ | GENERIC_WRITE, TRUE);
+    if (!NT_SUCCESS(Status))
+        return Status;
+
+    ASSERT((PCONSOLE)Console == Buffer->Header.Console);
+
+    Status = ConDrvGetConsoleScreenBufferInfo((PCONSOLE)Console,
+                                              Buffer,
+                                              &CurrentScreenBufferSize,
+                                              &CurrentCursorPosition,
+                                              &CurrentViewOrigin,
+                                              &CurrentViewSize,
+                                              &CurrentMaximumViewSize,
+                                              &CurrentAttributes);
+    if (!NT_SUCCESS(Status))
+        goto Quit;
+
+    /*
+     * When shrinking the backing buffer, the window must already fit inside
+     * the requested size. Grow operations can resize the buffer first.
+     */
+    if (ScreenBufferInfoExRequest->ScreenBufferSize.X < CurrentViewSize.X ||
+        ScreenBufferInfoExRequest->ScreenBufferSize.Y < CurrentViewSize.Y)
+    {
+        if (CurrentViewOrigin.X != ScreenBufferInfoExRequest->ViewOrigin.X ||
+            CurrentViewOrigin.Y != ScreenBufferInfoExRequest->ViewOrigin.Y ||
+            CurrentViewSize.X   != ScreenBufferInfoExRequest->ViewSize.X   ||
+            CurrentViewSize.Y   != ScreenBufferInfoExRequest->ViewSize.Y)
+        {
+            Status = ConDrvSetConsoleWindowInfo((PCONSOLE)Console,
+                                                Buffer,
+                                                TRUE,
+                                                &WindowRect);
+            if (!NT_SUCCESS(Status))
+                goto Quit;
+
+            WindowAdjusted = TRUE;
+        }
+    }
+
+    if (CurrentScreenBufferSize.X != ScreenBufferInfoExRequest->ScreenBufferSize.X ||
+        CurrentScreenBufferSize.Y != ScreenBufferInfoExRequest->ScreenBufferSize.Y)
+    {
+        Status = ConDrvSetConsoleScreenBufferSize((PCONSOLE)Console,
+                                                  Buffer,
+                                                  &ScreenBufferInfoExRequest->ScreenBufferSize);
+        if (!NT_SUCCESS(Status))
+            goto Quit;
+    }
+
+    if (!WindowAdjusted &&
+        (CurrentViewOrigin.X != ScreenBufferInfoExRequest->ViewOrigin.X ||
+         CurrentViewOrigin.Y != ScreenBufferInfoExRequest->ViewOrigin.Y ||
+         CurrentViewSize.X   != ScreenBufferInfoExRequest->ViewSize.X   ||
+         CurrentViewSize.Y   != ScreenBufferInfoExRequest->ViewSize.Y))
+    {
+        Status = ConDrvSetConsoleWindowInfo((PCONSOLE)Console,
+                                            Buffer,
+                                            TRUE,
+                                            &WindowRect);
+        if (!NT_SUCCESS(Status))
+            goto Quit;
+    }
+
+    if (CurrentCursorPosition.X != ScreenBufferInfoExRequest->CursorPosition.X ||
+        CurrentCursorPosition.Y != ScreenBufferInfoExRequest->CursorPosition.Y)
+    {
+        Status = ConDrvSetConsoleCursorPosition((PCONSOLE)Console,
+                                                Buffer,
+                                                &ScreenBufferInfoExRequest->CursorPosition);
+        if (!NT_SUCCESS(Status))
+            goto Quit;
+    }
+
+    if (CurrentAttributes != ScreenBufferInfoExRequest->Attributes ||
+        Buffer->PopupDefaultAttrib != ScreenBufferInfoExRequest->PopupAttributes)
+    {
+        Status = ConDrvChangeScreenBufferAttributes((PCONSOLE)Console,
+                                                    Buffer,
+                                                    ScreenBufferInfoExRequest->Attributes,
+                                                    ScreenBufferInfoExRequest->PopupAttributes);
+        if (!NT_SUCCESS(Status))
+            goto Quit;
+    }
+
+    RtlCopyMemory(Console->Colors,
+                  ScreenBufferInfoExRequest->ColorTable,
+                  sizeof(Console->Colors));
+    TermRefreshInternalInfo(Console);
+
+Quit:
     ConSrvReleaseScreenBuffer(Buffer, TRUE);
     return Status;
 }

--- a/win32ss/user/winsrv/consrv/console.c
+++ b/win32ss/user/winsrv/consrv/console.c
@@ -230,7 +230,7 @@ ConsoleCreateUnicodeString(IN OUT PUNICODE_STRING UniDest,
 }
 
 // Adapted from reactos/lib/rtl/unicode.c, RtlFreeUnicodeString line 431
-static VOID
+VOID
 ConsoleFreeUnicodeString(IN PUNICODE_STRING UnicodeString)
 {
     if (UnicodeString->Buffer)
@@ -528,6 +528,54 @@ Finish:
     return RetVal;
 }
 
+/*
+ * VT feature policy. These are per-user settings, so they must be read while
+ * impersonating the client - RTL_REGISTRY_USER resolves to CSRSS's own hive
+ * otherwise. That also rules out caching them across consoles.
+ */
+typedef struct _CONSRV_VT_POLICY
+{
+    ULONG AllowOscClipboard;
+    ULONG AllowOscHyperlinks;
+    ULONG AllowDcsPassthrough;
+} CONSRV_VT_POLICY, *PCONSRV_VT_POLICY;
+
+static VOID
+ConSrvReadVtPolicy(PCONSRV_VT_POLICY Policy)
+{
+    RTL_QUERY_REGISTRY_TABLE QueryTable[4];
+    ULONG i;
+
+    static const struct
+    {
+        PCWSTR Name;
+        ULONG Offset;
+    } Values[] =
+    {
+        {L"AllowVtOscClipboard",  FIELD_OFFSET(CONSRV_VT_POLICY, AllowOscClipboard)},
+        {L"AllowVtOscHyperlinks", FIELD_OFFSET(CONSRV_VT_POLICY, AllowOscHyperlinks)},
+        {L"AllowVtDcsPassthrough", FIELD_OFFSET(CONSRV_VT_POLICY, AllowDcsPassthrough)},
+    };
+
+    /* Permissive unless the user says otherwise */
+    Policy->AllowOscClipboard = Policy->AllowOscHyperlinks = Policy->AllowDcsPassthrough = TRUE;
+
+    RtlZeroMemory(QueryTable, sizeof(QueryTable));
+    for (i = 0; i < ARRAYSIZE(Values); ++i)
+    {
+        PULONG Target = (PULONG)((PUCHAR)Policy + Values[i].Offset);
+
+        QueryTable[i].Flags = RTL_QUERY_REGISTRY_DIRECT;
+        QueryTable[i].Name = (PWSTR)Values[i].Name;
+        QueryTable[i].EntryContext = Target;
+        QueryTable[i].DefaultType = REG_DWORD;
+        QueryTable[i].DefaultData = Target;
+        QueryTable[i].DefaultLength = sizeof(*Target);
+    }
+
+    RtlQueryRegistryValues(RTL_REGISTRY_USER, L"Console", QueryTable, NULL, NULL);
+}
+
 NTSTATUS NTAPI
 ConSrvInitConsole(OUT PHANDLE NewConsoleHandle,
                   OUT PCONSRV_CONSOLE* NewConsole,
@@ -541,6 +589,7 @@ ConSrvInitConsole(OUT PHANDLE NewConsoleHandle,
     BYTE ConsoleInfoBuffer[sizeof(CONSOLE_STATE_INFO) + MAX_PATH * sizeof(WCHAR)]; // CONSRV console information
     PCONSOLE_STATE_INFO ConsoleInfo = (PCONSOLE_STATE_INFO)&ConsoleInfoBuffer;
     CONSOLE_INFO DrvConsoleInfo; // Console information for CONDRV
+    CONSRV_VT_POLICY VtPolicy;
 
     SIZE_T Length = 0;
 
@@ -641,6 +690,9 @@ ConSrvInitConsole(OUT PHANDLE NewConsoleHandle,
 #endif
     }
 
+    /* Read the user's VT feature policy while we can still see their hive */
+    ConSrvReadVtPolicy(&VtPolicy);
+
     /* 6. Revert impersonation */
     CsrRevertToSelf();
 
@@ -693,6 +745,11 @@ ConSrvInitConsole(OUT PHANDLE NewConsoleHandle,
     }
 
     DPRINT("Console initialized\n");
+
+    /* Apply the user's VT feature policy over the driver's permissive defaults */
+    Console->AllowVtOscClipboard = !!VtPolicy.AllowOscClipboard;
+    Console->AllowVtOscHyperlinks = !!VtPolicy.AllowOscHyperlinks;
+    Console->AllowVtDcsPassthrough = !!VtPolicy.AllowDcsPassthrough;
 
     /*** Register ConSrv features ***/
 

--- a/win32ss/user/winsrv/consrv/console.h
+++ b/win32ss/user/winsrv/consrv/console.h
@@ -26,6 +26,10 @@ typedef struct _CONSOLE_INIT_INFO
 VOID NTAPI
 ConSrvInitConsoleSupport(VOID);
 
+/* Frees a UNICODE_STRING whose buffer came from the console heap */
+VOID
+ConsoleFreeUnicodeString(IN PUNICODE_STRING UnicodeString);
+
 NTSTATUS NTAPI
 ConSrvInitConsole(OUT PHANDLE NewConsoleHandle,
                   OUT struct _CONSRV_CONSOLE** /* PCONSRV_CONSOLE* */ NewConsole,

--- a/win32ss/user/winsrv/consrv/consrv.h
+++ b/win32ss/user/winsrv/consrv/consrv.h
@@ -23,6 +23,25 @@
 #include <wincon.h>
 #include <wincon_undoc.h>
 
+/*
+ * Virtual-terminal console modes. These are gated behind NTDDI_WIN10_RS1 in
+ * <wincon.h>, but consrv is built with _WIN32_WINNT=0x600 (see consrv.cmake)
+ * and implements them regardless, so make them visible module-wide instead of
+ * relaxing the public SDK header.
+ */
+#ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
+#define ENABLE_VIRTUAL_TERMINAL_INPUT       0x0200
+#endif
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING  0x0004
+#endif
+#ifndef DISABLE_NEWLINE_AUTO_RETURN
+#define DISABLE_NEWLINE_AUTO_RETURN         0x0008
+#endif
+#ifndef ENABLE_LVB_GRID_WORLDWIDE
+#define ENABLE_LVB_GRID_WORLDWIDE           0x0010
+#endif
+
 #define NTOS_MODE_USER
 #include <ndk/mmfuncs.h>
 

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -645,12 +645,7 @@ OnNcCreate(HWND hWnd, LPCREATESTRUCTW Create)
     GuiData->IsWindowActive = FALSE;
 
     /* Initialize the fonts */
-    if (!InitFonts(GuiData,
-                   GuiData->GuiInfo.FaceName,
-                   GuiData->GuiInfo.FontWeight,
-                   GuiData->GuiInfo.FontFamily,
-                   GuiData->GuiInfo.FontSize,
-                   0, FALSE))
+    if (!InitFontsFromSettings(GuiData, 0, FALSE))
     {
         /* Reset only the output code page if we don't have a suitable
          * font for it, possibly falling back to "United States (OEM)". */
@@ -666,12 +661,7 @@ OnNcCreate(HWND hWnd, LPCREATESTRUCTW Create)
 
         /* We will use a fallback font if we cannot find
          * anything for this replacement code page. */
-        if (!InitFonts(GuiData,
-                       GuiData->GuiInfo.FaceName,
-                       GuiData->GuiInfo.FontWeight,
-                       GuiData->GuiInfo.FontFamily,
-                       GuiData->GuiInfo.FontSize,
-                       0, TRUE))
+        if (!InitFontsFromSettings(GuiData, 0, TRUE))
         {
             DPRINT1("Failed to initialize font '%S' for code page %d\n",
                     GuiData->GuiInfo.FaceName, Console->OutputCodePage);

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -21,6 +21,7 @@
 #include <debug.h>
 
 #include "concfg/font.h"
+#include "../../include/vt.h"
 #include "guiterm.h"
 #include "resource.h"
 
@@ -1798,7 +1799,8 @@ OnMouse(PGUI_CONSOLE_DATA GuiData, UINT msg, WPARAM wParam, LPARAM lParam)
                 break;
         }
     }
-    else if (GetConsoleInputBufferMode(Console) & ENABLE_MOUSE_INPUT)
+    else if ((GetConsoleInputBufferMode(Console) & ENABLE_MOUSE_INPUT) ||
+             ConDrvVtIsMouseTrackingEnabled((PCONSOLE)Console))
     {
         INPUT_RECORD er;
         WORD  wKeyState         = GET_KEYSTATE_WPARAM(wParam);

--- a/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
@@ -1046,19 +1046,22 @@ GuiSetCodePage(IN OUT PFRONTEND This,
      * If the current font does not support the new code page, switch
      * to a different font supporting the code page but having similar
      * characteristics.
-     * If no font can be found for this code page, stay using the
-     * original font and refuse changing the code page.
+     * If no suitable font can be found, use a default fallback font
+     * so that the code page change is not rejected (this is especially
+     * important for UTF-8 code page 65001, used by modern TUI apps).
      */
-    if (!InitFonts(GuiData,
-                   GuiData->GuiInfo.FaceName,
-                   GuiData->GuiInfo.FontWeight,
-                   GuiData->GuiInfo.FontFamily,
-                   GuiData->GuiInfo.FontSize,
-                   CodePage, FALSE))
+    if (!InitFontsFromSettings(GuiData, CodePage, FALSE))
     {
-        DPRINT1("Failed to initialize font '%S' for code page %d - Refuse CP change\n",
+        DPRINT1("Failed to initialize font '%S' for code page %d - Trying with fallback\n",
                 GuiData->GuiInfo.FaceName, CodePage);
-        return FALSE;
+
+        /* Retry with a default fallback font */
+        if (!InitFontsFromSettings(GuiData, CodePage, TRUE))
+        {
+            DPRINT1("Failed to initialize fallback font for code page %d - Refuse CP change\n",
+                    CodePage);
+            return FALSE;
+        }
     }
 
     return TRUE;

--- a/win32ss/user/winsrv/consrv/frontends/gui/guiterm.h
+++ b/win32ss/user/winsrv/consrv/frontends/gui/guiterm.h
@@ -75,6 +75,16 @@ InitFonts(
     _In_opt_ UINT CodePage,
     _In_ BOOL UseDefaultFallback);
 
+/*
+ * InitFonts() with the face, weight, family and size the console is configured
+ * with - every caller wants those, so they should not each spell them out.
+ */
+FORCEINLINE BOOL
+InitFontsFromSettings(_Inout_ PGUI_CONSOLE_DATA GuiData, _In_opt_ UINT CodePage, _In_ BOOL UseDefaultFallback)
+{
+    return InitFonts(GuiData, GuiData->GuiInfo.FaceName, GuiData->GuiInfo.FontWeight, GuiData->GuiInfo.FontFamily, GuiData->GuiInfo.FontSize, CodePage, UseDefaultFallback);
+}
+
 VOID
 DeleteFonts(PGUI_CONSOLE_DATA GuiData);
 

--- a/win32ss/user/winsrv/consrv/frontends/gui/text.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/text.c
@@ -3,7 +3,7 @@
  * PROJECT:         ReactOS Console Server DLL
  * FILE:            win32ss/user/winsrv/consrv/frontends/gui/text.c
  * PURPOSE:         GUI Terminal Front-End - Support for text-mode screen-buffers
- * PROGRAMMERS:     Gé van Geldorp
+ * PROGRAMMERS:     Gï¿½ van Geldorp
  *                  Johannes Anderwald
  *                  Jeffrey Morlan
  *                  Hermes Belusca-Maito (hermes.belusca@sfr.fr)
@@ -34,6 +34,59 @@ PaletteRGBFromAttrib(PCONSRV_CONSOLE Console, WORD Attribute)
 
     GetPaletteEntries(hPalette, Attribute, 1, &pe);
     return PALETTERGB(pe.peRed, pe.peGreen, pe.peBlue);
+}
+
+/*
+ * The 16 palette colours resolved once per paint.
+ *
+ * PaletteRGBFromAttrib() is a GetPaletteEntries() round-trip into win32k when a
+ * palette handle is set, so calling it per cell would cost thousands of GDI
+ * calls per repaint. Cache the whole table up front instead - it cannot change
+ * while we hold the console lock.
+ */
+typedef struct _GUI_PALETTE_CACHE
+{
+    COLORREF Entries[16];
+} GUI_PALETTE_CACHE, *PGUI_PALETTE_CACHE;
+
+static VOID
+GuiBuildPaletteCache(PCONSRV_CONSOLE Console, PGUI_PALETTE_CACHE Cache)
+{
+    WORD Index;
+
+    for (Index = 0; Index < ARRAYSIZE(Cache->Entries); ++Index)
+        Cache->Entries[Index] = PaletteRGBFromAttrib(Console, Index);
+}
+
+/*
+ * Resolve one cell's colour: an extended 24-bit colour if the VT layer stored
+ * one, otherwise the palette entry the attribute selects.
+ */
+FORCEINLINE COLORREF
+GuiResolveColor(PGUI_PALETTE_CACHE Cache, PTEXTMODE_SCREEN_BUFFER Buffer, ULONG X, ULONG Y, WORD Attribute, BOOLEAN Foreground)
+{
+    COLORREF Color = Foreground ? ConioGetCellFgColor(Buffer, X, Y)
+                                : ConioGetCellBgColor(Buffer, X, Y);
+    if (Color != CLR_INVALID)
+        return Color & 0x00FFFFFF;
+
+    return Cache->Entries[(Foreground ? TextAttribFromAttrib(Attribute) : BkgdAttribFromAttrib(Attribute)) & 0x0F];
+}
+
+/*
+ * As above, but for a row whose base was resolved once by the caller - the paint
+ * loops walk a line at a time, so this keeps the ring-buffer index division out
+ * of the per-cell path. Row may be NULL when the plane is not allocated.
+ */
+FORCEINLINE COLORREF
+GuiResolveColorInRow(PGUI_PALETTE_CACHE Cache, const CELL_RGB *Row, ULONG X, WORD Attribute, BOOLEAN Foreground)
+{
+    COLORREF Color = Row ? (Foreground ? Row[X].Fg : Row[X].Bg) : CLR_INVALID;
+
+    if (Color != CLR_INVALID)
+        return Color & 0x00FFFFFF;
+
+    return Cache->Entries[(Foreground ? TextAttribFromAttrib(Attribute) : BkgdAttribFromAttrib(Attribute)) & 0x0F];
 }
 
 static VOID
@@ -373,6 +426,7 @@ GuiPaintCaret(
 
     ULONG CursorX, CursorY, CursorHeight;
     HBRUSH CursorBrush, OldBrush;
+    COLORREF CursorColor;
     WORD Attribute;
 
     if (Buffer->CursorInfo.bVisible &&
@@ -390,7 +444,14 @@ GuiPaintCaret(
             if (Attribute == DEFAULT_SCREEN_ATTRIB)
                 Attribute = Buffer->ScreenDefaultAttrib;
 
-            CursorBrush = CreateSolidBrush(PaletteRGBFromAttrib(Console, TextAttribFromAttrib(Attribute)));
+            /* One cell only, so resolve it directly rather than build the palette cache */
+            CursorColor = ConioGetCellFgColor(Buffer, CursorX, CursorY);
+            if (CursorColor == CLR_INVALID)
+                CursorColor = PaletteRGBFromAttrib(Console, TextAttribFromAttrib(Attribute));
+            else
+                CursorColor &= 0x00FFFFFF;
+
+            CursorBrush = CreateSolidBrush(CursorColor);
             OldBrush    = SelectObject(GuiData->hMemDC, CursorBrush);
 
             if (Attribute & COMMON_LVB_LEADING_BYTE)
@@ -441,8 +502,10 @@ GuiPaintTextModeBuffer(PTEXTMODE_SCREEN_BUFFER Buffer,
     PCHAR_INFO From;
     PWCHAR To;
     WORD LastAttribute, Attribute;
+    COLORREF LastTextColor, LastBkColor, CellTextColor, CellBkColor;
     HFONT OldFont, NewFont;
     BOOLEAN IsUnderline;
+    GUI_PALETTE_CACHE Palette;
 
     // ASSERT(Console == GuiData->Console);
 
@@ -470,27 +533,33 @@ GuiPaintTextModeBuffer(PTEXTMODE_SCREEN_BUFFER Buffer,
     if (BottomLine >= (ULONG)Buffer->ScreenBufferSize.Y)
         BottomLine  = Buffer->ScreenBufferSize.Y - 1;
 
-    LastAttribute = ConioCoordToPointer(Buffer, LeftColumn, TopLine)->Attributes;
+    GuiBuildPaletteCache(Console, &Palette);
 
-    SetTextColor(GuiData->hMemDC, PaletteRGBFromAttrib(Console, TextAttribFromAttrib(LastAttribute)));
-    SetBkColor(GuiData->hMemDC, PaletteRGBFromAttrib(Console, BkgdAttribFromAttrib(LastAttribute)));
+    LastAttribute = ConioCoordToPointer(Buffer, LeftColumn, TopLine)->Attributes;
+    LastTextColor = GuiResolveColor(&Palette, Buffer, LeftColumn, TopLine, LastAttribute, TRUE);
+    LastBkColor   = GuiResolveColor(&Palette, Buffer, LeftColumn, TopLine, LastAttribute, FALSE);
+
+    SetTextColor(GuiData->hMemDC, LastTextColor);
+    SetBkColor(GuiData->hMemDC, LastBkColor);
 
     /* We use the underscore flag as a underline flag */
     IsUnderline = !!(LastAttribute & COMMON_LVB_UNDERSCORE);
     /* Select the new font */
-    NewFont = GuiData->Font[IsUnderline ? FONT_BOLD : FONT_NORMAL];
+    NewFont = GuiData->Font[IsUnderline ? FONT_UNDERLINE : FONT_NORMAL];
     OldFont = SelectObject(GuiData->hMemDC, NewFont);
 
     if (Console->IsCJK)
     {
         for (Line = TopLine; Line <= BottomLine; Line++)
         {
+            const CELL_RGB *RgbRow = ConioCellRgbRow(Buffer, Line);
+
             for (Char = LeftColumn; Char <= RightColumn; Char++)
             {
                 From = ConioCoordToPointer(Buffer, Char, Line);
                 Attribute = From->Attributes;
-                SetTextColor(GuiData->hMemDC, PaletteRGBFromAttrib(Console, TextAttribFromAttrib(Attribute)));
-                SetBkColor(GuiData->hMemDC, PaletteRGBFromAttrib(Console, BkgdAttribFromAttrib(Attribute)));
+                SetTextColor(GuiData->hMemDC, GuiResolveColorInRow(&Palette, RgbRow, Char, Attribute, TRUE));
+                SetBkColor(GuiData->hMemDC, GuiResolveColorInRow(&Palette, RgbRow, Char, Attribute, FALSE));
 
                 /* Change underline state if needed */
                 if (!!(Attribute & COMMON_LVB_UNDERSCORE) != IsUnderline)
@@ -498,7 +567,7 @@ GuiPaintTextModeBuffer(PTEXTMODE_SCREEN_BUFFER Buffer,
                     IsUnderline = !!(Attribute & COMMON_LVB_UNDERSCORE);
 
                     /* Select the new font */
-                    NewFont = GuiData->Font[IsUnderline ? FONT_BOLD : FONT_NORMAL];
+                    NewFont = GuiData->Font[IsUnderline ? FONT_UNDERLINE : FONT_NORMAL];
                     SelectObject(GuiData->hMemDC, NewFont);
                 }
 
@@ -517,17 +586,35 @@ GuiPaintTextModeBuffer(PTEXTMODE_SCREEN_BUFFER Buffer,
         for (Line = TopLine; Line <= BottomLine; Line++)
         {
             WCHAR LineBuffer[80];   // Buffer containing a part or all the line to be displayed
+            const CELL_RGB *RgbRow = ConioCellRgbRow(Buffer, Line);
             From  = ConioCoordToPointer(Buffer, LeftColumn, Line);  // Get the first code of the line
             Start = LeftColumn;
             To    = LineBuffer;
+            LastAttribute = From->Attributes;
+            LastTextColor = GuiResolveColorInRow(&Palette, RgbRow, LeftColumn, LastAttribute, TRUE);
+            LastBkColor   = GuiResolveColorInRow(&Palette, RgbRow, LeftColumn, LastAttribute, FALSE);
+            SetTextColor(GuiData->hMemDC, LastTextColor);
+            SetBkColor(GuiData->hMemDC, LastBkColor);
+
+            IsUnderline = !!(LastAttribute & COMMON_LVB_UNDERSCORE);
+            NewFont = GuiData->Font[IsUnderline ? FONT_UNDERLINE : FONT_NORMAL];
+            SelectObject(GuiData->hMemDC, NewFont);
 
             for (Char = LeftColumn; Char <= RightColumn; Char++)
             {
+                Attribute = From->Attributes;
+                CellTextColor = GuiResolveColorInRow(&Palette, RgbRow, Char, Attribute, TRUE);
+                CellBkColor = GuiResolveColorInRow(&Palette, RgbRow, Char, Attribute, FALSE);
+
                 /*
                  * We flush the buffer if the new attribute is different
                  * from the current one, or if the buffer is full.
                  */
-                if (From->Attributes != LastAttribute || (Char - Start == sizeof(LineBuffer) / sizeof(WCHAR)))
+                if (((Attribute != LastAttribute) ||
+                     (CellTextColor != LastTextColor) ||
+                     (CellBkColor != LastBkColor) ||
+                     (Char - Start == sizeof(LineBuffer) / sizeof(WCHAR))) &&
+                    Char > Start)
                 {
                     TextOutW(GuiData->hMemDC,
                              Start * GuiData->CharWidth,
@@ -536,19 +623,23 @@ GuiPaintTextModeBuffer(PTEXTMODE_SCREEN_BUFFER Buffer,
                              Char - Start);
                     Start = Char;
                     To    = LineBuffer;
-                    Attribute = From->Attributes;
-                    if (Attribute != LastAttribute)
+
+                    if ((Attribute != LastAttribute) ||
+                        (CellTextColor != LastTextColor) ||
+                        (CellBkColor != LastBkColor))
                     {
                         LastAttribute = Attribute;
-                        SetTextColor(GuiData->hMemDC, PaletteRGBFromAttrib(Console, TextAttribFromAttrib(LastAttribute)));
-                        SetBkColor(GuiData->hMemDC, PaletteRGBFromAttrib(Console, BkgdAttribFromAttrib(LastAttribute)));
+                        LastTextColor = CellTextColor;
+                        LastBkColor = CellBkColor;
+                        SetTextColor(GuiData->hMemDC, LastTextColor);
+                        SetBkColor(GuiData->hMemDC, LastBkColor);
 
                         /* Change underline state if needed */
                         if (!!(LastAttribute & COMMON_LVB_UNDERSCORE) != IsUnderline)
                         {
                             IsUnderline = !!(LastAttribute & COMMON_LVB_UNDERSCORE);
                             /* Select the new font */
-                            NewFont = GuiData->Font[IsUnderline ? FONT_BOLD : FONT_NORMAL];
+                            NewFont = GuiData->Font[IsUnderline ? FONT_UNDERLINE : FONT_NORMAL];
                             SelectObject(GuiData->hMemDC, NewFont);
                         }
                     }

--- a/win32ss/user/winsrv/consrv/frontends/terminal.c
+++ b/win32ss/user/winsrv/consrv/frontends/terminal.c
@@ -9,6 +9,7 @@
 /* INCLUDES *******************************************************************/
 
 #include <consrv.h>
+#include "../include/vt.h"
 #include "concfg/font.h"
 
 // #include "frontends/gui/guiterm.h"
@@ -18,6 +19,7 @@
 
 #define NDEBUG
 #include <debug.h>
+
 
 
 
@@ -477,8 +479,23 @@ ConSrvTermReadStream(IN OUT PTERMINAL This,
 ClearLineBuffer(PTEXTMODE_SCREEN_BUFFER Buff);
 
 static VOID
-ConioNextLine(PTEXTMODE_SCREEN_BUFFER Buff, PSMALL_RECT UpdateRect, PUINT ScrolledLines)
+ConioNextLine(PCONSRV_CONSOLE Console,
+              PTEXTMODE_SCREEN_BUFFER Buff,
+              PSMALL_RECT UpdateRect,
+              PUINT ScrolledLines)
 {
+    Buff->VtState.PrivateModes &= ~VT_PRIVMODE_DELAYED_EOL_WRAP;
+
+    if (ConioIsVtActive(Buff))
+    {
+        ConDrvVtAdvanceLine((PCONSOLE)Console, Buff);
+        UpdateRect->Left = 0;
+        UpdateRect->Right = Buff->ScreenBufferSize.X - 1;
+        UpdateRect->Top = min(UpdateRect->Top, Buff->CursorPosition.Y);
+        UpdateRect->Bottom = max(UpdateRect->Bottom, Buff->CursorPosition.Y);
+        return;
+    }
+
     /* If we hit bottom, slide the viewable screen */
     if (++Buff->CursorPosition.Y == Buff->ScreenBufferSize.Y)
     {
@@ -499,6 +516,41 @@ ConioNextLine(PTEXTMODE_SCREEN_BUFFER Buff, PSMALL_RECT UpdateRect, PUINT Scroll
     UpdateRect->Bottom = Buff->CursorPosition.Y;
 }
 
+/*
+ * The cursor has run past the last column: decide what that means.
+ *
+ * With DISABLE_NEWLINE_AUTO_RETURN the wrap is deferred - the cursor stays on
+ * the last column and the line only advances when the next printable character
+ * arrives (VT "delayed EOL wrap"). Without wrapping at all, the cursor snaps
+ * back to where this write started.
+ */
+static VOID
+ConioWrapAtEol(PCONSRV_CONSOLE Console,
+               PTEXTMODE_SCREEN_BUFFER Buff,
+               PSMALL_RECT UpdateRect,
+               PUINT ScrolledLines,
+               PSHORT CursorStartX)
+{
+    if (!(Buff->Mode & ENABLE_WRAP_AT_EOL_OUTPUT))
+    {
+        /* The cursor wraps back to its starting position on the same line */
+        Buff->CursorPosition.X = *CursorStartX;
+        return;
+    }
+
+    if (Buff->Mode & DISABLE_NEWLINE_AUTO_RETURN)
+    {
+        Buff->CursorPosition.X = Buff->ScreenBufferSize.X - 1;
+        Buff->VtState.PrivateModes |= VT_PRIVMODE_DELAYED_EOL_WRAP;
+        return;
+    }
+
+    /* Wrapping mode: Go to next line */
+    Buff->CursorPosition.X = 0;
+    *CursorStartX = Buff->CursorPosition.X;
+    ConioNextLine(Console, Buff, UpdateRect, ScrolledLines);
+}
+
 static NTSTATUS
 ConioWriteConsole(PFRONTEND FrontEnd,
                   PTEXTMODE_SCREEN_BUFFER Buff,
@@ -513,12 +565,27 @@ ConioWriteConsole(PFRONTEND FrontEnd,
     SMALL_RECT UpdateRect;
     SHORT CursorStartX, CursorStartY;
     UINT ScrolledLines;
+    int CellWidth;
     BOOLEAN bFullwidth;
     BOOLEAN bCJK = Console->IsCJK;
+    BOOLEAN bVtActive = ConioIsVtActive(Buff);
+    COLORREF FgColorValue;
+    COLORREF BgColorValue;
 
     /* If nothing to write, bail out now */
     if (Length == 0)
         return STATUS_SUCCESS;
+
+    /*
+     * The current VT colour cannot change while we consume this buffer: the VT
+     * parser applies SGR between calls to us, never during one. Resolve it once.
+     */
+    FgColorValue = (bVtActive && Buff->VtState.UseRgbForeground) ? Buff->VtState.CurrentFgColor : CLR_INVALID;
+    BgColorValue = (bVtActive && Buff->VtState.UseRgbBackground) ? Buff->VtState.CurrentBgColor : CLR_INVALID;
+
+    /* Extended colours are only ever stored while VT is driving the buffer */
+    if (FgColorValue != CLR_INVALID || BgColorValue != CLR_INVALID)
+        ConioEnsureCellColors(Buff);
 
     CursorStartX = Buff->CursorPosition.X;
     CursorStartY = Buff->CursorPosition.Y;
@@ -530,6 +597,22 @@ ConioWriteConsole(PFRONTEND FrontEnd,
 
     for (i = 0; i < Length; i++)
     {
+        if (Buff->VtState.PrivateModes & VT_PRIVMODE_DELAYED_EOL_WRAP)
+        {
+            if (!(Buff->Mode & ENABLE_PROCESSED_OUTPUT) ||
+                (Buffer[i] != L'\r' && Buffer[i] != L'\n' &&
+                 Buffer[i] != L'\b' && Buffer[i] != L'\a'))
+            {
+                Buff->CursorPosition.X = 0;
+                CursorStartX = Buff->CursorPosition.X;
+                ConioNextLine(Console, Buff, &UpdateRect, &ScrolledLines);
+            }
+            else if (Buffer[i] != L'\a')
+            {
+                Buff->VtState.PrivateModes &= ~VT_PRIVMODE_DELAYED_EOL_WRAP;
+            }
+        }
+
         /*
          * If we are in processed mode, interpret special characters and
          * display them correctly. Otherwise, just put them into the buffer.
@@ -548,9 +631,17 @@ ConioWriteConsole(PFRONTEND FrontEnd,
             /* --- LF --- */
             else if (Buffer[i] == L'\n')
             {
-                Buff->CursorPosition.X = 0; // TODO: Make this behaviour optional!
-                CursorStartX = Buff->CursorPosition.X;
-                ConioNextLine(Buff, &UpdateRect, &ScrolledLines);
+                Buff->VtState.PrivateModes &= ~VT_PRIVMODE_DELAYED_EOL_WRAP;
+                if (Buff->Mode & DISABLE_NEWLINE_AUTO_RETURN)
+                {
+                    CursorStartX = Buff->CursorPosition.X;
+                }
+                else
+                {
+                    Buff->CursorPosition.X = 0;
+                    CursorStartX = Buff->CursorPosition.X;
+                }
+                ConioNextLine(Console, Buff, &UpdateRect, &ScrolledLines);
                 continue;
             }
             /* --- BS --- */
@@ -612,6 +703,7 @@ ConioWriteConsole(PFRONTEND FrontEnd,
                     if (Attrib)
                         Ptr->Attributes = Buff->ScreenDefaultAttrib;
                     Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
+                    ConioSetCellColors(Buff, Buff->CursorPosition.X, Buff->CursorPosition.Y, CLR_INVALID, CLR_INVALID);
 
                     if (Buff->CursorPosition.X > 0)
                         Buff->CursorPosition.X--;
@@ -623,6 +715,7 @@ ConioWriteConsole(PFRONTEND FrontEnd,
                 if (Attrib)
                     Ptr->Attributes = Buff->ScreenDefaultAttrib;
                 Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
+                ConioSetCellColors(Buff, Buff->CursorPosition.X, Buff->CursorPosition.Y, CLR_INVALID, CLR_INVALID);
 
                 UpdateRect.Left  = min(min(UpdateRect.Left , Buff->CursorPosition.X), OldX);
                 UpdateRect.Right = max(max(UpdateRect.Right, Buff->CursorPosition.X), OldX);
@@ -657,6 +750,7 @@ ConioWriteConsole(PFRONTEND FrontEnd,
                     if (Attrib)
                         Ptr->Attributes = Buff->ScreenDefaultAttrib;
                     Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
+                    ConioSetCellColors(Buff, Buff->CursorPosition.X, Buff->CursorPosition.Y, CLR_INVALID, CLR_INVALID);
 
                     ++Ptr;
                     Buff->CursorPosition.X++;
@@ -670,24 +764,14 @@ ConioWriteConsole(PFRONTEND FrontEnd,
                         if (Attrib)
                             Ptr->Attributes = Buff->ScreenDefaultAttrib;
                         Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
+                        ConioSetCellColors(Buff, Buff->CursorPosition.X, Buff->CursorPosition.Y, CLR_INVALID, CLR_INVALID);
                     }
                 }
                 UpdateRect.Right = max(UpdateRect.Right, Buff->CursorPosition.X);
 
                 if (Buff->CursorPosition.X >= Buff->ScreenBufferSize.X)
                 {
-                    if (Buff->Mode & ENABLE_WRAP_AT_EOL_OUTPUT)
-                    {
-                        /* Wrapping mode: Go to next line */
-                        Buff->CursorPosition.X = 0;
-                        CursorStartX = Buff->CursorPosition.X;
-                        ConioNextLine(Buff, &UpdateRect, &ScrolledLines);
-                    }
-                    else
-                    {
-                        /* The cursor wraps back to its starting position on the same line */
-                        Buff->CursorPosition.X = CursorStartX;
-                    }
+                    ConioWrapAtEol(Console, Buff, &UpdateRect, &ScrolledLines, &CursorStartX);
                 }
                 continue;
             }
@@ -698,11 +782,38 @@ ConioWriteConsole(PFRONTEND FrontEnd,
                 continue;
             }
         }
+        /*
+         * Determine the display width. Everything below U+0080 occupies exactly
+         * one cell, so skip the (non-inlined, bisecting) helper for the case
+         * that dominates console output - this is what IS_FULL_WIDTH does too.
+         */
+        if ((USHORT)Buffer[i] < 0x0080)
+        {
+            CellWidth = 1;
+        }
+        else
+        {
+            CellWidth = mk_wcwidth_cjk(Buffer[i]);
+            if (CellWidth < 0)
+                CellWidth = 1;
+
+            /*
+             * Zero-width (combining) characters have no cell of their own.
+             * Dropping them is a terminal-emulation decision, so only do it
+             * while VT is driving this buffer; a plain WriteConsole keeps its
+             * old contract of storing whatever the client wrote.
+             */
+            if (CellWidth == 0)
+            {
+                if (bVtActive) continue;
+                CellWidth = 1;
+            }
+        }
+
         UpdateRect.Left  = min(UpdateRect.Left , Buff->CursorPosition.X);
         UpdateRect.Right = max(UpdateRect.Right, Buff->CursorPosition.X);
 
-        /* For Chinese, Japanese and Korean */
-        bFullwidth = (bCJK && IS_FULL_WIDTH(Buffer[i]));
+        bFullwidth = (bCJK && CellWidth == 2);
 
         /* Check whether we can insert the full-width character */
         if (bFullwidth)
@@ -710,12 +821,18 @@ ConioWriteConsole(PFRONTEND FrontEnd,
             /* It spans two cells and should all fit on the current line */
             if (Buff->CursorPosition.X >= Buff->ScreenBufferSize.X - 1)
             {
+                /*
+                 * Deliberately not ConioWrapAtEol(): a delayed wrap would leave
+                 * the cursor on the last column, where a two-cell character
+                 * still does not fit, and the check below would drop it. A
+                 * full-width character at the right edge must wrap immediately.
+                 */
                 if (Buff->Mode & ENABLE_WRAP_AT_EOL_OUTPUT)
                 {
                     /* Wrapping mode: Go to next line */
                     Buff->CursorPosition.X = 0;
                     CursorStartX = Buff->CursorPosition.X;
-                    ConioNextLine(Buff, &UpdateRect, &ScrolledLines);
+                    ConioNextLine(Console, Buff, &UpdateRect, &ScrolledLines);
                 }
                 else
                 {
@@ -756,6 +873,7 @@ ConioWriteConsole(PFRONTEND FrontEnd,
                 if (Attrib)
                     Ptr->Attributes = Buff->ScreenDefaultAttrib;
                 Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
+                ConioSetCellColors(Buff, Buff->CursorPosition.X - 1, Buff->CursorPosition.Y, CLR_INVALID, CLR_INVALID);
             }
             Ptr = ConioCoordToPointer(Buff, Buff->CursorPosition.X, Buff->CursorPosition.Y);
         }
@@ -771,6 +889,7 @@ ConioWriteConsole(PFRONTEND FrontEnd,
                 Ptr->Attributes = Buff->ScreenDefaultAttrib;
             Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
             Ptr->Attributes |= COMMON_LVB_LEADING_BYTE;
+            ConioSetCellColors(Buff, Buff->CursorPosition.X, Buff->CursorPosition.Y, FgColorValue, BgColorValue);
 
             /* Set the trailing byte */
             Buff->CursorPosition.X++;
@@ -780,6 +899,7 @@ ConioWriteConsole(PFRONTEND FrontEnd,
                 Ptr->Attributes = Buff->ScreenDefaultAttrib;
             Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
             Ptr->Attributes |= COMMON_LVB_TRAILING_BYTE;
+            ConioSetCellColors(Buff, Buff->CursorPosition.X, Buff->CursorPosition.Y, FgColorValue, BgColorValue);
 
             UpdateRect.Right++;
         }
@@ -789,6 +909,7 @@ ConioWriteConsole(PFRONTEND FrontEnd,
             if (Attrib)
                 Ptr->Attributes = Buff->ScreenDefaultAttrib;
             Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
+            ConioSetCellColors(Buff, Buff->CursorPosition.X, Buff->CursorPosition.Y, FgColorValue, BgColorValue);
         }
 
         ++Ptr;
@@ -803,23 +924,13 @@ ConioWriteConsole(PFRONTEND FrontEnd,
                 if (Attrib)
                     Ptr->Attributes = Buff->ScreenDefaultAttrib;
                 Ptr->Attributes &= ~COMMON_LVB_SBCSDBCS;
+                ConioSetCellColors(Buff, Buff->CursorPosition.X, Buff->CursorPosition.Y, CLR_INVALID, CLR_INVALID);
             }
         }
 
         if (Buff->CursorPosition.X >= Buff->ScreenBufferSize.X)
         {
-            if (Buff->Mode & ENABLE_WRAP_AT_EOL_OUTPUT)
-            {
-                /* Wrapping mode: Go to next line */
-                Buff->CursorPosition.X = 0;
-                CursorStartX = Buff->CursorPosition.X;
-                ConioNextLine(Buff, &UpdateRect, &ScrolledLines);
-            }
-            else
-            {
-                /* The cursor wraps back to its starting position on the same line */
-                Buff->CursorPosition.X = CursorStartX;
-            }
+            ConioWrapAtEol(Console, Buff, &UpdateRect, &ScrolledLines, &CursorStartX);
         }
     }
 
@@ -959,6 +1070,158 @@ ConSrvTermShowMouseCursor(IN OUT PTERMINAL This,
     return FrontEnd->Vtbl->ShowMouseCursor(FrontEnd, Show);
 }
 
+/*
+ * Console-level state the driver needs but does not own.
+ *
+ * The VT engine lives in condrv/ and only has a PCONSOLE, yet DECSET/OSC
+ * sequences legitimately change the window title, the palette and the
+ * clipboard - all of which belong to CONSRV_CONSOLE or to a frontend. These
+ * entries give it a PCONSOLE-typed way in, so condrv/ never casts to
+ * PCONSRV_CONSOLE nor calls USER32 itself.
+ */
+
+static BOOL NTAPI
+ConSrvTermSetTitle(IN OUT PTERMINAL This,
+                   IN PCWSTR Title,
+                   IN ULONG Length)
+{
+    PFRONTEND FrontEnd = This->Context;
+    PCONSRV_CONSOLE Console = FrontEnd->Console;
+    PWCHAR Buffer;
+
+    if (!Title) return FALSE;
+
+    /* Allocate first, so a failure leaves the existing title untouched */
+    Buffer = ConsoleAllocHeap(HEAP_ZERO_MEMORY, Length + sizeof(WCHAR));
+    if (!Buffer) return FALSE;
+
+    RtlCopyMemory(Buffer, Title, Length);
+    Buffer[Length / sizeof(WCHAR)] = UNICODE_NULL;
+
+    /* Same ownership rules as SrvSetConsoleTitle */
+    ConsoleFreeUnicodeString(&Console->Title);
+    Console->Title.Buffer = Buffer;
+    Console->Title.Length = Length;
+    Console->Title.MaximumLength = Length + sizeof(WCHAR);
+
+    TermChangeTitle(Console);
+    return TRUE;
+}
+
+static BOOL NTAPI
+ConSrvTermGetColorTable(IN OUT PTERMINAL This,
+                        OUT COLORREF* Colors,
+                        IN ULONG Count)
+{
+    PFRONTEND FrontEnd = This->Context;
+    PCONSRV_CONSOLE Console = FrontEnd->Console;
+
+    if (!Colors || Count == 0 || Count > ARRAYSIZE(Console->Colors))
+        return FALSE;
+
+    RtlCopyMemory(Colors, Console->Colors, Count * sizeof(COLORREF));
+    return TRUE;
+}
+
+static BOOL NTAPI
+ConSrvTermSetColorTable(IN OUT PTERMINAL This,
+                        IN const COLORREF* Colors,
+                        IN ULONG Count)
+{
+    PFRONTEND FrontEnd = This->Context;
+    PCONSRV_CONSOLE Console = FrontEnd->Console;
+
+    if (!Colors || Count == 0 || Count > ARRAYSIZE(Console->Colors))
+        return FALSE;
+
+    RtlCopyMemory(Console->Colors, Colors, Count * sizeof(COLORREF));
+    return TRUE;
+}
+
+static BOOL NTAPI
+ConSrvTermGetClipboardText(IN OUT PTERMINAL This,
+                           OUT PWCHAR* Text,
+                           OUT PULONG Length)
+{
+    PFRONTEND FrontEnd = This->Context;
+    PCONSRV_CONSOLE Console = FrontEnd->Console;
+    HANDLE hData;
+    PCWSTR ClipText;
+    SIZE_T Chars;
+    PWCHAR Copy = NULL;
+
+    *Text = NULL;
+    *Length = 0;
+
+    /*
+     * Use the console window as the clipboard owner: the CSR API thread has no
+     * window of its own and no guaranteed window-station association.
+     */
+    if (!OpenClipboard(TermGetConsoleWindowHandle(Console)))
+        return FALSE;
+
+    hData = GetClipboardData(CF_UNICODETEXT);
+    if (hData)
+    {
+        ClipText = GlobalLock(hData);
+        if (ClipText)
+        {
+            Chars = wcslen(ClipText);
+            Copy = ConsoleAllocHeap(0, (Chars + 1) * sizeof(WCHAR));
+            if (Copy)
+            {
+                RtlCopyMemory(Copy, ClipText, Chars * sizeof(WCHAR));
+                Copy[Chars] = UNICODE_NULL;
+                *Text = Copy;
+                *Length = (ULONG)Chars;
+            }
+            GlobalUnlock(hData);
+        }
+    }
+
+    CloseClipboard();
+    return (Copy != NULL);
+}
+
+static BOOL NTAPI
+ConSrvTermSetClipboardText(IN OUT PTERMINAL This,
+                           IN PCWSTR Text,
+                           IN ULONG Length)
+{
+    PFRONTEND FrontEnd = This->Context;
+    PCONSRV_CONSOLE Console = FrontEnd->Console;
+    HANDLE hData;
+    PWCHAR Dest;
+    BOOL Success = FALSE;
+
+    if (!Text) return FALSE;
+
+    if (!OpenClipboard(TermGetConsoleWindowHandle(Console)))
+        return FALSE;
+
+    hData = GlobalAlloc(GMEM_MOVEABLE, (Length + 1) * sizeof(WCHAR));
+    if (hData)
+    {
+        Dest = GlobalLock(hData);
+        if (Dest)
+        {
+            RtlCopyMemory(Dest, Text, Length * sizeof(WCHAR));
+            Dest[Length] = UNICODE_NULL;
+            GlobalUnlock(hData);
+
+            EmptyClipboard();
+            if (SetClipboardData(CF_UNICODETEXT, hData))
+                Success = TRUE;
+        }
+
+        /* The clipboard owns hData once SetClipboardData succeeds */
+        if (!Success) GlobalFree(hData);
+    }
+
+    CloseClipboard();
+    return Success;
+}
+
 static TERMINAL_VTBL ConSrvTermVtbl =
 {
     ConSrvTermInitTerminal,
@@ -977,6 +1240,11 @@ static TERMINAL_VTBL ConSrvTermVtbl =
     ConSrvTermSetPalette,
     ConSrvTermSetCodePage,
     ConSrvTermShowMouseCursor,
+    ConSrvTermSetTitle,
+    ConSrvTermGetColorTable,
+    ConSrvTermSetColorTable,
+    ConSrvTermGetClipboardText,
+    ConSrvTermSetClipboardText,
 };
 
 #if 0

--- a/win32ss/user/winsrv/consrv/frontends/terminal.c
+++ b/win32ss/user/winsrv/consrv/frontends/terminal.c
@@ -741,7 +741,14 @@ ConioWriteConsole(PFRONTEND FrontEnd,
 
                 UpdateRect.Left = min(UpdateRect.Left, Buff->CursorPosition.X);
 
-                EndX = (Buff->CursorPosition.X + TAB_WIDTH) & ~(TAB_WIDTH - 1);
+                /*
+                  * With VT active the stop positions are whatever HTS/TBC left in
+                  * the tab-stop table; otherwise keep the fixed 8-column grid.
+                  */
+                if (ConioIsVtActive(Buff))
+                    EndX = (UINT)VtFindNextTabStop(Buff, Buff->CursorPosition.X);
+                else
+                    EndX = (Buff->CursorPosition.X + TAB_WIDTH) & ~(TAB_WIDTH - 1);
                 EndX = min(EndX, (UINT)Buff->ScreenBufferSize.X);
 
                 while ((UINT)Buff->CursorPosition.X < EndX)

--- a/win32ss/user/winsrv/consrv/include/conio.h
+++ b/win32ss/user/winsrv/consrv/include/conio.h
@@ -120,6 +120,9 @@ typedef struct _CONSOLE_SCREEN_BUFFER
  * CLR_INVALID in either field means "no extended colour, fall back to the
  * cell's attribute".
  */
+/* Number of entries in the console colour table */
+#define CONSOLE_COLOR_TABLE_SIZE 16
+
 typedef struct _CELL_RGB
 {
     COLORREF Fg;
@@ -151,15 +154,25 @@ typedef struct _TEXTMODE_SCREEN_BUFFER
     {
         BOOLEAN CursorSaved;        /* Whether a cursor position was saved */
         COORD   SavedCursorPos;     /* Last saved cursor position */
-        USHORT  SavedAttributes;    /* Saved SGR attributes */
+        USHORT  SavedAttributes;    /* SGR attributes parked by DECSC (ESC 7 / CSI s) */
         USHORT  CurrentAttributes;  /* Current SGR attributes */
         ULONG   PrivateModes;       /* Bitmask of active DEC private modes */
-        struct _TEXTMODE_SCREEN_BUFFER* AlternateBuffer; /* Alternate screen buffer */
-        struct _TEXTMODE_SCREEN_BUFFER* PrimaryBuffer;   /* Primary buffer when alternate active */
-        CONSOLE_CURSOR_INFO PrimaryCursorInfo;   /* Saved cursor info for primary buffer */
-        COORD   PrimaryCursorPos;                /* Saved cursor position for primary buffer */
-        COORD   PrimaryViewOrigin;               /* Saved viewport origin */
-        USHORT  PrimaryVirtualY;                 /* Saved scrollback origin */
+        /*
+         * Alternate screen (DECSET 1047/1049). The alternate screen is a
+         * content swap inside this same screen-buffer object rather than a
+         * second object: the primary's cells are parked here and restored on
+         * the way out, so the console's active buffer - and every handle to it -
+         * stays valid across the switch.
+         */
+        BOOLEAN AlternateActive;                 /* TRUE while the alternate screen is shown */
+        PCHAR_INFO SavedBuffer;                  /* Primary cells, parked */
+        struct _CELL_RGB* SavedCellRgb;          /* Primary extended colours, parked */
+        USHORT  SavedVirtualY;                   /* Saved scrollback origin */
+        COORD   SavedScreenCursorPos;            /* Saved cursor position */
+        CONSOLE_CURSOR_INFO SavedScreenCursorInfo; /* Saved cursor info */
+        COORD   SavedViewOrigin;                 /* Saved viewport origin */
+        SHORT   SavedScrollTop;                  /* Saved top margin */
+        SHORT   SavedScrollBottom;               /* Saved bottom margin */
         CONSOLE_CURSOR_INFO DefaultCursorInfo;   /* Default cursor info for DECSCUSR reset */
         BOOLEAN UseRgbForeground;                /* TRUE when foreground colour uses 24-bit RGB */
         BOOLEAN UseRgbBackground;                /* TRUE when background colour uses 24-bit RGB */
@@ -183,6 +196,8 @@ typedef struct _TEXTMODE_SCREEN_BUFFER
         ULONG   MouseButtonState;                /* Tracks currently pressed mouse buttons */
         PUCHAR  TabStops;                        /* Dynamic tab-stop bitmap (one byte per column) */
         USHORT  TabStopLength;                   /* Number of columns represented in TabStops */
+        SMALL_RECT DirtyRect;                    /* Region invalidated so far by this write */
+        BOOLEAN DirtyValid;                      /* TRUE when DirtyRect holds anything */
         WCHAR   PendingSequence[VT_PENDING_SEQUENCE_MAX]; /* Unterminated VT sequence kept across writes */
         USHORT  PendingSequenceLength;           /* Number of valid WCHARs in PendingSequence */
     } VtState;

--- a/win32ss/user/winsrv/consrv/include/conio.h
+++ b/win32ss/user/winsrv/consrv/include/conio.h
@@ -3,7 +3,7 @@
  * PROJECT:         ReactOS Console Server DLL
  * FILE:            win32ss/user/winsrv/consrv/include/conio.h
  * PURPOSE:         Public Console I/O Interface
- * PROGRAMMERS:     Gé van Geldorp
+ * PROGRAMMERS:     Gï¿½ van Geldorp
  *                  Jeffrey Morlan
  *                  Hermes Belusca-Maito (hermes.belusca@sfr.fr)
  */
@@ -111,6 +111,21 @@ typedef struct _CONSOLE_SCREEN_BUFFER
  * internally, I just wrap back to the top of the buffer.               *
  ************************************************************************/
 
+/*
+ * Extended (24-bit) per-cell colour. One array of pairs rather than two parallel
+ * planes: a cell's two colours are always read, written, filled and moved
+ * together, so keeping them adjacent makes every such operation a single
+ * statement and a single allocation.
+ *
+ * CLR_INVALID in either field means "no extended colour, fall back to the
+ * cell's attribute".
+ */
+typedef struct _CELL_RGB
+{
+    COLORREF Fg;
+    COLORREF Bg;
+} CELL_RGB, *PCELL_RGB;
+
 typedef struct _TEXTMODE_BUFFER_INFO
 {
     COORD   ScreenBufferSize;
@@ -130,7 +145,163 @@ typedef struct _TEXTMODE_SCREEN_BUFFER
 
     USHORT ScreenDefaultAttrib; /* Default screen char attribute */
     USHORT PopupDefaultAttrib;  /* Default popup char attribute */
+    PCELL_RGB CellRgb;          /* Extended per-cell colours, NULL until VT needs them */
+#define VT_PENDING_SEQUENCE_MAX 256
+    struct _VT_MODE_STATE
+    {
+        BOOLEAN CursorSaved;        /* Whether a cursor position was saved */
+        COORD   SavedCursorPos;     /* Last saved cursor position */
+        USHORT  SavedAttributes;    /* Saved SGR attributes */
+        USHORT  CurrentAttributes;  /* Current SGR attributes */
+        ULONG   PrivateModes;       /* Bitmask of active DEC private modes */
+        struct _TEXTMODE_SCREEN_BUFFER* AlternateBuffer; /* Alternate screen buffer */
+        struct _TEXTMODE_SCREEN_BUFFER* PrimaryBuffer;   /* Primary buffer when alternate active */
+        CONSOLE_CURSOR_INFO PrimaryCursorInfo;   /* Saved cursor info for primary buffer */
+        COORD   PrimaryCursorPos;                /* Saved cursor position for primary buffer */
+        COORD   PrimaryViewOrigin;               /* Saved viewport origin */
+        USHORT  PrimaryVirtualY;                 /* Saved scrollback origin */
+        CONSOLE_CURSOR_INFO DefaultCursorInfo;   /* Default cursor info for DECSCUSR reset */
+        BOOLEAN UseRgbForeground;                /* TRUE when foreground colour uses 24-bit RGB */
+        BOOLEAN UseRgbBackground;                /* TRUE when background colour uses 24-bit RGB */
+        COLORREF CurrentFgColor;                 /* Current 24-bit foreground colour */
+        COLORREF CurrentBgColor;                 /* Current 24-bit background colour */
+        COLORREF SavedFgColor;                   /* Saved foreground colour for DECSC */
+        COLORREF SavedBgColor;                   /* Saved background colour for DECSC */
+        BOOLEAN SavedUseRgbForeground;           /* Saved RGB flag for foreground */
+        BOOLEAN SavedUseRgbBackground;           /* Saved RGB flag for background */
+        SHORT   ScrollTop;                       /* Top margin for scrolling (0-based) */
+        SHORT   ScrollBottom;                    /* Bottom margin for scrolling (0-based inclusive) */
+        BOOLEAN HyperlinkActive;                 /* TRUE when OSC 8 hyperlink is active */
+        UNICODE_STRING HyperlinkUri;             /* Current hyperlink target */
+        UCHAR   Charsets[4];                     /* Character sets designated into G0..G3 */
+        UCHAR   ActiveCharset;                   /* Active GL charset slot (0-3) */
+        UCHAR   PendingSingleShift;              /* Pending single-shift slot override (SS2/SS3) */
+        UCHAR   SavedCharsets[4];                /* G0..G3 saved by DECSC */
+        UCHAR   SavedActiveCharset;              /* Saved active charset selector for DECSC */
+        WCHAR   LastWrittenChar;                 /* Last printable glyph emitted for REP */
+        BOOLEAN LastCharValid;                   /* Tracks whether LastWrittenChar is valid */
+        ULONG   MouseButtonState;                /* Tracks currently pressed mouse buttons */
+        PUCHAR  TabStops;                        /* Dynamic tab-stop bitmap (one byte per column) */
+        USHORT  TabStopLength;                   /* Number of columns represented in TabStops */
+        WCHAR   PendingSequence[VT_PENDING_SEQUENCE_MAX]; /* Unterminated VT sequence kept across writes */
+        USHORT  PendingSequenceLength;           /* Number of valid WCHARs in PendingSequence */
+    } VtState;
 } TEXTMODE_SCREEN_BUFFER, *PTEXTMODE_SCREEN_BUFFER;
+
+/*
+ * Cell addressing and the extended per-cell colours.
+ *
+ * CellRgb is an optional side array indexed exactly like Buffer: it stays NULL
+ * until a VT sequence actually asks for a 24-bit colour (see
+ * ConioEnsureCellColors), so a console that never enables VT pays nothing for
+ * it. Because it is a separate allocation, every operation that moves, fills or
+ * copies cells must carry it along - always go through the helpers below rather
+ * than touching the array directly, so there is one place per kind of operation
+ * instead of one per call site.
+ *
+ * A run of cells inside a single row is contiguous in both arrays, so row-span
+ * helpers can use RtlMoveMemory/RtlFillMemory.
+ */
+
+FORCEINLINE ULONG
+ConioCoordToIndex(PTEXTMODE_SCREEN_BUFFER Buff, ULONG X, ULONG Y)
+{
+    ASSERT(X < (ULONG)Buff->ScreenBufferSize.X);
+    ASSERT(Y < (ULONG)Buff->ScreenBufferSize.Y);
+    return ((Y + Buff->VirtualY) % Buff->ScreenBufferSize.Y) * Buff->ScreenBufferSize.X + X;
+}
+
+/* TRUE when the VT parser owns this buffer's output. Derived from the mode bit
+ * so there is exactly one representation of "is VT on". */
+FORCEINLINE BOOLEAN
+ConioIsVtActive(PTEXTMODE_SCREEN_BUFFER Buff)
+{
+    return !!(Buff->Mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+}
+
+/* Base of row Y in the colour array, or NULL when it is not allocated */
+FORCEINLINE PCELL_RGB
+ConioCellRgbRow(PTEXTMODE_SCREEN_BUFFER Buff, ULONG Y)
+{
+    if (!Buff->CellRgb) return NULL;
+    return Buff->CellRgb + ConioCoordToIndex(Buff, 0, Y);
+}
+
+FORCEINLINE COLORREF
+ConioGetCellFgColor(PTEXTMODE_SCREEN_BUFFER Buff, ULONG X, ULONG Y)
+{
+    if (!Buff->CellRgb) return CLR_INVALID;
+    return Buff->CellRgb[ConioCoordToIndex(Buff, X, Y)].Fg;
+}
+
+FORCEINLINE COLORREF
+ConioGetCellBgColor(PTEXTMODE_SCREEN_BUFFER Buff, ULONG X, ULONG Y)
+{
+    if (!Buff->CellRgb) return CLR_INVALID;
+    return Buff->CellRgb[ConioCoordToIndex(Buff, X, Y)].Bg;
+}
+
+FORCEINLINE VOID
+ConioSetCellColors(PTEXTMODE_SCREEN_BUFFER Buff, ULONG X, ULONG Y, COLORREF Fg, COLORREF Bg)
+{
+    PCELL_RGB Cell;
+
+    if (!Buff->CellRgb) return;
+
+    Cell = &Buff->CellRgb[ConioCoordToIndex(Buff, X, Y)];
+    Cell->Fg = Fg;
+    Cell->Bg = Bg;
+}
+
+/* Set Count cells' colours starting at (X,Y); the run must stay inside row Y */
+FORCEINLINE VOID
+ConioFillCellColors(PTEXTMODE_SCREEN_BUFFER Buff, ULONG X, ULONG Y, ULONG Count, COLORREF Fg, COLORREF Bg)
+{
+    PCELL_RGB Row;
+    ULONG i;
+
+    if (Count == 0) return;
+
+    Row = ConioCellRgbRow(Buff, Y);
+    if (!Row) return;
+    Row += X;
+
+    /* CLR_INVALID is all-ones, so clearing a run is one memset */
+    if (Fg == CLR_INVALID && Bg == CLR_INVALID)
+    {
+        RtlFillMemory(Row, Count * sizeof(CELL_RGB), 0xFF);
+        return;
+    }
+
+    for (i = 0; i < Count; ++i)
+    {
+        Row[i].Fg = Fg;
+        Row[i].Bg = Bg;
+    }
+}
+
+/* Move Count cells' colours between already-computed array indices */
+FORCEINLINE VOID
+ConioMoveCellColorsByIndex(PTEXTMODE_SCREEN_BUFFER Buff, ULONG DstIndex, ULONG SrcIndex, ULONG Count)
+{
+    if (Count == 0 || !Buff->CellRgb) return;
+    RtlMoveMemory(Buff->CellRgb + DstIndex, Buff->CellRgb + SrcIndex, Count * sizeof(CELL_RGB));
+}
+
+/* Move Count cells' colours within or between rows; runs must stay inside their row */
+FORCEINLINE VOID
+ConioMoveCellColors(PTEXTMODE_SCREEN_BUFFER Buff, ULONG DstX, ULONG DstY, ULONG SrcX, ULONG SrcY, ULONG Count)
+{
+    if (Count == 0 || !Buff->CellRgb) return;
+    ConioMoveCellColorsByIndex(Buff, ConioCoordToIndex(Buff, DstX, DstY), ConioCoordToIndex(Buff, SrcX, SrcY), Count);
+}
+
+/*
+ * Allocate the colour array on first use. Returns FALSE (leaving it NULL, i.e.
+ * attribute-only rendering) if the allocation fails - callers treat extended
+ * colour as best-effort and must not fail the write because of it.
+ */
+BOOLEAN ConioEnsureCellColors(PTEXTMODE_SCREEN_BUFFER Buff);
 
 
 /*
@@ -255,6 +426,18 @@ typedef struct _TERMINAL_VTBL
     INT  (NTAPI *ShowMouseCursor)(IN OUT PTERMINAL This,
                                   BOOL Show);
 
+    /*
+     * Console-level state the driver may need but does not own. These take only
+     * PCONSOLE-level types so that condrv/ never has to reach up into
+     * CONSRV_CONSOLE or into a frontend.
+     */
+    BOOL (NTAPI *SetTitle)(IN OUT PTERMINAL This, IN PCWSTR Title, IN ULONG Length);
+    BOOL (NTAPI *GetColorTable)(IN OUT PTERMINAL This, OUT COLORREF* Colors, IN ULONG Count);
+    BOOL (NTAPI *SetColorTable)(IN OUT PTERMINAL This, IN const COLORREF* Colors, IN ULONG Count);
+    /* On success *Text is a NUL-terminated buffer the caller frees with ConsoleFreeHeap() */
+    BOOL (NTAPI *GetClipboardText)(IN OUT PTERMINAL This, OUT PWCHAR* Text, OUT PULONG Length);
+    BOOL (NTAPI *SetClipboardText)(IN OUT PTERMINAL This, IN PCWSTR Text, IN ULONG Length);
+
 #if 0 // Possible future terminal interface
     BOOL (NTAPI *GetTerminalProperty)(IN OUT PTERMINAL This,
                                       ULONG Flag,
@@ -309,6 +492,9 @@ typedef struct _CONSOLE
     COORD   ConsoleSize;                    /* The current size of the console, for text-mode only */
     BOOLEAN FixedSize;                      /* TRUE if the console is of fixed size */
     BOOLEAN IsCJK;                          /* TRUE if Chinese, Japanese or Korean (CJK) */
+    BOOLEAN AllowVtOscClipboard;            /* TRUE when OSC 52 clipboard access is permitted */
+    BOOLEAN AllowVtOscHyperlinks;           /* TRUE when OSC 8 hyperlinks are permitted */
+    BOOLEAN AllowVtDcsPassthrough;          /* TRUE when raw DCS payloads may be processed */
 } CONSOLE, *PCONSOLE;
 
 /* console.c */

--- a/win32ss/user/winsrv/consrv/include/term.h
+++ b/win32ss/user/winsrv/consrv/include/term.h
@@ -8,6 +8,15 @@
 
 #pragma once
 
+/*
+ * TRUE when a real terminal is plugged into the console. The dummy terminal
+ * installed by ResetTerminal() pends every operation, so callers that must not
+ * perform side effects before a possible STATUS_PENDING test this first.
+ * Defined in condrv/dummyterm.c.
+ */
+BOOLEAN ConDrvIsTerminalAttached(IN struct _CONSOLE* Console);
+
+
 /* Macros used to call functions in the TERMINAL_VTBL virtual table */
 
 #define TermReadStream(Console, /**/ Unicode, /**/ Buffer, ReadControl, Parameter, NumCharsToRead, NumCharsRead) \

--- a/win32ss/user/winsrv/consrv/include/term.h
+++ b/win32ss/user/winsrv/consrv/include/term.h
@@ -39,6 +39,16 @@
     (Console)->TermIFace.Vtbl->SetCodePage(&(Console)->TermIFace, (CodePage))
 #define TermShowMouseCursor(Console, Show) \
     (Console)->TermIFace.Vtbl->ShowMouseCursor(&(Console)->TermIFace, (Show))
+#define TermSetTitle(Console, Title, Length) \
+    (Console)->TermIFace.Vtbl->SetTitle(&(Console)->TermIFace, (Title), (Length))
+#define TermGetColorTable(Console, Colors, Count) \
+    (Console)->TermIFace.Vtbl->GetColorTable(&(Console)->TermIFace, (Colors), (Count))
+#define TermSetColorTable(Console, Colors, Count) \
+    (Console)->TermIFace.Vtbl->SetColorTable(&(Console)->TermIFace, (Colors), (Count))
+#define TermGetClipboardText(Console, Text, Length) \
+    (Console)->TermIFace.Vtbl->GetClipboardText(&(Console)->TermIFace, (Text), (Length))
+#define TermSetClipboardText(Console, Text, Length) \
+    (Console)->TermIFace.Vtbl->SetClipboardText(&(Console)->TermIFace, (Text), (Length))
 
 
 /* Macros used to call functions in the FRONTEND_VTBL virtual table */

--- a/win32ss/user/winsrv/consrv/include/vt.h
+++ b/win32ss/user/winsrv/consrv/include/vt.h
@@ -60,6 +60,10 @@ ConDrvVtTranslateInput(PCONSOLE Console,
                        PULONG TranslatedCount,
                        PBOOLEAN AllocatedBuffer);
 
+BOOLEAN
+NTAPI
+ConDrvVtIsMouseTrackingEnabled(PCONSOLE Console);
+
 VOID
 NTAPI
 VtResetTabStops(PTEXTMODE_SCREEN_BUFFER ScreenBuffer);

--- a/win32ss/user/winsrv/consrv/include/vt.h
+++ b/win32ss/user/winsrv/consrv/include/vt.h
@@ -32,6 +32,11 @@ VOID
 NTAPI
 ConDrvVtInvalidateBufferRgb(PTEXTMODE_SCREEN_BUFFER ScreenBuffer);
 
+/* Owns how a change to the console colour table reaches the screen */
+VOID
+NTAPI
+ConDrvVtRefreshPalette(PCONSOLE Console);
+
 VOID
 NTAPI
 ConDrvVtAdvanceLine(PCONSOLE Console,
@@ -70,5 +75,8 @@ VtHandleTabClear(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
 
 SHORT
 NTAPI
-VtFindNextTabStop(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
-                  SHORT StartColumn);
+VtFindNextTabStop(PTEXTMODE_SCREEN_BUFFER ScreenBuffer, SHORT StartColumn);
+
+SHORT
+NTAPI
+VtFindPrevTabStop(PTEXTMODE_SCREEN_BUFFER ScreenBuffer, SHORT StartColumn);

--- a/win32ss/user/winsrv/consrv/include/vt.h
+++ b/win32ss/user/winsrv/consrv/include/vt.h
@@ -1,0 +1,74 @@
+/*
+ * COPYRIGHT:       See COPYING in the top level directory
+ * PROJECT:         ReactOS Console Server DLL
+ * FILE:            win32ss/user/winsrv/consrv/include/vt.h
+ * PURPOSE:         Virtual Terminal processing stubs
+ */
+
+#pragma once
+
+#include "conio.h"
+
+
+#define VT_PRIVMODE_MOUSE_BUTTON_TRACKING    0x00000001
+#define VT_PRIVMODE_MOUSE_SGR_EXTENDED       0x00000002
+#define VT_PRIVMODE_BRACKETED_PASTE          0x00000004
+#define VT_PRIVMODE_META_SENDS_ESCAPE        0x00000008
+#define VT_PRIVMODE_ALTERNATE_SCREEN_BUFFER  0x00000010
+#define VT_PRIVMODE_ORIGIN_MODE              0x00000020
+#define VT_PRIVMODE_COLUMN_132               0x00000040
+#define VT_PRIVMODE_CURSOR_KEYS_APPLICATION  0x00000080
+#define VT_PRIVMODE_KEYPAD_APPLICATION       0x00000100
+#define VT_PRIVMODE_FOCUS_EVENT              0x00000200
+#define VT_PRIVMODE_MOUSE_X10                0x00000400
+#define VT_PRIVMODE_MOUSE_ANY_EVENT          0x00000800
+#define VT_PRIVMODE_DELAYED_EOL_WRAP         0x00001000
+
+VOID
+NTAPI
+ConDrvVtInitializeBuffer(PTEXTMODE_SCREEN_BUFFER ScreenBuffer);
+
+VOID
+NTAPI
+ConDrvVtInvalidateBufferRgb(PTEXTMODE_SCREEN_BUFFER ScreenBuffer);
+
+VOID
+NTAPI
+ConDrvVtAdvanceLine(PCONSOLE Console,
+                    PTEXTMODE_SCREEN_BUFFER ScreenBuffer);
+
+NTSTATUS
+NTAPI
+ConDrvVtWriteConsole(PCONSOLE Console,
+                     PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                     PCWSTR Buffer,
+                     ULONG Length,
+                     PULONG NumCharsProcessed,
+                     PBOOLEAN Handled);
+
+NTSTATUS
+NTAPI
+ConDrvVtTranslateInput(PCONSOLE Console,
+                       PINPUT_RECORD InputRecords,
+                       ULONG NumRecords,
+                       PINPUT_RECORD *TranslatedRecords,
+                       PULONG TranslatedCount,
+                       PBOOLEAN AllocatedBuffer);
+
+VOID
+NTAPI
+VtResetTabStops(PTEXTMODE_SCREEN_BUFFER ScreenBuffer);
+
+VOID
+NTAPI
+VtSetTabStopAtCursor(PTEXTMODE_SCREEN_BUFFER ScreenBuffer);
+
+VOID
+NTAPI
+VtHandleTabClear(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                 ULONG Mode);
+
+SHORT
+NTAPI
+VtFindNextTabStop(PTEXTMODE_SCREEN_BUFFER ScreenBuffer,
+                  SHORT StartColumn);

--- a/win32ss/user/winsrv/consrv/init.c
+++ b/win32ss/user/winsrv/consrv/init.c
@@ -118,6 +118,8 @@ PCSR_API_ROUTINE ConsoleServerApiDispatchTable[ConsolepMaxApiNumber - CONSRV_FIR
     // SrvSetConsoleCurrentFont,               // Added in Vista+
     // SrvSetScreenBufferInfo,                 // Added in Vista+
     // SrvConsoleClientConnect,                // Added in Win7
+    SrvGetConsoleScreenBufferInfoEx,        // Added in Vista+
+    SrvSetConsoleScreenBufferInfoEx,        // Added in Vista+
 };
 
 BOOLEAN ConsoleServerApiServerValidTable[ConsolepMaxApiNumber - CONSRV_FIRST_API_NUMBER] =
@@ -214,6 +216,8 @@ BOOLEAN ConsoleServerApiServerValidTable[ConsolepMaxApiNumber - CONSRV_FIRST_API
     // FALSE,   // SrvSetConsoleCurrentFont,
     // FALSE,   // SrvSetScreenBufferInfo,
     // FALSE,   // SrvConsoleClientConnect,
+    FALSE,   // SrvGetConsoleScreenBufferInfoEx,
+    FALSE,   // SrvSetConsoleScreenBufferInfoEx,
 };
 
 /*
@@ -315,6 +319,8 @@ PCHAR ConsoleServerApiNameTable[ConsolepMaxApiNumber - CONSRV_FIRST_API_NUMBER] 
     // "SetConsoleCurrentFont",
     // "SetScreenBufferInfo",
     // "ConsoleClientConnect",
+    "GetConsoleScreenBufferInfoEx",
+    "SetConsoleScreenBufferInfoEx",
 };
 #endif
 

--- a/win32ss/user/winsrv/consrv/popup.c
+++ b/win32ss/user/winsrv/consrv/popup.c
@@ -8,7 +8,7 @@
  * NOTE:            Strongly inspired by the DrawBox function
  *                  from base/setup/usetup/interface/usetup.c, written by:
  *                  Eric Kohl (revision 3753)
- *                  Hervé Poussineau (revision 24718)
+ *                  Hervï¿½ Poussineau (revision 24718)
  *                  and *UiDisplayMenu from FreeLdr.
  */
 
@@ -177,6 +177,36 @@ DrawBox(PTEXTMODE_SCREEN_BUFFER Buffer,
                             &Written);
 }
 
+/*
+ * Copy the extended cell colours of the area the popup covers between the
+ * screen buffer and the popup's saved copy: Restore == FALSE saves the buffer
+ * into the popup, Restore == TRUE puts them back. A row of the covered
+ * rectangle is contiguous in both, so this is one memcpy per row.
+ */
+static VOID
+PopupCopyCellColors(IN PPOPUP_WINDOW Popup, IN BOOLEAN Restore)
+{
+    PTEXTMODE_SCREEN_BUFFER Buffer = Popup->ScreenBuffer;
+    SIZE_T RowBytes = (SIZE_T)Popup->Size.X * sizeof(CELL_RGB);
+    SIZE_T Index = 0;
+    SHORT LocalY;
+
+    if (!Popup->OldCellRgb) return;
+
+    for (LocalY = 0; LocalY < Popup->Size.Y; ++LocalY, Index += Popup->Size.X)
+    {
+        PCELL_RGB Row = ConioCellRgbRow(Buffer, Popup->Origin.Y + LocalY);
+
+        if (!Row) return;
+        Row += Popup->Origin.X;
+
+        if (Restore)
+            RtlCopyMemory(Row, &Popup->OldCellRgb[Index], RowBytes);
+        else
+            RtlCopyMemory(&Popup->OldCellRgb[Index], Row, RowBytes);
+    }
+}
+
 
 /* PUBLIC FUNCTIONS ***********************************************************/
 
@@ -192,6 +222,7 @@ CreatePopupWindow(
     PTEXTMODE_SCREEN_BUFFER Buffer;
     PPOPUP_WINDOW Popup;
     SMALL_RECT Region;
+    SIZE_T CellCount;
 
     ASSERT((PCONSOLE)Console == ScreenBuffer->Header.Console);
 
@@ -209,16 +240,30 @@ CreatePopupWindow(
     Popup->Origin.Y = yTop;
     Popup->Size.X = Width;
     Popup->Size.Y = Height;
+    Popup->OldCellRgb = NULL;
+    CellCount = (SIZE_T)Popup->Size.X * Popup->Size.Y;
 
     /* Save old contents */
     Popup->OldContents = ConsoleAllocHeap(HEAP_ZERO_MEMORY,
-                                          Popup->Size.X * Popup->Size.Y *
-                                            sizeof(*Popup->OldContents));
+                                          CellCount * sizeof(*Popup->OldContents));
     if (Popup->OldContents == NULL)
     {
         ConsoleFreeHeap(Popup);
         return NULL;
     }
+
+    /* Only mirror the extended colours if the screen buffer has any */
+    if (Buffer->CellRgb)
+    {
+        Popup->OldCellRgb = ConsoleAllocHeap(0, CellCount * sizeof(CELL_RGB));
+        if (!Popup->OldCellRgb)
+        {
+            ConsoleFreeHeap(Popup->OldContents);
+            ConsoleFreeHeap(Popup);
+            return NULL;
+        }
+    }
+
     Region.Left   = Popup->Origin.X;
     Region.Top    = Popup->Origin.Y;
     Region.Right  = Popup->Origin.X + Popup->Size.X - 1;
@@ -228,6 +273,8 @@ CreatePopupWindow(
                             TRUE,
                             Popup->OldContents,
                             &Region);
+
+    PopupCopyCellColors(Popup, FALSE);
 
     /* Draw it */
     DrawBox(Buffer,
@@ -262,7 +309,10 @@ DestroyPopupWindow(
                              Popup->OldContents,
                              &Region);
 
+    PopupCopyCellColors(Popup, TRUE);
+
     /* Free memory */
+    if (Popup->OldCellRgb) ConsoleFreeHeap(Popup->OldCellRgb);
     ConsoleFreeHeap(Popup->OldContents);
     ConsoleFreeHeap(Popup);
 }

--- a/win32ss/user/winsrv/consrv/popup.h
+++ b/win32ss/user/winsrv/consrv/popup.h
@@ -22,6 +22,7 @@ typedef struct _POPUP_WINDOW
     COORD       Size;               /* Size of the popup window */
 
     PCHAR_INFO  OldContents;        /* The data under the popup window */
+    PCELL_RGB   OldCellRgb;         /* Saved per-cell extended colours */
     PPOPUP_INPUT_ROUTINE PopupInputRoutine; /* Routine called when input is received */
 } POPUP_WINDOW, *PPOPUP_WINDOW;
 


### PR DESCRIPTION
This VT implementation was tested with Edit, the Rust text editor, and works correctly. I will run more tests before making the PR ready for review.

It adds VT input and output processing to CONSRV while keeping the classic console path unchanged. This includes CSI, OSC, and DCS sequences, alternate screens, scrolling, keyboard and mouse input, 24-bit color, and the extended screen-buffer APIs.

https://jira.reactos.org/browse/CORE-20705

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: