### PR TITLE
[MSI] HACK Fix MS Office Destroying Tahoma Fonts

### DIFF
--- a/dll/win32/msi/files.c
+++ b/dll/win32/msi/files.c
@@ -84,9 +84,9 @@ static BOOL copy_file( MSIPACKAGE *package, const WCHAR *src, const WCHAR *dst, 
     {
         if (GetSystemWindowsDirectoryW(PathWin, ARRAYSIZE(PathWin)))
         {
-            wcscat(PathTahoma, PathWin);
+            wcscpy(PathTahoma, PathWin);
             wcscat(PathTahoma, L"\\Fonts\\TAHOMA.TTF");
-            wcscat(PathTahomabd, PathWin);
+            wcscpy(PathTahomabd, PathWin);
             wcscat(PathTahomabd, L"\\Fonts\\TAHOMABD.TTF");
         }
         else

--- a/dll/win32/msi/files.c
+++ b/dll/win32/msi/files.c
@@ -75,23 +75,22 @@ static BOOL copy_file( MSIPACKAGE *package, const WCHAR *src, const WCHAR *dst, 
     /* HACK: Protect Tahoma.ttf and Tahomabd.ttf from overwrites
      * until next reboot. See CORE-19789. */
     static WCHAR PathWin[MAX_PATH] = { 0 };
-    static WCHAR PathTahoma[MAX_PATH] = { 0 };
-    static WCHAR PathTahomabd[MAX_PATH] = { 0 };
+    static WCHAR PathTahoma[MAX_PATH];
+    static WCHAR PathTahomabd[MAX_PATH];
     WCHAR PathTmp[MAX_PATH];
 
+    /* Initialize check */
     if (PathWin[0] == UNICODE_NULL)
-        GetSystemWindowsDirectoryW(PathWin, ARRAYSIZE(PathWin));
-
-    if (PathTahoma[0] == UNICODE_NULL)
     {
-        wcscat(PathTahoma, PathWin);
-        wcscat(PathTahoma, L"\\Fonts\\TAHOMA.TTF");
-    }
-
-    if (PathTahomabd[0] == UNICODE_NULL)
-    {
-        wcscat(PathTahomabd, PathWin);
-        wcscat(PathTahomabd, L"\\Fonts\\TAHOMABD.TTF");
+        if (GetSystemWindowsDirectoryW(PathWin, ARRAYSIZE(PathWin)))
+        {
+            wcscat(PathTahoma, PathWin);
+            wcscat(PathTahoma, L"\\Fonts\\TAHOMA.TTF");
+            wcscat(PathTahomabd, PathWin);
+            wcscat(PathTahomabd, L"\\Fonts\\TAHOMABD.TTF");
+        }
+        else
+            WARN("Failed to GetSystemWindowsDirectoryW - %lu\n", GetLastError());
     }
 
     if (_wcsicmp(dst, PathTahoma) == 0)

--- a/dll/win32/msi/files.c
+++ b/dll/win32/msi/files.c
@@ -102,7 +102,8 @@ static BOOL copy_file( MSIPACKAGE *package, const WCHAR *src, const WCHAR *dst, 
         ERR("HACK. Should be using Windows File Protection\n");
         wcscpy(PathTmp, PathWin);
         wcscat(PathTmp, L"\\Fonts\\TAHOMA.tmp");
-        if (CopyFileW(src, PathTmp, FALSE))
+        ret = CopyFileW(src, PathTmp, FALSE);
+        if (ret)
         {
             MoveFileExW(PathTahoma, NULL, MOVEFILE_DELAY_UNTIL_REBOOT);
             MoveFileExW(PathTmp, PathTahoma, MOVEFILE_DELAY_UNTIL_REBOOT);
@@ -113,7 +114,8 @@ static BOOL copy_file( MSIPACKAGE *package, const WCHAR *src, const WCHAR *dst, 
         ERR("HACK. Should be using Windows File Protection\n");
         wcscpy(PathTmp, PathWin);
         wcscat(PathTmp, L"\\Fonts\\TAHOMABD.tmp");
-        if (CopyFileW(src, PathTmp, FALSE))
+        ret = CopyFileW(src, PathTmp, FALSE);
+        if (ret)
         {
             MoveFileExW(PathTahomabd, NULL, MOVEFILE_DELAY_UNTIL_REBOOT);
             MoveFileExW(PathTmp, PathTahomabd, MOVEFILE_DELAY_UNTIL_REBOOT);

--- a/dll/win32/msi/files.c
+++ b/dll/win32/msi/files.c
@@ -45,6 +45,9 @@
 #include "shlwapi.h"
 #include "patchapi.h"
 #include "wine/debug.h"
+#ifdef __REACTOS__
+#include <assert.h>
+#endif
 
 WINE_DEFAULT_DEBUG_CHANNEL(msi);
 
@@ -93,23 +96,28 @@ static BOOL copy_file( MSIPACKAGE *package, const WCHAR *src, const WCHAR *dst, 
             WARN("Failed to GetSystemWindowsDirectoryW - %lu\n", GetLastError());
     }
 
+    assert(*dst);
     if (_wcsicmp(dst, PathTahoma) == 0)
     {
         ERR("HACK. Should be using Windows File Protection\n");
         wcscpy(PathTmp, PathWin);
         wcscat(PathTmp, L"\\Fonts\\TAHOMA.tmp");
-        ret = CopyFileW(src, PathTmp, FALSE);
-        MoveFileExW(PathTahoma, NULL, MOVEFILE_DELAY_UNTIL_REBOOT);
-        MoveFileExW(PathTmp, PathTahoma, MOVEFILE_DELAY_UNTIL_REBOOT);
+        if (CopyFileW(src, PathTmp, FALSE))
+        {
+            MoveFileExW(PathTahoma, NULL, MOVEFILE_DELAY_UNTIL_REBOOT);
+            MoveFileExW(PathTmp, PathTahoma, MOVEFILE_DELAY_UNTIL_REBOOT);
+        }
     }
     else if (_wcsicmp(dst, PathTahomabd) == 0)
     {
         ERR("HACK. Should be using Windows File Protection\n");
         wcscpy(PathTmp, PathWin);
         wcscat(PathTmp, L"\\Fonts\\TAHOMABD.tmp");
-        ret = CopyFileW(src, PathTmp, FALSE);
-        MoveFileExW(PathTahomabd, NULL, MOVEFILE_DELAY_UNTIL_REBOOT);
-        MoveFileExW(PathTmp, PathTahomabd, MOVEFILE_DELAY_UNTIL_REBOOT);
+        if (CopyFileW(src, PathTmp, FALSE))
+        {
+            MoveFileExW(PathTahomabd, NULL, MOVEFILE_DELAY_UNTIL_REBOOT);
+            MoveFileExW(PathTmp, PathTahomabd, MOVEFILE_DELAY_UNTIL_REBOOT);
+        }
     }
     else
         ret = CopyFileW( src, dst, fail_if_exists );

--- a/dll/win32/msi/files.c
+++ b/dll/win32/msi/files.c
@@ -71,7 +71,43 @@ static BOOL copy_file( MSIPACKAGE *package, const WCHAR *src, const WCHAR *dst, 
 {
     BOOL ret;
     msi_disable_fs_redirection( package );
+#ifdef __REACTOS__
+    /* HACK: Protect Tahoma.ttf and Tahomabd.ttf from overwrites
+     * until next reboot. See CORE-19789. */
+    WCHAR PathWin[MAX_PATH];
+    WCHAR PathTahoma[MAX_PATH] = { 0 };
+    WCHAR PathTahomabd[MAX_PATH] = { 0 };
+    WCHAR PathTmp[MAX_PATH];
+
+    GetSystemWindowsDirectoryW(PathWin, MAX_PATH);
+    wcscat(PathTahoma, PathWin);
+    wcscat(PathTahoma, L"\\Fonts\\TAHOMA.TTF");
+    wcscat(PathTahomabd, PathWin);
+    wcscat(PathTahomabd, L"\\Fonts\\TAHOMABD.TTF");
+
+    if (_wcsicmp(dst, PathTahoma) == 0)
+    {
+        ERR("HACK. Should be using WFP or SFC\n");
+        wcscpy(PathTmp, PathWin);
+        wcscat(PathTmp, L"\\Fonts\\TAHOMA.tmp");
+        ret = CopyFileW( src, PathTmp, FALSE);
+        MoveFileExW(PathTahoma, NULL, MOVEFILE_DELAY_UNTIL_REBOOT);
+        MoveFileExW(PathTmp, PathTahoma, MOVEFILE_DELAY_UNTIL_REBOOT);
+    }
+    else if (_wcsicmp(dst, PathTahomabd) == 0)
+    {
+        ERR("HACK. Should be using WFP or SFC\n");
+        wcscpy(PathTmp, PathWin);
+        wcscat(PathTmp, L"\\Fonts\\TAHOMABD.tmp");
+        ret = CopyFileW( src, PathTmp, FALSE);
+        MoveFileExW(PathTahomabd, NULL, MOVEFILE_DELAY_UNTIL_REBOOT);
+        MoveFileExW(PathTmp, PathTahomabd, MOVEFILE_DELAY_UNTIL_REBOOT);
+    }
+    else
+        ret = CopyFileW( src, dst, fail_if_exists );
+#else
     ret = CopyFileW( src, dst, fail_if_exists );
+#endif
     msi_revert_fs_redirection( package );
     return ret;
 }

--- a/dll/win32/msi/files.c
+++ b/dll/win32/msi/files.c
@@ -74,32 +74,41 @@ static BOOL copy_file( MSIPACKAGE *package, const WCHAR *src, const WCHAR *dst, 
 #ifdef __REACTOS__
     /* HACK: Protect Tahoma.ttf and Tahomabd.ttf from overwrites
      * until next reboot. See CORE-19789. */
-    WCHAR PathWin[MAX_PATH];
-    WCHAR PathTahoma[MAX_PATH] = { 0 };
-    WCHAR PathTahomabd[MAX_PATH] = { 0 };
+    static WCHAR PathWin[MAX_PATH] = { 0 };
+    static WCHAR PathTahoma[MAX_PATH] = { 0 };
+    static WCHAR PathTahomabd[MAX_PATH] = { 0 };
     WCHAR PathTmp[MAX_PATH];
 
-    GetSystemWindowsDirectoryW(PathWin, MAX_PATH);
-    wcscat(PathTahoma, PathWin);
-    wcscat(PathTahoma, L"\\Fonts\\TAHOMA.TTF");
-    wcscat(PathTahomabd, PathWin);
-    wcscat(PathTahomabd, L"\\Fonts\\TAHOMABD.TTF");
+    if (PathWin[0] == UNICODE_NULL)
+        GetSystemWindowsDirectoryW(PathWin, ARRAYSIZE(PathWin));
+
+    if (PathTahoma[0] == UNICODE_NULL)
+    {
+        wcscat(PathTahoma, PathWin);
+        wcscat(PathTahoma, L"\\Fonts\\TAHOMA.TTF");
+    }
+
+    if (PathTahomabd[0] == UNICODE_NULL)
+    {
+        wcscat(PathTahomabd, PathWin);
+        wcscat(PathTahomabd, L"\\Fonts\\TAHOMABD.TTF");
+    }
 
     if (_wcsicmp(dst, PathTahoma) == 0)
     {
-        ERR("HACK. Should be using WFP or SFC\n");
+        ERR("HACK. Should be using Windows File Protection\n");
         wcscpy(PathTmp, PathWin);
         wcscat(PathTmp, L"\\Fonts\\TAHOMA.tmp");
-        ret = CopyFileW( src, PathTmp, FALSE);
+        ret = CopyFileW(src, PathTmp, FALSE);
         MoveFileExW(PathTahoma, NULL, MOVEFILE_DELAY_UNTIL_REBOOT);
         MoveFileExW(PathTmp, PathTahoma, MOVEFILE_DELAY_UNTIL_REBOOT);
     }
     else if (_wcsicmp(dst, PathTahomabd) == 0)
     {
-        ERR("HACK. Should be using WFP or SFC\n");
+        ERR("HACK. Should be using Windows File Protection\n");
         wcscpy(PathTmp, PathWin);
         wcscat(PathTmp, L"\\Fonts\\TAHOMABD.tmp");
-        ret = CopyFileW( src, PathTmp, FALSE);
+        ret = CopyFileW(src, PathTmp, FALSE);
         MoveFileExW(PathTahomabd, NULL, MOVEFILE_DELAY_UNTIL_REBOOT);
         MoveFileExW(PathTmp, PathTahomabd, MOVEFILE_DELAY_UNTIL_REBOOT);
     }


### PR DESCRIPTION
CORE-19789

## Purpose

_Fix Tahoma font destruction by MS Installers by not allowing Tahoma.ttf overwrites._

JIRA issue: [CORE-19789](https://jira.reactos.org/browse/CORE-19789)

## Proposed changes

_When MSI attempts to overwrite files for tahoma.ttf and tahomabd.ttf convert these._
_Now they will set up these files to be replaced on the next boot._

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109182,109184 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109181,109186 LGTM

Before PR:

<img width="1042" height="856" alt="Word2000-install-ending-bad-01" src="https://github.com/user-attachments/assets/8c41ed18-18bf-4787-89a5-3b956336bd26" />

After PR:

<img width="1042" height="856" alt="Word2000-install-ending-OK-01" src="https://github.com/user-attachments/assets/4538ef87-f718-42be-8ba8-3f3ae1992d2e" />