### PR TITLE
[KDGDB] Complete x86 GDB remote protocol support

### DIFF
--- a/drivers/base/kdgdb/CMakeLists.txt
+++ b/drivers/base/kdgdb/CMakeLists.txt
@@ -13,9 +13,9 @@ list(APPEND SOURCE
 
 # TODO: ARM...
 if(ARCH STREQUAL "i386")
-    list(APPEND SOURCE i386_sup.c)
+    list(APPEND SOURCE i386_sup.c hwbp_x86.c)
 elseif(ARCH STREQUAL "amd64")
-    list(APPEND SOURCE amd64_sup.c)
+    list(APPEND SOURCE amd64_sup.c hwbp_x86.c)
 endif()
 
 add_library(kdgdb MODULE

--- a/drivers/base/kdgdb/CMakeLists.txt
+++ b/drivers/base/kdgdb/CMakeLists.txt
@@ -4,6 +4,7 @@ spec2def(kdgdb.dll kdgdb.spec)
 list(APPEND SOURCE
     gdb_input.c
     gdb_receive.c
+    gdb_regs.c
     gdb_send.c
     kdcom.c
     kdpacket.c

--- a/drivers/base/kdgdb/amd64_sup.c
+++ b/drivers/base/kdgdb/amd64_sup.c
@@ -7,6 +7,43 @@
 
 #include "kdgdb.h"
 
+const CHAR gdb_target_xml[] =
+    "<?xml version=\"1.0\"?><!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
+    "<target version=\"1.0\"><architecture>i386:x86-64</architecture>"
+    "<feature name=\"org.gnu.gdb.i386.core\">"
+    "<reg name=\"rax\" bitsize=\"64\" type=\"int64\"/><reg name=\"rbx\" bitsize=\"64\" type=\"int64\"/>"
+    "<reg name=\"rcx\" bitsize=\"64\" type=\"int64\"/><reg name=\"rdx\" bitsize=\"64\" type=\"int64\"/>"
+    "<reg name=\"rsi\" bitsize=\"64\" type=\"int64\"/><reg name=\"rdi\" bitsize=\"64\" type=\"int64\"/>"
+    "<reg name=\"rbp\" bitsize=\"64\" type=\"data_ptr\"/><reg name=\"rsp\" bitsize=\"64\" type=\"data_ptr\"/>"
+    "<reg name=\"r8\" bitsize=\"64\" type=\"int64\"/><reg name=\"r9\" bitsize=\"64\" type=\"int64\"/>"
+    "<reg name=\"r10\" bitsize=\"64\" type=\"int64\"/><reg name=\"r11\" bitsize=\"64\" type=\"int64\"/>"
+    "<reg name=\"r12\" bitsize=\"64\" type=\"int64\"/><reg name=\"r13\" bitsize=\"64\" type=\"int64\"/>"
+    "<reg name=\"r14\" bitsize=\"64\" type=\"int64\"/><reg name=\"r15\" bitsize=\"64\" type=\"int64\"/>"
+    "<reg name=\"rip\" bitsize=\"64\" type=\"code_ptr\"/><reg name=\"eflags\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"cs\" bitsize=\"32\" type=\"uint32\"/><reg name=\"ss\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"ds\" bitsize=\"32\" type=\"uint32\"/><reg name=\"es\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"fs\" bitsize=\"32\" type=\"uint32\"/><reg name=\"gs\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"st0\" bitsize=\"80\" type=\"i387_ext\"/><reg name=\"st1\" bitsize=\"80\" type=\"i387_ext\"/>"
+    "<reg name=\"st2\" bitsize=\"80\" type=\"i387_ext\"/><reg name=\"st3\" bitsize=\"80\" type=\"i387_ext\"/>"
+    "<reg name=\"st4\" bitsize=\"80\" type=\"i387_ext\"/><reg name=\"st5\" bitsize=\"80\" type=\"i387_ext\"/>"
+    "<reg name=\"st6\" bitsize=\"80\" type=\"i387_ext\"/><reg name=\"st7\" bitsize=\"80\" type=\"i387_ext\"/>"
+    "<reg name=\"fctrl\" bitsize=\"32\" type=\"uint32\"/><reg name=\"fstat\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"ftag\" bitsize=\"32\" type=\"uint32\"/><reg name=\"fiseg\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"fioff\" bitsize=\"32\" type=\"uint32\"/><reg name=\"foseg\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"fooff\" bitsize=\"32\" type=\"uint32\"/><reg name=\"fop\" bitsize=\"32\" type=\"uint32\"/>"
+    "</feature><feature name=\"org.gnu.gdb.i386.sse\">"
+    "<reg name=\"xmm0\" bitsize=\"128\" type=\"uint128\"/><reg name=\"xmm1\" bitsize=\"128\" type=\"uint128\"/>"
+    "<reg name=\"xmm2\" bitsize=\"128\" type=\"uint128\"/><reg name=\"xmm3\" bitsize=\"128\" type=\"uint128\"/>"
+    "<reg name=\"xmm4\" bitsize=\"128\" type=\"uint128\"/><reg name=\"xmm5\" bitsize=\"128\" type=\"uint128\"/>"
+    "<reg name=\"xmm6\" bitsize=\"128\" type=\"uint128\"/><reg name=\"xmm7\" bitsize=\"128\" type=\"uint128\"/>"
+    "<reg name=\"xmm8\" bitsize=\"128\" type=\"uint128\"/><reg name=\"xmm9\" bitsize=\"128\" type=\"uint128\"/>"
+    "<reg name=\"xmm10\" bitsize=\"128\" type=\"uint128\"/><reg name=\"xmm11\" bitsize=\"128\" type=\"uint128\"/>"
+    "<reg name=\"xmm12\" bitsize=\"128\" type=\"uint128\"/><reg name=\"xmm13\" bitsize=\"128\" type=\"uint128\"/>"
+    "<reg name=\"xmm14\" bitsize=\"128\" type=\"uint128\"/><reg name=\"xmm15\" bitsize=\"128\" type=\"uint128\"/>"
+    "<reg name=\"mxcsr\" bitsize=\"32\" type=\"uint32\"/>"
+    "</feature></target>";
+const SIZE_T gdb_target_xml_length = sizeof(gdb_target_xml) - 1;
+
 enum reg_name
 {
     RAX, RBX, RCX, RDX, RSI, RDI, RBP, RSP,
@@ -15,10 +52,13 @@ enum reg_name
     EFLAGS,
     CS, SS, DS, ES, FS, GS,
     ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7,
-    FCTRL, FSTAT, FTAG, FISEG, FIOFF, FOSEG, FOOFF, FOP
+    FCTRL, FSTAT, FTAG, FISEG, FIOFF, FOSEG, FOOFF, FOP,
+    XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7,
+    XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14, XMM15,
+    MXCSR
 };
 
-static const unsigned char reg_size[] =
+const UCHAR gdb_reg_size[] =
 {
     8, 8, 8, 8, 8, 8, 8, 8,
     8, 8, 8, 8, 8, 8, 8, 8,
@@ -26,13 +66,21 @@ static const unsigned char reg_size[] =
     4,
     4, 4, 4, 4, 4, 4,
     10, 10, 10, 10, 10, 10, 10, 10,
-    8, 8, 8, 8, 8, 8, 8, 8
+    4, 4, 4, 4, 4, 4, 4, 4,
+    16, 16, 16, 16, 16, 16, 16, 16,
+    16, 16, 16, 16, 16, 16, 16, 16,
+    4
 };
+const ULONG gdb_reg_count = RTL_NUMBER_OF(gdb_reg_size);
 
-static
 const void*
-ctx_to_reg(CONTEXT* ctx, enum reg_name name)
+gdb_ctx_to_reg(
+    _In_ CONTEXT* ctx,
+    _In_ ULONG Register,
+    _Out_ PULONG ScalarValue)
 {
+    enum reg_name name = (enum reg_name)Register;
+
     switch (name)
     {
         case RAX: return &ctx->Rax;
@@ -53,20 +101,98 @@ ctx_to_reg(CONTEXT* ctx, enum reg_name name)
         case R14: return &ctx->R14;
         case R15: return &ctx->R15;
         case EFLAGS: return &ctx->EFlags;
-        case CS: return &ctx->SegCs;
-        case DS: return &ctx->SegSs;
-        case ES: return &ctx->SegEs;
-        case FS: return &ctx->SegFs;
-        case GS: return &ctx->SegGs;
-        case SS: return &ctx->SegSs;
+        case CS: *ScalarValue = ctx->SegCs; return ScalarValue;
+        case SS: *ScalarValue = ctx->SegSs; return ScalarValue;
+        case DS: *ScalarValue = ctx->SegDs; return ScalarValue;
+        case ES: *ScalarValue = ctx->SegEs; return ScalarValue;
+        case FS: *ScalarValue = ctx->SegFs; return ScalarValue;
+        case GS: *ScalarValue = ctx->SegGs; return ScalarValue;
+        case ST0:
+        case ST1:
+        case ST2:
+        case ST3:
+        case ST4:
+        case ST5:
+        case ST6:
+        case ST7:
+            return &ctx->FltSave.FloatRegisters[name - ST0];
+        case FCTRL: *ScalarValue = ctx->FltSave.ControlWord; return ScalarValue;
+        case FSTAT: *ScalarValue = ctx->FltSave.StatusWord; return ScalarValue;
+        case FTAG: *ScalarValue = ctx->FltSave.TagWord; return ScalarValue;
+        case FISEG: *ScalarValue = ctx->FltSave.ErrorSelector; return ScalarValue;
+        case FIOFF: *ScalarValue = ctx->FltSave.ErrorOffset; return ScalarValue;
+        case FOSEG: *ScalarValue = ctx->FltSave.DataSelector; return ScalarValue;
+        case FOOFF: *ScalarValue = ctx->FltSave.DataOffset; return ScalarValue;
+        case FOP: *ScalarValue = ctx->FltSave.ErrorOpcode; return ScalarValue;
+        case XMM0:
+        case XMM1:
+        case XMM2:
+        case XMM3:
+        case XMM4:
+        case XMM5:
+        case XMM6:
+        case XMM7:
+        case XMM8:
+        case XMM9:
+        case XMM10:
+        case XMM11:
+        case XMM12:
+        case XMM13:
+        case XMM14:
+        case XMM15:
+            return &ctx->FltSave.XmmRegisters[name - XMM0];
+        case MXCSR: return &ctx->MxCsr;
     }
     return NULL;
 }
-
-static
-const void*
-thread_to_reg(PETHREAD Thread, enum reg_name reg_name)
+BOOLEAN
+gdb_set_ctx_reg(
+    _Inout_ CONTEXT* Context,
+    _In_ ULONG Register,
+    _In_reads_bytes_(Size) const UCHAR* Value,
+    _In_ SIZE_T Size)
 {
+    enum reg_name Name = (enum reg_name)Register;
+    ULONG ScalarValue;
+    PVOID Storage;
+
+    if (Register >= gdb_reg_count || Size != gdb_reg_size[Register])
+        return FALSE;
+
+    if (Size == sizeof(ScalarValue))
+        RtlCopyMemory(&ScalarValue, Value, sizeof(ScalarValue));
+
+    switch (Name)
+    {
+        case CS: Context->SegCs = (USHORT)ScalarValue; return TRUE;
+        case SS: Context->SegSs = (USHORT)ScalarValue; return TRUE;
+        case DS: Context->SegDs = (USHORT)ScalarValue; return TRUE;
+        case ES: Context->SegEs = (USHORT)ScalarValue; return TRUE;
+        case FS: Context->SegFs = (USHORT)ScalarValue; return TRUE;
+        case GS: Context->SegGs = (USHORT)ScalarValue; return TRUE;
+        case FCTRL: Context->FltSave.ControlWord = (USHORT)ScalarValue; return TRUE;
+        case FSTAT: Context->FltSave.StatusWord = (USHORT)ScalarValue; return TRUE;
+        case FTAG: Context->FltSave.TagWord = (UCHAR)ScalarValue; return TRUE;
+        case FISEG: Context->FltSave.ErrorSelector = (USHORT)ScalarValue; return TRUE;
+        case FIOFF: Context->FltSave.ErrorOffset = ScalarValue; return TRUE;
+        case FOSEG: Context->FltSave.DataSelector = (USHORT)ScalarValue; return TRUE;
+        case FOOFF: Context->FltSave.DataOffset = ScalarValue; return TRUE;
+        case FOP: Context->FltSave.ErrorOpcode = (USHORT)ScalarValue; return TRUE;
+        default:
+            Storage = (PVOID)gdb_ctx_to_reg(Context, Register, &ScalarValue);
+            if (Storage == NULL)
+                return FALSE;
+            RtlCopyMemory(Storage, Value, Size);
+            return TRUE;
+    }
+}
+
+const void*
+gdb_thread_to_reg(
+    _In_ PETHREAD Thread,
+    _In_ ULONG Register)
+{
+    enum reg_name reg_name = (enum reg_name)Register;
     static const void* NullValue = NULL;
 
 #if 0
@@ -137,123 +263,4 @@ thread_to_reg(PETHREAD Thread, enum reg_name reg_name)
     }
 
     return NULL;
-}
-
-KDSTATUS
-gdb_send_registers(void)
-{
-    CHAR RegisterStr[17];
-    const UCHAR* RegisterPtr;
-    unsigned short i;
-    unsigned short size;
-
-    start_gdb_packet();
-
-    KDDBGPRINT("Sending registers of thread %" PRIxPTR ".\n", gdb_dbg_tid);
-    KDDBGPRINT("Current thread_id: %p.\n", PsGetThreadId((PETHREAD)(ULONG_PTR)CurrentStateChange.Thread));
-    if (((gdb_dbg_pid == 0) && (gdb_dbg_tid == 0)) ||
-            gdb_tid_to_handle(gdb_dbg_tid) == PsGetThreadId((PETHREAD)(ULONG_PTR)CurrentStateChange.Thread))
-    {
-        for (i = 0; i < 24; i++)
-        {
-            RegisterPtr = ctx_to_reg(&CurrentContext, i);
-            size = reg_size[i] * 2;
-            RegisterStr[size] = 0;
-            while (size)
-            {
-                size--;
-                RegisterStr[size] = hex_chars[RegisterPtr[size/2] & 0xF];
-                size--;
-                RegisterStr[size] = hex_chars[RegisterPtr[size/2] >> 4];
-            }
-
-            send_gdb_partial_packet(RegisterStr);
-        }
-    }
-    else
-    {
-        PETHREAD DbgThread;
-
-        DbgThread = find_thread(gdb_dbg_pid, gdb_dbg_tid);
-
-        if (DbgThread == NULL)
-        {
-            /* Thread is dead */
-            send_gdb_partial_packet("E03");
-            return finish_gdb_packet();
-        }
-
-        for (i = 0; i < 24; i++)
-        {
-            RegisterPtr = thread_to_reg(DbgThread, i);
-            size = reg_size[i] * 2;
-            RegisterStr[size] = 0;
-            while (size)
-            {
-                if (RegisterPtr)
-                {
-                    size--;
-                    RegisterStr[size] = hex_chars[RegisterPtr[size/2] & 0xF];
-                    size--;
-                    RegisterStr[size] = hex_chars[RegisterPtr[size/2] >> 4];
-                }
-                else
-                {
-                    size--;
-                    RegisterStr[size] = 'x';
-                    size--;
-                    RegisterStr[size] = 'x';
-                }
-            }
-
-            send_gdb_partial_packet(RegisterStr);
-        }
-    }
-
-    return finish_gdb_packet();
-}
-
-KDSTATUS
-gdb_send_register(void)
-{
-    enum reg_name reg_name;
-    const void* ptr;
-
-    /* Get the GDB register name (gdb_input = "pXX") */
-    reg_name = (hex_value(gdb_input[1]) << 4) | hex_value(gdb_input[2]);
-
-    if (((gdb_dbg_pid == 0) && (gdb_dbg_tid == 0)) ||
-            gdb_tid_to_handle(gdb_dbg_tid) == PsGetThreadId((PETHREAD)(ULONG_PTR)CurrentStateChange.Thread))
-    {
-        /* We can get it from the context of the current exception */
-        ptr = ctx_to_reg(&CurrentContext, reg_name);
-    }
-    else
-    {
-        PETHREAD DbgThread;
-
-        DbgThread = find_thread(gdb_dbg_pid, gdb_dbg_tid);
-
-        if (DbgThread == NULL)
-        {
-            /* Thread is dead */
-            return send_gdb_packet("E03");
-        }
-
-        ptr = thread_to_reg(DbgThread, reg_name);
-    }
-
-    if (!ptr)
-    {
-        unsigned char size = reg_size[reg_name];
-        start_gdb_packet();
-        while (size--)
-            send_gdb_partial_packet("xx");
-        return finish_gdb_packet();
-    }
-    else
-    {
-        KDDBGPRINT("KDGDB: Sending registers as memory.\n");
-        return send_gdb_memory(ptr, reg_size[reg_name]);
-    }
 }

--- a/drivers/base/kdgdb/gdb_input.c
+++ b/drivers/base/kdgdb/gdb_input.c
@@ -8,12 +8,17 @@
 #include "kdgdb.h"
 
 /* LOCALS *********************************************************************/
-static ULONG_PTR gdb_run_tid;
+static UINT_PTR gdb_run_tid;
 static struct
 {
     ULONG_PTR Address;
     ULONG Handle;
 } BreakPointHandles[32];
+static LIST_ENTRY* ThreadInfoProcessEntry;
+static LIST_ENTRY* ThreadInfoThreadEntry;
+static UINT_PTR ThreadInfoInitialTid;
+static BOOLEAN ThreadInfoCurrentPending;
+static BOOLEAN ThreadInfoIdlePending;
 
 
 /* GLOBALS ********************************************************************/
@@ -29,38 +34,613 @@ LOOP_IF_SUCCESS(int x)
 
 /* PRIVATE FUNCTIONS **********************************************************/
 static
-UINT_PTR
-hex_to_tid(char* buffer)
+VOID
+reset_thread_info(VOID)
 {
-    ULONG_PTR ret = 0;
-    char hex;
-    while (*buffer)
-    {
-        hex = hex_value(*buffer++);
-        if (hex < 0)
-            return ret;
-        ret <<= 4;
-        ret += hex;
-    }
-    return ret;
+    PETHREAD CurrentThread = (PETHREAD)(ULONG_PTR)CurrentStateChange.Thread;
+
+    ThreadInfoInitialTid = handle_to_gdb_tid(PsGetThreadId(CurrentThread));
+    ThreadInfoCurrentPending = TRUE;
+    ThreadInfoIdlePending = (ThreadInfoInitialTid != 1);
+    ThreadInfoThreadEntry = NULL;
+
+    if (ps_initialized())
+        ThreadInfoProcessEntry = ProcessListHead->Flink;
+    else
+        ThreadInfoProcessEntry = NULL;
 }
-#define hex_to_pid hex_to_tid
+
+/*
+ * Emit the next thread of the enumeration, returning its length.
+ * Zero means the enumeration is over: all the cursors above are then either
+ * NULL or parked on the list head, so a further call keeps returning zero.
+ */
+static
+LONG
+get_next_thread_info(
+    _Out_writes_(BufferSize) char* Buffer,
+    _In_ SIZE_T BufferSize)
+{
+    if (ThreadInfoCurrentPending)
+    {
+        PETHREAD Thread = (PETHREAD)(ULONG_PTR)CurrentStateChange.Thread;
+
+        ThreadInfoCurrentPending = FALSE;
+        return format_gdb_tid(Buffer, BufferSize,
+                              PsGetThreadProcessId(Thread),
+                              ThreadInfoInitialTid);
+    }
+
+    if (ThreadInfoIdlePending)
+    {
+        ThreadInfoIdlePending = FALSE;
+        return format_gdb_tid(Buffer, BufferSize, gdb_pid_to_handle(1), 1);
+    }
+
+    while (ThreadInfoProcessEntry &&
+           ThreadInfoProcessEntry != ProcessListHead)
+    {
+        PEPROCESS Process;
+
+        Process = CONTAINING_RECORD(ThreadInfoProcessEntry,
+                                    EPROCESS,
+                                    ActiveProcessLinks);
+        if (ThreadInfoThreadEntry == NULL)
+            ThreadInfoThreadEntry = Process->ThreadListHead.Flink;
+
+        while (ThreadInfoThreadEntry != &Process->ThreadListHead)
+        {
+            PETHREAD Thread;
+            UINT_PTR Tid;
+
+            Thread = CONTAINING_RECORD(ThreadInfoThreadEntry,
+                                       ETHREAD,
+                                       ThreadListEntry);
+            ThreadInfoThreadEntry = ThreadInfoThreadEntry->Flink;
+            Tid = handle_to_gdb_tid(Thread->Cid.UniqueThread);
+
+            if ((Tid == ThreadInfoInitialTid) || (Tid == 1))
+                continue;
+
+            return format_gdb_tid(Buffer, BufferSize,
+                                  Process->UniqueProcessId, Tid);
+        }
+
+        ThreadInfoProcessEntry = ThreadInfoProcessEntry->Flink;
+        ThreadInfoThreadEntry = NULL;
+    }
+
+    return 0;
+}
 
 static
-ULONG64
-hex_to_address(char* buffer)
+KDSTATUS
+send_thread_info(
+    _In_ BOOLEAN Reset)
 {
-    ULONG64 ret = 0;
-    char hex;
-    while (*buffer)
+    char gdb_out[40];
+    SIZE_T PacketLength;
+    LONG Length;
+
+    if (Reset)
+        reset_thread_info();
+
+    Length = get_next_thread_info(gdb_out, sizeof(gdb_out));
+    if (Length <= 0)
+        return send_gdb_packet("l");
+
+    start_gdb_packet();
+    send_gdb_partial_packet("m");
+    send_gdb_partial_packet(gdb_out);
+    PacketLength = 1 + Length;
+
+    while ((GDB_PACKET_MAX_SIZE - PacketLength) >= sizeof(gdb_out))
     {
-        hex = hex_value(*buffer++);
-        if (hex < 0)
-            return ret;
-        ret <<= 4;
-        ret += hex;
+        Length = get_next_thread_info(gdb_out, sizeof(gdb_out));
+        if (Length <= 0)
+            break;
+
+        send_gdb_partial_packet(",");
+        send_gdb_partial_packet(gdb_out);
+        PacketLength += 1 + Length;
     }
-    return ret;
+
+    return finish_gdb_packet();
+}
+
+/*
+ * Rendering the library list twice - once to measure it, once to emit the
+ * requested window - avoids buffering the whole XML document, which can be
+ * several kilobytes. The measuring pass is simply a stream with a zero length
+ * window, which never matches a chunk and so emits nothing.
+ */
+typedef struct _GDB_XFER_STREAM
+{
+    ULONG64 Offset;
+    ULONG64 Length;
+    ULONG64 Position;
+} GDB_XFER_STREAM;
+
+static
+VOID
+stream_xfer_data(
+    _Inout_ GDB_XFER_STREAM* Stream,
+    _In_reads_bytes_(Length) const VOID* Buffer,
+    _In_ SIZE_T Length)
+{
+    ULONG64 ChunkStart = Stream->Position;
+    ULONG64 ChunkEnd = ChunkStart + Length;
+    ULONG64 RangeStart;
+    ULONG64 RangeEnd;
+
+    Stream->Position = ChunkEnd;
+    if (ChunkEnd <= Stream->Offset || ChunkStart >= Stream->Offset + Stream->Length)
+        return;
+
+    RangeStart = max(ChunkStart, Stream->Offset);
+    RangeEnd = min(ChunkEnd, Stream->Offset + Stream->Length);
+    send_gdb_partial_binary((const UCHAR*)Buffer + (SIZE_T)(RangeStart - ChunkStart),
+                            (SIZE_T)(RangeEnd - RangeStart));
+}
+
+#define STREAM_XFER_LITERAL(Stream, Literal) \
+    stream_xfer_data((Stream), (Literal), sizeof(Literal) - 1)
+
+static
+VOID
+stream_library_name(
+    _Inout_ GDB_XFER_STREAM* Stream,
+    _In_ const UNICODE_STRING* Name)
+{
+    USHORT i;
+
+    if (Name->Buffer == NULL)
+        return;
+
+    for (i = 0; i < Name->Length / sizeof(WCHAR); i++)
+    {
+        WCHAR WideCharacter = Name->Buffer[i];
+        CHAR Character;
+
+        if (WideCharacter >= L'A' && WideCharacter <= L'Z')
+            WideCharacter += L'a' - L'A';
+
+        if (WideCharacter > 0x7f)
+        {
+            Character = '?';
+            stream_xfer_data(Stream, &Character, sizeof(Character));
+            continue;
+        }
+
+        Character = (CHAR)WideCharacter;
+        switch (Character)
+        {
+            case '&':
+                STREAM_XFER_LITERAL(Stream, "&amp;");
+                break;
+            case '<':
+                STREAM_XFER_LITERAL(Stream, "&lt;");
+                break;
+            case '>':
+                STREAM_XFER_LITERAL(Stream, "&gt;");
+                break;
+            case '"':
+                STREAM_XFER_LITERAL(Stream, "&quot;");
+                break;
+            case '\'':
+                STREAM_XFER_LITERAL(Stream, "&apos;");
+                break;
+            default:
+                stream_xfer_data(Stream, &Character, sizeof(Character));
+                break;
+        }
+    }
+}
+
+static
+VOID
+stream_libraries_xml(
+    _Inout_ GDB_XFER_STREAM* Stream)
+{
+    LIST_ENTRY* CurrentEntry;
+
+    STREAM_XFER_LITERAL(Stream, "<?xml version=\"1.0\"?>");
+    STREAM_XFER_LITERAL(Stream, "<library-list>");
+
+    if (modules_initialized())
+    {
+        for (CurrentEntry = ModuleListHead->Flink;
+             CurrentEntry != ModuleListHead;
+             CurrentEntry = CurrentEntry->Flink)
+        {
+            PLDR_DATA_TABLE_ENTRY TableEntry;
+            CHAR Address[2 + sizeof(ULONG_PTR) * 2 + 1];
+            PVOID DllBase;
+            LONG AddressLength;
+
+            TableEntry = CONTAINING_RECORD(CurrentEntry,
+                                           LDR_DATA_TABLE_ENTRY,
+                                           InLoadOrderLinks);
+            DllBase = (PVOID)((ULONG_PTR)TableEntry->DllBase + 0x1000);
+
+            STREAM_XFER_LITERAL(Stream, "<library name=\"C:\\");
+            stream_library_name(Stream, &TableEntry->BaseDllName);
+            STREAM_XFER_LITERAL(Stream, "\"><segment address=\"0x");
+            AddressLength = _snprintf(Address, sizeof(Address), "%p", DllBase);
+            if (AddressLength > 0)
+                stream_xfer_data(Stream, Address, AddressLength);
+            STREAM_XFER_LITERAL(Stream, "\"/></library>");
+        }
+    }
+
+    STREAM_XFER_LITERAL(Stream, "</library-list>");
+}
+
+static
+VOID
+stream_thread_xml(
+    _Inout_ GDB_XFER_STREAM* Stream,
+    _In_ PETHREAD Thread,
+    _In_ BOOLEAN Current)
+{
+    CHAR ThreadId[40];
+    LONG Length;
+
+    STREAM_XFER_LITERAL(Stream, "<thread id=\"");
+    Length = format_gdb_tid(ThreadId,
+                           sizeof(ThreadId),
+                           PsGetThreadProcessId(Thread),
+                           handle_to_gdb_tid(PsGetThreadId(Thread)));
+    if (Length > 0)
+        stream_xfer_data(Stream, ThreadId, Length);
+    if (Current)
+    {
+        CHAR Core[2 + sizeof(ULONG) * 2 + 1];
+
+        STREAM_XFER_LITERAL(Stream, "\" core=\"");
+        Length = _snprintf(Core, sizeof(Core), "%x", CurrentStateChange.Processor);
+        if (Length > 0)
+            stream_xfer_data(Stream, Core, Length);
+    }
+    STREAM_XFER_LITERAL(Stream, "\"/>");
+}
+
+static
+VOID
+stream_threads_xml(
+    _Inout_ GDB_XFER_STREAM* Stream)
+{
+    PETHREAD CurrentThread = (PETHREAD)(ULONG_PTR)CurrentStateChange.Thread;
+    LIST_ENTRY* ProcessEntry;
+
+    STREAM_XFER_LITERAL(Stream, "<?xml version=\"1.0\"?>");
+    STREAM_XFER_LITERAL(Stream, "<threads>");
+    stream_thread_xml(Stream, CurrentThread, TRUE);
+
+    if (TheIdleThread && TheIdleThread != CurrentThread)
+        stream_thread_xml(Stream, TheIdleThread, FALSE);
+
+    if (ps_initialized())
+    {
+        for (ProcessEntry = ProcessListHead->Flink;
+             ProcessEntry != ProcessListHead;
+             ProcessEntry = ProcessEntry->Flink)
+        {
+            PEPROCESS Process;
+            LIST_ENTRY* ThreadEntry;
+
+            Process = CONTAINING_RECORD(ProcessEntry,
+                                         EPROCESS,
+                                         ActiveProcessLinks);
+            for (ThreadEntry = Process->ThreadListHead.Flink;
+                 ThreadEntry != &Process->ThreadListHead;
+                 ThreadEntry = ThreadEntry->Flink)
+            {
+                PETHREAD Thread;
+
+                Thread = CONTAINING_RECORD(ThreadEntry,
+                                           ETHREAD,
+                                           ThreadListEntry);
+                if (Thread != CurrentThread && Thread != TheIdleThread)
+                    stream_thread_xml(Stream, Thread, FALSE);
+            }
+        }
+    }
+
+    STREAM_XFER_LITERAL(Stream, "</threads>");
+}
+
+typedef VOID (*PGDB_XFER_STREAMER)(_Inout_ GDB_XFER_STREAM* Stream);
+
+static
+KDSTATUS
+send_xfer_stream(
+    _In_ PGDB_XFER_STREAMER Streamer,
+    _In_ ULONG64 RequestedOffset,
+    _In_ ULONG64 RequestedLength)
+{
+    GDB_XFER_STREAM Stream = {0};
+    ULONG64 Offset;
+    ULONG64 Length;
+    ULONG64 TotalLength;
+
+    /* Measuring pass: a zero length window emits nothing */
+    Streamer(&Stream);
+    TotalLength = Stream.Position;
+
+    Offset = min(RequestedOffset, TotalLength);
+    Length = min(RequestedLength, (ULONG64)GDB_XFER_MAX_SIZE);
+    Length = min(Length, TotalLength - Offset);
+
+    start_gdb_packet();
+    send_gdb_partial_packet((Offset + Length < TotalLength) ? "m" : "l");
+    Stream.Offset = Offset;
+    Stream.Length = Length;
+    Stream.Position = 0;
+    Streamer(&Stream);
+    return finish_gdb_packet();
+}
+
+static
+KDSTATUS
+send_xfer_buffer(
+    _In_reads_bytes_(BufferLength) const VOID* Buffer,
+    _In_ SIZE_T BufferLength,
+    _In_ ULONG64 Offset,
+    _In_ ULONG64 Length)
+{
+    if (Offset > BufferLength)
+        Offset = BufferLength;
+    if (Length > GDB_XFER_MAX_SIZE)
+        Length = GDB_XFER_MAX_SIZE;
+    if (Length > BufferLength - Offset)
+        Length = BufferLength - Offset;
+
+    start_gdb_packet();
+    send_gdb_partial_packet((Offset + Length < BufferLength) ? "m" : "l");
+    send_gdb_partial_binary((const UCHAR*)Buffer + (SIZE_T)Offset, (SIZE_T)Length);
+    return finish_gdb_packet();
+}
+
+/*
+ * Monitor output is streamed into as few 'O' packets as possible: every
+ * finished packet costs a full round-trip waiting for GDB to acknowledge it,
+ * and a listing can run to hundreds of lines.
+ */
+static ULONG MonitorPacketLength;
+
+static
+KDSTATUS
+flush_monitor_output(VOID)
+{
+    if (MonitorPacketLength == 0)
+        return KdPacketReceived;
+
+    MonitorPacketLength = 0;
+    return finish_gdb_packet();
+}
+
+static
+KDSTATUS
+send_monitor_output(
+    _In_z_ _Printf_format_string_ const CHAR* Format,
+    ...)
+{
+    CHAR Buffer[256];
+    LONG Length;
+    va_list Arguments;
+    KDSTATUS Status;
+
+    va_start(Arguments, Format);
+    Length = _vsnprintf(Buffer, sizeof(Buffer), Format, Arguments);
+    va_end(Arguments);
+    if (Length < 0)
+        Length = sizeof(Buffer) - 1;
+
+    /* Start a packet, or close the current one if this line no longer fits */
+    if (MonitorPacketLength != 0 &&
+        (MonitorPacketLength + Length * 2) > GDB_MEMORY_MAX_SIZE)
+    {
+        Status = flush_monitor_output();
+        if (Status != KdPacketReceived)
+            return Status;
+    }
+
+    if (MonitorPacketLength == 0)
+    {
+        start_gdb_packet();
+        send_gdb_partial_packet("O");
+        MonitorPacketLength = 1;
+    }
+
+    send_gdb_partial_memory(Buffer, Length);
+    MonitorPacketLength += Length * 2;
+    return KdPacketReceived;
+}
+
+#define MONITOR_PRINT(...) \
+    do { \
+        if (Status == KdPacketReceived) \
+            Status = send_monitor_output(__VA_ARGS__); \
+    } while (0)
+
+static
+VOID
+copy_module_name(
+    _In_ const UNICODE_STRING* Name,
+    _Out_writes_(BufferSize) CHAR* Buffer,
+    _In_ SIZE_T BufferSize)
+{
+    SIZE_T Length;
+    SIZE_T i;
+
+    if (BufferSize == 0)
+        return;
+    if (Name->Buffer == NULL)
+    {
+        Buffer[0] = '\0';
+        return;
+    }
+
+    Length = min(Name->Length / sizeof(WCHAR), BufferSize - 1);
+    for (i = 0; i < Length; i++)
+    {
+        WCHAR WideCharacter = Name->Buffer[i];
+
+        if (WideCharacter >= L'A' && WideCharacter <= L'Z')
+            WideCharacter += L'a' - L'A';
+        Buffer[i] = (WideCharacter <= 0x7f) ? (CHAR)WideCharacter : '?';
+    }
+    Buffer[Length] = '\0';
+}
+
+static
+KDSTATUS
+handle_gdb_monitor_command(VOID)
+{
+    CHAR CommandBuffer[128];
+    CHAR* Command;
+    SIZE_T CommandLength;
+    KDSTATUS Status = KdPacketReceived;
+
+    if (gdb_input_length < 6 ||
+        ((gdb_input_length - 6) & 1) != 0 ||
+        (gdb_input_length - 6) / 2 >= sizeof(CommandBuffer) ||
+        !gdb_decode_hex(&gdb_input[6],
+                        gdb_input_length - 6,
+                        CommandBuffer,
+                        (gdb_input_length - 6) / 2))
+    {
+        return send_gdb_packet("E01");
+    }
+
+    CommandLength = (gdb_input_length - 6) / 2;
+    CommandBuffer[CommandLength] = '\0';
+    Command = CommandBuffer;
+    while (*Command == ' ' || *Command == '\t')
+        Command++;
+    while (CommandLength != 0 &&
+           (CommandBuffer[CommandLength - 1] == ' ' ||
+            CommandBuffer[CommandLength - 1] == '\t'))
+    {
+        CommandBuffer[--CommandLength] = '\0';
+    }
+
+    if (strcmp(Command, "help") == 0 || *Command == '\0')
+    {
+        MONITOR_PRINT("KDGDB monitor commands:\n");
+        MONITOR_PRINT("  version    kernel and KD protocol information\n");
+        MONITOR_PRINT("  processes  active process list\n");
+        MONITOR_PRINT("  threads    active thread list\n");
+        MONITOR_PRINT("  modules    loaded kernel module list\n");
+    }
+    else if (strcmp(Command, "version") == 0)
+    {
+        MONITOR_PRINT("KD %u.%u protocol %u machine 0x%x\n",
+                      KdVersion.MajorVersion,
+                      KdVersion.MinorVersion,
+                      KdVersion.ProtocolVersion,
+                      KdVersion.MachineType);
+        MONITOR_PRINT("kernel base 0x%I64x processor %u\n",
+                      KdVersion.KernBase,
+                      CurrentStateChange.Processor);
+    }
+    else if (strcmp(Command, "processes") == 0)
+    {
+        LIST_ENTRY* ProcessEntry;
+
+        MONITOR_PRINT("pid              process\n");
+        if (TheIdleProcess)
+            MONITOR_PRINT("%-16" PRIxPTR " Idle\n", handle_to_gdb_pid(NULL));
+
+        if (ps_initialized())
+        {
+            for (ProcessEntry = ProcessListHead->Flink;
+                 ProcessEntry != ProcessListHead && Status == KdPacketReceived;
+                 ProcessEntry = ProcessEntry->Flink)
+            {
+                PEPROCESS Process;
+
+                Process = CONTAINING_RECORD(ProcessEntry,
+                                             EPROCESS,
+                                             ActiveProcessLinks);
+                MONITOR_PRINT("%-16" PRIxPTR " %.15s\n",
+                              handle_to_gdb_pid(Process->UniqueProcessId),
+                              Process->ImageFileName);
+            }
+        }
+    }
+    else if (strcmp(Command, "threads") == 0)
+    {
+        LIST_ENTRY* ProcessEntry;
+
+        MONITOR_PRINT("tid              pid              state priority process\n");
+        if (ps_initialized())
+        {
+            for (ProcessEntry = ProcessListHead->Flink;
+                 ProcessEntry != ProcessListHead && Status == KdPacketReceived;
+                 ProcessEntry = ProcessEntry->Flink)
+            {
+                PEPROCESS Process;
+                LIST_ENTRY* ThreadEntry;
+
+                Process = CONTAINING_RECORD(ProcessEntry,
+                                             EPROCESS,
+                                             ActiveProcessLinks);
+                for (ThreadEntry = Process->ThreadListHead.Flink;
+                     ThreadEntry != &Process->ThreadListHead && Status == KdPacketReceived;
+                     ThreadEntry = ThreadEntry->Flink)
+                {
+                    PETHREAD Thread;
+
+                    Thread = CONTAINING_RECORD(ThreadEntry,
+                                               ETHREAD,
+                                               ThreadListEntry);
+                    MONITOR_PRINT("%-16" PRIxPTR " %-16" PRIxPTR " %-5u %-8d %.15s\n",
+                                  handle_to_gdb_tid(Thread->Cid.UniqueThread),
+                                  handle_to_gdb_pid(Process->UniqueProcessId),
+                                  Thread->Tcb.State,
+                                  Thread->Tcb.Priority,
+                                  Process->ImageFileName);
+                }
+            }
+        }
+    }
+    else if (strcmp(Command, "modules") == 0)
+    {
+        LIST_ENTRY* ModuleEntry;
+
+        MONITOR_PRINT("base              size       module\n");
+        if (modules_initialized())
+        {
+            for (ModuleEntry = ModuleListHead->Flink;
+                 ModuleEntry != ModuleListHead && Status == KdPacketReceived;
+                 ModuleEntry = ModuleEntry->Flink)
+            {
+                PLDR_DATA_TABLE_ENTRY Module;
+                CHAR Name[96];
+
+                Module = CONTAINING_RECORD(ModuleEntry,
+                                           LDR_DATA_TABLE_ENTRY,
+                                           InLoadOrderLinks);
+                copy_module_name(&Module->BaseDllName, Name, sizeof(Name));
+                MONITOR_PRINT("%p %08lx %s\n",
+                              Module->DllBase,
+                              Module->SizeOfImage,
+                              Name);
+            }
+        }
+    }
+    else
+    {
+        MONITOR_PRINT("Unknown KDGDB monitor command: %s\n", Command);
+    }
+
+    if (Status == KdPacketReceived)
+        Status = flush_monitor_output();
+    if (Status != KdPacketReceived)
+        return Status;
+    return send_gdb_packet("OK");
 }
 
 /* H* packets */
@@ -68,45 +648,31 @@ static
 KDSTATUS
 handle_gdb_set_thread(void)
 {
+    const char* End = &gdb_input[gdb_input_length];
+    UINT_PTR Pid;
+    UINT_PTR Tid;
     KDSTATUS Status;
+
+    if (gdb_input_length < 3 ||
+        (gdb_input[1] != 'c' && gdb_input[1] != 'g') ||
+        !parse_gdb_thread_id(&gdb_input[2], End, &Pid, &Tid))
+    {
+        return send_gdb_packet("E01");
+    }
+
+    if (Tid != 0 && Tid != (UINT_PTR)-1 && find_thread(Pid, Tid) == NULL)
+        return send_gdb_packet("E03");
 
     switch (gdb_input[1])
     {
     case 'c':
-        if (strcmp(&gdb_input[2], "-1") == 0)
-            gdb_run_tid = (ULONG_PTR)-1;
-        else
-            gdb_run_tid = hex_to_tid(&gdb_input[2]);
+        gdb_run_tid = Tid;
         Status = send_gdb_packet("OK");
         break;
     case 'g':
         KDDBGPRINT("Setting debug thread: %s.\n", gdb_input);
-#if MONOPROCESS
-        gdb_dbg_pid = 0;
-        if (strncmp(&gdb_input[2], "-1", 2) == 0)
-        {
-            gdb_dbg_tid = (UINT_PTR)-1;
-        }
-        else
-        {
-            gdb_dbg_tid = hex_to_tid(&gdb_input[2]);
-        }
-#else
-        if (strncmp(&gdb_input[2], "p-1", 3) == 0)
-        {
-            gdb_dbg_pid = (UINT_PTR)-1;
-            gdb_dbg_tid = (UINT_PTR)-1;
-        }
-        else
-        {
-            char* ptr = strstr(gdb_input, ".") + 1;
-            gdb_dbg_pid = hex_to_pid(&gdb_input[3]);
-            if (strncmp(ptr, "-1", 2) == 0)
-                gdb_dbg_tid = (UINT_PTR)-1;
-            else
-                gdb_dbg_tid = hex_to_tid(ptr);
-        }
-#endif
+        gdb_dbg_pid = Pid;
+        gdb_dbg_tid = Tid;
         Status = send_gdb_packet("OK");
         break;
     default:
@@ -121,24 +687,18 @@ static
 KDSTATUS
 handle_gdb_thread_alive(void)
 {
-    ULONG_PTR Pid, Tid;
+    const char* End = &gdb_input[gdb_input_length];
+    UINT_PTR Pid, Tid;
     PETHREAD Thread;
     KDSTATUS Status;
 
-#if MONOPROCESS
-    Pid = 0;
-    Tid = hex_to_tid(&gdb_input[1]);
+    if (!parse_gdb_thread_id(&gdb_input[1], End, &Pid, &Tid) ||
+        Tid == 0 || Tid == (UINT_PTR)-1)
+    {
+        return send_gdb_packet("E01");
+    }
 
-    KDDBGPRINT("Checking if %p is alive.\n", Tid);
-
-#else
-    Pid = hex_to_pid(&gdb_input[2]);
-    Tid = hex_to_tid(strstr(gdb_input, ".") + 1);
-
-    /* We cannot use PsLookupProcessThreadByCid as we could be running at any IRQL.
-     * So loop. */
     KDDBGPRINT("Checking if p%p.%p is alive.\n", Pid, Tid);
-#endif
 
     Thread = find_thread(Pid, Tid);
 
@@ -155,137 +715,66 @@ static
 KDSTATUS
 handle_gdb_query(void)
 {
-    if (strncmp(gdb_input, "qSupported:", 11) == 0)
+    if ((strcmp(gdb_input, "qSupported") == 0) ||
+        (strncmp(gdb_input, "qSupported:", 11) == 0))
     {
 #if MONOPROCESS
-        return send_gdb_packet("PacketSize=1000;qXfer:libraries:read+;");
+        return send_gdb_packet("PacketSize=1000;QStartNoAckMode+;binary-upload+;qXfer:exec-file:read+;qXfer:features:read+;qXfer:libraries:read+;qXfer:threads:read+;vContSupported+;");
 #else
-        return send_gdb_packet("PacketSize=1000;multiprocess+;qXfer:libraries:read+;");
+        return send_gdb_packet("PacketSize=1000;QStartNoAckMode+;binary-upload+;multiprocess+;qXfer:exec-file:read+;qXfer:features:read+;qXfer:libraries:read+;qXfer:threads:read+;vContSupported+;");
 #endif
     }
 
-    if (strncmp(gdb_input, "qAttached", 9) == 0)
+    if (strcmp(gdb_input, "qAttached") == 0)
     {
-#if MONOPROCESS
         return send_gdb_packet("1");
-#else
-        UINT_PTR queried_pid = hex_to_pid(&gdb_input[10]);
-        /* Let's say we created system process */
-        if (gdb_pid_to_handle(queried_pid) == NULL)
-            return send_gdb_packet("0");
-        else
-            return send_gdb_packet("1");
-#endif
     }
 
     if (strncmp(gdb_input, "qRcmd,", 6) == 0)
     {
-        return send_gdb_packet("OK");
+        return handle_gdb_monitor_command();
     }
 
     if (strcmp(gdb_input, "qC") == 0)
     {
-        char gdb_out[64];
-#if MONOPROCESS
-        sprintf(gdb_out, "QC:%" PRIxPTR ";",
-            handle_to_gdb_tid(PsGetThreadId((PETHREAD)(ULONG_PTR)CurrentStateChange.Thread)));
-#else
-        sprintf(gdb_out, "QC:p%" PRIxPTR ".%" PRIxPTR ";",
-            handle_to_gdb_pid(PsGetThreadProcessId((PETHREAD)(ULONG_PTR)CurrentStateChange.Thread)),
-            handle_to_gdb_tid(PsGetThreadId((PETHREAD)(ULONG_PTR)CurrentStateChange.Thread)));
-#endif
+        PETHREAD Thread = (PETHREAD)(ULONG_PTR)CurrentStateChange.Thread;
+        char gdb_out[64] = "QC";
+
+        format_gdb_tid(&gdb_out[2], sizeof(gdb_out) - 2,
+                       PsGetThreadProcessId(Thread),
+                       handle_to_gdb_tid(PsGetThreadId(Thread)));
         return send_gdb_packet(gdb_out);
     }
 
-    if (strncmp(gdb_input, "qfThreadInfo", 12) == 0)
-    {
-        PEPROCESS Process;
-        char gdb_out[40];
-        LIST_ENTRY* CurrentProcessEntry;
+    if (strcmp(gdb_input, "qfThreadInfo") == 0)
+        return send_thread_info(TRUE);
 
-        CurrentProcessEntry = ProcessListHead->Flink;
-        if (CurrentProcessEntry == NULL) /* Ps is not initialized */
-        {
-#if MONOPROCESS
-            return send_gdb_packet("m1");
-#else
-            return send_gdb_packet("mp1.1");
-#endif
-        }
-
-        /* We will push threads as we find them */
-        start_gdb_packet();
-
-        /* Start with the system thread */
-#if MONOPROCESS
-        send_gdb_partial_packet("m1");
-#else
-        send_gdb_partial_packet("mp1.1");
-#endif
-
-        /* List all the processes */
-        for ( ;
-            CurrentProcessEntry != ProcessListHead;
-            CurrentProcessEntry = CurrentProcessEntry->Flink)
-        {
-            LIST_ENTRY* CurrentThreadEntry;
-
-            Process = CONTAINING_RECORD(CurrentProcessEntry, EPROCESS, ActiveProcessLinks);
-
-            /* List threads from this process */
-            for ( CurrentThreadEntry = Process->ThreadListHead.Flink;
-                 CurrentThreadEntry != &Process->ThreadListHead;
-                 CurrentThreadEntry = CurrentThreadEntry->Flink)
-            {
-                PETHREAD Thread = CONTAINING_RECORD(CurrentThreadEntry, ETHREAD, ThreadListEntry);
-
-#if MONOPROCESS
-                _snprintf(gdb_out, 40, ",%" PRIxPTR, handle_to_gdb_tid(Thread->Cid.UniqueThread));
-#else
-                _snprintf(gdb_out, 40, ",p%" PRIxPTR ".%" PRIxPTR,
-                    handle_to_gdb_pid(Process->UniqueProcessId),
-                    handle_to_gdb_tid(Thread->Cid.UniqueThread));
-#endif
-                send_gdb_partial_packet(gdb_out);
-            }
-        }
-
-        return finish_gdb_packet();
-    }
-
-    if (strncmp(gdb_input, "qsThreadInfo", 12) == 0)
-    {
-        /* We sent the whole thread list on first qfThreadInfo call */
-        return send_gdb_packet("l");
-    }
+    if (strcmp(gdb_input, "qsThreadInfo") == 0)
+        return send_thread_info(FALSE);
 
     if (strncmp(gdb_input, "qGetTIBAddr:", 12) == 0)
     {
-        ULONG_PTR Pid, Tid;
+        const char* End = &gdb_input[gdb_input_length];
+        UINT_PTR Pid, Tid;
         PETHREAD Thread;
 
-#if MONOPROCESS
-        Pid = 0;
-        Tid = hex_to_tid(&gdb_input[12]);
-
-        KDDBGPRINT(" %p.\n", Tid);
+        if (!parse_gdb_thread_id(&gdb_input[12], End, &Pid, &Tid) ||
+            Tid == 0 || Tid == (UINT_PTR)-1)
+        {
+            return send_gdb_packet("E01");
+        }
 
         Thread = find_thread(Pid, Tid);
-#else
-        Pid = hex_to_pid(&gdb_input[13]);
-        Tid = hex_to_tid(strstr(&gdb_input[13], ".") + 1);
+        if (Thread == NULL)
+            return send_gdb_packet("E03");
 
-        /* We cannot use PsLookupProcessThreadByCid as we could be running at any IRQL.
-         * So loop. */
-        KDDBGPRINT(" p%p.%p.\n", Pid, Tid);
-        Thread = find_thread(Pid, Tid);
-#endif
         return send_gdb_memory(&Thread->Tcb.Teb, sizeof(Thread->Tcb.Teb));
     }
 
     if (strncmp(gdb_input, "qThreadExtraInfo,", 17) == 0)
     {
-        ULONG_PTR Pid, Tid;
+        const char* End = &gdb_input[gdb_input_length];
+        UINT_PTR Pid, Tid;
         PETHREAD Thread;
         PEPROCESS Process;
         char out_string[64];
@@ -293,24 +782,23 @@ handle_gdb_query(void)
 
         KDDBGPRINT("Giving extra info for");
 
-#if MONOPROCESS
-        Pid = 0;
-        Tid = hex_to_tid(&gdb_input[17]);
-
-        KDDBGPRINT(" %p.\n", Tid);
+        if (!parse_gdb_thread_id(&gdb_input[17], End, &Pid, &Tid) ||
+            Tid == 0 || Tid == (UINT_PTR)-1)
+        {
+            return send_gdb_packet("E01");
+        }
 
         Thread = find_thread(Pid, Tid);
+
+        if (Thread == NULL)
+            return send_gdb_packet("E03");
+
+#if MONOPROCESS
         Process = CONTAINING_RECORD(Thread->Tcb.Process, EPROCESS, Pcb);
 #else
-        Pid = hex_to_pid(&gdb_input[18]);
-        Tid = hex_to_tid(strstr(&gdb_input[18], ".") + 1);
-
-        /* We cannot use PsLookupProcessThreadByCid as we could be running at any IRQL.
-         * So loop. */
-        KDDBGPRINT(" p%p.%p.\n", Pid, Tid);
-
         Process = find_process(Pid);
-        Thread = find_thread(Pid, Tid);
+        if (Process == NULL)
+            return send_gdb_packet("E03");
 #endif
 
         if (PsGetThreadProcessId(Thread) == 0)
@@ -337,121 +825,80 @@ handle_gdb_query(void)
         return send_gdb_packet("OK");
     }
 
+    if (strncmp(gdb_input, "qXfer:features:read:target.xml:", 31) == 0)
+    {
+        const char* End = &gdb_input[gdb_input_length];
+        const char* Rest;
+        ULONG64 Window[2];
+
+        if (!parse_hex_fields(&gdb_input[31], End, ",", Window, RTL_NUMBER_OF(Window), &Rest) ||
+            Rest != End)
+        {
+            return send_gdb_packet("E01");
+        }
+
+        return send_xfer_buffer(gdb_target_xml,
+                                gdb_target_xml_length,
+                                Window[0],
+                                Window[1]);
+    }
+
+    if (strncmp(gdb_input, "qXfer:exec-file:read::", 22) == 0)
+    {
+        static const CHAR KernelName[] = "C:\\ntoskrnl.exe";
+        const char* End = &gdb_input[gdb_input_length];
+        const char* Rest;
+        ULONG64 Window[2];
+
+        if (!parse_hex_fields(&gdb_input[22], End, ",", Window, RTL_NUMBER_OF(Window), &Rest) ||
+            Rest != End)
+        {
+            return send_gdb_packet("E01");
+        }
+
+        return send_xfer_buffer(KernelName,
+                                sizeof(KernelName) - 1,
+                                Window[0],
+                                Window[1]);
+    }
+
     if (strncmp(gdb_input, "qXfer:libraries:read::", 22) == 0)
     {
-        static LIST_ENTRY* CurrentEntry = NULL;
-        char str_helper[256];
-        char name_helper[64];
-        ULONG_PTR Offset = hex_to_address(&gdb_input[22]);
-        ULONG_PTR ToSend = hex_to_address(strstr(&gdb_input[22], ",") + 1);
-        ULONG Sent = 0;
-        static BOOLEAN allDone = FALSE;
+        const char* End = &gdb_input[gdb_input_length];
+        const char* Rest;
+        ULONG64 Window[2];
 
         KDDBGPRINT("KDGDB: qXfer:libraries:read\n");
 
-        /* Start the packet */
-        start_gdb_packet();
-
-        if (allDone)
+        if (!parse_hex_fields(&gdb_input[22], End, ",", Window, RTL_NUMBER_OF(Window), &Rest) ||
+            Rest != End)
         {
-            send_gdb_partial_packet("l");
-            allDone = FALSE;
-            return finish_gdb_packet();
+            return send_gdb_packet("E01");
         }
 
-        send_gdb_partial_packet("m");
-        Sent++;
+        return send_xfer_stream(stream_libraries_xml, Window[0], Window[1]);
+    }
 
-        /* Are we starting ? */
-        if (Offset == 0)
+    if (strncmp(gdb_input, "qXfer:threads:read::", 20) == 0)
+    {
+        const char* End = &gdb_input[gdb_input_length];
+        const char* Rest;
+        ULONG64 Window[2];
+
+        if (!parse_hex_fields(&gdb_input[20], End, ",", Window, RTL_NUMBER_OF(Window), &Rest) ||
+            Rest != End)
         {
-            Sent += send_gdb_partial_binary("<?xml version=\"1.0\"?>", 21);
-            Sent += send_gdb_partial_binary("<library-list>", 14);
-
-            CurrentEntry = ModuleListHead->Flink;
-
-            if (!CurrentEntry)
-            {
-                /* Ps is not initialized. Send end of XML data or mark that we are finished. */
-                Sent += send_gdb_partial_binary("</library-list>", 15);
-                allDone = TRUE;
-                return finish_gdb_packet();
-            }
+            return send_gdb_packet("E01");
         }
 
-        for ( ;
-            CurrentEntry != ModuleListHead;
-            CurrentEntry = CurrentEntry->Flink)
-        {
-            PLDR_DATA_TABLE_ENTRY TableEntry = CONTAINING_RECORD(CurrentEntry, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
-            PVOID DllBase = (PVOID)((ULONG_PTR)TableEntry->DllBase + 0x1000);
-            LONG mem_length;
-            USHORT i;
-
-            /* Convert names to lower case. Yes this _is_ ugly */
-            for (i = 0; i < (TableEntry->BaseDllName.Length / sizeof(WCHAR)); i++)
-            {
-                name_helper[i] = (char)TableEntry->BaseDllName.Buffer[i];
-                if (name_helper[i] >= 'A' && name_helper[i] <= 'Z')
-                    name_helper[i] += 'a' - 'A';
-            }
-            name_helper[i] = 0;
-
-            /* GDB doesn't load the file if you don't prefix it with a drive letter... */
-            mem_length = _snprintf(str_helper, 256, "<library name=\"C:\\%s\"><segment address=\"0x%p\"/></library>", &name_helper, DllBase);
-
-            /* DLL name must be too long. */
-            if (mem_length < 0)
-            {
-                KDDBGPRINT("Failed to report %wZ\n", &TableEntry->BaseDllName);
-                continue;
-            }
-
-            if ((Sent + mem_length) > ToSend)
-            {
-                /* We're done for this pass */
-                return finish_gdb_packet();
-            }
-
-            Sent += send_gdb_partial_binary(str_helper, mem_length);
-        }
-
-        if ((ToSend - Sent) > 15)
-        {
-            Sent += send_gdb_partial_binary("</library-list>", 15);
-            allDone = TRUE;
-        }
-
-        return finish_gdb_packet();
+        return send_xfer_stream(stream_threads_xml, Window[0], Window[1]);
     }
 
     KDDBGPRINT("KDGDB: Unknown query: %s\n", gdb_input);
     return send_gdb_packet("");
 }
 
-#if 0
-static
-KDSTATUS
-handle_gdb_registers(
-    _Out_ DBGKD_MANIPULATE_STATE64* State,
-    _Out_ PSTRING MessageData,
-    _Out_ PULONG MessageLength)
-{
-    /*
-    if (gdb_dbg_thread)
-        KDDBGPRINT("Should get registers from other thread!\n");
-    */
-
-    State->ApiNumber = DbgKdGetContextApi;
-    State->ReturnStatus = STATUS_SUCCESS; /* ? */
-    State->Processor = CurrentStateChange.Processor;
-    State->ProcessorLevel = CurrentStateChange.ProcessorLevel;
-    if (MessageData)
-        MessageData->Length = 0;
-    *MessageLength = 0;
-    return KdPacketReceived;
-}
-#endif
+static BOOLEAN ReadMemoryBinary;
 
 static
 BOOLEAN
@@ -478,6 +925,12 @@ ReadMemorySendHandler(
     /* Check status. Allow to send partial data. */
     if (!MessageData->Length && !NT_SUCCESS(State->ReturnStatus))
         send_gdb_ntstatus(State->ReturnStatus);
+    else if (ReadMemoryBinary)
+    {
+        start_gdb_packet();
+        send_gdb_partial_binary(MessageData->Buffer, MessageData->Length);
+        finish_gdb_packet();
+    }
     else
         send_gdb_memory(MessageData->Buffer, MessageData->Length);
     KdpSendPacketHandler = NULL;
@@ -491,8 +944,8 @@ ReadMemorySendHandler(
 #endif
     {
         /* Only do this if Ps is initialized */
-        if (ProcessListHead->Flink)
-            __writecr3(PsGetCurrentProcess()->Pcb.DirectoryTableBase[0]);
+        if (ps_initialized())
+            __writecr3(KdpGetDirectoryTableBase(&PsGetCurrentProcess()->Pcb));
     }
 
     return TRUE;
@@ -506,6 +959,23 @@ handle_gdb_read_mem(
     _Out_ PULONG MessageLength,
     _Inout_ PKD_CONTEXT KdContext)
 {
+    const char* End = &gdb_input[gdb_input_length];
+    const char* Rest;
+    ULONG64 Request[2];
+    ULONG64 Address;
+    ULONG64 Length;
+
+    if (!parse_hex_fields(&gdb_input[1], End, ",", Request, RTL_NUMBER_OF(Request), &Rest) ||
+        Rest != End || Request[1] > GDB_MEMORY_MAX_SIZE)
+    {
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    }
+
+    Address = Request[0];
+    Length = Request[1];
+    if (Length == 0)
+        return LOOP_IF_SUCCESS(send_gdb_packet(""));
+
     State->ApiNumber = DbgKdReadVirtualMemoryApi;
     State->ReturnStatus = STATUS_SUCCESS; /* ? */
     State->Processor = CurrentStateChange.Processor;
@@ -532,7 +1002,7 @@ handle_gdb_read_mem(
             KDDBGPRINT("The current GDB debug thread is invalid!");
             return LOOP_IF_SUCCESS(send_gdb_packet("E03"));
         }
-        __writecr3(AttachedProcess->DirectoryTableBase[0]);
+        __writecr3(KdpGetDirectoryTableBase(AttachedProcess));
     }
 #else
     if ((gdb_dbg_pid != 0) && gdb_pid_to_handle(gdb_dbg_pid) != PsGetCurrentProcessId())
@@ -544,13 +1014,14 @@ handle_gdb_read_mem(
             return LOOP_IF_SUCCESS(send_gdb_packet("E03"));
         }
         /* Only do this if Ps is initialized */
-        if (ProcessListHead->Flink)
-            __writecr3(AttachedProcess->Pcb.DirectoryTableBase[0]);
+        if (ps_initialized())
+            __writecr3(KdpGetDirectoryTableBase(&AttachedProcess->Pcb));
     }
 #endif
 
-    State->u.ReadMemory.TargetBaseAddress = hex_to_address(&gdb_input[1]);
-    State->u.ReadMemory.TransferCount = hex_to_address(strstr(&gdb_input[1], ",") + 1);
+    State->u.ReadMemory.TargetBaseAddress = Address;
+    State->u.ReadMemory.TransferCount = (ULONG)Length;
+    ReadMemoryBinary = (gdb_input[0] == 'x');
 
     /* KD will reply with KdSendPacket. Catch it */
     KdpSendPacketHandler = ReadMemorySendHandler;
@@ -595,8 +1066,8 @@ WriteMemorySendHandler(
 #endif
     {
         /* Only do this if Ps is initialized */
-        if (ProcessListHead->Flink)
-            __writecr3(PsGetCurrentProcess()->Pcb.DirectoryTableBase[0]);
+        if (ps_initialized())
+            __writecr3(KdpGetDirectoryTableBase(&PsGetCurrentProcess()->Pcb));
     }
     return TRUE;
 }
@@ -609,18 +1080,54 @@ handle_gdb_write_mem(
     _Out_ PULONG MessageLength,
     _Inout_ PKD_CONTEXT KdContext)
 {
-    /* Maximal input buffer is 0x1000. Each byte is encoded on two bytes by GDB */
-    static UCHAR OutBuffer[0x800];
+    static UCHAR OutBuffer[GDB_PACKET_MAX_SIZE];
+    const char* End = &gdb_input[gdb_input_length];
+    const char* Blob;
+    /* 'M' carries a hex-encoded payload, 'X' a binary one */
+    BOOLEAN IsHexEncoded = (gdb_input[0] == 'M');
+    ULONG64 Request[2];
+    ULONG64 Address;
+    ULONG64 Length;
     ULONG BufferLength;
-    char* blob_ptr;
-    UCHAR* OutPtr;
+
+    if (!parse_hex_fields(&gdb_input[1], End, ",:", Request, RTL_NUMBER_OF(Request), &Blob))
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+
+    Address = Request[0];
+    Length = Request[1];
+    if (Length > (IsHexEncoded ? GDB_MEMORY_MAX_SIZE : sizeof(OutBuffer)))
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+
+    BufferLength = (ULONG)Length;
+    if (IsHexEncoded)
+    {
+        /* gdb_decode_hex enforces that the blob is exactly twice as long */
+        if (!gdb_decode_hex(Blob, (ULONG)(End - Blob), OutBuffer, BufferLength))
+            return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    }
+    else
+    {
+        if ((ULONG64)(End - Blob) != Length)
+            return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+        RtlCopyMemory(OutBuffer, Blob, BufferLength);
+    }
+
+    if (BufferLength == 0)
+    {
+        /* Nothing to do */
+        return LOOP_IF_SUCCESS(send_gdb_packet("OK"));
+    }
 
     State->ApiNumber = DbgKdWriteVirtualMemoryApi;
     State->ReturnStatus = STATUS_SUCCESS; /* ? */
     State->Processor = CurrentStateChange.Processor;
     State->ProcessorLevel = CurrentStateChange.ProcessorLevel;
+    State->u.WriteMemory.TargetBaseAddress = Address;
+    State->u.WriteMemory.TransferCount = BufferLength;
+    MessageData->Length = BufferLength;
+    MessageData->Buffer = (CHAR*)OutBuffer;
 
-    /* Set the TLB according to the process being read. Pid 0 means any process. */
+    /* Set the TLB according to the process being written. Pid 0 means any process. */
 #if MONOPROCESS
     if ((gdb_dbg_tid != 0) && gdb_tid_to_handle(gdb_dbg_tid) != PsGetCurrentThreadId())
     {
@@ -638,7 +1145,7 @@ handle_gdb_write_mem(
             KDDBGPRINT("The current GDB debug thread is invalid!");
             return LOOP_IF_SUCCESS(send_gdb_packet("E03"));
         }
-        __writecr3(AttachedProcess->DirectoryTableBase[0]);
+        __writecr3(KdpGetDirectoryTableBase(AttachedProcess));
     }
 #else
     if ((gdb_dbg_pid != 0) && gdb_pid_to_handle(gdb_dbg_pid) != PsGetCurrentProcessId())
@@ -646,55 +1153,60 @@ handle_gdb_write_mem(
         PEPROCESS AttachedProcess = find_process(gdb_dbg_pid);
         if (AttachedProcess == NULL)
         {
-            KDDBGPRINT("The current GDB debug thread is invalid!");
+            KDDBGPRINT("The current GDB debug process is invalid!");
             return LOOP_IF_SUCCESS(send_gdb_packet("E03"));
         }
         /* Only do this if Ps is initialized */
-        if (ProcessListHead->Flink)
-            __writecr3(AttachedProcess->Pcb.DirectoryTableBase[0]);
+        if (ps_initialized())
+            __writecr3(KdpGetDirectoryTableBase(&AttachedProcess->Pcb));
     }
 #endif
-
-    State->u.WriteMemory.TargetBaseAddress = hex_to_address(&gdb_input[1]);
-    BufferLength = hex_to_address(strstr(&gdb_input[1], ",") + 1);
-    if (BufferLength == 0)
-    {
-        /* Nothing to do */
-        return LOOP_IF_SUCCESS(send_gdb_packet("OK"));
-    }
-
-    State->u.WriteMemory.TransferCount = BufferLength;
-    MessageData->Length = BufferLength;
-    MessageData->Buffer = (CHAR*)OutBuffer;
-
-    OutPtr = OutBuffer;
-    blob_ptr = strstr(strstr(&gdb_input[1], ",") + 1, ":") + 1;
-    while (BufferLength)
-    {
-        if (BufferLength >= 4)
-        {
-            *((ULONG*)OutPtr) = *((ULONG*)blob_ptr);
-            OutPtr += 4;
-            blob_ptr += 4;
-            BufferLength -= 4;
-        }
-        else if (BufferLength >= 2)
-        {
-            *((USHORT*)OutPtr) = *((USHORT*)blob_ptr);
-            OutPtr += 2;
-            blob_ptr += 2;
-            BufferLength -= 2;
-        }
-        else
-        {
-            *OutPtr++ = *blob_ptr++;
-            BufferLength--;
-        }
-    }
 
     /* KD will reply with KdSendPacket. Catch it */
     KdpSendPacketHandler = WriteMemorySendHandler;
     return KdPacketReceived;
+}
+
+static
+KDSTATUS
+handle_gdb_write_registers(
+    _Out_ DBGKD_MANIPULATE_STATE64* State,
+    _Out_ PSTRING MessageData,
+    _Out_ PULONG MessageLength,
+    _Inout_ PKD_CONTEXT KdContext)
+{
+    if (!gdb_write_registers(&gdb_input[1], gdb_input_length - 1))
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+
+    return SetContextManipulateHandlerWithReply(State,
+                                                MessageData,
+                                                MessageLength,
+                                                KdContext);
+}
+
+static
+KDSTATUS
+handle_gdb_write_register(
+    _Out_ DBGKD_MANIPULATE_STATE64* State,
+    _Out_ PSTRING MessageData,
+    _Out_ PULONG MessageLength,
+    _Inout_ PKD_CONTEXT KdContext)
+{
+    const char* End = &gdb_input[gdb_input_length];
+    const char* Value;
+    ULONG64 Register;
+
+    if (!parse_hex_fields(&gdb_input[1], End, "=", &Register, 1, &Value) ||
+        Register > MAXULONG ||
+        !gdb_write_register((ULONG)Register, Value, (ULONG)(End - Value)))
+    {
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    }
+
+    return SetContextManipulateHandlerWithReply(State,
+                                                MessageData,
+                                                MessageLength,
+                                                KdContext);
 }
 
 static
@@ -729,9 +1241,9 @@ WriteBreakPointSendHandler(
     {
         /* Keep track of the address+handle couple */
         ULONG i;
-        for (i = 0; i < (sizeof(BreakPointHandles) / sizeof(BreakPointHandles[0])); i++)
+        for (i = 0; i < RTL_NUMBER_OF(BreakPointHandles); i++)
         {
-            if (BreakPointHandles[i].Address == 0)
+            if (BreakPointHandles[i].Handle == 0)
             {
                 BreakPointHandles[i].Address = (ULONG_PTR)State->u.WriteBreakPoint.BreakPointAddress;
                 BreakPointHandles[i].Handle = State->u.WriteBreakPoint.BreakPointHandle;
@@ -745,6 +1257,34 @@ WriteBreakPointSendHandler(
     return TRUE;
 }
 
+typedef enum _GDB_BREAKPOINT_PACKET
+{
+    GdbBreakpointInvalid,
+    GdbBreakpointUnsupported,
+    GdbBreakpointSupported
+} GDB_BREAKPOINT_PACKET;
+
+static
+GDB_BREAKPOINT_PACKET
+parse_breakpoint_packet(
+    _Out_ PULONG64 Address)
+{
+    const char* End = &gdb_input[gdb_input_length];
+    const char* Rest;
+    ULONG64 Fields[3];
+
+    /* Type,Address,Kind - the kind may be followed by unsupported conditions */
+    if (!parse_hex_fields(&gdb_input[1], End, ",,", Fields, RTL_NUMBER_OF(Fields), &Rest))
+        return GdbBreakpointInvalid;
+
+    *Address = Fields[1];
+    if (Fields[0] != 0 || Rest != End)
+        return GdbBreakpointUnsupported;
+    if (Fields[2] == 0)
+        return GdbBreakpointInvalid;
+    return GdbBreakpointSupported;
+}
+
 static
 KDSTATUS
 handle_gdb_insert_breakpoint(
@@ -753,6 +1293,11 @@ handle_gdb_insert_breakpoint(
     _Out_ PULONG MessageLength,
     _Inout_ PKD_CONTEXT KdContext)
 {
+    ULONG64 Address;
+    GDB_BREAKPOINT_PACKET Packet;
+    ULONG i;
+    BOOLEAN HasFreeSlot = FALSE;
+
     State->ReturnStatus = STATUS_SUCCESS; /* ? */
     State->Processor = CurrentStateChange.Processor;
     State->ProcessorLevel = CurrentStateChange.ProcessorLevel;
@@ -760,41 +1305,38 @@ handle_gdb_insert_breakpoint(
         MessageData->Length = 0;
     *MessageLength = 0;
 
-    switch (gdb_input[1])
+    Packet = parse_breakpoint_packet(&Address);
+    if (Packet == GdbBreakpointInvalid)
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    if (Packet == GdbBreakpointUnsupported)
+        return LOOP_IF_SUCCESS(send_gdb_packet(""));
+
+    KDDBGPRINT("Inserting breakpoint at %p.\n", (void*)(ULONG_PTR)Address);
+
+    for (i = 0; i < RTL_NUMBER_OF(BreakPointHandles); i++)
     {
-        case '0':
+        if (BreakPointHandles[i].Handle != 0 &&
+            BreakPointHandles[i].Address == (ULONG_PTR)Address)
         {
-            ULONG_PTR Address = hex_to_address(&gdb_input[3]);
-            ULONG i;
-            BOOLEAN HasFreeSlot = FALSE;
-
-            KDDBGPRINT("Inserting breakpoint at %p.\n", (void*)Address);
-
-            for (i = 0; i < (sizeof(BreakPointHandles) / sizeof(BreakPointHandles[0])); i++)
-            {
-                if (BreakPointHandles[i].Address == 0)
-                    HasFreeSlot = TRUE;
-            }
-
-            if (!HasFreeSlot)
-            {
-                /* We don't have a way to keep track of this break point. Fail. */
-                KDDBGPRINT("No breakpoint slot available!\n");
-                return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
-            }
-
-            State->ApiNumber = DbgKdWriteBreakPointApi;
-            State->u.WriteBreakPoint.BreakPointAddress = Address;
-            /* FIXME : ignoring all other Z0 arguments */
-
-            /* KD will reply with KdSendPacket. Catch it */
-            KdpSendPacketHandler = WriteBreakPointSendHandler;
-            return KdPacketReceived;
+            return LOOP_IF_SUCCESS(send_gdb_packet("OK"));
         }
+
+        if (BreakPointHandles[i].Handle == 0)
+            HasFreeSlot = TRUE;
     }
 
-    KDDBGPRINT("Unhandled 'Z' packet: %s\n", gdb_input);
-    return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    if (!HasFreeSlot)
+    {
+        KDDBGPRINT("No breakpoint slot available!\n");
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    }
+
+    State->ApiNumber = DbgKdWriteBreakPointApi;
+    State->u.WriteBreakPoint.BreakPointAddress = Address;
+
+    /* KD will reply with KdSendPacket. Catch it */
+    KdpSendPacketHandler = WriteBreakPointSendHandler;
+    return KdPacketReceived;
 }
 
 static
@@ -822,7 +1364,7 @@ RestoreBreakPointSendHandler(
 
     /* We ignore failure here. If DbgKdRestoreBreakPointApi fails,
      * this means that the breakpoint was already invalid for KD. So clean it up on our side. */
-    for (i = 0; i < (sizeof(BreakPointHandles) / sizeof(BreakPointHandles[0])); i++)
+    for (i = 0; i < RTL_NUMBER_OF(BreakPointHandles); i++)
     {
         if (BreakPointHandles[i].Handle == State->u.RestoreBreakPoint.BreakPointHandle)
         {
@@ -847,6 +1389,10 @@ handle_gdb_remove_breakpoint(
     _Out_ PULONG MessageLength,
     _Inout_ PKD_CONTEXT KdContext)
 {
+    ULONG64 Address;
+    GDB_BREAKPOINT_PACKET Packet;
+    ULONG i, Handle = 0;
+
     State->ReturnStatus = STATUS_SUCCESS; /* ? */
     State->Processor = CurrentStateChange.Processor;
     State->ProcessorLevel = CurrentStateChange.ProcessorLevel;
@@ -854,42 +1400,151 @@ handle_gdb_remove_breakpoint(
         MessageData->Length = 0;
     *MessageLength = 0;
 
-    switch (gdb_input[1])
+    Packet = parse_breakpoint_packet(&Address);
+    if (Packet == GdbBreakpointInvalid)
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    if (Packet == GdbBreakpointUnsupported)
+        return LOOP_IF_SUCCESS(send_gdb_packet(""));
+
+    KDDBGPRINT("Removing breakpoint on %p.\n", (void*)(ULONG_PTR)Address);
+
+    for (i = 0; i < RTL_NUMBER_OF(BreakPointHandles); i++)
     {
-        case '0':
+        if (BreakPointHandles[i].Handle != 0 &&
+            BreakPointHandles[i].Address == (ULONG_PTR)Address)
         {
-            ULONG_PTR Address = hex_to_address(&gdb_input[3]);
-            ULONG i, Handle = 0;
-
-            KDDBGPRINT("Removing breakpoint on %p.\n", (void*)Address);
-
-            for (i = 0; i < (sizeof(BreakPointHandles) / sizeof(BreakPointHandles[0])); i++)
-            {
-                if (BreakPointHandles[i].Address == Address)
-                {
-                    Handle = BreakPointHandles[i].Handle;
-                    break;
-                }
-            }
-
-            if (Handle == 0)
-            {
-                KDDBGPRINT("Received %s, but breakpoint was never inserted?!\n", gdb_input);
-                return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
-            }
-
-            State->ApiNumber = DbgKdRestoreBreakPointApi;
-            State->u.RestoreBreakPoint.BreakPointHandle = Handle;
-            /* FIXME : ignoring all other z0 arguments */
-
-            /* KD will reply with KdSendPacket. Catch it */
-            KdpSendPacketHandler = RestoreBreakPointSendHandler;
-            return KdPacketReceived;
+            Handle = BreakPointHandles[i].Handle;
+            break;
         }
     }
 
-    KDDBGPRINT("Unhandled 'Z' packet: %s\n", gdb_input);
-    return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    if (Handle == 0)
+    {
+        KDDBGPRINT("Received %s, but breakpoint was never inserted?!\n", gdb_input);
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    }
+
+    State->ApiNumber = DbgKdRestoreBreakPointApi;
+    State->u.RestoreBreakPoint.BreakPointHandle = Handle;
+
+    /* KD will reply with KdSendPacket. Catch it */
+    KdpSendPacketHandler = RestoreBreakPointSendHandler;
+    return KdPacketReceived;
+}
+
+static
+KDSTATUS
+handle_gdb_detach(
+    _Out_ DBGKD_MANIPULATE_STATE64* State,
+    _Out_ PSTRING MessageData,
+    _Out_ PULONG MessageLength,
+    _Inout_ PKD_CONTEXT KdContext)
+{
+    KDSTATUS Status = send_gdb_packet("OK");
+
+    if (Status != KdPacketReceived)
+        return Status;
+
+    /* A later debugger connection starts in acknowledgement mode again. */
+    gdb_no_ack_mode = FALSE;
+    return ContinueManipulateStateHandler(State, MessageData, MessageLength, KdContext);
+}
+
+static
+KDSTATUS
+handle_gdb_set(VOID)
+{
+    KDSTATUS Status;
+
+    if (strcmp(gdb_input, "QStartNoAckMode") != 0)
+        return LOOP_IF_SUCCESS(send_gdb_packet(""));
+
+    /*
+     * The OK packet itself still uses acknowledgement mode. Switch only after
+     * it has been acknowledged, as required by the remote protocol.
+     */
+    Status = send_gdb_packet("OK");
+    if (Status == KdPacketReceived)
+        gdb_no_ack_mode = TRUE;
+    return LOOP_IF_SUCCESS(Status);
+}
+
+static
+BOOLEAN
+parse_resume_address(
+    _Out_ PBOOLEAN HasAddress,
+    _Out_ PULONG64 Address)
+{
+    const char* Current = &gdb_input[1];
+    const char* End = &gdb_input[gdb_input_length];
+
+    *HasAddress = FALSE;
+
+    /* vCont carries no resume address */
+    if (gdb_input[0] == 'v')
+        return TRUE;
+
+    if (gdb_input[0] == 'C' || gdb_input[0] == 'S')
+    {
+        ULONG64 Signal;
+
+        if (!parse_hex_value(Current, End, &Signal, &Current) ||
+            Signal > 0xff)
+        {
+            return FALSE;
+        }
+
+        if (Current == End)
+            return TRUE;
+        if (*Current++ != ';')
+            return FALSE;
+    }
+
+    if (Current == End)
+        return TRUE;
+    if (!parse_hex_value(Current, End, Address, &Current) || Current != End)
+        return FALSE;
+
+    *HasAddress = TRUE;
+    return TRUE;
+}
+
+/* Push the modified context back to KD, then let the target run */
+static
+KDSTATUS
+set_context_then_continue(
+    _Out_ DBGKD_MANIPULATE_STATE64* State,
+    _Out_ PSTRING MessageData,
+    _Out_ PULONG MessageLength,
+    _Inout_ PKD_CONTEXT KdContext)
+{
+    SetContextManipulateHandler(State, MessageData, MessageLength, KdContext);
+    KdpManipulateStateHandler = ContinueManipulateStateHandler;
+    return KdPacketReceived;
+}
+
+/*
+ * We stopped on one of our own breakpoint instructions, so the program counter
+ * must be moved past it before resuming. Returns whether it was moved.
+ */
+static
+BOOLEAN
+step_over_breakpoint(VOID)
+{
+    DBGKM_EXCEPTION64* Exception = &CurrentStateChange.u.Exception;
+    ULONG_PTR ProgramCounter = KdpGetContextPc(&CurrentContext);
+
+    if (CurrentStateChange.NewState != DbgKdExceptionStateChange)
+        return FALSE;
+
+    if ((Exception->ExceptionRecord.ExceptionCode == STATUS_BREAKPOINT)
+        && ((*(KD_BREAKPOINT_TYPE*)ProgramCounter) == KD_BREAKPOINT_VALUE))
+    {
+        KdpSetContextPc(&CurrentContext, ProgramCounter + KD_BREAKPOINT_SIZE);
+        return TRUE;
+    }
+
+    return FALSE;
 }
 
 static
@@ -900,43 +1555,44 @@ handle_gdb_c(
     _Out_ PULONG MessageLength,
     _Inout_ PKD_CONTEXT KdContext)
 {
-    KDSTATUS Status;
+    BOOLEAN HasAddress;
+    BOOLEAN WasSingleStepping;
+    ULONG64 Address;
 
-    /* Tell GDB everything is fine, we will handle it */
-    Status = send_gdb_packet("OK");
-    if (Status != KdPacketReceived)
-        return Status;
+    if (!parse_resume_address(&HasAddress, &Address))
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
 
+    WasSingleStepping = (CurrentContext.EFlags & EFLAGS_TF) != 0;
+    KdpClearSingleStep(&CurrentContext);
+    if (HasAddress)
+    {
+        KdpSetContextPc(&CurrentContext, (ULONG_PTR)Address);
+        return set_context_then_continue(State, MessageData, MessageLength, KdContext);
+    }
+
+    if (step_over_breakpoint())
+        return set_context_then_continue(State, MessageData, MessageLength, KdContext);
+
+#if defined(_M_IX86) || defined(_M_AMD64)
+    /* Unlike single stepping, continuing also steps over a runtime check failure */
     if (CurrentStateChange.NewState == DbgKdExceptionStateChange)
     {
         DBGKM_EXCEPTION64* Exception = &CurrentStateChange.u.Exception;
         ULONG_PTR ProgramCounter = KdpGetContextPc(&CurrentContext);
 
-        /* See if we should update the program counter */
-        if ((Exception->ExceptionRecord.ExceptionCode == STATUS_BREAKPOINT)
-            && ((*(KD_BREAKPOINT_TYPE*)ProgramCounter) == KD_BREAKPOINT_VALUE))
-        {
-            /* We must get past the breakpoint instruction */
-            KdpSetContextPc(&CurrentContext, ProgramCounter + KD_BREAKPOINT_SIZE);
-
-            SetContextManipulateHandler(State, MessageData, MessageLength, KdContext);
-            KdpManipulateStateHandler = ContinueManipulateStateHandler;
-            return KdPacketReceived;
-        }
-#if defined(_M_IX86) || defined(_M_AMD64)
         if ((Exception->ExceptionRecord.ExceptionCode == STATUS_ASSERTION_FAILURE)
             && ((*(KD_BREAKPOINT_TYPE*)ProgramCounter) == 0xCD)
             && (*((KD_BREAKPOINT_TYPE*)ProgramCounter + 1) == 0x2C))
         {
             /* INT 2C (a.k.a. runtime check failure) */
             KdpSetContextPc(&CurrentContext, ProgramCounter + 2);
-
-            SetContextManipulateHandler(State, MessageData, MessageLength, KdContext);
-            KdpManipulateStateHandler = ContinueManipulateStateHandler;
-            return KdPacketReceived;
+            return set_context_then_continue(State, MessageData, MessageLength, KdContext);
         }
-#endif
     }
+#endif
+
+    if (WasSingleStepping)
+        return set_context_then_continue(State, MessageData, MessageLength, KdContext);
 
     return ContinueManipulateStateHandler(State, MessageData, MessageLength, KdContext);
 }
@@ -949,12 +1605,21 @@ handle_gdb_s(
     _Out_ PULONG MessageLength,
     _Inout_ PKD_CONTEXT KdContext)
 {
+    BOOLEAN HasAddress;
+    ULONG64 Address;
+
+    if (!parse_resume_address(&HasAddress, &Address))
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+
     KDDBGPRINT("Single stepping.\n");
+    if (HasAddress)
+        KdpSetContextPc(&CurrentContext, (ULONG_PTR)Address);
+    else
+        step_over_breakpoint();
+
     /* Set CPU single step mode and continue */
     KdpSetSingleStep(&CurrentContext);
-    SetContextManipulateHandler(State, MessageData, MessageLength, KdContext);
-    KdpManipulateStateHandler = ContinueManipulateStateHandler;
-    return KdPacketReceived;
+    return set_context_then_continue(State, MessageData, MessageLength, KdContext);
 }
 
 static
@@ -965,27 +1630,62 @@ handle_gdb_v(
     _Out_ PULONG MessageLength,
     _Inout_ PKD_CONTEXT KdContext)
 {
-    if (strncmp(gdb_input, "vCont", 5) == 0)
+    const char* Current;
+    const char* End = &gdb_input[gdb_input_length];
+    CHAR ResumeAction = '\0';
+
+    if (strcmp(gdb_input, "vCont?") == 0)
+        return LOOP_IF_SUCCESS(send_gdb_packet("vCont;c;s"));
+
+    if (strcmp(gdb_input, "vMustReplyEmpty") == 0)
+        return LOOP_IF_SUCCESS(send_gdb_packet(""));
+
+    if (gdb_input_length < 7 || strncmp(gdb_input, "vCont;", 6) != 0)
+        return LOOP_IF_SUCCESS(send_gdb_packet(""));
+
+    Current = &gdb_input[6];
+    while (Current != End)
     {
-        if (gdb_input[5] == '?')
+        CHAR Action = *Current++;
+
+        if ((Action != 'c' && Action != 's') ||
+            (ResumeAction != '\0' && ResumeAction != Action))
         {
-            /* Report what we support */
-            return LOOP_IF_SUCCESS(send_gdb_packet("vCont;c;s"));
+            return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+        }
+        ResumeAction = Action;
+
+        if (Current != End && *Current == ':')
+        {
+            const char* ThreadEnd;
+            UINT_PTR Pid;
+            UINT_PTR Tid;
+
+            Current++;
+            ThreadEnd = Current;
+            while (ThreadEnd != End && *ThreadEnd != ';')
+                ThreadEnd++;
+            if (!parse_gdb_thread_id(Current, ThreadEnd, &Pid, &Tid) ||
+                (Tid != 0 && Tid != (UINT_PTR)-1 && find_thread(Pid, Tid) == NULL))
+            {
+                return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+            }
+            gdb_run_tid = Tid;
+            Current = ThreadEnd;
         }
 
-        if (strncmp(gdb_input, "vCont;c", 7) == 0)
+        if (Current != End)
         {
-            return handle_gdb_c(State, MessageData, MessageLength, KdContext);
-        }
-
-        if (strncmp(gdb_input, "vCont;s", 7) == 0)
-        {
-            return handle_gdb_s(State, MessageData, MessageLength, KdContext);
+            if (*Current++ != ';' || Current == End)
+                return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
         }
     }
 
-    KDDBGPRINT("Unhandled 'v' packet: %s\n", gdb_input);
-    return LOOP_IF_SUCCESS(send_gdb_packet(""));
+    if (ResumeAction == 'c')
+        return handle_gdb_c(State, MessageData, MessageLength, KdContext);
+    if (ResumeAction == 's')
+        return handle_gdb_s(State, MessageData, MessageLength, KdContext);
+    return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
 }
 
 KDSTATUS
@@ -1015,7 +1715,7 @@ gdb_receive_and_interpret_packet(
             Status = LOOP_IF_SUCCESS(gdb_send_exception());
             break;
         case '!':
-            Status = LOOP_IF_SUCCESS(send_gdb_packet("OK"));
+            Status = LOOP_IF_SUCCESS(send_gdb_packet(""));
             break;
         case 'c':
         case 'C':
@@ -1024,19 +1724,35 @@ gdb_receive_and_interpret_packet(
         case 'g':
             Status = LOOP_IF_SUCCESS(gdb_send_registers());
             break;
+        case 'D':
+            Status = handle_gdb_detach(State, MessageData, MessageLength, KdContext);
+            break;
+        case 'G':
+            Status = handle_gdb_write_registers(State, MessageData, MessageLength, KdContext);
+            break;
         case 'H':
             Status = LOOP_IF_SUCCESS(handle_gdb_set_thread());
             break;
         case 'm':
             Status = handle_gdb_read_mem(State, MessageData, MessageLength, KdContext);
             break;
+        case 'M':
+            Status = handle_gdb_write_mem(State, MessageData, MessageLength, KdContext);
+            break;
         case 'p':
             Status = LOOP_IF_SUCCESS(gdb_send_register());
+            break;
+        case 'P':
+            Status = handle_gdb_write_register(State, MessageData, MessageLength, KdContext);
+            break;
+        case 'Q':
+            Status = handle_gdb_set();
             break;
         case 'q':
             Status = LOOP_IF_SUCCESS(handle_gdb_query());
             break;
         case 's':
+        case 'S':
             Status = handle_gdb_s(State, MessageData, MessageLength, KdContext);
             break;
         case 'T':
@@ -1047,6 +1763,9 @@ gdb_receive_and_interpret_packet(
             break;
         case 'X':
             Status = handle_gdb_write_mem(State, MessageData, MessageLength, KdContext);
+            break;
+        case 'x':
+            Status = handle_gdb_read_mem(State, MessageData, MessageLength, KdContext);
             break;
         case 'z':
             Status = handle_gdb_remove_breakpoint(State, MessageData, MessageLength, KdContext);

--- a/drivers/base/kdgdb/gdb_input.c
+++ b/drivers/base/kdgdb/gdb_input.c
@@ -853,9 +853,9 @@ handle_gdb_query(void)
         (strncmp(gdb_input, "qSupported:", 11) == 0))
     {
 #if MONOPROCESS
-        return send_gdb_packet("PacketSize=1000;QStartNoAckMode+;binary-upload+;qXfer:exec-file:read+;qXfer:features:read+;qXfer:libraries:read+;qXfer:threads:read+;vContSupported+;");
+        return send_gdb_packet("PacketSize=1000;QStartNoAckMode+;binary-upload+;qXfer:exec-file:read+;qXfer:features:read+;qXfer:libraries:read+;qXfer:memory-map:read+;qXfer:threads:read+;vContSupported+;");
 #else
-        return send_gdb_packet("PacketSize=1000;QStartNoAckMode+;binary-upload+;multiprocess+;qXfer:exec-file:read+;qXfer:features:read+;qXfer:libraries:read+;qXfer:threads:read+;vContSupported+;");
+        return send_gdb_packet("PacketSize=1000;QStartNoAckMode+;binary-upload+;multiprocess+;qXfer:exec-file:read+;qXfer:features:read+;qXfer:libraries:read+;qXfer:memory-map:read+;qXfer:threads:read+;vContSupported+;");
 #endif
     }
 
@@ -1013,6 +1013,19 @@ handle_gdb_query(void)
         return send_xfer_stream(stream_libraries_xml, Window[0], Window[1]);
     }
 
+    if (strncmp(gdb_input, "qXfer:memory-map:read::", 23) == 0)
+    {
+        static const CHAR MemoryMap[] = "<?xml version=\"1.0\"?><memory-map></memory-map>";
+        const char* End = &gdb_input[gdb_input_length];
+        const char* Rest;
+        ULONG64 Window[2];
+
+        if (!parse_hex_fields(&gdb_input[23], End, ",", Window, RTL_NUMBER_OF(Window), &Rest) || Rest != End)
+            return send_gdb_packet("E01");
+
+        return send_xfer_buffer(MemoryMap, sizeof(MemoryMap) - 1, Window[0], Window[1]);
+    }
+
     if (strncmp(gdb_input, "qXfer:threads:read::", 20) == 0)
     {
         const char* End = &gdb_input[gdb_input_length];
@@ -1030,6 +1043,117 @@ handle_gdb_query(void)
 
     KDDBGPRINT("KDGDB: Unknown query: %s\n", gdb_input);
     return send_gdb_packet("");
+}
+
+static UCHAR SearchPattern[PACKET_MAX_SIZE];
+
+static
+BOOLEAN
+SearchMemorySendHandler(_In_ ULONG PacketType, _In_ PSTRING MessageHeader, _In_ PSTRING MessageData)
+{
+    DBGKD_MANIPULATE_STATE64* State = (DBGKD_MANIPULATE_STATE64*)MessageHeader->Buffer;
+
+    UNREFERENCED_PARAMETER(MessageData);
+
+    if (PacketType != PACKET_TYPE_KD_STATE_MANIPULATE || State->ApiNumber != DbgKdSearchMemoryApi)
+    {
+        KDDBGPRINT("Wrong packet received after DbgKdSearchMemoryApi request.\n");
+        return FALSE;
+    }
+
+    if (NT_SUCCESS(State->ReturnStatus))
+    {
+        CHAR Reply[2 + sizeof(ULONG64) * 2 + 1];
+
+        _snprintf(Reply, sizeof(Reply), "1,%" PRIx64, State->u.SearchMemory.FoundAddress);
+        send_gdb_packet(Reply);
+    }
+    else if (State->ReturnStatus == STATUS_NOT_FOUND)
+    {
+        send_gdb_packet("0");
+    }
+    else
+    {
+        send_gdb_ntstatus(State->ReturnStatus);
+    }
+
+    KdpSendPacketHandler = NULL;
+    KdpManipulateStateHandler = NULL;
+
+#if MONOPROCESS
+    if (gdb_dbg_tid != 0)
+#else
+    if ((gdb_dbg_pid != 0) && gdb_pid_to_handle(gdb_dbg_pid) != PsGetCurrentProcessId())
+#endif
+    {
+        if (ps_initialized())
+            __writecr3(KdpGetDirectoryTableBase(&PsGetCurrentProcess()->Pcb));
+    }
+
+    return TRUE;
+}
+
+static
+KDSTATUS
+handle_gdb_search_memory(_Out_ DBGKD_MANIPULATE_STATE64* State, _Out_ PSTRING MessageData, _Out_ PULONG MessageLength, _Inout_ PKD_CONTEXT KdContext)
+{
+    const char* Current = &gdb_input[15];
+    const char* End = &gdb_input[gdb_input_length];
+    ULONG64 Address;
+    ULONG64 Length;
+    ULONG PatternLength;
+
+    UNREFERENCED_PARAMETER(KdContext);
+
+    if (!parse_hex_value(Current, End, &Address, &Current) || Current == End || *Current++ != ';' ||
+        !parse_hex_value(Current, End, &Length, &Current) || Current == End || *Current++ != ';')
+    {
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    }
+
+    PatternLength = (ULONG)(End - Current);
+    if (PatternLength == 0 || PatternLength > sizeof(SearchPattern) || Address > MAXULONG_PTR || Length > MAXULONGLONG - Address)
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    if (PatternLength > Length)
+        return LOOP_IF_SUCCESS(send_gdb_packet("0"));
+
+    RtlCopyMemory(SearchPattern, Current, PatternLength);
+    State->ApiNumber = DbgKdSearchMemoryApi;
+    State->ReturnStatus = STATUS_SUCCESS;
+    State->Processor = CurrentStateChange.Processor;
+    State->ProcessorLevel = CurrentStateChange.ProcessorLevel;
+    State->u.SearchMemory.SearchAddress = Address;
+    State->u.SearchMemory.SearchLength = Length;
+    State->u.SearchMemory.PatternLength = PatternLength;
+    MessageData->Buffer = (CHAR*)SearchPattern;
+    MessageData->Length = (USHORT)PatternLength;
+    *MessageLength = PatternLength;
+
+#if MONOPROCESS
+    if ((gdb_dbg_tid != 0) && gdb_tid_to_handle(gdb_dbg_tid) != PsGetCurrentThreadId())
+    {
+        PETHREAD AttachedThread = find_thread(0, gdb_dbg_tid);
+        PKPROCESS AttachedProcess;
+
+        if (AttachedThread == NULL || AttachedThread->Tcb.Process == NULL)
+            return LOOP_IF_SUCCESS(send_gdb_packet("E03"));
+        AttachedProcess = AttachedThread->Tcb.Process;
+        __writecr3(KdpGetDirectoryTableBase(AttachedProcess));
+    }
+#else
+    if ((gdb_dbg_pid != 0) && gdb_pid_to_handle(gdb_dbg_pid) != PsGetCurrentProcessId())
+    {
+        PEPROCESS AttachedProcess = find_process(gdb_dbg_pid);
+
+        if (AttachedProcess == NULL)
+            return LOOP_IF_SUCCESS(send_gdb_packet("E03"));
+        if (ps_initialized())
+            __writecr3(KdpGetDirectoryTableBase(&AttachedProcess->Pcb));
+    }
+#endif
+
+    KdpSendPacketHandler = SearchMemorySendHandler;
+    return KdPacketReceived;
 }
 
 static BOOLEAN ReadMemoryBinary;
@@ -1856,6 +1980,9 @@ handle_gdb_v(
     if (strcmp(gdb_input, "vMustReplyEmpty") == 0)
         return LOOP_IF_SUCCESS(send_gdb_packet(""));
 
+    if (strcmp(gdb_input, "vCtrlC") == 0)
+        return LOOP_IF_SUCCESS(send_gdb_packet("OK"));
+
     if (gdb_input_length < 7 || strncmp(gdb_input, "vCont;", 6) != 0)
         return LOOP_IF_SUCCESS(send_gdb_packet(""));
 
@@ -1965,7 +2092,10 @@ gdb_receive_and_interpret_packet(
             Status = handle_gdb_set();
             break;
         case 'q':
-            Status = LOOP_IF_SUCCESS(handle_gdb_query());
+            if (gdb_input_length >= 15 && strncmp(gdb_input, "qSearch:memory:", 15) == 0)
+                Status = handle_gdb_search_memory(State, MessageData, MessageLength, KdContext);
+            else
+                Status = LOOP_IF_SUCCESS(handle_gdb_query());
             break;
         case 's':
         case 'S':

--- a/drivers/base/kdgdb/gdb_input.c
+++ b/drivers/base/kdgdb/gdb_input.c
@@ -1715,7 +1715,7 @@ gdb_receive_and_interpret_packet(
             Status = LOOP_IF_SUCCESS(gdb_send_exception());
             break;
         case '!':
-            Status = LOOP_IF_SUCCESS(send_gdb_packet(""));
+            Status = LOOP_IF_SUCCESS(send_gdb_packet("OK"));
             break;
         case 'c':
         case 'C':

--- a/drivers/base/kdgdb/gdb_input.c
+++ b/drivers/base/kdgdb/gdb_input.c
@@ -104,7 +104,7 @@ apply_hardware_breakpoints(VOID)
     if (KdDebuggerDataBlock == NULL)
         return FALSE;
 
-#if defined(_M_IX86)
+#if defined(_M_IX86) && (defined(__GNUC__) || defined(__clang__))
     ProcessorBlockAddress = KdDebuggerDataBlock->KiProcessorBlock.ptr;
 #else
     ProcessorBlockAddress = (ULONG_PTR)KdDebuggerDataBlock->KiProcessorBlock;
@@ -1112,7 +1112,7 @@ handle_gdb_search_memory(_Out_ DBGKD_MANIPULATE_STATE64* State, _Out_ PSTRING Me
     }
 
     PatternLength = (ULONG)(End - Current);
-    if (PatternLength == 0 || PatternLength > sizeof(SearchPattern) || Address > MAXULONG_PTR || Length > MAXULONGLONG - Address)
+    if (PatternLength == 0 || PatternLength > sizeof(SearchPattern) || Address > MAXULONG_PTR || Length > ~(ULONG64)0 - Address)
         return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
     if (PatternLength > Length)
         return LOOP_IF_SUCCESS(send_gdb_packet("0"));

--- a/drivers/base/kdgdb/gdb_input.c
+++ b/drivers/base/kdgdb/gdb_input.c
@@ -14,6 +14,14 @@ static struct
     ULONG_PTR Address;
     ULONG Handle;
 } BreakPointHandles[32];
+typedef struct _GDB_HARDWARE_BREAKPOINT
+{
+    ULONG64 Address;
+    ULONG Kind;
+    UCHAR Type;
+    BOOLEAN Active;
+} GDB_HARDWARE_BREAKPOINT;
+static GDB_HARDWARE_BREAKPOINT HardwareBreakpoints[4];
 static LIST_ENTRY* ThreadInfoProcessEntry;
 static LIST_ENTRY* ThreadInfoThreadEntry;
 static UINT_PTR ThreadInfoInitialTid;
@@ -24,6 +32,132 @@ static BOOLEAN ThreadInfoIdlePending;
 /* GLOBALS ********************************************************************/
 UINT_PTR gdb_dbg_pid;
 UINT_PTR gdb_dbg_tid;
+
+#define GDB_DR7_GLOBAL_ENABLE(Slot) (2ULL << ((Slot) * 2))
+#define GDB_DR7_CONTROL_SHIFT(Slot) (16 + ((Slot) * 4))
+#define GDB_DR7_RESERVED_BIT 0x400ULL
+
+static ULONG64
+hardware_breakpoint_control(_In_ const GDB_HARDWARE_BREAKPOINT* Breakpoint)
+{
+    ULONG64 Access;
+    ULONG64 Length;
+
+    if (Breakpoint->Type == 1)
+        return 0;
+
+    /* x86 has no read-only encoding, so Z3 uses read/write to avoid missing reads. */
+    Access = (Breakpoint->Type == 2) ? 1 : 3;
+    switch (Breakpoint->Kind)
+    {
+        case 1: Length = 0; break;
+        case 2: Length = 1; break;
+        case 4: Length = 3; break;
+        case 8: Length = 2; break;
+        default: return ~(ULONG64)0;
+    }
+
+    return Access | (Length << 2);
+}
+
+ULONG64
+gdb_hardware_breakpoint_dr7(VOID)
+{
+    ULONG64 Dr7 = 0;
+    ULONG i;
+
+    for (i = 0; i < RTL_NUMBER_OF(HardwareBreakpoints); i++)
+    {
+        ULONG64 Control;
+
+        if (!HardwareBreakpoints[i].Active)
+            continue;
+
+        Control = hardware_breakpoint_control(&HardwareBreakpoints[i]);
+        Dr7 |= GDB_DR7_GLOBAL_ENABLE(i) | (Control << GDB_DR7_CONTROL_SHIFT(i));
+    }
+
+    return Dr7 ? Dr7 | GDB_DR7_RESERVED_BIT : 0;
+}
+
+static VOID
+set_debug_address(_Inout_ PKSPECIAL_REGISTERS Registers, _In_ ULONG Slot, _In_ ULONG64 Address)
+{
+    switch (Slot)
+    {
+        case 0: Registers->KernelDr0 = (ULONG_PTR)Address; break;
+        case 1: Registers->KernelDr1 = (ULONG_PTR)Address; break;
+        case 2: Registers->KernelDr2 = (ULONG_PTR)Address; break;
+        case 3: Registers->KernelDr3 = (ULONG_PTR)Address; break;
+    }
+}
+
+static BOOLEAN
+apply_hardware_breakpoints(VOID)
+{
+    PKPRCB* ProcessorBlock;
+    ULONG_PTR ProcessorBlockAddress;
+    ULONG64 Dr7;
+    ULONG Processor;
+    ULONG Slot;
+
+    if (KdDebuggerDataBlock == NULL)
+        return FALSE;
+
+#if defined(_M_IX86)
+    ProcessorBlockAddress = KdDebuggerDataBlock->KiProcessorBlock.ptr;
+#else
+    ProcessorBlockAddress = (ULONG_PTR)KdDebuggerDataBlock->KiProcessorBlock;
+#endif
+    if (ProcessorBlockAddress == 0)
+        return FALSE;
+
+    ProcessorBlock = (PKPRCB*)ProcessorBlockAddress;
+    Dr7 = gdb_hardware_breakpoint_dr7();
+    for (Processor = 0; Processor < CurrentStateChange.NumberProcessors; Processor++)
+    {
+        PKSPECIAL_REGISTERS Registers;
+
+        if (ProcessorBlock[Processor] == NULL)
+            continue;
+
+        Registers = &ProcessorBlock[Processor]->ProcessorState.SpecialRegisters;
+        for (Slot = 0; Slot < RTL_NUMBER_OF(HardwareBreakpoints); Slot++)
+            set_debug_address(Registers, Slot, HardwareBreakpoints[Slot].Active ? HardwareBreakpoints[Slot].Address : 0);
+        Registers->KernelDr6 = 0;
+        Registers->KernelDr7 = (ULONG_PTR)Dr7;
+    }
+
+    CurrentStateChange.ControlReport.Dr6 = 0;
+    CurrentStateChange.ControlReport.Dr7 = Dr7;
+    return TRUE;
+}
+
+BOOLEAN
+gdb_get_watchpoint_stop(_Out_ const CHAR** Reason, _Out_ PULONG64 Address)
+{
+    ULONG64 Dr6;
+    ULONG Slot;
+
+    if (CurrentStateChange.NewState != DbgKdExceptionStateChange ||
+        CurrentStateChange.u.Exception.ExceptionRecord.ExceptionCode != STATUS_SINGLE_STEP)
+    {
+        return FALSE;
+    }
+
+    Dr6 = CurrentStateChange.ControlReport.Dr6;
+    for (Slot = 0; Slot < RTL_NUMBER_OF(HardwareBreakpoints); Slot++)
+    {
+        if (!(Dr6 & (1ULL << Slot)) || !HardwareBreakpoints[Slot].Active || HardwareBreakpoints[Slot].Type == 1)
+            continue;
+
+        *Reason = HardwareBreakpoints[Slot].Type == 2 ? "watch" : HardwareBreakpoints[Slot].Type == 3 ? "rwatch" : "awatch";
+        *Address = HardwareBreakpoints[Slot].Address;
+        return TRUE;
+    }
+
+    return FALSE;
+}
 
 static inline
 KDSTATUS
@@ -1266,8 +1400,7 @@ typedef enum _GDB_BREAKPOINT_PACKET
 
 static
 GDB_BREAKPOINT_PACKET
-parse_breakpoint_packet(
-    _Out_ PULONG64 Address)
+parse_breakpoint_packet(_Out_ PULONG Type, _Out_ PULONG64 Address, _Out_ PULONG Kind)
 {
     const char* End = &gdb_input[gdb_input_length];
     const char* Rest;
@@ -1277,12 +1410,87 @@ parse_breakpoint_packet(
     if (!parse_hex_fields(&gdb_input[1], End, ",,", Fields, RTL_NUMBER_OF(Fields), &Rest))
         return GdbBreakpointInvalid;
 
+    if (Fields[0] > MAXULONG || Fields[1] > MAXULONG_PTR || Fields[2] > MAXULONG)
+        return GdbBreakpointInvalid;
+
+    *Type = (ULONG)Fields[0];
     *Address = Fields[1];
-    if (Fields[0] != 0 || Rest != End)
+    *Kind = (ULONG)Fields[2];
+    if (*Type > 4 || Rest != End)
         return GdbBreakpointUnsupported;
-    if (Fields[2] == 0)
+    if (*Kind == 0)
         return GdbBreakpointInvalid;
     return GdbBreakpointSupported;
+}
+
+static KDSTATUS
+handle_gdb_insert_hardware_breakpoint(_In_ ULONG Type, _In_ ULONG64 Address, _In_ ULONG Kind)
+{
+    GDB_HARDWARE_BREAKPOINT Breakpoint = {Address, Kind, (UCHAR)Type, TRUE};
+    ULONG FreeSlot = RTL_NUMBER_OF(HardwareBreakpoints);
+    ULONG Slot;
+
+    if ((Type == 1 && Kind != 1) || hardware_breakpoint_control(&Breakpoint) == ~(ULONG64)0 || (Kind > 1 && (Address & (Kind - 1)) != 0))
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+#if defined(_M_IX86)
+    if (Kind == 8)
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+#endif
+
+    for (Slot = 0; Slot < RTL_NUMBER_OF(HardwareBreakpoints); Slot++)
+    {
+        if (HardwareBreakpoints[Slot].Active &&
+            HardwareBreakpoints[Slot].Type == Type &&
+            HardwareBreakpoints[Slot].Address == Address &&
+            HardwareBreakpoints[Slot].Kind == Kind)
+        {
+            return LOOP_IF_SUCCESS(send_gdb_packet("OK"));
+        }
+        if (!HardwareBreakpoints[Slot].Active && FreeSlot == RTL_NUMBER_OF(HardwareBreakpoints))
+            FreeSlot = Slot;
+    }
+
+    if (FreeSlot == RTL_NUMBER_OF(HardwareBreakpoints))
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+
+    HardwareBreakpoints[FreeSlot] = Breakpoint;
+    if (!apply_hardware_breakpoints())
+    {
+        RtlZeroMemory(&HardwareBreakpoints[FreeSlot], sizeof(HardwareBreakpoints[FreeSlot]));
+        return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    }
+
+    return LOOP_IF_SUCCESS(send_gdb_packet("OK"));
+}
+
+static KDSTATUS
+handle_gdb_remove_hardware_breakpoint(_In_ ULONG Type, _In_ ULONG64 Address, _In_ ULONG Kind)
+{
+    ULONG Slot;
+
+    for (Slot = 0; Slot < RTL_NUMBER_OF(HardwareBreakpoints); Slot++)
+    {
+        GDB_HARDWARE_BREAKPOINT Previous;
+
+        if (!HardwareBreakpoints[Slot].Active ||
+            HardwareBreakpoints[Slot].Type != Type ||
+            HardwareBreakpoints[Slot].Address != Address ||
+            HardwareBreakpoints[Slot].Kind != Kind)
+        {
+            continue;
+        }
+
+        Previous = HardwareBreakpoints[Slot];
+        RtlZeroMemory(&HardwareBreakpoints[Slot], sizeof(HardwareBreakpoints[Slot]));
+        if (!apply_hardware_breakpoints())
+        {
+            HardwareBreakpoints[Slot] = Previous;
+            return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+        }
+        break;
+    }
+
+    return LOOP_IF_SUCCESS(send_gdb_packet("OK"));
 }
 
 static
@@ -1293,7 +1501,9 @@ handle_gdb_insert_breakpoint(
     _Out_ PULONG MessageLength,
     _Inout_ PKD_CONTEXT KdContext)
 {
+    ULONG Type;
     ULONG64 Address;
+    ULONG Kind;
     GDB_BREAKPOINT_PACKET Packet;
     ULONG i;
     BOOLEAN HasFreeSlot = FALSE;
@@ -1305,11 +1515,13 @@ handle_gdb_insert_breakpoint(
         MessageData->Length = 0;
     *MessageLength = 0;
 
-    Packet = parse_breakpoint_packet(&Address);
+    Packet = parse_breakpoint_packet(&Type, &Address, &Kind);
     if (Packet == GdbBreakpointInvalid)
         return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
     if (Packet == GdbBreakpointUnsupported)
         return LOOP_IF_SUCCESS(send_gdb_packet(""));
+    if (Type != 0)
+        return handle_gdb_insert_hardware_breakpoint(Type, Address, Kind);
 
     KDDBGPRINT("Inserting breakpoint at %p.\n", (void*)(ULONG_PTR)Address);
 
@@ -1389,7 +1601,9 @@ handle_gdb_remove_breakpoint(
     _Out_ PULONG MessageLength,
     _Inout_ PKD_CONTEXT KdContext)
 {
+    ULONG Type;
     ULONG64 Address;
+    ULONG Kind;
     GDB_BREAKPOINT_PACKET Packet;
     ULONG i, Handle = 0;
 
@@ -1400,11 +1614,13 @@ handle_gdb_remove_breakpoint(
         MessageData->Length = 0;
     *MessageLength = 0;
 
-    Packet = parse_breakpoint_packet(&Address);
+    Packet = parse_breakpoint_packet(&Type, &Address, &Kind);
     if (Packet == GdbBreakpointInvalid)
         return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
     if (Packet == GdbBreakpointUnsupported)
         return LOOP_IF_SUCCESS(send_gdb_packet(""));
+    if (Type != 0)
+        return handle_gdb_remove_hardware_breakpoint(Type, Address, Kind);
 
     KDDBGPRINT("Removing breakpoint on %p.\n", (void*)(ULONG_PTR)Address);
 

--- a/drivers/base/kdgdb/gdb_input.c
+++ b/drivers/base/kdgdb/gdb_input.c
@@ -14,13 +14,6 @@ static struct
     ULONG_PTR Address;
     ULONG Handle;
 } BreakPointHandles[32];
-typedef struct _GDB_HARDWARE_BREAKPOINT
-{
-    ULONG64 Address;
-    ULONG Kind;
-    UCHAR Type;
-    BOOLEAN Active;
-} GDB_HARDWARE_BREAKPOINT;
 static GDB_HARDWARE_BREAKPOINT HardwareBreakpoints[4];
 static LIST_ENTRY* ThreadInfoProcessEntry;
 static LIST_ENTRY* ThreadInfoThreadEntry;
@@ -33,63 +26,10 @@ static BOOLEAN ThreadInfoIdlePending;
 UINT_PTR gdb_dbg_pid;
 UINT_PTR gdb_dbg_tid;
 
-#define GDB_DR7_GLOBAL_ENABLE(Slot) (2ULL << ((Slot) * 2))
-#define GDB_DR7_CONTROL_SHIFT(Slot) (16 + ((Slot) * 4))
-#define GDB_DR7_RESERVED_BIT 0x400ULL
-
-static ULONG64
-hardware_breakpoint_control(_In_ const GDB_HARDWARE_BREAKPOINT* Breakpoint)
+const GDB_HARDWARE_BREAKPOINT*
+gdb_hardware_breakpoints(VOID)
 {
-    ULONG64 Access;
-    ULONG64 Length;
-
-    if (Breakpoint->Type == 1)
-        return 0;
-
-    /* x86 has no read-only encoding, so Z3 uses read/write to avoid missing reads. */
-    Access = (Breakpoint->Type == 2) ? 1 : 3;
-    switch (Breakpoint->Kind)
-    {
-        case 1: Length = 0; break;
-        case 2: Length = 1; break;
-        case 4: Length = 3; break;
-        case 8: Length = 2; break;
-        default: return ~(ULONG64)0;
-    }
-
-    return Access | (Length << 2);
-}
-
-ULONG64
-gdb_hardware_breakpoint_dr7(VOID)
-{
-    ULONG64 Dr7 = 0;
-    ULONG i;
-
-    for (i = 0; i < RTL_NUMBER_OF(HardwareBreakpoints); i++)
-    {
-        ULONG64 Control;
-
-        if (!HardwareBreakpoints[i].Active)
-            continue;
-
-        Control = hardware_breakpoint_control(&HardwareBreakpoints[i]);
-        Dr7 |= GDB_DR7_GLOBAL_ENABLE(i) | (Control << GDB_DR7_CONTROL_SHIFT(i));
-    }
-
-    return Dr7 ? Dr7 | GDB_DR7_RESERVED_BIT : 0;
-}
-
-static VOID
-set_debug_address(_Inout_ PKSPECIAL_REGISTERS Registers, _In_ ULONG Slot, _In_ ULONG64 Address)
-{
-    switch (Slot)
-    {
-        case 0: Registers->KernelDr0 = (ULONG_PTR)Address; break;
-        case 1: Registers->KernelDr1 = (ULONG_PTR)Address; break;
-        case 2: Registers->KernelDr2 = (ULONG_PTR)Address; break;
-        case 3: Registers->KernelDr3 = (ULONG_PTR)Address; break;
-    }
+    return HardwareBreakpoints;
 }
 
 static BOOLEAN
@@ -97,9 +37,7 @@ apply_hardware_breakpoints(VOID)
 {
     PKPRCB* ProcessorBlock;
     ULONG_PTR ProcessorBlockAddress;
-    ULONG64 Dr7;
     ULONG Processor;
-    ULONG Slot;
 
     if (KdDebuggerDataBlock == NULL)
         return FALSE;
@@ -113,30 +51,23 @@ apply_hardware_breakpoints(VOID)
         return FALSE;
 
     ProcessorBlock = (PKPRCB*)ProcessorBlockAddress;
-    Dr7 = gdb_hardware_breakpoint_dr7();
     for (Processor = 0; Processor < CurrentStateChange.NumberProcessors; Processor++)
     {
-        PKSPECIAL_REGISTERS Registers;
-
         if (ProcessorBlock[Processor] == NULL)
             continue;
 
-        Registers = &ProcessorBlock[Processor]->ProcessorState.SpecialRegisters;
-        for (Slot = 0; Slot < RTL_NUMBER_OF(HardwareBreakpoints); Slot++)
-            set_debug_address(Registers, Slot, HardwareBreakpoints[Slot].Active ? HardwareBreakpoints[Slot].Address : 0);
-        Registers->KernelDr6 = 0;
-        Registers->KernelDr7 = (ULONG_PTR)Dr7;
+        gdb_arch_program_hw_breakpoints(
+            &ProcessorBlock[Processor]->ProcessorState.SpecialRegisters,
+            HardwareBreakpoints);
     }
 
-    CurrentStateChange.ControlReport.Dr6 = 0;
-    CurrentStateChange.ControlReport.Dr7 = Dr7;
+    gdb_arch_report_hw_breakpoints(HardwareBreakpoints);
     return TRUE;
 }
 
 BOOLEAN
 gdb_get_watchpoint_stop(_Out_ const CHAR** Reason, _Out_ PULONG64 Address)
 {
-    ULONG64 Dr6;
     ULONG Slot;
 
     if (CurrentStateChange.NewState != DbgKdExceptionStateChange ||
@@ -145,13 +76,17 @@ gdb_get_watchpoint_stop(_Out_ const CHAR** Reason, _Out_ PULONG64 Address)
         return FALSE;
     }
 
-    Dr6 = CurrentStateChange.ControlReport.Dr6;
-    for (Slot = 0; Slot < RTL_NUMBER_OF(HardwareBreakpoints); Slot++)
+    for (Slot = 0; Slot < gdb_hw_breakpoint_count; Slot++)
     {
-        if (!(Dr6 & (1ULL << Slot)) || !HardwareBreakpoints[Slot].Active || HardwareBreakpoints[Slot].Type == 1)
+        if (!HardwareBreakpoints[Slot].Active ||
+            HardwareBreakpoints[Slot].Type == GDB_HW_EXECUTE ||
+            !gdb_arch_hw_breakpoint_hit(HardwareBreakpoints, Slot))
+        {
             continue;
+        }
 
-        *Reason = HardwareBreakpoints[Slot].Type == 2 ? "watch" : HardwareBreakpoints[Slot].Type == 3 ? "rwatch" : "awatch";
+        *Reason = HardwareBreakpoints[Slot].Type == GDB_HW_WRITE ? "watch" :
+                  HardwareBreakpoints[Slot].Type == GDB_HW_READ ? "rwatch" : "awatch";
         *Address = HardwareBreakpoints[Slot].Address;
         return TRUE;
     }
@@ -1551,17 +1486,19 @@ static KDSTATUS
 handle_gdb_insert_hardware_breakpoint(_In_ ULONG Type, _In_ ULONG64 Address, _In_ ULONG Kind)
 {
     GDB_HARDWARE_BREAKPOINT Breakpoint = {Address, Kind, (UCHAR)Type, TRUE};
-    ULONG FreeSlot = RTL_NUMBER_OF(HardwareBreakpoints);
+    ULONG FreeSlot = gdb_hw_breakpoint_count;
     ULONG Slot;
 
-    if ((Type == 1 && Kind != 1) || hardware_breakpoint_control(&Breakpoint) == ~(ULONG64)0 || (Kind > 1 && (Address & (Kind - 1)) != 0))
+    if (!gdb_arch_hw_breakpoint_valid(&Breakpoint))
+    {
         return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
+    }
 #if defined(_M_IX86)
     if (Kind == 8)
         return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
 #endif
 
-    for (Slot = 0; Slot < RTL_NUMBER_OF(HardwareBreakpoints); Slot++)
+    for (Slot = 0; Slot < gdb_hw_breakpoint_count; Slot++)
     {
         if (HardwareBreakpoints[Slot].Active &&
             HardwareBreakpoints[Slot].Type == Type &&
@@ -1570,11 +1507,11 @@ handle_gdb_insert_hardware_breakpoint(_In_ ULONG Type, _In_ ULONG64 Address, _In
         {
             return LOOP_IF_SUCCESS(send_gdb_packet("OK"));
         }
-        if (!HardwareBreakpoints[Slot].Active && FreeSlot == RTL_NUMBER_OF(HardwareBreakpoints))
+        if (!HardwareBreakpoints[Slot].Active && FreeSlot == gdb_hw_breakpoint_count)
             FreeSlot = Slot;
     }
 
-    if (FreeSlot == RTL_NUMBER_OF(HardwareBreakpoints))
+    if (FreeSlot == gdb_hw_breakpoint_count)
         return LOOP_IF_SUCCESS(send_gdb_packet("E01"));
 
     HardwareBreakpoints[FreeSlot] = Breakpoint;
@@ -1592,7 +1529,7 @@ handle_gdb_remove_hardware_breakpoint(_In_ ULONG Type, _In_ ULONG64 Address, _In
 {
     ULONG Slot;
 
-    for (Slot = 0; Slot < RTL_NUMBER_OF(HardwareBreakpoints); Slot++)
+    for (Slot = 0; Slot < gdb_hw_breakpoint_count; Slot++)
     {
         GDB_HARDWARE_BREAKPOINT Previous;
 

--- a/drivers/base/kdgdb/gdb_receive.c
+++ b/drivers/base/kdgdb/gdb_receive.c
@@ -8,7 +8,8 @@
 #include "kdgdb.h"
 
 /* GLOBALS ********************************************************************/
-CHAR gdb_input[0x1000];
+CHAR gdb_input[GDB_PACKET_MAX_SIZE + 1];
+ULONG gdb_input_length;
 
 /* GLOBAL FUNCTIONS ***********************************************************/
 char
@@ -34,7 +35,10 @@ gdb_receive_packet(_Inout_ PKD_CONTEXT KdContext)
     UCHAR Byte;
     KDSTATUS Status;
     CHAR CheckSum, ReceivedCheckSum;
+    BOOLEAN PacketTooLarge;
+    char HighNibble, LowNibble;
 
+wait_for_packet:
     do
     {
         Status = KdpReceiveByte(&Byte);
@@ -45,6 +49,7 @@ gdb_receive_packet(_Inout_ PKD_CONTEXT KdContext)
 get_packet:
     CheckSum = 0;
     ByteBuffer = (UCHAR*)gdb_input;
+    PacketTooLarge = FALSE;
 
     while (TRUE)
     {
@@ -69,28 +74,44 @@ get_packet:
             CheckSum += (CHAR)Byte;
             Byte ^= 0x20;
         }
-        *ByteBuffer++ = Byte;
+
+        if (ByteBuffer < (UCHAR*)&gdb_input[GDB_PACKET_MAX_SIZE])
+            *ByteBuffer++ = Byte;
+        else
+            PacketTooLarge = TRUE;
     }
 
     /* Get Check sum (two bytes) */
     Status = KdpReceiveByte(&Byte);
     if (Status != KdPacketReceived)
-        goto end;
-    ReceivedCheckSum = hex_value(Byte) << 4;
+        return Status;
+    HighNibble = hex_value(Byte);
 
     Status = KdpReceiveByte(&Byte);
     if (Status != KdPacketReceived)
-        goto end;
-    ReceivedCheckSum += hex_value(Byte);
+        return Status;
+    LowNibble = hex_value(Byte);
 
-end:
-    if (ReceivedCheckSum != CheckSum)
+    if ((HighNibble < 0) || (LowNibble < 0))
     {
-        /* Do not acknowledge to GDB */
-        KDDBGPRINT("Check sums don't match!");
+        if (gdb_no_ack_mode)
+            goto wait_for_packet;
         KdpSendByte('-');
         return KdPacketNeedsResend;
     }
+
+    ReceivedCheckSum = (HighNibble << 4) | LowNibble;
+    if (PacketTooLarge || (ReceivedCheckSum != CheckSum))
+    {
+        KDDBGPRINT(PacketTooLarge ? "Packet exceeds advertised size!" : "Checksums don't match!");
+        if (gdb_no_ack_mode)
+            goto wait_for_packet;
+        KdpSendByte('-');
+        return KdPacketNeedsResend;
+    }
+
+    gdb_input_length = (ULONG)(ByteBuffer - (UCHAR*)gdb_input);
+    *ByteBuffer = '\0';
 
     /* Ensure there is nothing left in the pipe */
     while (KdpPollByte(&Byte) == KdPacketReceived)
@@ -106,8 +127,8 @@ end:
         }
     }
 
-    /* Acknowledge */
-    KdpSendByte('+');
+    if (!gdb_no_ack_mode)
+        KdpSendByte('+');
 
     return KdPacketReceived;
 }

--- a/drivers/base/kdgdb/gdb_regs.c
+++ b/drivers/base/kdgdb/gdb_regs.c
@@ -1,0 +1,200 @@
+/*
+ * COPYRIGHT:       GPL, see COPYING in the top level directory
+ * PROJECT:         ReactOS kernel
+ * FILE:            drivers/base/kdgdb/gdb_regs.c
+ * PURPOSE:         Architecture independent register access for the GDB stub.
+ *
+ * The architecture specific files only describe the register file, through
+ * gdb_reg_size/gdb_reg_count and the gdb_ctx_to_reg/gdb_set_ctx_reg/
+ * gdb_thread_to_reg accessors. Everything below is common to all of them.
+ */
+
+#include "kdgdb.h"
+
+/* PRIVATE FUNCTIONS **********************************************************/
+static
+BOOLEAN
+debug_thread_is_current(VOID)
+{
+    UINT_PTR CurrentTid;
+
+    CurrentTid = handle_to_gdb_tid(PsGetThreadId((PETHREAD)(ULONG_PTR)CurrentStateChange.Thread));
+    return gdb_dbg_tid == 0 ||
+           gdb_dbg_tid == (UINT_PTR)-1 ||
+           gdb_dbg_tid == CurrentTid;
+}
+
+/* GDB expects a fixed size register block, so registers we cannot provide
+ * must still be sent, as a run of 'x' characters. */
+static
+VOID
+send_gdb_unavailable_register(
+    _In_ ULONG Register)
+{
+    UCHAR Size = gdb_reg_size[Register];
+
+    while (Size--)
+        send_gdb_partial_packet("xx");
+}
+
+/* GLOBAL FUNCTIONS ***********************************************************/
+KDSTATUS
+gdb_send_registers(void)
+{
+    const UCHAR* RegisterPtr;
+    ULONG ScalarValue;
+    ULONG i;
+
+    start_gdb_packet();
+
+    KDDBGPRINT("Sending registers of thread %" PRIxPTR ".\n", gdb_dbg_tid);
+    KDDBGPRINT("Current thread_id: %p.\n", PsGetThreadId((PETHREAD)(ULONG_PTR)CurrentStateChange.Thread));
+    if (debug_thread_is_current())
+    {
+        for (i = 0; i < gdb_reg_count; i++)
+        {
+            RegisterPtr = gdb_ctx_to_reg(&CurrentContext, i, &ScalarValue);
+            send_gdb_partial_memory(RegisterPtr, gdb_reg_size[i]);
+        }
+    }
+    else
+    {
+        PETHREAD DbgThread;
+
+        DbgThread = find_thread(gdb_dbg_pid, gdb_dbg_tid);
+
+        if (DbgThread == NULL)
+        {
+            /* Thread is dead */
+            send_gdb_partial_packet("E03");
+            return finish_gdb_packet();
+        }
+
+        for (i = 0; i < gdb_reg_count; i++)
+        {
+            RegisterPtr = gdb_thread_to_reg(DbgThread, i);
+            if (RegisterPtr)
+                send_gdb_partial_memory(RegisterPtr, gdb_reg_size[i]);
+            else
+                send_gdb_unavailable_register(i);
+        }
+    }
+
+    return finish_gdb_packet();
+}
+
+KDSTATUS
+gdb_send_register(void)
+{
+    const char* End = &gdb_input[gdb_input_length];
+    const char* Next;
+    const void* ptr;
+    ULONG ScalarValue;
+    ULONG64 Register;
+
+    /* Get the GDB register number (gdb_input = "pXX") */
+    if (!parse_hex_value(&gdb_input[1], End, &Register, &Next) ||
+        Next != End ||
+        Register >= gdb_reg_count)
+    {
+        return send_gdb_packet("E01");
+    }
+
+    if (debug_thread_is_current())
+    {
+        /* We can get it from the context of the current exception */
+        ptr = gdb_ctx_to_reg(&CurrentContext, (ULONG)Register, &ScalarValue);
+    }
+    else
+    {
+        PETHREAD DbgThread;
+
+        DbgThread = find_thread(gdb_dbg_pid, gdb_dbg_tid);
+
+        if (DbgThread == NULL)
+        {
+            /* Thread is dead */
+            return send_gdb_packet("E03");
+        }
+
+        ptr = gdb_thread_to_reg(DbgThread, (ULONG)Register);
+    }
+
+    if (!ptr)
+    {
+        start_gdb_packet();
+        send_gdb_unavailable_register((ULONG)Register);
+        return finish_gdb_packet();
+    }
+
+    KDDBGPRINT("KDGDB: Sending registers as memory.\n");
+    return send_gdb_memory(ptr, gdb_reg_size[Register]);
+}
+
+BOOLEAN
+gdb_write_register(
+    _In_ ULONG Register,
+    _In_reads_(Length) const CHAR* Value,
+    _In_ ULONG Length)
+{
+    CONTEXT Context;
+    UCHAR RegisterValue[GDB_MAX_REGISTER_SIZE];
+
+    if (!debug_thread_is_current() ||
+        Register >= gdb_reg_count ||
+        !gdb_decode_hex(Value, Length, RegisterValue, gdb_reg_size[Register]))
+    {
+        return FALSE;
+    }
+
+    /* Only commit once the whole write is known to be good */
+    Context = CurrentContext;
+    if (!gdb_set_ctx_reg(&Context, Register, RegisterValue, gdb_reg_size[Register]))
+        return FALSE;
+
+    CurrentContext = Context;
+    return TRUE;
+}
+
+BOOLEAN
+gdb_write_registers(
+    _In_reads_(Length) const CHAR* Value,
+    _In_ ULONG Length)
+{
+    CONTEXT Context;
+    UCHAR RegisterValue[GDB_MAX_REGISTER_SIZE];
+    ULONG ExpectedLength = 0;
+    ULONG Offset = 0;
+    ULONG Register;
+
+    if (!debug_thread_is_current())
+        return FALSE;
+
+    for (Register = 0; Register < gdb_reg_count; Register++)
+        ExpectedLength += gdb_reg_size[Register] * 2;
+    if (Length != ExpectedLength)
+        return FALSE;
+
+    /* Only commit once the whole block is known to be good */
+    Context = CurrentContext;
+    for (Register = 0; Register < gdb_reg_count; Register++)
+    {
+        ULONG RegisterLength = gdb_reg_size[Register] * 2;
+
+        if (!gdb_decode_hex(&Value[Offset],
+                            RegisterLength,
+                            RegisterValue,
+                            gdb_reg_size[Register]) ||
+            !gdb_set_ctx_reg(&Context,
+                             Register,
+                             RegisterValue,
+                             gdb_reg_size[Register]))
+        {
+            return FALSE;
+        }
+        Offset += RegisterLength;
+    }
+
+    CurrentContext = Context;
+    return TRUE;
+}

--- a/drivers/base/kdgdb/gdb_send.c
+++ b/drivers/base/kdgdb/gdb_send.c
@@ -204,6 +204,8 @@ gdb_send_exception()
 {
     char gdb_out[1024];
     char* ptr = gdb_out;
+    const CHAR* WatchReason;
+    ULONG64 WatchAddress;
     PETHREAD Thread = (PETHREAD)(ULONG_PTR)CurrentStateChange.Thread;
 
     /* Report to GDB */
@@ -219,6 +221,8 @@ gdb_send_exception()
 
     if (CurrentStateChange.NewState == DbgKdLoadSymbolsStateChange)
         ptr += sprintf(ptr, "library:");
+    else if (gdb_get_watchpoint_stop(&WatchReason, &WatchAddress))
+        ptr += sprintf(ptr, "%s:%" PRIx64 ";", WatchReason, WatchAddress);
 
 #if MONOPROCESS
     ptr += sprintf(ptr, "thread:%" PRIxPTR ";",

--- a/drivers/base/kdgdb/gdb_send.c
+++ b/drivers/base/kdgdb/gdb_send.c
@@ -11,6 +11,9 @@
 const char hex_chars[] = "0123456789abcdef";
 static CHAR currentChecksum = 0;
 
+/* GLOBALS ********************************************************************/
+BOOLEAN gdb_no_ack_mode = FALSE;
+
 /* PRIVATE FUNCTIONS **********************************************************/
 static
 char*
@@ -80,6 +83,9 @@ finish_gdb_packet(void)
     KdpSendByte('#');
     KdpSendByte(hex_chars[(currentChecksum >> 4) & 0xf]);
     KdpSendByte(hex_chars[currentChecksum & 0xf]);
+
+    if (gdb_no_ack_mode)
+        return KdPacketReceived;
 
     /* Wait for acknowledgement */
     Status = KdpReceiveByte(&ack);

--- a/drivers/base/kdgdb/hwbp_x86.c
+++ b/drivers/base/kdgdb/hwbp_x86.c
@@ -1,0 +1,130 @@
+/*
+ * COPYRIGHT:       Copyright 2026 Ahmed ARIF <arif.ing@outlook.com>
+ * LICENSE:         GPL, see COPYING in the top level directory
+ * PROJECT:         ReactOS kernel
+ * FILE:            drivers/base/kdgdb/hwbp_x86.c
+ * PURPOSE:         Hardware debug register support for i386 and amd64.
+ *
+ * x86 has a single pool of four debug registers, each of which can serve any
+ * of the GDB hardware breakpoint types, selected by the R/W field of DR7.
+ */
+
+#include "kdgdb.h"
+
+#define GDB_DR7_GLOBAL_ENABLE(Slot) (2ULL << ((Slot) * 2))
+#define GDB_DR7_CONTROL_SHIFT(Slot) (16 + ((Slot) * 4))
+#define GDB_DR7_RESERVED_BIT 0x400ULL
+
+const ULONG gdb_hw_breakpoint_count = 4;
+
+static
+ULONG64
+hardware_breakpoint_control(
+    _In_ const GDB_HARDWARE_BREAKPOINT* Breakpoint)
+{
+    ULONG64 Access;
+    ULONG64 Length;
+
+    if (Breakpoint->Type == GDB_HW_EXECUTE)
+        return 0;
+
+    /* x86 has no read-only encoding, so Z3 uses read/write to avoid missing reads. */
+    Access = (Breakpoint->Type == GDB_HW_WRITE) ? 1 : 3;
+    switch (Breakpoint->Kind)
+    {
+        case 1: Length = 0; break;
+        case 2: Length = 1; break;
+        case 4: Length = 3; break;
+        case 8: Length = 2; break;
+        default: return ~(ULONG64)0;
+    }
+
+    return Access | (Length << 2);
+}
+
+BOOLEAN
+gdb_arch_hw_breakpoint_valid(
+    _In_ const GDB_HARDWARE_BREAKPOINT* Breakpoint)
+{
+    if (Breakpoint->Type < GDB_HW_EXECUTE ||
+        Breakpoint->Type > GDB_HW_ACCESS)
+    {
+        return FALSE;
+    }
+
+    if (Breakpoint->Type == GDB_HW_EXECUTE)
+        return Breakpoint->Kind == 1;
+
+    return hardware_breakpoint_control(Breakpoint) != ~(ULONG64)0 &&
+           (Breakpoint->Kind == 1 ||
+            (Breakpoint->Address & (Breakpoint->Kind - 1)) == 0);
+}
+
+static
+ULONG64
+hardware_breakpoint_dr7(
+    _In_ const GDB_HARDWARE_BREAKPOINT* Breakpoints)
+{
+    ULONG64 Dr7 = 0;
+    ULONG i;
+
+    for (i = 0; i < gdb_hw_breakpoint_count; i++)
+    {
+        ULONG64 Control;
+
+        if (!Breakpoints[i].Active)
+            continue;
+
+        Control = hardware_breakpoint_control(&Breakpoints[i]);
+        Dr7 |= GDB_DR7_GLOBAL_ENABLE(i) | (Control << GDB_DR7_CONTROL_SHIFT(i));
+    }
+
+    return Dr7 ? Dr7 | GDB_DR7_RESERVED_BIT : 0;
+}
+
+VOID
+gdb_arch_program_hw_breakpoints(
+    _Inout_ PKSPECIAL_REGISTERS Registers,
+    _In_ const GDB_HARDWARE_BREAKPOINT* Breakpoints)
+{
+    ULONG_PTR Address[4];
+    ULONG Slot;
+
+    for (Slot = 0; Slot < gdb_hw_breakpoint_count; Slot++)
+        Address[Slot] = Breakpoints[Slot].Active ? (ULONG_PTR)Breakpoints[Slot].Address : 0;
+
+    Registers->KernelDr0 = Address[0];
+    Registers->KernelDr1 = Address[1];
+    Registers->KernelDr2 = Address[2];
+    Registers->KernelDr3 = Address[3];
+    Registers->KernelDr6 = 0;
+    Registers->KernelDr7 = (ULONG_PTR)hardware_breakpoint_dr7(Breakpoints);
+}
+
+VOID
+gdb_arch_report_hw_breakpoints(
+    _In_ const GDB_HARDWARE_BREAKPOINT* Breakpoints)
+{
+    CurrentStateChange.ControlReport.Dr6 = 0;
+    CurrentStateChange.ControlReport.Dr7 = hardware_breakpoint_dr7(Breakpoints);
+}
+
+BOOLEAN
+gdb_arch_hw_breakpoint_hit(
+    _In_ const GDB_HARDWARE_BREAKPOINT* Breakpoints,
+    _In_ ULONG Slot)
+{
+    UNREFERENCED_PARAMETER(Breakpoints);
+
+    /* DR6 reports the slots that fired as a bitmask */
+    return (CurrentStateChange.ControlReport.Dr6 & (1ULL << Slot)) != 0;
+}
+
+VOID
+gdb_arch_set_continue_control(
+    _Inout_ DBGKD_MANIPULATE_STATE64* State,
+    _In_ const GDB_HARDWARE_BREAKPOINT* Breakpoints)
+{
+    State->u.Continue2.ControlSet.TraceFlag = (CurrentContext.EFlags & EFLAGS_TF) != 0;
+    State->u.Continue2.ControlSet.Dr7 = hardware_breakpoint_dr7(Breakpoints);
+}

--- a/drivers/base/kdgdb/i386_sup.c
+++ b/drivers/base/kdgdb/i386_sup.c
@@ -7,6 +7,35 @@
 
 #include "kdgdb.h"
 
+const CHAR gdb_target_xml[] =
+    "<?xml version=\"1.0\"?><!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
+    "<target version=\"1.0\"><architecture>i386</architecture>"
+    "<feature name=\"org.gnu.gdb.i386.core\">"
+    "<reg name=\"eax\" bitsize=\"32\" type=\"int32\"/><reg name=\"ecx\" bitsize=\"32\" type=\"int32\"/>"
+    "<reg name=\"edx\" bitsize=\"32\" type=\"int32\"/><reg name=\"ebx\" bitsize=\"32\" type=\"int32\"/>"
+    "<reg name=\"esp\" bitsize=\"32\" type=\"data_ptr\"/><reg name=\"ebp\" bitsize=\"32\" type=\"data_ptr\"/>"
+    "<reg name=\"esi\" bitsize=\"32\" type=\"int32\"/><reg name=\"edi\" bitsize=\"32\" type=\"int32\"/>"
+    "<reg name=\"eip\" bitsize=\"32\" type=\"code_ptr\"/><reg name=\"eflags\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"cs\" bitsize=\"32\" type=\"uint32\"/><reg name=\"ss\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"ds\" bitsize=\"32\" type=\"uint32\"/><reg name=\"es\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"fs\" bitsize=\"32\" type=\"uint32\"/><reg name=\"gs\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"st0\" bitsize=\"80\" type=\"i387_ext\"/><reg name=\"st1\" bitsize=\"80\" type=\"i387_ext\"/>"
+    "<reg name=\"st2\" bitsize=\"80\" type=\"i387_ext\"/><reg name=\"st3\" bitsize=\"80\" type=\"i387_ext\"/>"
+    "<reg name=\"st4\" bitsize=\"80\" type=\"i387_ext\"/><reg name=\"st5\" bitsize=\"80\" type=\"i387_ext\"/>"
+    "<reg name=\"st6\" bitsize=\"80\" type=\"i387_ext\"/><reg name=\"st7\" bitsize=\"80\" type=\"i387_ext\"/>"
+    "<reg name=\"fctrl\" bitsize=\"32\" type=\"uint32\"/><reg name=\"fstat\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"ftag\" bitsize=\"32\" type=\"uint32\"/><reg name=\"fiseg\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"fioff\" bitsize=\"32\" type=\"uint32\"/><reg name=\"foseg\" bitsize=\"32\" type=\"uint32\"/>"
+    "<reg name=\"fooff\" bitsize=\"32\" type=\"uint32\"/><reg name=\"fop\" bitsize=\"32\" type=\"uint32\"/>"
+    "</feature><feature name=\"org.gnu.gdb.i386.sse\">"
+    "<reg name=\"xmm0\" bitsize=\"128\" type=\"uint128\"/><reg name=\"xmm1\" bitsize=\"128\" type=\"uint128\"/>"
+    "<reg name=\"xmm2\" bitsize=\"128\" type=\"uint128\"/><reg name=\"xmm3\" bitsize=\"128\" type=\"uint128\"/>"
+    "<reg name=\"xmm4\" bitsize=\"128\" type=\"uint128\"/><reg name=\"xmm5\" bitsize=\"128\" type=\"uint128\"/>"
+    "<reg name=\"xmm6\" bitsize=\"128\" type=\"uint128\"/><reg name=\"xmm7\" bitsize=\"128\" type=\"uint128\"/>"
+    "<reg name=\"mxcsr\" bitsize=\"32\" type=\"uint32\"/>"
+    "</feature></target>";
+const SIZE_T gdb_target_xml_length = sizeof(gdb_target_xml) - 1;
+
 enum reg_name
 {
     EAX, ECX, EDX, EBX, ESP, EBP, ESI, EDI,
@@ -19,12 +48,27 @@ enum reg_name
     MXCSR
 };
 
-static
-const void*
-ctx_to_reg(CONTEXT* ctx, enum reg_name name, unsigned short* size)
+const UCHAR gdb_reg_size[] =
 {
-    /* For general registers: 32bits */
-    *size = 4;
+    4, 4, 4, 4, 4, 4, 4, 4,
+    4,
+    4,
+    4, 4, 4, 4, 4, 4,
+    10, 10, 10, 10, 10, 10, 10, 10,
+    4, 4, 4, 4, 4, 4, 4, 4,
+    16, 16, 16, 16, 16, 16, 16, 16,
+    4
+};
+const ULONG gdb_reg_count = RTL_NUMBER_OF(gdb_reg_size);
+
+const void*
+gdb_ctx_to_reg(
+    _In_ CONTEXT* ctx,
+    _In_ ULONG Register,
+    _Out_ PULONG ScalarValue)
+{
+    enum reg_name name = (enum reg_name)Register;
+
     switch (name)
     {
     case EAX: return &ctx->Eax;
@@ -52,17 +96,18 @@ ctx_to_reg(CONTEXT* ctx, enum reg_name name, unsigned short* size)
     case ST5:
     case ST6:
     case ST7:
-        *size = 10;
         return &ctx->FloatSave.RegisterArea[10 * (name - ST0)];
     /* X87 registers */
     case FCTRL: return &ctx->FloatSave.ControlWord;
     case FSTAT: return &ctx->FloatSave.StatusWord;
     case FTAG: return &ctx->FloatSave.TagWord;
-    case FISEG: return &ctx->FloatSave.DataSelector;
-    case FIOFF: return &ctx->FloatSave.DataOffset;
-    case FOSEG: return &ctx->FloatSave.ErrorSelector;
-    case FOOFF: return &ctx->FloatSave.ErrorOffset;
-    case FOP: return &ctx->FloatSave.Cr0NpxState;
+    case FISEG: return &ctx->FloatSave.ErrorSelector;
+    case FIOFF: return &ctx->FloatSave.ErrorOffset;
+    case FOSEG: return &ctx->FloatSave.DataSelector;
+    case FOOFF: return &ctx->FloatSave.DataOffset;
+    case FOP:
+        *ScalarValue = *(UNALIGNED USHORT*)&ctx->ExtendedRegisters[6];
+        return ScalarValue;
     /* SSE */
     case XMM0:
     case XMM1:
@@ -72,17 +117,44 @@ ctx_to_reg(CONTEXT* ctx, enum reg_name name, unsigned short* size)
     case XMM5:
     case XMM6:
     case XMM7:
-        *size = 16;
         return &ctx->ExtendedRegisters[160 + (name - XMM0)*16];
     case MXCSR: return &ctx->ExtendedRegisters[24];
     }
     return NULL;
 }
-
-static
-const void*
-thread_to_reg(PETHREAD Thread, enum reg_name reg_name, unsigned short* size)
+BOOLEAN
+gdb_set_ctx_reg(
+    _Inout_ CONTEXT* Context,
+    _In_ ULONG Register,
+    _In_reads_bytes_(Size) const UCHAR* Value,
+    _In_ SIZE_T Size)
 {
+    ULONG ScalarValue;
+    PVOID Storage;
+
+    if (Register >= gdb_reg_count || Size != gdb_reg_size[Register])
+        return FALSE;
+
+    if ((enum reg_name)Register == FOP)
+    {
+        RtlCopyMemory(&ScalarValue, Value, sizeof(ScalarValue));
+        *(UNALIGNED USHORT*)&Context->ExtendedRegisters[6] = (USHORT)ScalarValue;
+        return TRUE;
+    }
+
+    Storage = (PVOID)gdb_ctx_to_reg(Context, Register, &ScalarValue);
+    if (Storage == NULL)
+        return FALSE;
+    RtlCopyMemory(Storage, Value, Size);
+    return TRUE;
+}
+
+const void*
+gdb_thread_to_reg(
+    _In_ PETHREAD Thread,
+    _In_ ULONG Register)
+{
+    enum reg_name reg_name = (enum reg_name)Register;
     static const void* NullValue = NULL;
 
     if (!Thread->Tcb.InitialStack)
@@ -94,7 +166,6 @@ thread_to_reg(PETHREAD Thread, enum reg_name reg_name, unsigned short* size)
             case EBP:
             case EIP:
                 KDDBGPRINT("Returning NULL for register %d.\n", reg_name);
-                *size = 4;
                 return &NullValue;
             default:
                 return NULL;
@@ -105,7 +176,6 @@ thread_to_reg(PETHREAD Thread, enum reg_name reg_name, unsigned short* size)
     {
         PKTRAP_FRAME TrapFrame = Thread->Tcb.TrapFrame;
 
-        *size = 4;
         switch (reg_name)
         {
             case EAX: return &TrapFrame->Eax;
@@ -134,7 +204,6 @@ thread_to_reg(PETHREAD Thread, enum reg_name reg_name, unsigned short* size)
     {
         static PULONG Esp;
         Esp = Thread->Tcb.KernelStack;
-        *size = 4;
         switch (reg_name)
         {
             case EBP: return &Esp[3];
@@ -146,118 +215,4 @@ thread_to_reg(PETHREAD Thread, enum reg_name reg_name, unsigned short* size)
     }
 
     return NULL;
-}
-
-KDSTATUS
-gdb_send_registers(void)
-{
-    CHAR RegisterStr[9];
-    const UCHAR* RegisterPtr;
-    unsigned short i;
-    unsigned short size;
-
-    RegisterStr[8] = '\0';
-
-    start_gdb_packet();
-
-    KDDBGPRINT("Sending registers of thread %" PRIxPTR ".\n", gdb_dbg_tid);
-    KDDBGPRINT("Current thread_id: %p.\n", PsGetThreadId((PETHREAD)(ULONG_PTR)CurrentStateChange.Thread));
-    if (((gdb_dbg_pid == 0) && (gdb_dbg_tid == 0)) ||
-            gdb_tid_to_handle(gdb_dbg_tid) == PsGetThreadId((PETHREAD)(ULONG_PTR)CurrentStateChange.Thread))
-    {
-        for (i = 0; i < 16; i++)
-        {
-            RegisterPtr = ctx_to_reg(&CurrentContext, i, &size);
-            RegisterStr[0] = hex_chars[RegisterPtr[0] >> 4];
-            RegisterStr[1] = hex_chars[RegisterPtr[0] & 0xF];
-            RegisterStr[2] = hex_chars[RegisterPtr[1] >> 4];
-            RegisterStr[3] = hex_chars[RegisterPtr[1] & 0xF];
-            RegisterStr[4] = hex_chars[RegisterPtr[2] >> 4];
-            RegisterStr[5] = hex_chars[RegisterPtr[2] & 0xF];
-            RegisterStr[6] = hex_chars[RegisterPtr[3] >> 4];
-            RegisterStr[7] = hex_chars[RegisterPtr[3] & 0xF];
-
-            send_gdb_partial_packet(RegisterStr);
-        }
-    }
-    else
-    {
-        PETHREAD DbgThread;
-
-        DbgThread = find_thread(gdb_dbg_pid, gdb_dbg_tid);
-
-        if (DbgThread == NULL)
-        {
-            /* Thread is dead */
-            send_gdb_partial_packet("E03");
-            return finish_gdb_packet();
-        }
-
-        for (i = 0; i < 16; i++)
-        {
-            RegisterPtr = thread_to_reg(DbgThread, i, &size);
-            if (RegisterPtr)
-            {
-                RegisterStr[0] = hex_chars[RegisterPtr[0] >> 4];
-                RegisterStr[1] = hex_chars[RegisterPtr[0] & 0xF];
-                RegisterStr[2] = hex_chars[RegisterPtr[1] >> 4];
-                RegisterStr[3] = hex_chars[RegisterPtr[1] & 0xF];
-                RegisterStr[4] = hex_chars[RegisterPtr[2] >> 4];
-                RegisterStr[5] = hex_chars[RegisterPtr[2] & 0xF];
-                RegisterStr[6] = hex_chars[RegisterPtr[3] >> 4];
-                RegisterStr[7] = hex_chars[RegisterPtr[3] & 0xF];
-
-                send_gdb_partial_packet(RegisterStr);
-            }
-            else
-            {
-                send_gdb_partial_packet("xxxxxxxx");
-            }
-        }
-    }
-
-    return finish_gdb_packet();
-}
-
-KDSTATUS
-gdb_send_register(void)
-{
-    enum reg_name reg_name;
-    const void* ptr;
-    unsigned short size;
-
-    /* Get the GDB register name (gdb_input = "pXX") */
-    reg_name = (hex_value(gdb_input[1]) << 4) | hex_value(gdb_input[2]);
-
-    if (((gdb_dbg_pid == 0) && (gdb_dbg_tid == 0)) ||
-            gdb_tid_to_handle(gdb_dbg_tid) == PsGetThreadId((PETHREAD)(ULONG_PTR)CurrentStateChange.Thread))
-    {
-        /* We can get it from the context of the current exception */
-        ptr = ctx_to_reg(&CurrentContext, reg_name, &size);
-    }
-    else
-    {
-        PETHREAD DbgThread;
-
-        DbgThread = find_thread(gdb_dbg_pid, gdb_dbg_tid);
-
-        if (DbgThread == NULL)
-        {
-            /* Thread is dead */
-            return send_gdb_packet("E03");
-        }
-
-        ptr = thread_to_reg(DbgThread, reg_name, &size);
-    }
-
-    if (!ptr)
-    {
-        /* Undefined. Let's assume 32 bit register */
-        return send_gdb_packet("xxxxxxxx");
-    }
-    else
-    {
-        KDDBGPRINT("KDGDB: Sending registers as memory.\n");
-        return send_gdb_memory(ptr, size);
-    }
 }

--- a/drivers/base/kdgdb/kdcom.c
+++ b/drivers/base/kdgdb/kdcom.c
@@ -17,9 +17,28 @@
 /* GLOBALS ********************************************************************/
 
 CPPORT KdComPort;
+BOOLEAN gdb_vctrlc_pending;
 #ifdef KDDEBUG
 CPPORT KdDebugComPort;
 #endif
+
+typedef enum _GDB_POLL_STATE
+{
+    GdbPollIdle,
+    GdbPollPayload,
+    GdbPollChecksumHigh,
+    GdbPollChecksumLow,
+    GdbPollDiscard,
+    GdbPollDiscardChecksumHigh,
+    GdbPollDiscardChecksumLow
+} GDB_POLL_STATE;
+
+static GDB_POLL_STATE GdbPollState;
+static ULONG GdbPollPayloadIndex;
+static UCHAR GdbPollChecksum;
+static UCHAR GdbPollReceivedChecksum;
+
+#define GDB_POLL_PACKET_TIMEOUT_US 2000
 
 /* DEBUGGING ******************************************************************/
 
@@ -288,23 +307,102 @@ KDSTATUS
 NTAPI
 KdpPollBreakIn(VOID)
 {
-    KDSTATUS KdStatus;
+    static const CHAR VCtrlCPayload[] = "vCtrlC";
+    ULONG EmptyPolls = 0;
     UCHAR Byte;
 
-    KdStatus = KdpPollByte(&Byte);
-    if (KdStatus == KdPacketReceived)
+    while (TRUE)
     {
+        if (KdpPollByte(&Byte) != KdPacketReceived)
+        {
+            if (GdbPollState == GdbPollIdle || EmptyPolls++ >= GDB_POLL_PACKET_TIMEOUT_US)
+                break;
+            KeStallExecutionProcessor(1);
+            continue;
+        }
+        EmptyPolls = 0;
+
         if (Byte == 0x03)
         {
+            GdbPollState = GdbPollIdle;
             KDDBGPRINT("BreakIn Polled.\n");
             return KdPacketReceived;
         }
-        else if (Byte == '$')
+
+        if (Byte == '$')
         {
-            /* GDB tried to send a new packet. N-ack it. */
-            KdpSendByte('-');
+            GdbPollState = GdbPollPayload;
+            GdbPollPayloadIndex = 0;
+            GdbPollChecksum = 0;
+            continue;
         }
+
+        switch (GdbPollState)
+        {
+            case GdbPollIdle:
+                break;
+
+            case GdbPollPayload:
+                if (Byte == '#')
+                {
+                    if (GdbPollPayloadIndex != sizeof(VCtrlCPayload) - 1)
+                        goto RejectPacket;
+                    GdbPollState = GdbPollChecksumHigh;
+                    break;
+                }
+
+                GdbPollChecksum += Byte;
+                if (GdbPollPayloadIndex >= sizeof(VCtrlCPayload) - 1 || Byte != VCtrlCPayload[GdbPollPayloadIndex++])
+                    GdbPollState = GdbPollDiscard;
+                break;
+
+            case GdbPollChecksumHigh:
+            {
+                CHAR Value = hex_value(Byte);
+
+                if (Value < 0)
+                    goto RejectPacket;
+                GdbPollReceivedChecksum = (UCHAR)Value << 4;
+                GdbPollState = GdbPollChecksumLow;
+                break;
+            }
+
+            case GdbPollChecksumLow:
+            {
+                CHAR Value = hex_value(Byte);
+
+                if (Value < 0 || GdbPollChecksum != (UCHAR)(GdbPollReceivedChecksum | Value))
+                    goto RejectPacket;
+
+                GdbPollState = GdbPollIdle;
+                if (!gdb_no_ack_mode)
+                    KdpSendByte('+');
+                gdb_vctrlc_pending = TRUE;
+                KDDBGPRINT("vCtrlC BreakIn Polled.\n");
+                return KdPacketReceived;
+            }
+
+            case GdbPollDiscard:
+                if (Byte == '#')
+                    GdbPollState = GdbPollDiscardChecksumHigh;
+                break;
+
+            case GdbPollDiscardChecksumHigh:
+                GdbPollState = GdbPollDiscardChecksumLow;
+                break;
+
+            case GdbPollDiscardChecksumLow:
+                goto RejectPacket;
+        }
+
+        continue;
+
+RejectPacket:
+        GdbPollState = GdbPollIdle;
+        if (!gdb_no_ack_mode)
+            KdpSendByte('-');
     }
+
     return KdPacketTimedOut;
 }
 

--- a/drivers/base/kdgdb/kdgdb.h
+++ b/drivers/base/kdgdb/kdgdb.h
@@ -24,6 +24,14 @@
 /* To undefine once https://sourceware.org/bugzilla/show_bug.cgi?id=17397 is resolved */
 #define MONOPROCESS 1
 
+#define GDB_PACKET_MAX_SIZE 0x1000
+/* Each byte takes two characters once hex-encoded */
+#define GDB_MEMORY_MAX_SIZE (GDB_PACKET_MAX_SIZE / 2)
+/* qXfer replies additionally carry a one-character 'm'/'l' continuation flag */
+#define GDB_XFER_MAX_SIZE (GDB_MEMORY_MAX_SIZE - 1)
+/* Size of the largest register any supported architecture exposes to GDB */
+#define GDB_MAX_REGISTER_SIZE 16
+
 #ifndef KDDEBUG
 #define KDDBGPRINT(...)
 #else
@@ -43,6 +51,33 @@ FORCEINLINE UINT_PTR handle_to_gdb_tid(HANDLE Handle)
     return (UINT_PTR)Handle + 1;
 }
 #define handle_to_gdb_pid handle_to_gdb_tid
+
+/* Format a thread as GDB expects it, which depends on multiprocess support */
+FORCEINLINE
+LONG
+format_gdb_tid(
+    _Out_writes_(BufferSize) char* Buffer,
+    _In_ SIZE_T BufferSize,
+    _In_ HANDLE ProcessId,
+    _In_ UINT_PTR Tid)
+{
+#if MONOPROCESS
+    UNREFERENCED_PARAMETER(ProcessId);
+    return _snprintf(Buffer, BufferSize, "%" PRIxPTR, Tid);
+#else
+    return _snprintf(Buffer, BufferSize, "p%" PRIxPTR ".%" PRIxPTR,
+                     handle_to_gdb_pid(ProcessId), Tid);
+#endif
+}
+
+FORCEINLINE ULONG_PTR KdpGetDirectoryTableBase(PKPROCESS Process)
+{
+#if (NTDDI_VERSION >= NTDDI_LONGHORN)
+    return Process->DirectoryTableBase;
+#else
+    return Process->DirectoryTableBase[0];
+#endif
+}
 
 FORCEINLINE
 VOID
@@ -75,7 +110,9 @@ extern UINT_PTR gdb_dbg_pid;
 extern KDSTATUS gdb_receive_and_interpret_packet(_Out_ DBGKD_MANIPULATE_STATE64* State, _Out_ PSTRING MessageData, _Out_ PULONG MessageLength, _Inout_ PKD_CONTEXT KdContext);
 
 /* gdb_receive.c */
-extern CHAR gdb_input[];
+extern CHAR gdb_input[GDB_PACKET_MAX_SIZE + 1];
+extern ULONG gdb_input_length;
+extern BOOLEAN gdb_no_ack_mode;
 KDSTATUS NTAPI gdb_receive_packet(_Inout_ PKD_CONTEXT KdContext);
 char hex_value(char ch);
 
@@ -105,21 +142,64 @@ extern DBGKD_GET_VERSION64 KdVersion;
 extern KDDEBUGGER_DATA64* KdDebuggerDataBlock;
 extern LIST_ENTRY* ProcessListHead;
 extern LIST_ENTRY* ModuleListHead;
+/* The lists are only linked once Ps/the loader have gotten far enough */
+FORCEINLINE BOOLEAN ps_initialized(VOID)
+{
+    return (ProcessListHead != NULL) && (ProcessListHead->Flink != NULL);
+}
+FORCEINLINE BOOLEAN modules_initialized(VOID)
+{
+    return (ModuleListHead != NULL) && (ModuleListHead->Flink != NULL);
+}
 extern KDP_SEND_HANDLER KdpSendPacketHandler;
 extern KDP_MANIPULATESTATE_HANDLER KdpManipulateStateHandler;
 /* Common ManipulateState handlers */
 extern KDSTATUS ContinueManipulateStateHandler(_Out_ DBGKD_MANIPULATE_STATE64* State, _Out_ PSTRING MessageData, _Out_ PULONG MessageLength, _Inout_ PKD_CONTEXT KdContext);
 extern KDSTATUS SetContextManipulateHandler(_Out_ DBGKD_MANIPULATE_STATE64* State, _Out_ PSTRING MessageData, _Out_ PULONG MessageLength, _Inout_ PKD_CONTEXT KdContext);
+extern KDSTATUS SetContextManipulateHandlerWithReply(_Out_ DBGKD_MANIPULATE_STATE64* State, _Out_ PSTRING MessageData, _Out_ PULONG MessageLength, _Inout_ PKD_CONTEXT KdContext);
 extern PEPROCESS TheIdleProcess;
 extern PETHREAD TheIdleThread;
 
 /* utils.c */
 extern PEPROCESS find_process( _In_ UINT_PTR Pid);
 extern PETHREAD find_thread(_In_ UINT_PTR Pid, _In_ UINT_PTR Tid);
+extern BOOLEAN gdb_decode_hex(
+    _In_reads_(InputLength) const CHAR* Input,
+    _In_ ULONG InputLength,
+    _Out_writes_bytes_(OutputLength) VOID* Output,
+    _In_ SIZE_T OutputLength);
+extern BOOLEAN parse_hex_value(
+    _In_reads_(End - Buffer) const char* Buffer,
+    _In_ const char* End,
+    _Out_ PULONG64 Value,
+    _Out_opt_ const char** Next);
+extern BOOLEAN parse_hex_fields(
+    _In_reads_(End - Buffer) const char* Buffer,
+    _In_ const char* End,
+    _In_z_ const char* Delimiters,
+    _Out_writes_(Count) PULONG64 Values,
+    _In_ ULONG Count,
+    _Out_opt_ const char** Rest);
+extern BOOLEAN parse_gdb_thread_id(
+    _In_reads_(End - Buffer) const char* Buffer,
+    _In_ const char* End,
+    _Out_ PUINT_PTR Pid,
+    _Out_ PUINT_PTR Tid);
 
-/* arch_sup.c */
+/* gdb_regs.c */
 extern KDSTATUS gdb_send_register(void);
 extern KDSTATUS gdb_send_registers(void);
+extern BOOLEAN gdb_write_register(_In_ ULONG Register, _In_reads_(Length) const CHAR* Value, _In_ ULONG Length);
+extern BOOLEAN gdb_write_registers(_In_reads_(Length) const CHAR* Value, _In_ ULONG Length);
+
+/* arch_sup.c: the architecture only describes its register file */
+extern const UCHAR gdb_reg_size[];
+extern const ULONG gdb_reg_count;
+extern const void* gdb_ctx_to_reg(_In_ CONTEXT* Context, _In_ ULONG Register, _Out_ PULONG ScalarValue);
+extern BOOLEAN gdb_set_ctx_reg(_Inout_ CONTEXT* Context, _In_ ULONG Register, _In_reads_bytes_(Size) const UCHAR* Value, _In_ SIZE_T Size);
+extern const void* gdb_thread_to_reg(_In_ PETHREAD Thread, _In_ ULONG Register);
+extern const CHAR gdb_target_xml[];
+extern const SIZE_T gdb_target_xml_length;
 
 /* Architecture specific defines. See ntoskrnl/include/internal/arch/ke.h */
 #ifdef _M_IX86
@@ -134,6 +214,8 @@ extern KDSTATUS gdb_send_registers(void);
 /* Single step mode */
 #  define KdpSetSingleStep(Context) \
     ((Context)->EFlags |= EFLAGS_TF)
+#  define KdpClearSingleStep(Context) \
+    ((Context)->EFlags &= ~EFLAGS_TF)
 #elif defined(_M_AMD64)
 #  define KdpGetContextPc(Context) \
     ((Context)->Rip)
@@ -145,6 +227,8 @@ extern KDSTATUS gdb_send_registers(void);
 /* Single step mode */
 #  define KdpSetSingleStep(Context) \
     ((Context)->EFlags |= EFLAGS_TF)
+#  define KdpClearSingleStep(Context) \
+    ((Context)->EFlags &= ~EFLAGS_TF)
 #else
 #  error "Please define relevant macros for your architecture"
 #endif

--- a/drivers/base/kdgdb/kdgdb.h
+++ b/drivers/base/kdgdb/kdgdb.h
@@ -132,6 +132,7 @@ void send_gdb_ntstatus(_In_ NTSTATUS Status);
 extern const char hex_chars[];
 
 /* kdcom.c */
+extern BOOLEAN gdb_vctrlc_pending;
 KDSTATUS NTAPI KdpPollBreakIn(VOID);
 VOID NTAPI KdpSendByte(_In_ UCHAR Byte);
 KDSTATUS NTAPI KdpReceiveByte(_Out_ PUCHAR OutByte);

--- a/drivers/base/kdgdb/kdgdb.h
+++ b/drivers/base/kdgdb/kdgdb.h
@@ -104,12 +104,29 @@ typedef KDSTATUS (*KDP_MANIPULATESTATE_HANDLER)(
     _Inout_ PKD_CONTEXT KdContext
 );
 
+/*
+ * Hardware debug support. GDB numbers the Z packet types this way; the
+ * architecture backend owns the mapping to its hardware debug registers.
+ */
+#define GDB_HW_EXECUTE 1
+#define GDB_HW_WRITE   2
+#define GDB_HW_READ    3
+#define GDB_HW_ACCESS  4
+
+typedef struct _GDB_HARDWARE_BREAKPOINT
+{
+    ULONG64 Address;
+    ULONG Kind;
+    UCHAR Type;
+    BOOLEAN Active;
+} GDB_HARDWARE_BREAKPOINT;
+
 /* gdb_input.c */
 extern UINT_PTR gdb_dbg_tid;
 extern UINT_PTR gdb_dbg_pid;
 extern KDSTATUS gdb_receive_and_interpret_packet(_Out_ DBGKD_MANIPULATE_STATE64* State, _Out_ PSTRING MessageData, _Out_ PULONG MessageLength, _Inout_ PKD_CONTEXT KdContext);
-extern ULONG64 gdb_hardware_breakpoint_dr7(VOID);
 extern BOOLEAN gdb_get_watchpoint_stop(_Out_ const CHAR** Reason, _Out_ PULONG64 Address);
+extern const GDB_HARDWARE_BREAKPOINT* gdb_hardware_breakpoints(VOID);
 
 /* gdb_receive.c */
 extern CHAR gdb_input[GDB_PACKET_MAX_SIZE + 1];
@@ -194,6 +211,24 @@ extern KDSTATUS gdb_send_register(void);
 extern KDSTATUS gdb_send_registers(void);
 extern BOOLEAN gdb_write_register(_In_ ULONG Register, _In_reads_(Length) const CHAR* Value, _In_ ULONG Length);
 extern BOOLEAN gdb_write_registers(_In_reads_(Length) const CHAR* Value, _In_ ULONG Length);
+
+/*
+ * hwbp_*.c: the architecture owns its debug register file. Slots are indices
+ * into the shared table above; which slot can serve which Z type, and how a
+ * hit is detected, is entirely architecture specific.
+ */
+extern const ULONG gdb_hw_breakpoint_count;
+extern BOOLEAN gdb_arch_hw_breakpoint_valid(_In_ const GDB_HARDWARE_BREAKPOINT* Breakpoint);
+extern VOID gdb_arch_program_hw_breakpoints(
+    _Inout_ PKSPECIAL_REGISTERS Registers,
+    _In_ const GDB_HARDWARE_BREAKPOINT* Breakpoints);
+extern VOID gdb_arch_report_hw_breakpoints(_In_ const GDB_HARDWARE_BREAKPOINT* Breakpoints);
+extern BOOLEAN gdb_arch_hw_breakpoint_hit(
+    _In_ const GDB_HARDWARE_BREAKPOINT* Breakpoints,
+    _In_ ULONG Slot);
+extern VOID gdb_arch_set_continue_control(
+    _Inout_ DBGKD_MANIPULATE_STATE64* State,
+    _In_ const GDB_HARDWARE_BREAKPOINT* Breakpoints);
 
 /* arch_sup.c: the architecture only describes its register file */
 extern const UCHAR gdb_reg_size[];

--- a/drivers/base/kdgdb/kdgdb.h
+++ b/drivers/base/kdgdb/kdgdb.h
@@ -108,6 +108,8 @@ typedef KDSTATUS (*KDP_MANIPULATESTATE_HANDLER)(
 extern UINT_PTR gdb_dbg_tid;
 extern UINT_PTR gdb_dbg_pid;
 extern KDSTATUS gdb_receive_and_interpret_packet(_Out_ DBGKD_MANIPULATE_STATE64* State, _Out_ PSTRING MessageData, _Out_ PULONG MessageLength, _Inout_ PKD_CONTEXT KdContext);
+extern ULONG64 gdb_hardware_breakpoint_dr7(VOID);
+extern BOOLEAN gdb_get_watchpoint_stop(_Out_ const CHAR** Reason, _Out_ PULONG64 Address);
 
 /* gdb_receive.c */
 extern CHAR gdb_input[GDB_PACKET_MAX_SIZE + 1];

--- a/drivers/base/kdgdb/kdpacket.c
+++ b/drivers/base/kdgdb/kdpacket.c
@@ -277,8 +277,7 @@ ContinueManipulateStateHandler(
         MessageData->Length = 0;
     *MessageLength = 0;
     State->u.Continue2.ContinueStatus = STATUS_SUCCESS;
-    State->u.Continue2.ControlSet.TraceFlag = (CurrentContext.EFlags & EFLAGS_TF) != 0;
-    State->u.Continue2.ControlSet.Dr7 = gdb_hardware_breakpoint_dr7();
+    gdb_arch_set_continue_control(State, gdb_hardware_breakpoints());
     State->u.Continue2.ControlSet.CurrentSymbolStart = 1;
     State->u.Continue2.ControlSet.CurrentSymbolEnd = 1;
 

--- a/drivers/base/kdgdb/kdpacket.c
+++ b/drivers/base/kdgdb/kdpacket.c
@@ -96,7 +96,39 @@ SetContextSendHandler(
     {
         /* Should we bugcheck ? */
         KDDBGPRINT("BAD BAD BAD not manipulating state for sending context.\n");
-        return FALSE;
+    }
+
+    KdpSendPacketHandler = NULL;
+    return TRUE;
+}
+
+/*
+ * Same as above, but the GDB packet that triggered the write - 'P' or 'G' -
+ * still owes GDB a reply, which can only be sent once KD has confirmed it.
+ */
+static
+BOOLEAN
+SetContextReplySendHandler(
+    _In_ ULONG PacketType,
+    _In_ PSTRING MessageHeader,
+    _In_ PSTRING MessageData
+)
+{
+    DBGKD_MANIPULATE_STATE64* State = (DBGKD_MANIPULATE_STATE64*)MessageHeader->Buffer;
+
+    if ((PacketType != PACKET_TYPE_KD_STATE_MANIPULATE)
+            || (State->ApiNumber != DbgKdSetContextApi))
+    {
+        KDDBGPRINT("BAD BAD BAD not manipulating state for sending context.\n");
+        send_gdb_packet("E01");
+    }
+    else if (!NT_SUCCESS(State->ReturnStatus))
+    {
+        send_gdb_ntstatus(State->ReturnStatus);
+    }
+    else
+    {
+        send_gdb_packet("OK");
     }
 
     KdpSendPacketHandler = NULL;
@@ -130,6 +162,20 @@ SetContextManipulateHandler(
     KdpManipulateStateHandler = NULL;
 
     return KdPacketReceived;
+}
+
+KDSTATUS
+SetContextManipulateHandlerWithReply(
+    _Out_ DBGKD_MANIPULATE_STATE64* State,
+    _Out_ PSTRING MessageData,
+    _Out_ PULONG MessageLength,
+    _Inout_ PKD_CONTEXT KdContext)
+{
+    KDSTATUS Status;
+
+    Status = SetContextManipulateHandler(State, MessageData, MessageLength, KdContext);
+    KdpSendPacketHandler = SetContextReplySendHandler;
+    return Status;
 }
 
 static

--- a/drivers/base/kdgdb/kdpacket.c
+++ b/drivers/base/kdgdb/kdpacket.c
@@ -264,14 +264,18 @@ ContinueManipulateStateHandler(
 )
 {
     /* Let's go on */
-    State->ApiNumber = DbgKdContinueApi;
+    State->ApiNumber = DbgKdContinueApi2;
     State->ReturnStatus = STATUS_SUCCESS; /* ? */
     State->Processor = CurrentStateChange.Processor;
     State->ProcessorLevel = CurrentStateChange.ProcessorLevel;
     if (MessageData)
         MessageData->Length = 0;
     *MessageLength = 0;
-    State->u.Continue.ContinueStatus = STATUS_SUCCESS;
+    State->u.Continue2.ContinueStatus = STATUS_SUCCESS;
+    State->u.Continue2.ControlSet.TraceFlag = (CurrentContext.EFlags & EFLAGS_TF) != 0;
+    State->u.Continue2.ControlSet.Dr7 = gdb_hardware_breakpoint_dr7();
+    State->u.Continue2.ControlSet.CurrentSymbolStart = 1;
+    State->u.Continue2.ControlSet.CurrentSymbolEnd = 1;
 
     /* We definitely are at the end of the send <-> receive loop, if any */
     KdpSendPacketHandler = NULL;

--- a/drivers/base/kdgdb/kdpacket.c
+++ b/drivers/base/kdgdb/kdpacket.c
@@ -203,6 +203,11 @@ send_kd_state_change(DBGKD_ANY_WAIT_STATE_CHANGE* StateChange)
 #else
         gdb_dbg_pid = handle_to_gdb_pid(PsGetThreadProcessId(Thread));
 #endif
+        if (gdb_vctrlc_pending)
+        {
+            gdb_vctrlc_pending = FALSE;
+            send_gdb_packet("OK");
+        }
         gdb_send_exception();
         /* Next receive call will ask for the context */
         KdpManipulateStateHandler = GetContextManipulateHandler;

--- a/drivers/base/kdgdb/utils.c
+++ b/drivers/base/kdgdb/utils.c
@@ -7,6 +7,175 @@
 
 #include "kdgdb.h"
 
+/* Decode a run of hex digit pairs into raw bytes */
+BOOLEAN
+gdb_decode_hex(
+    _In_reads_(InputLength) const CHAR* Input,
+    _In_ ULONG InputLength,
+    _Out_writes_bytes_(OutputLength) VOID* Output,
+    _In_ SIZE_T OutputLength)
+{
+    UCHAR* OutputBytes = Output;
+    SIZE_T i;
+
+    if (InputLength != OutputLength * 2)
+        return FALSE;
+
+    for (i = 0; i < OutputLength; i++)
+    {
+        CHAR HighNibble = hex_value(Input[i * 2]);
+        CHAR LowNibble = hex_value(Input[i * 2 + 1]);
+
+        if (HighNibble < 0 || LowNibble < 0)
+            return FALSE;
+
+        OutputBytes[i] = (UCHAR)((HighNibble << 4) | LowNibble);
+    }
+
+    return TRUE;
+}
+
+/*
+ * Parse one hexadecimal number. Fails on empty input and on overflow.
+ * Stops at the first non-hex character, reported through Next.
+ */
+BOOLEAN
+parse_hex_value(
+    _In_reads_(End - Buffer) const char* Buffer,
+    _In_ const char* End,
+    _Out_ PULONG64 Value,
+    _Out_opt_ const char** Next)
+{
+    ULONG64 Result = 0;
+    const char* Current = Buffer;
+
+    if (Current == End || hex_value(*Current) < 0)
+        return FALSE;
+
+    while (Current != End)
+    {
+        char Digit = hex_value(*Current);
+
+        if (Digit < 0)
+            break;
+
+        if (Result > ((~(ULONG64)0 - (ULONG64)Digit) >> 4))
+            return FALSE;
+
+        Result = (Result << 4) | (ULONG64)Digit;
+        Current++;
+    }
+
+    *Value = Result;
+    if (Next)
+        *Next = Current;
+    return TRUE;
+}
+
+/*
+ * Parse a list of Count hexadecimal fields. Delimiters holds the character
+ * required after each field, and may be shorter than Count: once it runs out
+ * no separator is expected. Rest, when asked for, receives the position where
+ * parsing stopped, so callers that require the fields to span the whole packet
+ * can check it against End themselves.
+ */
+BOOLEAN
+parse_hex_fields(
+    _In_reads_(End - Buffer) const char* Buffer,
+    _In_ const char* End,
+    _In_z_ const char* Delimiters,
+    _Out_writes_(Count) PULONG64 Values,
+    _In_ ULONG Count,
+    _Out_opt_ const char** Rest)
+{
+    const char* Current = Buffer;
+    ULONG i;
+
+    for (i = 0; i < Count; i++)
+    {
+        if (!parse_hex_value(Current, End, &Values[i], &Current))
+            return FALSE;
+
+        if (Delimiters[i] == '\0')
+            break;
+
+        if (Current == End || *Current != Delimiters[i])
+            return FALSE;
+        Current++;
+    }
+
+    if (Rest)
+        *Rest = Current;
+    return TRUE;
+}
+
+static
+BOOLEAN
+parse_gdb_id_component(
+    _In_reads_(End - Buffer) const char* Buffer,
+    _In_ const char* End,
+    _Out_ PUINT_PTR Value,
+    _Out_ const char** Next)
+{
+    ULONG64 ParsedValue;
+    const char* Current;
+
+    if ((End - Buffer) >= 2 && Buffer[0] == '-' && Buffer[1] == '1')
+    {
+        *Value = (UINT_PTR)-1;
+        *Next = Buffer + 2;
+        return TRUE;
+    }
+
+    if (!parse_hex_value(Buffer, End, &ParsedValue, &Current) ||
+        ParsedValue > (ULONG64)(UINT_PTR)-1)
+    {
+        return FALSE;
+    }
+
+    *Value = (UINT_PTR)ParsedValue;
+    *Next = Current;
+    return TRUE;
+}
+
+BOOLEAN
+parse_gdb_thread_id(
+    _In_reads_(End - Buffer) const char* Buffer,
+    _In_ const char* End,
+    _Out_ PUINT_PTR Pid,
+    _Out_ PUINT_PTR Tid)
+{
+    const char* Current;
+
+#if MONOPROCESS
+    *Pid = 0;
+    return parse_gdb_id_component(Buffer, End, Tid, &Current) &&
+           Current == End;
+#else
+    if (Buffer == End || *Buffer++ != 'p' ||
+        !parse_gdb_id_component(Buffer, End, Pid, &Current))
+    {
+        return FALSE;
+    }
+
+    if (Current == End)
+    {
+        *Tid = (UINT_PTR)-1;
+        return TRUE;
+    }
+
+    if (*Current++ != '.' ||
+        !parse_gdb_id_component(Current, End, Tid, &Current) ||
+        Current != End ||
+        (*Pid == (UINT_PTR)-1 && *Tid != (UINT_PTR)-1))
+    {
+        return FALSE;
+    }
+
+    return TRUE;
+#endif
+}
+
 /*
  * We cannot use PsLookupProcessThreadByCid or alike as we could be running at any IRQL.
  * So we have to loop over the process list.
@@ -16,13 +185,26 @@ PEPROCESS
 find_process(
     _In_ UINT_PTR Pid)
 {
+    PETHREAD CurrentThread;
     HANDLE ProcessId = gdb_pid_to_handle(Pid);
     LIST_ENTRY* ProcessEntry;
     PEPROCESS Process;
 
+    if (Pid == 0)
+    {
+        CurrentThread = (PETHREAD)(ULONG_PTR)CurrentStateChange.Thread;
+        return CONTAINING_RECORD(CurrentThread->Tcb.Process, EPROCESS, Pcb);
+    }
+
+    if (Pid == (UINT_PTR)-1)
+        return NULL;
+
     /* Special case for idle process */
     if (ProcessId == NULL)
         return TheIdleProcess;
+
+    if (!ps_initialized())
+        return NULL;
 
     for (ProcessEntry = ProcessListHead->Flink;
             ProcessEntry != ProcessListHead;
@@ -42,6 +224,8 @@ find_thread(
     _In_ UINT_PTR Pid,
     _In_ UINT_PTR Tid)
 {
+    PETHREAD CurrentThread;
+    UINT_PTR CurrentTid;
     HANDLE ThreadId = gdb_tid_to_handle(Tid);
     PETHREAD Thread;
     PEPROCESS Process;
@@ -50,14 +234,13 @@ find_thread(
     LIST_ENTRY* ProcessEntry;
 #endif
 
-    if (
-#if !MONOPROCESS
-    (Pid == 0) &&
-#endif
-    (Tid == 0))
+    CurrentThread = (PETHREAD)(ULONG_PTR)CurrentStateChange.Thread;
+    CurrentTid = handle_to_gdb_tid(PsGetThreadId(CurrentThread));
+
+    if (Tid == 0 || Tid == (UINT_PTR)-1 || Tid == CurrentTid)
     {
-        /* Zero means any, so use the current one */
-        return (PETHREAD)(ULONG_PTR)CurrentStateChange.Thread;
+        /* Zero and -1 mean any, so use the current one */
+        return CurrentThread;
     }
 
 #if MONOPROCESS
@@ -65,6 +248,9 @@ find_thread(
     /* Special case for the idle thread */
     if (Tid == 1)
         return TheIdleThread;
+
+    if (!ps_initialized())
+        return NULL;
 
     for (ProcessEntry = ProcessListHead->Flink;
         ProcessEntry != ProcessListHead;

--- a/ntoskrnl/kd64/amd64/kdx64.c
+++ b/ntoskrnl/kd64/amd64/kdx64.c
@@ -17,6 +17,37 @@
 
 /* FUNCTIONS *****************************************************************/
 
+static
+VOID
+KdpCaptureLegacyFloatingState(
+    _Inout_ PCONTEXT Context)
+{
+    DECLSPEC_ALIGN(16) XMM_SAVE_AREA32 FloatingState;
+
+    _fxsave64(&FloatingState);
+    KdpMoveMemory(&Context->FltSave,
+                  &FloatingState,
+                  FIELD_OFFSET(XMM_SAVE_AREA32, XmmRegisters));
+}
+
+static
+VOID
+KdpRestoreLegacyFloatingState(
+    _In_ PCONTEXT Context)
+{
+    DECLSPEC_ALIGN(16) XMM_SAVE_AREA32 FloatingState;
+
+    /*
+     * Preserve the debugger's live SSE state while applying only the x87
+     * fields exposed through the KD context.
+     */
+    _fxsave64(&FloatingState);
+    KdpMoveMemory(&FloatingState,
+                  &Context->FltSave,
+                  FIELD_OFFSET(XMM_SAVE_AREA32, XmmRegisters));
+    _fxrstor64(&FloatingState);
+}
+
 VOID
 NTAPI
 KdpGetStateChange(IN PDBGKD_MANIPULATE_STATE64 State,
@@ -58,6 +89,8 @@ KdpGetStateChange(IN PDBGKD_MANIPULATE_STATE64 State,
                 State->u.Continue2.ControlSet.CurrentSymbolStart;
             KdpCurrentSymbolEnd= State->u.Continue2.ControlSet.CurrentSymbolEnd;
         }
+
+        KdpRestoreLegacyFloatingState(Context);
     }
 }
 
@@ -66,13 +99,11 @@ NTAPI
 KdpSetContextState(IN PDBGKD_ANY_WAIT_STATE_CHANGE WaitStateChange,
                    IN PCONTEXT Context)
 {
-    PKPRCB Prcb = KeGetCurrentPrcb();
+    KdpCaptureLegacyFloatingState(Context);
 
     /* Copy i386 specific debug registers */
-    WaitStateChange->ControlReport.Dr6 = Prcb->ProcessorState.SpecialRegisters.
-                                         KernelDr6;
-    WaitStateChange->ControlReport.Dr7 = Prcb->ProcessorState.SpecialRegisters.
-                                         KernelDr7;
+    WaitStateChange->ControlReport.Dr6 = Context->Dr6;
+    WaitStateChange->ControlReport.Dr7 = Context->Dr7;
 
     /* Copy i386 specific segments */
     WaitStateChange->ControlReport.SegCs = (USHORT)Context->SegCs;

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -193,14 +193,81 @@ KdpSearchMemory(IN PDBGKD_MANIPULATE_STATE64 State,
                 IN PSTRING Data,
                 IN PCONTEXT Context)
 {
-    //PDBGKD_SEARCH_MEMORY SearchMemory = &State->u.SearchMemory;
+    PDBGKD_SEARCH_MEMORY SearchMemory = &State->u.SearchMemory;
+    static UCHAR SearchBuffer[PACKET_MAX_SIZE];
+    static USHORT PrefixTable[PACKET_MAX_SIZE];
+    const UCHAR* Pattern = (const UCHAR*)Data->Buffer;
+    ULONG PatternLength = SearchMemory->PatternLength;
+    ULONG64 Address = SearchMemory->SearchAddress;
+    ULONG64 Remaining = SearchMemory->SearchLength;
+    ULONG Matched = 0;
+    ULONG ActualLength;
+    ULONG ChunkLength;
+    ULONG i;
+    NTSTATUS Status;
     STRING Header;
 
-    /* TODO */
-    KdpDprintf("Memory Search support is unimplemented!\n");
+    UNREFERENCED_PARAMETER(Context);
 
-    /* Send a failure packet */
-    State->ReturnStatus = STATUS_UNSUCCESSFUL;
+    if (PatternLength == 0 || PatternLength != Data->Length || PatternLength > RTL_NUMBER_OF(PrefixTable) || Remaining > ~(ULONG64)0 - Address)
+    {
+        Status = STATUS_INVALID_PARAMETER;
+        goto SendReply;
+    }
+
+    if (PatternLength > Remaining)
+    {
+        Status = STATUS_NOT_FOUND;
+        goto SendReply;
+    }
+
+    PrefixTable[0] = 0;
+    for (i = 1; i < PatternLength; i++)
+    {
+        ULONG Prefix = PrefixTable[i - 1];
+
+        while (Prefix != 0 && Pattern[i] != Pattern[Prefix])
+            Prefix = PrefixTable[Prefix - 1];
+        if (Pattern[i] == Pattern[Prefix])
+            Prefix++;
+        PrefixTable[i] = (USHORT)Prefix;
+    }
+
+    Status = STATUS_NOT_FOUND;
+    while (Remaining != 0)
+    {
+        ChunkLength = Remaining > sizeof(SearchBuffer) ? sizeof(SearchBuffer) : (ULONG)Remaining;
+        ActualLength = 0;
+        Status = KdpCopyMemoryChunks(Address, SearchBuffer, ChunkLength, 0, MMDBG_COPY_UNSAFE, &ActualLength);
+
+        for (i = 0; i < ActualLength; i++)
+        {
+            while (Matched != 0 && SearchBuffer[i] != Pattern[Matched])
+                Matched = PrefixTable[Matched - 1];
+            if (SearchBuffer[i] == Pattern[Matched])
+                Matched++;
+            if (Matched == PatternLength)
+            {
+                SearchMemory->FoundAddress = Address + i + 1 - PatternLength;
+                Status = STATUS_SUCCESS;
+                goto SendReply;
+            }
+        }
+
+        Address += ActualLength;
+        Remaining -= ActualLength;
+        if (!NT_SUCCESS(Status) || ActualLength != ChunkLength)
+        {
+            if (NT_SUCCESS(Status))
+                Status = STATUS_UNSUCCESSFUL;
+            goto SendReply;
+        }
+    }
+
+    Status = STATUS_NOT_FOUND;
+
+SendReply:
+    State->ReturnStatus = Status;
     Header.Length = sizeof(DBGKD_MANIPULATE_STATE64);
     Header.Buffer = (PCHAR)State;
     KdSendPacket(PACKET_TYPE_KD_STATE_MANIPULATE,

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -61,7 +61,8 @@ KdpCopyMemoryChunks(
     _Out_opt_ PULONG ActualSize)
 {
     NTSTATUS Status;
-    ULONG RemainingLength, CopyChunk;
+    ULONG64 StartAddress = Address;
+    ULONG RemainingLength, CopyChunk, CopiedLength;
 
     /* Check if we didn't get a chunk size or if it is too big */
     if (ChunkSize == 0)
@@ -117,14 +118,19 @@ KdpCopyMemoryChunks(
         RemainingLength = RemainingLength - CopyChunk;
     }
 
-    /* We may have modified executable code, flush the instruction cache */
-    KeSweepICache((PVOID)(ULONG_PTR)Address, TotalSize);
+    CopiedLength = TotalSize - RemainingLength;
+
+    /* Make debugger writes visible to instruction fetch. */
+    if ((Flags & MMDBG_COPY_WRITE) && CopiedLength != 0)
+    {
+        KeSweepICache((PVOID)(ULONG_PTR)StartAddress, CopiedLength);
+    }
 
     /*
      * Return the size we managed to copy and return
      * success if we could copy the whole range.
      */
-    if (ActualSize) *ActualSize = TotalSize - RemainingLength;
+    if (ActualSize) *ActualSize = CopiedLength;
     return RemainingLength == 0 ? STATUS_SUCCESS : STATUS_UNSUCCESSFUL;
 }
 

--- a/ntoskrnl/kd64/kdbreak.c
+++ b/ntoskrnl/kd64/kdbreak.c
@@ -84,8 +84,14 @@ KdpAddBreakpoint(IN PVOID Address)
                                      NULL);
         if (!NT_SUCCESS(Status))
         {
-            /* This should never happen */
-            KdpDprintf("Unable to write breakpoint to address 0x%p\n", Address);
+            /*
+             * The code page can be readable before the debugger's physical
+             * mapping is available. Defer the write just as we do when the
+             * initial read cannot be completed.
+             */
+            KdpDprintf("Failed to write breakpoint at address 0x%p, adding deferred breakpoint.\n", Address);
+            KdpBreakpointTable[i].Flags = KD_BREAKPOINT_ACTIVE | KD_BREAKPOINT_PENDING;
+            KdpOweBreakpoint = TRUE;
         }
     }
     else

--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -176,7 +176,7 @@ ENDFUNC
 PUBLIC KiDebugTrapOrFault
 FUNC KiDebugTrapOrFault
     /* Push pseudo error code */
-    EnterTrap TF_SAVE_ALL
+    EnterTrap (TF_SAVE_ALL OR TF_DEBUG)
 
     /* Check if the frame was from kernelmode */
     test word ptr [rbp + KTRAP_FRAME_SegCs], 3
@@ -190,7 +190,7 @@ KiDebugTrapOrFaultKMode:
     DispatchException STATUS_SINGLE_STEP, 0, 0, 0, 0
 
     /* Return */
-    ExitTrap TF_SAVE_ALL
+    ExitTrap (TF_SAVE_ALL OR TF_DEBUG)
 ENDFUNC
 
 EXTERN KiNmiInterruptHandler:PROC

--- a/ntoskrnl/mm/amd64/init.c
+++ b/ntoskrnl/mm/amd64/init.c
@@ -724,6 +724,9 @@ MiInitMachineDependent(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     /* Map the PFN database pages */
     MiBuildPfnDatabase(LoaderBlock);
 
+    /* The debugger can now map read-only code pages for owed breakpoints. */
+    KdSetOwedBreakpoints();
+
     /* Reset the ref/share count so that MmInitializeProcessAddressSpace works */
     PMMPFN Pfn = MiGetPfnEntry(PFN_FROM_PTE((PMMPTE)PXE_SELFMAP));
     Pfn->u2.ShareCount = 0;

--- a/sdk/cmake/config.cmake
+++ b/sdk/cmake/config.cmake
@@ -93,6 +93,17 @@ else()
     set(_WINKD_ FALSE CACHE BOOL "Whether to compile with the KD protocol.")
 endif()
 
+if(GDB)
+    if(NOT (ARCH STREQUAL "i386" OR ARCH STREQUAL "amd64"))
+        message(FATAL_ERROR "KDGDB is only supported on i386 and amd64")
+    endif()
+    # KDGDB speaks the KD protocol and replaces the integrated debugger.
+    # These deliberately shadow the cache entries set above, so that turning
+    # GDB on takes effect even in an already configured build directory.
+    set(KDBG FALSE)
+    set(_WINKD_ TRUE)
+endif()
+
 cmake_dependent_option(ISAPNP_ENABLE "Whether to enable the ISA PnP support." ON
                        "ARCH STREQUAL i386 AND NOT SARCH STREQUAL xbox" OFF)
 


### PR DESCRIPTION
KDGDB's x86 remote stub implemented only a small part of the GDB Remote Serial Protocol. Common debugger operations were missing or incomplete, GDB builds could select the wrong KD configuration, and deferred AMD64 software breakpoints could be lost when early memory-manager initialization reset the breakpoint table.

This completes the AMD64 and i386 all-stop stub.

Supported features:

- AMD64 and i386 all-stop debugging
- Register access
- Hexadecimal and binary memory access
- Thread selection and enumeration
- Execution control, including raw Ctrl-C and framed vCtrlC
- Software breakpoints
- x86 hardware breakpoints and Z2-Z4 watchpoints
- qSearch:memory with matches spanning packet-sized KD reads
- qXfer target, executable, library, thread, and memory-map transfers
- Monitor commands
- No-ack mode
- Extended remote mode
- KD selection for GDB builds
- Deferred AMD64 software-breakpoint retry after memory-manager initialization

Tested with GNU GDB 17.1

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
