### PR TITLE
[NTOS:MM] Add explicit 32-bit region size validation

### DIFF
--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -4603,6 +4603,14 @@ NtAllocateVirtualMemory(IN HANDLE ProcessHandle,
         return STATUS_INVALID_PARAMETER_4;
     }
 
+#ifndef _WIN64
+    if (PRegionSize >= MAXULONG)
+    {
+        DPRINT1("Region size is too large\n");
+        return STATUS_INVALID_PARAMETER_4;
+    }
+#endif
+
     /* Make sure there's a size specified */
     if (!PRegionSize)
     {


### PR DESCRIPTION
NtAllocateVirtualMemory has no direct check for a region size equal to the maximum 32-bit SIZE_T value:

Add a MAXULONG rejection only for 32-bit builds, where that request cannot fit in the user VAD space. 
Keep 64-bit builds on the existing MM_HIGHEST_VAD_ADDRESS limit so allocations above 4 GiB remain valid.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
