### PR TITLE
[NTOS:OB] Validate ACCESS_SYSTEM_SECURITY

### DIFF
--- a/ntoskrnl/ob/obhandle.c
+++ b/ntoskrnl/ob/obhandle.c
@@ -954,8 +954,17 @@ ObpIncrementHandleCount(IN PVOID Object,
         /* Check if the caller is trying to access system security */
         if (AccessState->RemainingDesiredAccess & ACCESS_SYSTEM_SECURITY)
         {
-            /* FIXME: TODO */
-            DPRINT1("ACCESS_SYSTEM_SECURITY not validated!\n");
+            /* Client must be warranted SeSecurityPrivilege to touch SACLs */
+            if (!SeSinglePrivilegeCheck(SeSecurityPrivilege, ProbeMode))
+            {
+                /* FIXME: Generate an audit alarm, security manager must be alerted */
+                Status = STATUS_PRIVILEGE_NOT_HELD;
+                goto Quickie;
+            }
+
+            /* Privilege held, grant it so the access state reflects reality */
+            AccessState->PreviouslyGrantedAccess |= ACCESS_SYSTEM_SECURITY;
+            AccessState->RemainingDesiredAccess &= ~ACCESS_SYSTEM_SECURITY;
         }
     }
 


### PR DESCRIPTION
## Purpose

Validate `ACCESS_SYSTEM_SECURITY` access requests when creating a new handle in `ObpIncrementHandleCount`.

JIRA issue: None

## Proposed changes
- Check for `SeSecurityPrivilege` (with `SeSinglePrivilegeCheck`) when a caller requests `ACCESS_SYSTEM_SECURITY` on handle creation.
- Take away `ACCESS_SYSTEM_SECURITY` from `RemainingDesiredAccess`/`PreviouslyGrantedAccess` if the privilege isn't held.

## Testbot runs (Filled in by Devs)
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109223,109229
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109228,109234