### PR TITLE
[NTOS:KE] Implement shared x86/x64 code to get/identify the CPU vendor

### DIFF
--- a/ntoskrnl/include/internal/arch/ke.h
+++ b/ntoskrnl/include/internal/arch/ke.h
@@ -21,6 +21,7 @@
 
 #ifdef _M_IX86
 #include <internal/i386/ke.h>
+#include <internal/x86x64/ke.h>
 #elif defined(_M_PPC)
 #include <internal/powerpc/ke.h>
 #elif defined(_M_MIPS)
@@ -29,6 +30,7 @@
 #include <internal/arm/ke.h>
 #elif defined(_M_AMD64)
 #include <internal/amd64/ke.h>
+#include <internal/x86x64/ke.h>
 #else
 #error "Unknown processor"
 #endif

--- a/ntoskrnl/include/internal/x86x64/ke.h
+++ b/ntoskrnl/include/internal/x86x64/ke.h
@@ -1,0 +1,20 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Header for x86 / x64 CPU-level support
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#pragma once
+
+#define CPU_VENDOR_STR_LEN 13
+
+VOID
+NTAPI
+KiGetCpuVendorString(
+    _Out_writes_z_(CPU_VENDOR_STR_LEN) CHAR VendorString[CPU_VENDOR_STR_LEN]);
+
+CPU_VENDORS
+NTAPI
+KiIdentifyCpuVendor(
+    _In_reads_z_(CPU_VENDOR_STR_LEN) const CHAR VendorString[CPU_VENDOR_STR_LEN]);

--- a/ntoskrnl/ke/amd64/cpu.c
+++ b/ntoskrnl/ke/amd64/cpu.c
@@ -34,10 +34,6 @@ BOOLEAN KiSMTProcessorsPresent;
 volatile LONG KiTbFlushTimeStamp;
 
 /* CPU Signatures */
-static const CHAR CmpIntelID[]       = "GenuineIntel";
-static const CHAR CmpAmdID[]         = "AuthenticAMD";
-static const CHAR CmpCentaurID[]     = "CentaurHauls";
-
 typedef union _CPU_SIGNATURE
 {
     struct
@@ -55,57 +51,20 @@ typedef union _CPU_SIGNATURE
 
 /* FUNCTIONS *****************************************************************/
 
-ULONG
-NTAPI
-KiGetCpuVendor(VOID)
-{
-    PKPRCB Prcb = KeGetCurrentPrcb();
-    CPU_INFO CpuInfo;
-
-    /* Get the Vendor ID and null-terminate it */
-    KiCpuId(&CpuInfo, 0);
-
-    /* Copy it to the PRCB and null-terminate it */
-    *(ULONG*)&Prcb->VendorString[0] = CpuInfo.Ebx;
-    *(ULONG*)&Prcb->VendorString[4] = CpuInfo.Edx;
-    *(ULONG*)&Prcb->VendorString[8] = CpuInfo.Ecx;
-    Prcb->VendorString[12] = 0;
-
-    /* Now check the CPU Type */
-    if (!strcmp((PCHAR)Prcb->VendorString, CmpIntelID))
-    {
-        Prcb->CpuVendor = CPU_INTEL;
-    }
-    else if (!strcmp((PCHAR)Prcb->VendorString, CmpAmdID))
-    {
-        Prcb->CpuVendor = CPU_AMD;
-    }
-    else if (!strcmp((PCHAR)Prcb->VendorString, CmpCentaurID))
-    {
-        DPRINT1("VIA CPUs not fully supported\n");
-        Prcb->CpuVendor = CPU_VIA;
-    }
-    else
-    {
-        /* Invalid CPU */
-        DPRINT1("%s CPU support not fully tested!\n", Prcb->VendorString);
-        Prcb->CpuVendor = CPU_UNKNOWN;
-    }
-
-    return Prcb->CpuVendor;
-}
-
 VOID
 NTAPI
 KiSetProcessorType(VOID)
 {
+    PKPRCB Prcb = KeGetCurrentPrcb();
     CPU_INFO CpuInfo;
     CPU_SIGNATURE CpuSignature;
     BOOLEAN ExtendModel;
     ULONG Stepping, Type, Vendor;
 
     /* This initializes Prcb->CpuVendor */
-    Vendor = KiGetCpuVendor();
+    KiGetCpuVendorString(Prcb->VendorString);
+    Prcb->CpuVendor = KiIdentifyCpuVendor(Prcb->VendorString);
+    Vendor = Prcb->CpuVendor;
 
     /* Do CPUID 1 now */
     KiCpuId(&CpuInfo, 1);
@@ -143,9 +102,9 @@ KiSetProcessorType(VOID)
     }
 
     /* Save them in the PRCB */
-    KeGetCurrentPrcb()->CpuID = TRUE;
-    KeGetCurrentPrcb()->CpuType = (UCHAR)Type;
-    KeGetCurrentPrcb()->CpuStep = (USHORT)Stepping;
+    Prcb->CpuID = TRUE;
+    Prcb->CpuType = (UCHAR)Type;
+    Prcb->CpuStep = (USHORT)Stepping;
 }
 
 /*!

--- a/ntoskrnl/ke/amd64/cpu.c
+++ b/ntoskrnl/ke/amd64/cpu.c
@@ -427,7 +427,6 @@ NTAPI
 KiGetCacheInformation(VOID)
 {
     PKIPCR Pcr = (PKIPCR)KeGetPcr();
-    ULONG Vendor;
     ULONG CacheRequests = 0, i;
     ULONG CurrentRegister;
     UCHAR RegisterByte;
@@ -437,12 +436,8 @@ KiGetCacheInformation(VOID)
     /* Set default L2 size */
     Pcr->SecondLevelCacheSize = 0;
 
-    /* Get the Vendor ID and make sure we support CPUID */
-    Vendor = KiGetCpuVendor();
-    if (!Vendor) return;
-
     /* Check the Vendor ID */
-    switch (Vendor)
+    switch (Pcr->Prcb.CpuVendor)
     {
         /* Handle Intel case */
         case CPU_INTEL:

--- a/ntoskrnl/ke/i386/cpu.c
+++ b/ntoskrnl/ke/i386/cpu.c
@@ -55,13 +55,6 @@ BOOLEAN KiFastCallCopyDoneOnce;
 volatile LONG KiTbFlushTimeStamp;
 
 /* CPU Signatures */
-static const CHAR CmpIntelID[]       = "GenuineIntel";
-static const CHAR CmpAmdID[]         = "AuthenticAMD";
-static const CHAR CmpCyrixID[]       = "CyrixInstead";
-static const CHAR CmpTransmetaID[]   = "GenuineTMx86";
-static const CHAR CmpCentaurID[]     = "CentaurHauls";
-static const CHAR CmpRiseID[]        = "RiseRiseRise";
-
 typedef union _CPU_SIGNATURE
 {
     struct
@@ -105,55 +98,12 @@ setCx86(UCHAR reg, UCHAR data)
 /* FUNCTIONS *****************************************************************/
 
 CODE_SEG("INIT")
+static
 ULONG
-NTAPI
 KiGetCpuVendor(VOID)
 {
-    PKPRCB Prcb = KeGetCurrentPrcb();
-    CPU_INFO CpuInfo;
-
-    /* Get the Vendor ID */
-    KiCpuId(&CpuInfo, 0);
-
-    /* Copy it to the PRCB and null-terminate it */
-    *(ULONG*)&Prcb->VendorString[0] = CpuInfo.Ebx;
-    *(ULONG*)&Prcb->VendorString[4] = CpuInfo.Edx;
-    *(ULONG*)&Prcb->VendorString[8] = CpuInfo.Ecx;
-    Prcb->VendorString[12] = 0;
-
-    /* Now check the CPU Type */
-    if (!strcmp(Prcb->VendorString, CmpIntelID))
-    {
-        return CPU_INTEL;
-    }
-    else if (!strcmp(Prcb->VendorString, CmpAmdID))
-    {
-        return CPU_AMD;
-    }
-    else if (!strcmp(Prcb->VendorString, CmpCyrixID))
-    {
-        DPRINT1("Cyrix CPU support not fully tested!\n");
-        return CPU_CYRIX;
-    }
-    else if (!strcmp(Prcb->VendorString, CmpTransmetaID))
-    {
-        DPRINT1("Transmeta CPU support not fully tested!\n");
-        return CPU_TRANSMETA;
-    }
-    else if (!strcmp(Prcb->VendorString, CmpCentaurID))
-    {
-        DPRINT1("Centaur CPU support not fully tested!\n");
-        return CPU_CENTAUR;
-    }
-    else if (!strcmp(Prcb->VendorString, CmpRiseID))
-    {
-        DPRINT1("Rise CPU support not fully tested!\n");
-        return CPU_RISE;
-    }
-
-    /* Unknown CPU */
-    DPRINT1("%s CPU support not fully tested!\n", Prcb->VendorString);
-    return CPU_UNKNOWN;
+    ASSERT(KeGetCurrentPrcb()->VendorString[0] != 0);
+    return KiIdentifyCpuVendor(KeGetCurrentPrcb()->VendorString);
 }
 
 CODE_SEG("INIT")
@@ -220,6 +170,9 @@ KiGetFeatureBits(VOID)
     UCHAR Ccr1;
     BOOLEAN ExtendedCPUID = TRUE;
     ULONG CpuFeatures = 0;
+
+    /* Get the CPU vendor string */
+    KiGetCpuVendorString(Prcb->VendorString);
 
     /* Get the Vendor ID */
     Vendor = KiGetCpuVendor();

--- a/ntoskrnl/ke/x86x64/cpuinfo.c
+++ b/ntoskrnl/ke/x86x64/cpuinfo.c
@@ -56,15 +56,18 @@ KiIdentifyCpuVendor(
     _In_reads_z_(CPU_VENDOR_STR_LEN) const CHAR VendorString[CPU_VENDOR_STR_LEN])
 {
     /* Identify the CPU vendor */
-    if (!strcmp(VendorString, "GenuineIntel"))
+    if (!strcmp(VendorString, "GenuineIntel") ||
+        !strcmp(VendorString, "GenuineIotel")) // Intel Xeon E3-1231 v3
     {
         return CPU_INTEL;
     }
-    else if (!strcmp(VendorString, "AuthenticAMD"))
+    else if (!strcmp(VendorString, "AuthenticAMD") ||
+             !strcmp(VendorString, "HygonGenuine"))
     {
         return CPU_AMD;
     }
-    else if (!strcmp(VendorString, "CentaurHauls"))
+    else if (!strcmp(VendorString, "CentaurHauls") ||
+             !strcmp(VendorString, "  Shanghai  "))
     {
         return CPU_VIA; // == CPU_CENTAUR
     }

--- a/ntoskrnl/ke/x86x64/cpuinfo.c
+++ b/ntoskrnl/ke/x86x64/cpuinfo.c
@@ -1,0 +1,87 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Routines for x86 / x64 CPU information gathering
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+/* INCLUDES *****************************************************************/
+
+#include <ntoskrnl.h>
+#include <x86x64/Cpuid.h>
+#define NDEBUG
+#include <debug.h>
+
+/* FUNCTIONS *****************************************************************/
+
+/*!
+ * \brief Get the CPUID information for a given CPU
+ *
+ * \param[out] VendorString - Pointer to a buffer to receive the vendor string
+ */
+VOID
+NTAPI
+KiGetCpuVendorString(
+    _Out_writes_z_(CPU_VENDOR_STR_LEN) CHAR VendorString[CPU_VENDOR_STR_LEN])
+{
+    CPUID_SIGNATURE_REGS Signature;
+
+    /* Get the Vendor string */
+    __cpuid(&Signature.AsInt32[0], CPUID_SIGNATURE);
+
+    /* Copy and null-terminate it */
+    *(ULONG*)&VendorString[0] = *(ULONG*)&Signature.SignatureScrambled[0];
+    *(ULONG*)&VendorString[4] = *(ULONG*)&Signature.SignatureScrambled[8];
+    *(ULONG*)&VendorString[8] = *(ULONG*)&Signature.SignatureScrambled[4];
+    VendorString[12] = 0;
+}
+
+/*!
+ * \brief Identify the CPU vendor by the vendor string
+ *
+ * \param[in] VendorString - Pointer to a buffer containing the vendor string
+ *
+ * \return The CPU_VENDOR enum value that corresponds to the vendor string
+ *
+ * \see
+ * - https://en.wikipedia.org/wiki/CPUID
+ * - https://github.com/InstLatx64/InstLatx64
+ *
+ * \remark This function is called very early during the boot process, before
+ *         the kernel debugger is initialized, so it must not do any debug prints.
+ */
+CPU_VENDORS
+NTAPI
+KiIdentifyCpuVendor(
+    _In_reads_z_(CPU_VENDOR_STR_LEN) const CHAR VendorString[CPU_VENDOR_STR_LEN])
+{
+    /* Identify the CPU vendor */
+    if (!strcmp(VendorString, "GenuineIntel"))
+    {
+        return CPU_INTEL;
+    }
+    else if (!strcmp(VendorString, "AuthenticAMD"))
+    {
+        return CPU_AMD;
+    }
+    else if (!strcmp(VendorString, "CentaurHauls"))
+    {
+        return CPU_VIA; // == CPU_CENTAUR
+    }
+#ifdef _M_I386
+    else if (!strcmp(VendorString, "CyrixInstead"))
+    {
+        return CPU_CYRIX;
+    }
+    else if (!strcmp(VendorString, "GenuineTMx86"))
+    {
+        return CPU_TRANSMETA;
+    }
+    else if (!strcmp(VendorString, "RiseRiseRise"))
+    {
+        return CPU_RISE;
+    }
+#endif // _M_I386
+
+    return CPU_UNKNOWN;
+}

--- a/ntoskrnl/ntos.cmake
+++ b/ntoskrnl/ntos.cmake
@@ -330,6 +330,7 @@ if(ARCH STREQUAL "i386")
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/traphdlr.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/usercall.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/v86vdm.c
+        ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/x86x64/cpuinfo.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/mm/i386/page.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/mm/i386/procsup.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/mm/ARM3/i386/init.c
@@ -365,7 +366,8 @@ elseif(ARCH STREQUAL "amd64")
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/stubs.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/traphandler.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/usercall.c
-        ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/xstate.c)
+        ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/xstate.c
+        ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/x86x64/cpuinfo.c)
 elseif(ARCH STREQUAL "arm")
     list(APPEND ASM_SOURCE
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ex/arm/ioport.s

--- a/sdk/include/ndk/amd64/ketypes.h
+++ b/sdk/include/ndk/amd64/ketypes.h
@@ -95,10 +95,10 @@ Author:
 //
 typedef enum
 {
-    CPU_UNKNOWN,
-    CPU_AMD,
-    CPU_INTEL,
-    CPU_VIA
+    CPU_UNKNOWN = 0,
+    CPU_AMD = 1,
+    CPU_INTEL = 2,
+    CPU_VIA = 3,
 } CPU_VENDORS;
 
 //


### PR DESCRIPTION
## Purpose

This implements shared code between x86 and x64 to get the CPU vendor string and identify the CPU vendor.
It's used in slightly different ways (due to different KPRCBs) for both x86 and x64.
It adds 3 additional vendor strings.

I have some more similar shared cpuid based code for getting the CPU "signature" (family, model, stepping), detailed cache information and clock/TSC frequency. (will be PR'ed individually)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109327,109334
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109323,109331