### PR TITLE
[KERNEL32] Make creation of a default timer queue thread safe

### DIFF
--- a/dll/win32/kernel32/client/timerqueue.c
+++ b/dll/win32/kernel32/client/timerqueue.c
@@ -19,20 +19,32 @@ HANDLE BasepDefaultTimerQueue = NULL;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
-/* FIXME - make this thread safe */
 BOOL
 WINAPI
 BasepCreateDefaultTimerQueue(VOID)
 {
     NTSTATUS Status;
+    HANDLE TimerQueue;
+
+    /* Already initialized */
+    if (BasepDefaultTimerQueue != NULL)
+        return TRUE;
 
     /* Create the timer queue */
-    Status = RtlCreateTimerQueue(&BasepDefaultTimerQueue);
+    Status = RtlCreateTimerQueue(&TimerQueue);
     if (!NT_SUCCESS(Status))
     {
         BaseSetLastNTError(Status);
         DPRINT1("Unable to create the default timer queue!\n");
         return FALSE;
+    }
+
+    /* Try to publish it. If another thread already did, throw ours away */
+    if (InterlockedCompareExchangePointer((PVOID *)&BasepDefaultTimerQueue,
+                                           TimerQueue,
+                                           NULL) != NULL)
+    {
+        RtlDeleteTimerQueueEx(TimerQueue, NULL);
     }
 
     return TRUE;


### PR DESCRIPTION
## Purpose

Resolve a FIXME that made `BasepCreateDefaultTimerQueue` not thread safe.

JIRA issue: None

## Proposed changes
- Add a fast path that returns TRUE if `BasepDefaultTimerQueue` is already initialized.
- Publish the queue with `InterlockedCompareExchangePointer`

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: