### PR TITLE
[COMCTL32] BUTTON_PaintWithTheme: Don't paint the themed button if it's not visible

### DIFF
--- a/dll/win32/comctl32/button.c
+++ b/dll/win32/comctl32/button.c
@@ -331,6 +331,10 @@ BOOL BUTTON_PaintWithTheme(HTHEME theme, const BUTTON_INFO *infoPtr, HDC hParamD
     if (infoPtr->u.image != 0)
         return FALSE;
 
+    /* If the button isn't visible, don't paint it (themed or not) */
+    if (!IsWindowVisible(infoPtr->hwnd))
+        return TRUE; /* Pretend it has been drawn successfully */
+
     dwStyle = GetWindowLongW(infoPtr->hwnd, GWL_STYLE);
     type = get_button_type(dwStyle);
 


### PR DESCRIPTION
## Purpose

When themes are enabled, don't paint the themed button if it's not visible.
The fallback non-themed code path in the `paint_button()` routine, already does a `IsWindowVisible()` check before painting the button.

I was testing the following corner case: you have a button in a dialog box, and the dialog box is maintained invisible by removing the `WS_VISIBLE` bit in its `WM_INITDIALOG` handler.
When the handler returns, the dialog manager sends a `WM_CHANGEUISTATE` message to all the items in the dialog, independently of its visiblity state.
The comctl32 button implementation receives this message, and triggers a button repaint. As a result, when theming is enabled, a lone button floating on the screen is displayed without this fix.

JIRA issue: None.

## Proposed changes

In `BUTTON_PaintWithTheme()`, check whether the button control is visible and if not, return early but successfully, because this is not a failure, so as not to cause a fallback to the non-themed code path.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109446,109448
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109445,109449

No problems.
