### PR TITLE
[USER32] DIALOG_CreateIndirect: Add missing DF_END checks and other remarks

### DIFF
--- a/modules/rostests/win32/user32/CMakeLists.txt
+++ b/modules/rostests/win32/user32/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(biditext)
+add_subdirectory(dialog_initvisible)
 add_subdirectory(editalign)
 add_subdirectory(menuaccels)
 add_subdirectory(messagebox)

--- a/modules/rostests/win32/user32/dialog_initvisible/CMakeLists.txt
+++ b/modules/rostests/win32/user32/dialog_initvisible/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+add_executable(dialog_initvisible dialog_initvisible.c dialog_initvisible.rc)
+set_module_type(dialog_initvisible win32gui UNICODE)
+add_importlibs(dialog_initvisible user32 msvcrt kernel32)
+add_rostests_file(TARGET dialog_initvisible SUBDIR suppl)

--- a/modules/rostests/win32/user32/dialog_initvisible/dialog_initvisible.c
+++ b/modules/rostests/win32/user32/dialog_initvisible/dialog_initvisible.c
@@ -1,0 +1,65 @@
+/*
+ * PROJECT:     ReactOS Tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests whether a dialog is getting visible even if WM_INITDIALOG ends it.
+ * COPYRIGHT:   Copyright 2026 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
+ */
+
+#define WIN32_NO_STATUS
+#include <windef.h>
+#include <winbase.h>
+#include <winuser.h>
+
+#define NTOS_MODE_USER
+#include <ndk/iotypes.h> // Needed for kdtypes.h
+#include <ndk/ketypes.h> //   "     "     "
+#include <ndk/kdtypes.h> // For SharedUserData
+
+#include "resource.h"
+
+INT_PTR CALLBACK
+AboutDlgProc(
+    _In_ HWND hDlg,
+    _In_ UINT uMsg,
+    _In_ WPARAM wParam,
+    _In_ LPARAM lParam)
+{
+    UNREFERENCED_PARAMETER(lParam);
+    switch (uMsg)
+    {
+        case WM_INITDIALOG:
+        {
+            /* Intentional breakpoint for you to step-by-step debug into a debugger! */
+            if (IsDebuggerPresent() || SharedUserData->KdDebuggerEnabled)
+                __debugbreak();
+
+            SendMessageW(hDlg, WM_COMMAND, MAKEWPARAM(IDOK, BN_CLICKED), 0);
+            EndDialog(hDlg, -1);
+            return (INT_PTR)TRUE;
+        }
+
+        case WM_COMMAND:
+        {
+            if (LOWORD(wParam) == IDOK || LOWORD(wParam) == IDCANCEL)
+            {
+                EndDialog(hDlg, LOWORD(wParam));
+                return (INT_PTR)TRUE;
+            }
+            break;
+        }
+    }
+    return (INT_PTR)FALSE;
+}
+
+int APIENTRY
+wWinMain(
+    _In_ HINSTANCE hInstance,
+    _In_ HINSTANCE hPrevInstance,
+    _In_ LPWSTR lpCmdLine,
+    _In_ int nCmdShow)
+{
+    UNREFERENCED_PARAMETER(hPrevInstance);
+    UNREFERENCED_PARAMETER(lpCmdLine);
+
+    return DialogBoxW(hInstance, MAKEINTRESOURCEW(IDD_ABOUTBOX), NULL, AboutDlgProc);
+}

--- a/modules/rostests/win32/user32/dialog_initvisible/dialog_initvisible.rc
+++ b/modules/rostests/win32/user32/dialog_initvisible/dialog_initvisible.rc
@@ -1,0 +1,17 @@
+
+#include <winnt.rh>
+#include <winuser.rh>
+#include "resource.h"
+
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
+
+// NOTE: Ensure the WS_VISIBLE flag is set for the test.
+IDD_ABOUTBOX DIALOGEX 0, 0, 135, 62
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU | WS_VISIBLE
+CAPTION "About Dialog_InitVisible"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Dialog_InitVisible, Version 1.0", IDC_STATIC, 7, 14, 114, 8, SS_NOPREFIX
+    LTEXT           "Copyright (C) 2026 ReactOS", IDC_STATIC, 7, 26, 114, 8
+    DEFPUSHBUTTON   "OK", IDOK, 78, 41, 50, 14, WS_GROUP
+END

--- a/modules/rostests/win32/user32/dialog_initvisible/resource.h
+++ b/modules/rostests/win32/user32/dialog_initvisible/resource.h
@@ -1,0 +1,2 @@
+#define IDD_ABOUTBOX    101
+#define IDC_STATIC      -1

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -1021,6 +1021,9 @@ static HWND DIALOG_CreateIndirect( HINSTANCE hInst, LPCVOID dlgTemplate,
             HWND focus = GetNextDlgTabItem( hwnd, 0, FALSE );
             if (!focus) focus = GetNextDlgGroupItem( hwnd, 0, FALSE );
             if (SendMessageW( hwnd, WM_INITDIALOG, (WPARAM)focus, param ) && IsWindow( hwnd ) &&
+#ifdef __REACTOS__
+                !(dlgInfo->flags & DF_END) && /* Ensure EndDialog wasn't called in WM_INITDIALOG */
+#endif
                 ((~template.style & DS_CONTROL) || (template.style & WS_VISIBLE)))
             {
                 /* By returning TRUE, app has requested a default focus assignment.
@@ -1048,12 +1051,21 @@ static HWND DIALOG_CreateIndirect( HINSTANCE hInst, LPCVOID dlgTemplate,
         }
 
 #ifdef __REACTOS__
+        /* Don't continue if the dialog has been destroyed in WM_INITDIALOG */
+        if (!IsWindow(hwnd))
+            return NULL;
+
 //// ReactOS Rev 30613 & 30644
         if (!(GetWindowLongPtrW( hwnd, GWL_STYLE ) & WS_CHILD))
             SendMessageW( hwnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_INITIALIZE, 0), 0);
-#endif
 
+        // TODO: Handle DS_SETFOREGROUND
+
+        /* Ensure EndDialog wasn't called in WM_INITDIALOG before making the dialog visible */
+        if (!(dlgInfo->flags & DF_END) && (template.style & WS_VISIBLE) && !(GetWindowLongPtrW(hwnd, GWL_STYLE) & WS_VISIBLE))
+#else
         if (template.style & WS_VISIBLE && !(GetWindowLongPtrW( hwnd, GWL_STYLE ) & WS_VISIBLE))
+#endif
         {
            ShowWindow( hwnd, SW_SHOWNORMAL ); /* SW_SHOW doesn't always work */
            UpdateWindow( hwnd );

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -986,7 +986,7 @@ static HWND DIALOG_CreateIndirect( HINSTANCE hInst, LPCVOID dlgTemplate,
     will be valid only after WM_CREATE message has been handled in DefDlgProc
     All the members of the structure get filled here using temp variables */
     dlgInfo = DIALOG_get_info( hwnd, TRUE );
-    // ReactOS
+#ifdef __REACTOS__
     if (dlgInfo == NULL)
     {
         if (hUserFont) DeleteObject( hUserFont );
@@ -994,7 +994,7 @@ static HWND DIALOG_CreateIndirect( HINSTANCE hInst, LPCVOID dlgTemplate,
         if (disabled_owner) EnableWindow( disabled_owner, TRUE );
         return 0;
     }
-    //
+#endif
     dlgInfo->hwndFocus   = 0;
     dlgInfo->hUserFont   = hUserFont;
     dlgInfo->hMenu       = hMenu;
@@ -1040,29 +1040,37 @@ static HWND DIALOG_CreateIndirect( HINSTANCE hInst, LPCVOID dlgTemplate,
                         SetFocus( hwnd );
                 }
             }
+#ifdef __REACTOS__
 //// ReactOS see 43396, Fixes setting focus on Open and Close dialogs to the FileName edit control in OpenOffice.
 //// This now breaks test_SaveRestoreFocus.
             //DEFDLG_SaveFocus( hwnd );
-////
+#endif
         }
+
+#ifdef __REACTOS__
 //// ReactOS Rev 30613 & 30644
         if (!(GetWindowLongPtrW( hwnd, GWL_STYLE ) & WS_CHILD))
             SendMessageW( hwnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_INITIALIZE, 0), 0);
-////
+#endif
+
         if (template.style & WS_VISIBLE && !(GetWindowLongPtrW( hwnd, GWL_STYLE ) & WS_VISIBLE))
         {
-           ShowWindow( hwnd, SW_SHOWNORMAL );   /* SW_SHOW doesn't always work */
+           ShowWindow( hwnd, SW_SHOWNORMAL ); /* SW_SHOW doesn't always work */
            UpdateWindow( hwnd );
+#ifdef __REACTOS__
            IntNotifyWinEvent(EVENT_SYSTEM_DIALOGSTART, hwnd, OBJID_WINDOW, CHILDID_SELF, 0);
+#endif
         }
         return hwnd;
     }
     if (disabled_owner) EnableWindow( disabled_owner, TRUE );
+#ifdef __REACTOS__
     IntNotifyWinEvent(EVENT_SYSTEM_DIALOGEND, hwnd, OBJID_WINDOW, CHILDID_SELF, 0);
+#endif
     if( IsWindow(hwnd) )
     {
       DestroyWindow( hwnd );
-      //// ReactOS
+#ifdef __REACTOS__
       if (owner)
       {  ERR("DIALOG_CreateIndirect 1\n");
          if ( NtUserGetThreadState(THREADSTATE_FOREGROUNDTHREAD) && // Rule #1.
@@ -1071,7 +1079,7 @@ static HWND DIALOG_CreateIndirect( HINSTANCE hInst, LPCVOID dlgTemplate,
             SetForegroundWindow(owner);
          }
       }
-      ////
+#endif
     }
     return 0;
 }


### PR DESCRIPTION
## Purpose

The `DF_END` flag is set when `EndDialog()` is invoked.
When this is done in a dialog's `WM_INITDIALOG` handler, further processing is halted after the handler returns.
This ensures in particular that the dialog isn't shown[^1], stays hidden, since it's going to be automatically destroyed next.

- Add a `DF_END` check just after invoking the `WM_INITDIALOG` handler, and don't execute the focus-assignment code block if the flag is set.

- Don't continue if the dialog has been forcefully destroyed (with a direct `DestroyWindow()` call) in `WM_INITDIALOG`.

- Don't try to make the dialog visible if the `DF_END` flag has been set.

- Add a TODO to remember we have to handle `DS_SETFOREGROUND`.

[^1]: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enddialog#remarks
  "A dialog box procedure can call EndDialog at any time, even during the
  processing of the WM_INITDIALOG message. If your application calls the
  function while WM_INITDIALOG is being processed, the dialog box is
  destroyed before it is shown and before the input focus is set."

JIRA issue: [CORE-20706](https://jira.reactos.org/browse/CORE-20706)

## Proposed changes

- ### `[ROSTESTS] Add an interactive "dialog_initvisible" test`

  Its purpose is to observe whether or not a dialog that has the `WS_VISIBLE` style explicitly set, briefly becomes visible even if it gets terminated early from its `WM_INITDIALOG` handler.
  (On Windows it does NOT become visible.)

- ### `[USER32] DIALOG_CreateIndirect: Add missing __REACTOS__ guards`

- ### `[USER32] DIALOG_CreateIndirect: Add missing DF_END checks and other remarks`

## TODO

- [x] Create a JIRA report.
- [x] Attach an interactive test.

## Interactive testing on Windows and ReactOS

- On Windows 2003:

  ✅ The dialog stays hidden after returning from its `WM_INITDIALOG` handler.

  https://github.com/user-attachments/assets/efd01e7f-9d2e-4221-b544-af3e586637a4

- On ReactOS -- Before the fix:

  ❌ The dialog is erroneously shown for a short time lapse after returning from its `WM_INITDIALOG` handler, and before fully exiting.

  https://github.com/user-attachments/assets/df14a753-5228-4b62-84ff-71b344b7948e

- On ReactOS -- After the fix:

  ✅ The dialog now correctly stays hidden after returning from its `WM_INITDIALOG` handler.

  https://github.com/user-attachments/assets/8884ec21-8593-4e15-9526-98c4f14a2725

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109477,109484
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109478,109485