### PR TITLE
[RAPPS][INF] Update Turkish (tr-TR) translation and fix typos

### DIFF
--- a/base/applications/rapps/lang/tr-TR.rc
+++ b/base/applications/rapps/lang/tr-TR.rc
@@ -5,6 +5,7 @@
  * TRANSLATORS: Copyright 2013-2016 Erdem Ersoy (eersoy93) <erdemersoy@erdemersoy.net>
  *              Copyright 2018 Ercan Ersoy (ercanersoy) <ercanersoy@ercanersoy.net>
  *              Copyright 2021 Süleyman Poyraz <zaryob.dev@gmail.com>
+ *              Copyright 2026 Ethem Çılgın (associan) <JaggedZenith@proton.me>
  */
 
 LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
@@ -66,7 +67,7 @@ BEGIN
     AUTORADIOBUTTON "Doğrudan (Vekil sunucu yok.)", IDC_NO_PROXY, 15, 195, 210, 10
     AUTORADIOBUTTON "Vekil Sunucu", IDC_USE_PROXY, 15, 210, 74, 10
     EDITTEXT IDC_PROXY_SERVER, 90, 210, 147, 12, ES_AUTOHSCROLL | WS_DISABLED
-    LTEXT "Şunun i̇çin vekil sunucu yok", -1, 26, 226, 64, 10
+    LTEXT "Şunun için vekil sunucu yok", -1, 26, 226, 64, 10
     EDITTEXT IDC_NO_PROXY_FOR, 90, 225, 147, 12, ES_AUTOHSCROLL | WS_DISABLED
     PUSHBUTTON "Varsayılanlar", IDC_DEFAULT_SETTINGS, 8, 245, 60, 14, WS_GROUP | WS_TABSTOP
     DEFPUSHBUTTON "Tamam", IDOK, 116, 245, 60, 14
@@ -121,7 +122,7 @@ BEGIN
     IDS_INFO_PUBLISHER "\nYayımcısı: "
     IDS_INFO_HELPLINK "\nYardım Bağlantısı: "
     IDS_INFO_HELPPHONE "\nYardım Telefonu: "
-    IDS_INFO_README "\nBenioku Dosyası: "
+    IDS_INFO_README "\nBeni Oku Dosyası: "
     IDS_INFO_REGOWNER "\nKayıtlı Olduğu Kullanıcısı: "
     IDS_INFO_PRODUCTID "\nÜrün Kimliği: "
     IDS_INFO_CONTACT "\nİletişim: "
@@ -206,7 +207,7 @@ BEGIN
     IDS_UNABLE_TO_WRITE "Diske yazılamıyor. Disk dolu olabilir."
     IDS_INSTALL_SELECTED "Seçileni Kur"
     IDS_SELECTEDFORINST "Kurulum için seçildi"
-    IDS_MISMATCH_CERT_INFO "Kullanılan sertifika bilimmiyor:\nAçıklama: %s\nSertifikayı Veren: %s\nYine de devam etmek istiyor musunuz?"
+    IDS_MISMATCH_CERT_INFO "Kullanılan sertifika bilinmiyor:\nAçıklama: %s\nSertifikayı Veren: %s\nYine de devam etmek istiyor musunuz?"
     IDS_UNABLE_PATH "Geçersiz dosya yolu biçimi."
     IDS_APP_DISPLAY_DETAILS "Detaylar"
     IDS_APP_DISPLAY_LIST "Liste"
@@ -262,12 +263,12 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Hata: %1 seçeneği bir veya daha fazla parametre içermeli.\n"
     IDS_CMD_INVALID_OPTION "Hata: Bilinmeyen veya geçersiz komut satırı seçeneği belirtildi.\n"
     IDS_CMD_FIND_RESULT_FOR "%1 için sonuç bulundu:\n"
-    IDS_CMD_PACKAGE_NOT_FOUND "%1 paketi bulunmadı.\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "%1 paketi bulunamadı.\n"
     IDS_CMD_PACKAGE_INFO "%1 paketi hakkındaki bilgi:\n"
 END
 
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Kaldırmak istediğinizden emin misiniz %s?"
-    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Kurulum tamamlandı, %s şimdi çalıştırılsın mı?"
 END

--- a/base/applications/rapps/lang/tr-TR.rc
+++ b/base/applications/rapps/lang/tr-TR.rc
@@ -1,10 +1,11 @@
 /*
- * PROJECT:     ReactOS Applications Manager
- * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
- * PURPOSE:     Turkish resource file
+ * PROJECT:      ReactOS Applications Manager
+ * LICENSE:      GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:      Turkish resource file
  * TRANSLATORS: Copyright 2013-2016 Erdem Ersoy (eersoy93) <erdemersoy@erdemersoy.net>
  *              Copyright 2018 Ercan Ersoy (ercanersoy) <ercanersoy@ercanersoy.net>
  *              Copyright 2021 Süleyman Poyraz <zaryob.dev@gmail.com>
+ *              Copyright 2026 Ethem Çılgın (associan) <JaggedZenith@proton.me>
  */
 
 LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
@@ -66,7 +67,7 @@ BEGIN
     AUTORADIOBUTTON "Doğrudan (Vekil sunucu yok.)", IDC_NO_PROXY, 15, 195, 210, 10
     AUTORADIOBUTTON "Vekil Sunucu", IDC_USE_PROXY, 15, 210, 74, 10
     EDITTEXT IDC_PROXY_SERVER, 90, 210, 147, 12, ES_AUTOHSCROLL | WS_DISABLED
-    LTEXT "Şunun i̇çin vekil sunucu yok", -1, 26, 226, 64, 10
+    LTEXT "Şunun için vekil sunucu yok", -1, 26, 226, 64, 10
     EDITTEXT IDC_NO_PROXY_FOR, 90, 225, 147, 12, ES_AUTOHSCROLL | WS_DISABLED
     PUSHBUTTON "Varsayılanlar", IDC_DEFAULT_SETTINGS, 8, 245, 60, 14, WS_GROUP | WS_TABSTOP
     DEFPUSHBUTTON "Tamam", IDOK, 116, 245, 60, 14
@@ -121,7 +122,7 @@ BEGIN
     IDS_INFO_PUBLISHER "\nYayımcısı: "
     IDS_INFO_HELPLINK "\nYardım Bağlantısı: "
     IDS_INFO_HELPPHONE "\nYardım Telefonu: "
-    IDS_INFO_README "\nBenioku Dosyası: "
+    IDS_INFO_README "\nBeni Oku Dosyası: "
     IDS_INFO_REGOWNER "\nKayıtlı Olduğu Kullanıcısı: "
     IDS_INFO_PRODUCTID "\nÜrün Kimliği: "
     IDS_INFO_CONTACT "\nİletişim: "
@@ -206,7 +207,7 @@ BEGIN
     IDS_UNABLE_TO_WRITE "Diske yazılamıyor. Disk dolu olabilir."
     IDS_INSTALL_SELECTED "Seçileni Kur"
     IDS_SELECTEDFORINST "Kurulum için seçildi"
-    IDS_MISMATCH_CERT_INFO "Kullanılan sertifika bilimmiyor:\nAçıklama: %s\nSertifikayı Veren: %s\nYine de devam etmek istiyor musunuz?"
+    IDS_MISMATCH_CERT_INFO "Kullanılan sertifika bilinmiyor:\nAçıklama: %s\nSertifikayı Veren: %s\nYine de devam etmek istiyor musunuz?"
     IDS_UNABLE_PATH "Geçersiz dosya yolu biçimi."
     IDS_APP_DISPLAY_DETAILS "Detaylar"
     IDS_APP_DISPLAY_LIST "Liste"
@@ -262,12 +263,12 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Hata: %1 seçeneği bir veya daha fazla parametre içermeli.\n"
     IDS_CMD_INVALID_OPTION "Hata: Bilinmeyen veya geçersiz komut satırı seçeneği belirtildi.\n"
     IDS_CMD_FIND_RESULT_FOR "%1 için sonuç bulundu:\n"
-    IDS_CMD_PACKAGE_NOT_FOUND "%1 paketi bulunmadı.\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "%1 paketi bulunamadı.\n"
     IDS_CMD_PACKAGE_INFO "%1 paketi hakkındaki bilgi:\n"
 END
 
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Kaldırmak istediğinizden emin misiniz %s?"
-    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Kurulum tamamlandı, %s şimdi çalıştırılsın mı?"
 END

--- a/media/inf/shortcuts.inf
+++ b/media/inf/shortcuts.inf
@@ -1484,8 +1484,8 @@ ENTERTAINMENT=Eğlence
 COMMUNICATIONS=İletişim
 GAMES=Oyunlar
 
-README_TITLE=Benioku
-README_DESC=ReactOS Benioku
+README_TITLE=Beni Oku
+README_DESC=ReactOS Beni Oku
 
 CMD_TITLE=Komut İstemi
 CMD_DESC=Komut İstemi'ni aç
@@ -1540,7 +1540,7 @@ SPIDER_TITLE=Örümcek Solitaire
 SPIDER_DESC=Örümcek Solitaire
 UTILMAN_TITLE=Erişilebilirlik Araçları Yöneticisi
 UTILMAN_DESC=Erişilebilirlik Araçları Yöneticisi'ni başlat
-IEXPLORE_TITLE=Wine Internet Explorer
+IEXPLORE_TITLE=Wine İnternet Gezgini
 IEXPLORE_DESC=Wine Web Tarayıcısı
 
 [Strings.0422]


### PR DESCRIPTION
## Summary
This PR improves and corrects several Turkish localization resources in **RAPPS** (Applications Manager) and **SYSSETUP** (shortcut definitions).

### RAPPS
- **Missing Translation:** Translated untranslated string `IDS_INSTGEN_CONFIRMINSTRUNAPP`.
- **Spelling & Typos:**
  - Fixed typo in `IDS_MISMATCH_CERT_INFO` (`bilimmiyor` -> `bilinmiyor`).
  - Fixed phrasing in `IDS_CMD_PACKAGE_NOT_FOUND` (`bulunmadı` -> `bulunamadı`).
  - Fixed spacing in `IDS_INFO_README` (`Benioku` -> `Beni Oku`).

### SHORTCUTS
- **Grammar Correction:** Updated `README_TITLE` and `README_DESC` ("Benioku" -> "Beni Oku").
- **Translation:** Translated Wine Internet Explorer title/description fields.