### PR TITLE
[NTOS:OB] Correct a typo

### DIFF
--- a/ntoskrnl/ob/obhandle.c
+++ b/ntoskrnl/ob/obhandle.c
@@ -724,7 +724,7 @@ ObpCloseHandleTableEntry(IN PHANDLE_TABLE HandleTable,
             return STATUS_HANDLE_NOT_CLOSABLE;
         }
 
-        /* Success, validate callout retrn */
+        /* Success, validate callout return */
         ObpCalloutEnd(CalloutIrql, "NtClose", ObjectType, Body);
     }
 


### PR DESCRIPTION
## Purpose

Fix a typo (retrn -> return) in `obhandle.c`.

JIRA issue: None

## Proposed changes
- Change "retrn" to "return"