### PR TITLE
[SETUP:REACTOS] Support unattended mode in the 1st stage GUI installer

### DIFF
--- a/base/setup/reactos/drivepage.c
+++ b/base/setup/reactos/drivepage.c
@@ -370,7 +370,8 @@ typedef struct _PARTCREATE_CTX
     ULONG MaxSizeMB;     //< Maximum possible partition size in MB.
     ULONG PartSizeMB;    //< Selected partition size in MB.
     BOOLEAN MBRExtPart;  //< Whether to create an MBR extended partition.
-    BOOLEAN ForceFormat; //< Whether to force formatting ('Do not format' option hidden).
+    BOOLEAN ForceFormat :1; //< Whether to force formatting ('Do not format' option hidden).
+    BOOLEAN AutoFormat  :1; //< Whether to auto-format (Format dialog stays hidden).
 } PARTCREATE_CTX, *PPARTCREATE_CTX;
 
 static INT_PTR
@@ -413,8 +414,27 @@ FormatDlgProcWorker(
                     SendDlgItemMessageW(hDlg, IDC_FSTYPE, CB_SETITEMDATA, iItem, (LPARAM)NULL);
             }
 
-            // FIXME: Read from SetupData.FsType; select the "FAT" FS instead.
-            DefaultFs = L"FAT";
+            if (SetupData.bUnattend)
+            {
+                /* In unattended mode, preselect the file system */
+                switch (SetupData.USetupData.FsType)
+                {
+                    /* 1 is for BtrFS */
+                    case 1:
+                        DefaultFs = L"BTRFS";
+                        break;
+
+                    /* If we don't understand input, default to FAT */
+                    default:
+                        DefaultFs = L"FAT";
+                        break;
+                }
+            }
+            else
+            {
+                /* By default select the "FAT" file system */
+                DefaultFs = L"FAT";
+            }
 
             /* Retrieve the selected volume and create information */
             ASSERT(PartCreateCtx->PartItem->Volume == PartCreateCtx->PartItem->PartEntry->Volume);
@@ -425,7 +445,7 @@ FormatDlgProcWorker(
              * otherwise use the "DefaultFs" */
             if (VolCreate && *VolCreate->FileSystemName)
                 FileSystem = VolCreate->FileSystemName;
-            else if (Volume && *Volume->Info.FileSystem)
+            else if (!SetupData.bUnattend && Volume && *Volume->Info.FileSystem)
                 FileSystem = Volume->Info.FileSystem;
             else
                 FileSystem = DefaultFs;
@@ -548,6 +568,8 @@ FormatDlgProcWorker(
     return FALSE;
 }
 
+#define PM_FMTDLG_SHOWHIDE  (WM_APP + 1)
+
 static INT_PTR
 CALLBACK
 FormatDlgProc(
@@ -571,8 +593,26 @@ FormatDlgProc(
 
             /* We actually want to format, so set the flag */
             PartCreateCtx->ForceFormat = TRUE;
+
+            /* In auto-format mode, hide the dialog and simulate press on OK.
+             * The file system is preselected by FormatDlgProcWorker(). */
+            if (PartCreateCtx->AutoFormat)
+            {
+                /* Win32 NOTE: No need to first invoke the helper dialog procedure,
+                 * before posting our messages. The posted messages are dealt with
+                 * *ONLY* after any messages potentially sent to ourselves by the
+                 * helper dialog procedure. */
+                //INT_PTR ret = FormatDlgProcWorker(PartCreateCtx, hDlg, uMsg, wParam, lParam);
+                PostMessageW(hDlg, PM_FMTDLG_SHOWHIDE, FALSE, 0);
+                PostMessageW(hDlg, WM_COMMAND, MAKEWPARAM(IDOK, BN_CLICKED), 0);
+                //return ret;
+            }
             break;
         }
+
+        case PM_FMTDLG_SHOWHIDE:
+            ShowWindow(hDlg, wParam ? SW_SHOW : SW_HIDE);
+            break;
 
         case WM_COMMAND:
         {
@@ -801,6 +841,35 @@ GetSelectedPartition(
             *phItem = hItem;
     }
     return PartItem;
+}
+
+static
+PPARTITEM
+FindPartitionItem(
+    _In_ HWND hTreeList,
+    _In_opt_ PPARTENTRY PartEntry,
+    _Out_opt_ HTLITEM* phItem)
+{
+    PPARTITEM PartItem = NULL;
+
+    /* Enumerate every cached data in the TreeList, and for each, check
+     * whether its corresponding PPARTENTRY is the one we are looking for */
+    HTLITEM hItem = TVI_ROOT;
+    while ((hItem = TreeList_GetNextItem(hTreeList, hItem, TVGN_NEXTITEM)))
+    {
+        PartItem = GetItemPartition(hTreeList, hItem);
+        if (!PartItem)
+            continue;
+
+        /* Return the first valid partition item (if PartEntry == NULL),
+         * or the one that matches the given partition entry */
+        if (!PartEntry || (PartItem->PartEntry == PartEntry))
+            break; /* Found it */
+        /* Not yet found */
+    }
+    if (phItem)
+        *phItem = hItem;
+    return (hItem ? PartItem : NULL);
 }
 
 PVOL_CREATE_INFO
@@ -1320,9 +1389,13 @@ DrawPartitionList(
         PrintDiskData(hWndList, NULL, DiskEntry);
     }
 
-    /* Select the first item */
-    // TreeList_SetFocusItem(hWndList, 1, 1);
-    TreeList_SelectItem(hWndList, 1);
+    /* Select the first usable partition/empty space */
+    {
+    HTLITEM hItem;
+    if (!FindPartitionItem(hWndList, NULL, &hItem))
+        hItem = (HTLITEM)1; // If none, select the first item, whatever it is.
+    TreeList_SelectItem(hWndList, hItem);
+    }
 }
 
 static VOID
@@ -1436,8 +1509,7 @@ DoCreatePartition(
     if (NextPart /*&& !NextPart->IsPartitioned*/)
         PrintPartitionData(hList, hParentItem, *phItem, NextPart);
 
-    /* Give the focus on and select the created partition */
-    // TreeList_SetFocusItem(hList, 1, 1);
+    /* Select the created partition */
     TreeList_SelectItem(hList, *phItem);
 
     return TRUE;
@@ -1542,8 +1614,7 @@ DoDeletePartition(
     /* Add back the "new" unpartitioned space */
     *phItem = PrintPartitionData(hList, hParentItem, hInsertAfter, PartEntry);
 
-    /* Give the focus on and select the unpartitioned space */
-    // TreeList_SetFocusItem(hList, 1, 1);
+    /* Select the unpartitioned space */
     TreeList_SelectItem(hList, *phItem);
 
     return TRUE;
@@ -1553,7 +1624,8 @@ DoDeletePartition(
 static BOOLEAN
 SelectInstallPartition(
     _In_ PSETUPDATA pSetupData,
-    _In_ HWND hwndDlg)
+    _In_ HWND hwndDlg,
+    _In_opt_ PPARTENTRY CurrentPartition)
 {
     HWND hList;
     HTLITEM hItem;
@@ -1561,7 +1633,16 @@ SelectInstallPartition(
     PPARTENTRY PartEntry;
 
     hList = GetDlgItem(hwndDlg, IDC_PARTITION);
-    PartItem = GetSelectedPartition(hList, &hItem);
+    if (CurrentPartition)
+    {
+        PartItem = FindPartitionItem(hList, CurrentPartition, &hItem);
+        if (hItem)
+            TreeList_SelectItem(hList, hItem);
+    }
+    else
+    {
+        PartItem = GetSelectedPartition(hList, &hItem);
+    }
     if (!PartItem)
         return FALSE; // Fail
     PartEntry = PartItem->PartEntry;
@@ -1635,7 +1716,8 @@ SelectInstallPartition(
     /* Force formatting only if the partition doesn't have a volume (may or may not be formatted) */
     if (PartEntry->Volume &&
         ((PartEntry->Volume->FormatState == Formatted) ||
-         (PartItem->VolCreate && *PartItem->VolCreate->FileSystemName)))
+         (PartItem->VolCreate && *PartItem->VolCreate->FileSystemName)) &&
+        !(pSetupData->bUnattend && pSetupData->USetupData.FormatPartition))
     {
         /*NOTHING*/;
     }
@@ -1644,7 +1726,13 @@ SelectInstallPartition(
         INT_PTR ret;
         PARTCREATE_CTX PartCreateCtx = {0};
 
-        /* Show the formatting dialog */
+        /* In unattended setup, try auto-formatting if required,
+         * otherwise show the dialog to ask the user what to do */
+        if (pSetupData->bUnattend && pSetupData->USetupData.FormatPartition)
+            PartCreateCtx.AutoFormat = TRUE;
+
+        /* Show the formatting dialog. In unattended setup, auto-format with
+         * "default" filesystem, or popup the dialog asking the user what to do. */
         PartCreateCtx.PartItem = PartItem;
         ret = DialogBoxParamW(pSetupData->hInstance,
                               MAKEINTRESOURCEW(IDD_FORMAT),
@@ -1660,6 +1748,8 @@ SelectInstallPartition(
     }
 
     /* The install partition has been found */
+    ASSERT((PartEntry->Volume && PartEntry->Volume->FormatState == Formatted) ||
+           (PartItem->VolCreate && *PartItem->VolCreate->FileSystemName));
     InstallPartition = PartEntry;
     return TRUE;
 }
@@ -2080,6 +2170,71 @@ DisableWizNext:
                     /* Keep the "Next" button disabled. It will be enabled
                      * only when the user selects a valid partition. */
                     PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK);
+
+                    /* In unattended mode, switch directly to the next page.
+                     * TODO: *UNLESS* there are inconsistencies in the data,
+                     * in which case we should stay on the page! */
+                    if (pSetupData->bUnattend) do
+                    {
+                        PPARTENTRY CurrentPartition;
+
+                        /* If DestinationDiskNumber or DestinationPartitionNumber are invalid
+                         * (see below), don't select the partition and show the list instead */
+                        if (pSetupData->USetupData.DestinationDiskNumber == -1 ||
+                            pSetupData->USetupData.DestinationPartitionNumber == -1)
+                        {
+                            break;
+                        }
+
+                        /* Determine the selected installation disk & partition */
+                        CurrentPartition = SelectPartition(pSetupData->PartitionList,
+                                                           pSetupData->USetupData.DestinationDiskNumber,
+                                                           pSetupData->USetupData.DestinationPartitionNumber);
+
+                        /* Now reset DestinationDiskNumber and DestinationPartitionNumber
+                         * to *invalid* values, so that if the corresponding partition is
+                         * determined to be invalid by the code below or in CreateInstallPartition,
+                         * we don't reselect it when SelectPartitionPage() is called again */
+                        pSetupData->USetupData.DestinationDiskNumber = -1;
+                        pSetupData->USetupData.DestinationPartitionNumber = -1;
+
+                        // FIXME: Here and in the AutoPartition case below, the CurrentPartition
+                        // may actually be unsuitable (MBR-extended, non-simple volume...).
+                        // More checks need to be made here!
+                        //
+                        // NOTE: We don't check for CurrentPartition->Volume in case
+                        // the partition doesn't contain a recognized volume/none exists.
+                        // We also don't check whether IsPartitioned is TRUE, because if
+                        // the partition is still empty space, we'll try to partition it.
+                        if (CurrentPartition && !IsContainerPartition(CurrentPartition->PartitionType))
+                            goto CreateInstallPartition;
+
+                        if (pSetupData->USetupData.AutoPartition)
+                        {
+                            /* Use whatever selected partition (or the first one) in the list */
+                            PPARTITEM PartItem;
+                            hList = GetDlgItem(hwndDlg, IDC_PARTITION);
+                            PartItem = GetSelectedPartition(hList, NULL);
+                            if (!PartItem)
+                                PartItem = FindPartitionItem(hList, NULL, NULL);
+                            if (PartItem)
+                                CurrentPartition = PartItem->PartEntry;
+
+                            // TODO: Do more checks, and loop until we find a valid partition.
+                            goto CreateInstallPartition;
+                        }
+                        break;
+
+CreateInstallPartition:
+                        /* Select the install partition and if success,
+                         * proceed with the installation */
+                        if (SelectInstallPartition(pSetupData, hwndDlg, CurrentPartition))
+                        {
+                            SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, -1);
+                            return TRUE;
+                        }
+                        /* Halt the installation and display the page */
+                    } while (0);
                     break;
                 }
 
@@ -2123,7 +2278,7 @@ DisableWizNext:
                 case PSN_WIZNEXT:
                 {
                     /* Select the install partition and if success, go to the next page */
-                    if (SelectInstallPartition(pSetupData, hwndDlg))
+                    if (SelectInstallPartition(pSetupData, hwndDlg, NULL))
                         break;
                     /* Failed, stay on the page */
                     SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, -1);

--- a/base/setup/reactos/reactos.c
+++ b/base/setup/reactos/reactos.c
@@ -22,7 +22,6 @@
 
 HANDLE ProcessHeap;
 SETUPDATA SetupData;
-static BOOLEAN IsUnattendedSetup;
 
 /* The partition where to perform the installation */
 PPARTENTRY InstallPartition = NULL;
@@ -1069,8 +1068,25 @@ DeviceDlgProc(
             switch (lpnm->code)
             {
                 case PSN_SETACTIVE:
-                    PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK | PSWIZB_NEXT);
+                {
+                    /* In unattended mode, don't allow going backwards further, i.e.
+                     * back to the Upgrade/Repair, the Install type, or the Start pages,
+                     * in case the setup is interrupted and the user manually goes back. */
+                    if (pSetupData->bUnattend)
+                        PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_NEXT);
+                    else
+                        PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK | PSWIZB_NEXT);
+
+                    /* In unattended mode, switch directly to the next page.
+                     * TODO: *UNLESS* there are inconsistencies in the data,
+                     * in which case we should stay on the page! */
+                    if (pSetupData->bUnattend)
+                    {
+                        SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, -1);
+                        return TRUE;
+                    }
                     break;
+                }
 
                 case PSN_QUERYCANCEL:
                 {
@@ -1178,6 +1194,13 @@ SummaryDlgProc(
                     WCHAR CurrentItemText[256];
 
                     ASSERT(InstallPartition);
+
+                    /* Skip the Summary page in unattended setup */
+                    if (pSetupData->bUnattend)
+                    {
+                        SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, -1);
+                        return TRUE;
+                    }
 
                     /* Show the current selected settings */
 
@@ -1473,15 +1496,9 @@ FsVolCallback(
     {
         if ((FSVOL_OP)Param1 == FSVOL_FORMAT)
         {
-            /*
-             * In case we just repair an existing installation, or make
-             * an unattended setup without formatting, just go to the
-             * filesystem check step.
-             */
+            /* In case we just repair an existing installation,
+             * just go to the file system check step */
             if (FsVolContext->pSetupData->RepairUpdateFlag)
-                return FSVOL_SKIP; /** HACK!! **/
-
-            if (IsUnattendedSetup && !FsVolContext->pSetupData->USetupData.FormatPartition)
                 return FSVOL_SKIP; /** HACK!! **/
 
             /* Set status text */
@@ -2808,6 +2825,19 @@ FinishDlgProc(
                                       pSetupData->hInstance,
                                       IDS_RESTARTBTN);
 
+                    /* Skip the Finish page in unattended setup */
+                    if (pSetupData->bUnattend /*&& !pSetupData->bStopInstall*/)
+                    {
+                        // FIXME: The macro should use PostMessageW, but our
+                        // prsht.h is wrong and uses SendMessageW instead...
+                        //PropSheet_PressButton(hWndParent, PSBTN_FINISH);
+                        PostMessageW(hWndParent, PSM_PRESSBUTTON, PSBTN_FINISH, 0);
+                        /* We need to "stay" on the page so that we can
+                         * receive the PSN_WIZFINISH notification */
+                        SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, 0);
+                        return TRUE;
+                    }
+
                     /* Re-enable the Close/Cancel buttons if we won't reboot */
                     if (!pSetupData->bMustReboot)
                         PropSheet_SetCloseCancel(hWndParent, TRUE);
@@ -2910,7 +2940,7 @@ BOOL LoadSetupData(
 
     /* If not unattended, overwrite language and locale with
      * the current ones of the running ReactOS instance */
-    if (!IsUnattendedSetup)
+    if (!pSetupData->bUnattend)
     {
         LCID LocaleID = GetUserDefaultLCID();
 
@@ -2934,7 +2964,7 @@ BOOL LoadSetupData(
 
     /* If not unattended, overwrite keyboard layout with
      * the current one of the running ReactOS instance */
-    if (!IsUnattendedSetup)
+    if (!pSetupData->bUnattend)
     {
         C_ASSERT(_countof(pSetupData->DefaultKBLayout) >= KL_NAMELENGTH);
         /* If the call fails, keep the default already stored in the buffer */
@@ -3599,6 +3629,13 @@ static const struct
     DLGPROC pfnDlgProc;
 } WizardPages[] =
 {
+    /*
+     * These pages are useful only in the interactive installation scenario.
+     * In ReactOS unattended setup, we directly perform a new installation,
+     * possibly erasing any old one, but no upgrades.
+     * NOTE: This may be subject to changes in the future.
+     */
+
     /* Start page */
     {FALSE, PSP_HIDEHEADER,
      MAKEINTRESOURCEW(IDD_STARTPAGE), NULL, NULL, StartDlgProc},
@@ -3615,20 +3652,24 @@ static const struct
      MAKEINTRESOURCEW(IDS_UPDATETITLE), MAKEINTRESOURCEW(IDS_UPDATESUBTITLE),
      UpgradeRepairDlgProc},
 
+    /*
+     * These pages are common to both interactive and unattended setup scenarios.
+     */
+
     /* Device Settings page */
-    {FALSE, PSP_USEHEADERTITLE | PSP_USEHEADERSUBTITLE,
+    {TRUE, PSP_USEHEADERTITLE | PSP_USEHEADERSUBTITLE,
      MAKEINTRESOURCEW(IDD_DEVICEPAGE),
      MAKEINTRESOURCEW(IDS_DEVICETITLE), MAKEINTRESOURCEW(IDS_DEVICESUBTITLE),
      DeviceDlgProc},
 
     /* Install device settings page / boot method / install directory */
-    {FALSE, PSP_USEHEADERTITLE | PSP_USEHEADERSUBTITLE,
+    {TRUE, PSP_USEHEADERTITLE | PSP_USEHEADERSUBTITLE,
      MAKEINTRESOURCEW(IDD_DRIVEPAGE),
      MAKEINTRESOURCEW(IDS_DRIVETITLE), MAKEINTRESOURCEW(IDS_DRIVESUBTITLE),
      DriveDlgProc},
 
     /* Summary page */
-    {FALSE, PSP_USEHEADERTITLE | PSP_USEHEADERSUBTITLE,
+    {TRUE, PSP_USEHEADERTITLE | PSP_USEHEADERSUBTITLE,
      MAKEINTRESOURCEW(IDD_SUMMARYPAGE),
      MAKEINTRESOURCEW(IDS_SUMMARYTITLE), MAKEINTRESOURCEW(IDS_SUMMARYSUBTITLE),
      SummaryDlgProc},
@@ -3760,7 +3801,7 @@ _tWinMain(HINSTANCE hInst,
     }
 
     /* Retrieve any supplemental options from the unattend file */
-    SetupData.bUnattend = IsUnattendedSetup = CheckUnattendedSetup(&SetupData.USetupData);
+    SetupData.bUnattend = CheckUnattendedSetup(&SetupData.USetupData);
 
     /* Load extra setup data (HW lists etc...) */
     if (!LoadSetupData(&SetupData))

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -2428,8 +2428,7 @@ Restart:
 
     if (IsUnattendedSetup)
     {
-        ASSERT(USetupData.FormatPartition);
-
+        /* In unattended mode, preselect the file system */
         switch (USetupData.FsType)
         {
             /* 1 is for BtrFS */
@@ -2461,8 +2460,20 @@ Restart:
 
     if (IsUnattendedSetup)
     {
-        ASSERT(USetupData.FormatPartition);
-        return FSVOL_DOIT;
+        /* In unattended setup, directly format the partition if requested.
+         * Otherwise, skip the partition if it doesn't require formatting.
+         * Else, ask the user what to do. */
+        if (USetupData.FormatPartition)
+        {
+            return FSVOL_DOIT;
+        }
+        else if (!ForceFormat)
+        {
+            /* Skip formatting this volume, but file system checks will be performed */
+            return FSVOL_SKIP;
+        }
+        // TODO: If unattended mode doesn't allow interaction,
+        // popup or log error and exit, since we don't allow regular interaction.
     }
 
     DrawFileSystemList(FileSystemList);
@@ -2671,15 +2682,9 @@ FsVolCallback(
     {
         if ((FSVOL_OP)Param1 == FSVOL_FORMAT)
         {
-            /*
-             * In case we just repair an existing installation, or make
-             * an unattended setup without formatting, just go to the
-             * file system check step.
-             */
+            /* In case we just repair an existing installation,
+             * just go to the file system check step */
             if (RepairUpdateFlag)
-                return FSVOL_SKIP; /** HACK!! **/
-
-            if (IsUnattendedSetup && !USetupData.FormatPartition)
                 return FSVOL_SKIP; /** HACK!! **/
         }
         return FSVOL_DOIT;
@@ -3953,6 +3958,9 @@ QuitPage(PINPUT_RECORD Ir)
     }
 
     CONSOLE_SetStatusText(MUIGetString(STRING_REBOOTCOMPUTER2));
+
+    if (IsUnattendedSetup)
+        return FLUSH_PAGE;
 
     /* Wait for maximum 15 seconds or an ENTER key before quitting */
     ProgressCountdown(Ir, 15);

--- a/base/system/userinit/livecd.c
+++ b/base/system/userinit/livecd.c
@@ -594,6 +594,7 @@ LocaleDlgProc(
     switch (uMsg)
     {
         case WM_INITDIALOG:
+        {
             /* Save pointer to the state */
             pState = (PSTATE)lParam;
             SetWindowLongPtrW(hwndDlg, GWLP_USERDATA, (DWORD_PTR)pState);
@@ -604,17 +605,15 @@ LocaleDlgProc(
             /* Fill the language and keyboard layout lists */
             CreateLanguagesList(GetDlgItem(hwndDlg, IDC_LANGUAGELIST), pState);
             CreateKeyboardLayoutList(GetDlgItem(hwndDlg, IDC_LAYOUTLIST));
+
+            /* In unattended mode, advance to the next page */
             if (pState->Unattend->bEnabled)
-            {
-                /* Advance to the next page */
-                PostMessageW(hwndDlg, WM_COMMAND, MAKEWPARAM(IDOK, BN_CLICKED), 0L);
-            }
-            return FALSE;
+                SendMessageW(hwndDlg, WM_COMMAND, MAKEWPARAM(IDOK, BN_CLICKED), 0);
+            return TRUE;
+        }
 
         case WM_DRAWITEM:
-            OnDrawItem((LPDRAWITEMSTRUCT)lParam,
-                       pState,
-                       IDC_LOCALELOGO);
+            OnDrawItem((LPDRAWITEMSTRUCT)lParam, pState, IDC_LOCALELOGO);
             return TRUE;
 
         case WM_COMMAND:
@@ -739,23 +738,25 @@ StartDlgProc(
             /* Center the dialog window */
             CenterWindow(hwndDlg);
 
-            /* If the ReactOS Installer could not be located, disable
-             * the "Install" button and directly start the LiveCD. */
+            /* If the ReactOS Installer could not be located, directly start
+             * the LiveCD. Otherwise, directly start the installer if we are
+             * in unattended mode. */
             if (!*Installer)
-                EnableWindow(GetDlgItem(hwndDlg, IDC_INSTALL), FALSE);
-
-            if (pState->Unattend->bEnabled || (*Installer == UNICODE_NULL))
             {
-                /* Click on the 'Run' button */
-                PostMessageW(hwndDlg, WM_COMMAND, MAKEWPARAM(IDC_RUN, BN_CLICKED), 0L);
+                /* Disable the "Install" button and click on "Run LiveCD" */
+                EnableWindow(GetDlgItem(hwndDlg, IDC_INSTALL), FALSE);
+                SendMessageW(hwndDlg, WM_COMMAND, MAKEWPARAM(IDC_RUN, BN_CLICKED), 0);
             }
-            return FALSE;
+            else if (pState->Unattend->bEnabled)
+            {
+                /* Click on "Install" */
+                SendMessageW(hwndDlg, WM_COMMAND, MAKEWPARAM(IDC_INSTALL, BN_CLICKED), 0);
+            }
+            return TRUE;
         }
 
         case WM_DRAWITEM:
-            OnDrawItem((LPDRAWITEMSTRUCT)lParam,
-                       pState,
-                       IDC_STARTLOGO);
+            OnDrawItem((LPDRAWITEMSTRUCT)lParam, pState, IDC_STARTLOGO);
             return TRUE;
 
         case WM_COMMAND:
@@ -809,7 +810,10 @@ StartDlgProc(
     return FALSE;
 }
 
-VOID ParseUnattend(LPCWSTR UnattendInf, LIVECD_UNATTEND* pUnattend)
+static VOID
+ParseUnattend(
+    _In_ LPCWSTR UnattendInf,
+    _Out_ LIVECD_UNATTEND* pUnattend)
 {
     WCHAR Buffer[MAX_PATH];
 
@@ -833,9 +837,15 @@ VOID ParseUnattend(LPCWSTR UnattendInf, LIVECD_UNATTEND* pUnattend)
         return;
     }
 
-    if (_wcsicmp(Buffer, L"yes"))
+    if (_wcsicmp(Buffer, L"yes") != 0)
     {
-        TRACE("Unattended setup is not enabled\n", Buffer);
+        TRACE("Unattended setup is not enabled\n");
+        return;
+    }
+    /* If the user presses Ctrl+Shift+F10, disable unattended setup */
+    if ((GetKeyState(VK_CONTROL) & GetKeyState(VK_SHIFT) & GetKeyState(VK_F10)) < 0)
+    {
+        WARN("Unattended setup is disabled by keypress\n");
         return;
     }
 
@@ -989,8 +999,24 @@ RunLiveCD(
     else
         WARN("Could not find the ReactOS Installer\n");
 
-    GetWindowsDirectoryW(UnattendInf, _countof(UnattendInf));
-    wcscat(UnattendInf, L"\\unattend.inf");
+    /* If the ReactOS Installer was located, use its path for the
+     * unattended file; otherwise, use the current ReactOS directory. */
+    StringCchCopyW(UnattendInf, _countof(UnattendInf), Installer);
+    if (*UnattendInf)
+    {
+        /* Find the last path separator and truncate the path there.
+         * If there is none, NUL the path. */
+        PWCHAR ptr = wcsrchr(UnattendInf, L'\\');
+        if (!ptr)
+            ptr = UnattendInf;
+        *ptr = UNICODE_NULL;
+    }
+    if (!*UnattendInf)
+    {
+        /* No actual path was found, fall back to the ReactOS directory */
+        GetWindowsDirectoryW(UnattendInf, _countof(UnattendInf));
+    }
+    StringCchCatW(UnattendInf, _countof(UnattendInf), L"\\unattend.inf");
     ParseUnattend(UnattendInf, &Unattend);
     pState->Unattend = &Unattend;
 

--- a/boot/bootdata/livecd/unattend.inf
+++ b/boot/bootdata/livecd/unattend.inf
@@ -1,7 +1,7 @@
 [Unattend]
 Signature = "$ReactOS$"
 
-; Set UnattendSetupEnabled to yes in order to boot the LiveImage immediately to desktop.
+; Set UnattendSetupEnabled to yes in order to immediately start the ReactOS installer.
 ; yes - unattend setup enabled
 ; no - unattend setup disabled
 UnattendSetupEnabled = no


### PR DESCRIPTION
## Purpose

Unattended support in the new 1st stage GUI installer was partially supported, but not completely.
This requires doing the following steps automatically:
1. select the partition where to install ReactOS, or partitioning empty space if necessary;
2. format the selected partition (if requested) with the correct filesystem, without showing the formatting dialog;
3. jump over the wizard pages -- some of them preinitializes the data before doing the jump. Unnecessary pages like the Welcome page, the install type selection page, etc. aren't included in the wizard pages list in this mode.

In case some unattended information isn't complete (or incorrect), halt on the concerned page(s) and allow the user to go back to the previously skipped pages.

When starting the bootcd in GUI mode, the installer isn't automatically started first, but a selector menu is show first (language and keyboard layout selection, then the choice of starting the live environment or the installer).
The selector menu code is now adjusted to find the primary unattended file and determine whether to directly start the installer or show the menu. The user can override the automatic start by using a keypress combination.

JIRA issue: [CORE-13525](https://jira.reactos.org/browse/CORE-13525)


## Proposed changes

- ### `[SETUP:REACTOS][USETUP] Improve unattended setup support`

  - Make unattended setup work for the 1st-stage GUI setup.

  - Remove an unattended setup hack for volumes format.

    Even in unattended setup and `FormatPartition == 0`, if the user chose to format the partition in the format dialog that pop up, then we *MUST* honour this choice!
    Otherwise, we would also have to ignore volume check for that volume (because we would get an assertion that the volume isn't formatted), **AND**, we wouldn't be able to install ReactOS there anyway because the volume isn't formatted!

- ### `[USERINIT] livecd.c: Change default actions in unattended mode, or if the installer cannot be found`

  - Just after initially caching the path to the ReactOS installer, check whether an unattend.inf file can be found in its directory; otherwise, fall back to an unattend file in the current ReactOS directory.

  - If this unattend.inf file specifies to run an unattended setup (`UnattendSetupEnabled` value set to `"yes"`), automatically start the ReactOS installer -- instead of starting the live environment desktop.

  - If the user presses Ctrl+Shift+F10 however, disable unattended setup (suggestion to override the behaviour with a keypress from Whindmar Saksit).


## TODO

- [x] Remove the last test commit once everybody is happy with the unattended behaviour.
