### PR TITLE
[NTOS:EX] Fix push lock release retry livelock

### DIFF
--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -63,6 +63,7 @@ list(APPEND KMTEST_DRV_SOURCE
     ntos_ex/ExHardError.c
     ntos_ex/ExInterlocked.c
     ntos_ex/ExPools.c
+    ntos_ex/ExPushLock.c
     ntos_ex/ExResource.c
     ntos_ex/ExSequencedList.c
     ntos_ex/ExSingleList.c

--- a/modules/rostests/kmtests/kmtest_drv/testlist.c
+++ b/modules/rostests/kmtests/kmtest_drv/testlist.c
@@ -15,6 +15,7 @@ KMT_TESTFUNC Test_ExHardError;
 KMT_TESTFUNC Test_ExHardErrorInteractive;
 KMT_TESTFUNC Test_ExInterlocked;
 KMT_TESTFUNC Test_ExPools;
+KMT_TESTFUNC Test_ExPushLock;
 KMT_TESTFUNC Test_ExResource;
 KMT_TESTFUNC Test_ExSequencedList;
 KMT_TESTFUNC Test_ExSingleList;
@@ -101,6 +102,7 @@ const KMT_TEST TestList[] =
     { "-ExHardErrorInteractive",            Test_ExHardErrorInteractive },
     { "ExInterlocked",                      Test_ExInterlocked },
     { "ExPools",                            Test_ExPools },
+    { "ExPushLock",                         Test_ExPushLock },
     { "ExResource",                         Test_ExResource },
     { "ExSequencedList",                    Test_ExSequencedList },
     { "ExSingleList",                       Test_ExSingleList },

--- a/modules/rostests/kmtests/ntos_ex/ExPushLock.c
+++ b/modules/rostests/kmtests/ntos_ex/ExPushLock.c
@@ -1,0 +1,1385 @@
+/*
+ * PROJECT:     ReactOS kernel tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Push lock tests
+ * COPYRIGHT:   Copyright 2026 Gleb Surikov <glebs.surikovs@gmail.com>
+ */
+
+#include <kmt_test.h>
+
+#define PUSH_LOCK_TIMEOUT_MS        5000
+#define PUSH_LOCK_POLL_INTERVAL_MS  1
+
+#define PUSH_LOCK_RELATIVE_TIMEOUT(Milliseconds) (-((LONGLONG)(Milliseconds) * 10 * 1000))
+
+#define PUSH_LOCK_MAX_WAITERS   4
+
+#define PUSH_LOCK_RACE_ITERATIONS       64
+#define PUSH_LOCK_CONTENTION_THREADS    6
+#define PUSH_LOCK_CONTENTION_ITERATIONS 2048
+
+#define PUSH_LOCK_CHECKSUM_XOR  0xA5A5A5A5UL
+
+typedef enum PUSH_LOCK_MODE
+{
+    PushLockModeShared,
+    PushLockModeExclusive
+} PUSH_LOCK_MODE;
+
+typedef enum PUSH_LOCK_RELEASE_KIND
+{
+    PushLockReleaseSpecific,
+    PushLockReleaseGeneric
+} PUSH_LOCK_RELEASE_KIND;
+
+typedef enum PUSH_LOCK_WAIT_CHAIN_STATE
+{
+    PushLockWaitChainInProgress,
+    PushLockWaitChainStable,
+    PushLockWaitChainInvalid
+} PUSH_LOCK_WAIT_CHAIN_STATE;
+
+typedef struct PUSH_LOCK_TEST_STATE
+{
+    EX_PUSH_LOCK Lock;
+
+    volatile LONG ActiveReaders;
+    volatile LONG ActiveWriters;
+    volatile LONG Violations;
+
+    volatile LONG SharedAcquisitions;
+    volatile LONG ExclusiveAcquisitions;
+    volatile LONG CompletedOperations;
+
+    /* These fields form one protected value. Writers deliberately update the
+       fields separately so that a reader can detect any overlap with a writer. */
+    volatile ULONG Sequence;
+    volatile ULONG SequenceInverse;
+    volatile ULONG Checksum;
+} PUSH_LOCK_TEST_STATE, *PPUSH_LOCK_TEST_STATE;
+
+typedef struct PUSH_LOCK_THREAD_CONTEXT
+{
+    PPUSH_LOCK_TEST_STATE State;
+    PUSH_LOCK_MODE Mode;
+    PUSH_LOCK_RELEASE_KIND ReleaseKind;
+    PKEVENT StartGate;
+    KEVENT ReadyEvent;
+    KEVENT AcquiredEvent;
+    KEVENT ReleaseEvent;
+    KEVENT DoneEvent;
+    ULONG Index;
+    ULONG Iterations;
+} PUSH_LOCK_THREAD_CONTEXT, *PPUSH_LOCK_THREAD_CONTEXT;
+
+C_ASSERT(sizeof(EX_PUSH_LOCK) == sizeof(ULONG_PTR));
+
+FORCEINLINE
+NTSTATUS
+PushLockWaitForEvent(
+    _In_ PKEVENT Event)
+{
+    LARGE_INTEGER Timeout;
+
+    Timeout.QuadPart = PUSH_LOCK_RELATIVE_TIMEOUT(PUSH_LOCK_TIMEOUT_MS);
+
+    return KeWaitForSingleObject(Event,
+                                 Executive,
+                                 KernelMode,
+                                 FALSE,
+                                 &Timeout);
+}
+
+FORCEINLINE
+VOID
+PushLockDelay(VOID)
+{
+    LARGE_INTEGER Delay;
+
+    Delay.QuadPart = PUSH_LOCK_RELATIVE_TIMEOUT(PUSH_LOCK_POLL_INTERVAL_MS);
+
+    KeDelayExecutionThread(KernelMode, FALSE, &Delay);
+}
+
+static
+EX_PUSH_LOCK
+PushLockReadValue(
+    _In_ PEX_PUSH_LOCK PushLock)
+{
+    EX_PUSH_LOCK Value;
+
+    /* Use a cmpxchg with identical xchg and comparand values as an
+       atomic read of the complete push lock word. A zero value remains zero,
+       and a nonzero value never matches the comparand, so the operation doesn't
+       modify the lock. */
+    Value.Ptr = InterlockedCompareExchangePointer(&PushLock->Ptr, NULL, NULL);
+
+    return Value;
+}
+
+/*
+ * This checks only relationships that are valid for every externally visible
+ * push lock state. In particular, an unlocked lock may still have Waiting set
+ * while a selected waiter is becoming ready.
+ */
+static
+BOOLEAN
+PushLockValueIsPlausible(
+    _In_ EX_PUSH_LOCK Value)
+{
+    ULONG_PTR WaitBlockAddress;
+
+    if (Value.Waking && !Value.Waiting)
+    {
+        return FALSE;
+    }
+
+    if (Value.MultipleShared && (!Value.Locked || !Value.Waiting))
+    {
+        return FALSE;
+    }
+
+    if (!Value.Waiting && (Value.Waking || Value.MultipleShared))
+    {
+        return FALSE;
+    }
+
+    if (!Value.Locked && !Value.Waiting && Value.Value != 0)
+    {
+        return FALSE;
+    }
+
+    /* When Waiting is set, the upper bits contain the address of the newest wait
+       block while the low bits retain the push lock flags */
+    if (Value.Waiting)
+    {
+        WaitBlockAddress = Value.Value & ~EX_PUSH_LOCK_PTR_BITS;
+        if (WaitBlockAddress == 0)
+        {
+            return FALSE;
+        }
+    }
+
+    return TRUE;
+}
+
+FORCEINLINE
+VOID
+PushLockRecordViolation(
+    _Inout_ PPUSH_LOCK_TEST_STATE State)
+{
+    InterlockedIncrement(&State->Violations);
+}
+
+static
+VOID
+PushLockSampleState(
+    _Inout_ PPUSH_LOCK_TEST_STATE State)
+{
+    if (!PushLockValueIsPlausible(PushLockReadValue(&State->Lock)))
+    {
+        PushLockRecordViolation(State);
+    }
+}
+
+static
+VOID
+PushLockAcquire(
+    _Inout_ PEX_PUSH_LOCK PushLock,
+    _In_ PUSH_LOCK_MODE Mode)
+{
+    if (Mode == PushLockModeExclusive)
+    {
+        ExfAcquirePushLockExclusive(PushLock);
+    }
+    else
+    {
+        ExfAcquirePushLockShared(PushLock);
+    }
+}
+
+static
+VOID
+PushLockRelease(
+    _Inout_ PEX_PUSH_LOCK PushLock,
+    _In_ PUSH_LOCK_MODE Mode,
+    _In_ PUSH_LOCK_RELEASE_KIND ReleaseKind)
+{
+    if (ReleaseKind == PushLockReleaseGeneric)
+    {
+        ExfReleasePushLock(PushLock);
+    }
+    else if (Mode == PushLockModeExclusive)
+    {
+        ExfReleasePushLockExclusive(PushLock);
+    }
+    else
+    {
+        ExfReleasePushLockShared(PushLock);
+    }
+}
+
+/*
+ * The counters below are independent of the push lock implementation. They
+ * detect overlapping writers and any reader that enters while a writer owns
+ * the protected region.
+ */
+static
+VOID
+PushLockEnterProtectedRegion(
+    _Inout_ PPUSH_LOCK_TEST_STATE State,
+    _In_ PUSH_LOCK_MODE Mode)
+{
+    LONG Count;
+
+    if (Mode == PushLockModeExclusive)
+    {
+        Count = InterlockedIncrement(&State->ActiveWriters);
+        if (Count != 1 || State->ActiveReaders != 0)
+        {
+            PushLockRecordViolation(State);
+        }
+
+        InterlockedIncrement(&State->ExclusiveAcquisitions);
+    }
+    else
+    {
+        /* Check on both sides of the reader increment. The second check detects a
+           writer that entered after the first load but before this reader published
+           itself. */
+        if (State->ActiveWriters != 0)
+        {
+            PushLockRecordViolation(State);
+        }
+
+        InterlockedIncrement(&State->ActiveReaders);
+
+        if (State->ActiveWriters != 0)
+        {
+            PushLockRecordViolation(State);
+        }
+
+        InterlockedIncrement(&State->SharedAcquisitions);
+    }
+}
+
+static
+VOID
+PushLockLeaveProtectedRegion(
+    _Inout_ PPUSH_LOCK_TEST_STATE State,
+    _In_ PUSH_LOCK_MODE Mode)
+{
+    LONG Count;
+
+    if (Mode == PushLockModeExclusive)
+    {
+        Count = InterlockedDecrement(&State->ActiveWriters);
+        if (Count != 0)
+        {
+            PushLockRecordViolation(State);
+        }
+    }
+    else
+    {
+        Count = InterlockedDecrement(&State->ActiveReaders);
+        if (Count < 0)
+        {
+            PushLockRecordViolation(State);
+        }
+    }
+}
+
+static
+VOID
+PushLockReadProtectedValue(
+    _Inout_ PPUSH_LOCK_TEST_STATE State)
+{
+    ULONG Sequence;
+    ULONG SequenceInverse;
+    ULONG Checksum;
+
+    /* A reader must observe all 3 fields from the same completed writer
+       update. Any mixture of old and new fields indicates overlap with an
+       x owner. */
+    Sequence = State->Sequence;
+    SequenceInverse = State->SequenceInverse;
+    Checksum = State->Checksum;
+
+    if (SequenceInverse != ~Sequence ||
+        Checksum != (Sequence ^ PUSH_LOCK_CHECKSUM_XOR))
+    {
+        PushLockRecordViolation(State);
+    }
+}
+
+static
+VOID
+PushLockWriteProtectedValue(
+    _Inout_ PPUSH_LOCK_TEST_STATE State)
+{
+    ULONG Sequence;
+
+    /* Publish an intentionally inconsistent value while the update is in
+       progress. A reader entering concurrently is likely to observe
+       either an invalid inverse or an invalid checksum. */
+    Sequence = State->Sequence + 1;
+    State->Sequence = Sequence;
+    /* Keep the 3 stores ordered. N.B. The barriers aren't intended to replace
+       the synchronization supplied by the push lock. */
+    KeMemoryBarrier();
+    State->SequenceInverse = ~Sequence;
+    KeMemoryBarrier();
+    State->Checksum = Sequence ^ PUSH_LOCK_CHECKSUM_XOR;
+}
+
+static
+VOID
+PushLockInitializeState(
+    _Out_ PPUSH_LOCK_TEST_STATE State)
+{
+    RtlZeroMemory(State, sizeof(*State));
+    State->SequenceInverse = ~(ULONG)0;
+    State->Checksum = PUSH_LOCK_CHECKSUM_XOR;
+}
+
+static
+VOID
+PushLockInitializeThreadContext(
+    _Out_ PPUSH_LOCK_THREAD_CONTEXT Context,
+    _Inout_ PPUSH_LOCK_TEST_STATE State,
+    _In_ PUSH_LOCK_MODE Mode,
+    _In_ PUSH_LOCK_RELEASE_KIND ReleaseKind)
+{
+    RtlZeroMemory(Context, sizeof(*Context));
+
+    Context->State = State;
+    Context->Mode = Mode;
+    Context->ReleaseKind = ReleaseKind;
+
+    KeInitializeEvent(&Context->ReadyEvent, NotificationEvent, FALSE);
+    KeInitializeEvent(&Context->AcquiredEvent, NotificationEvent, FALSE);
+    KeInitializeEvent(&Context->ReleaseEvent, NotificationEvent, FALSE);
+    KeInitializeEvent(&Context->DoneEvent, NotificationEvent, FALSE);
+}
+
+/*
+ * A controlled waiter acquires once and then remains in the protected region
+ * until the test releases it. This makes queue construction and waking
+ * observable without relying on timing after acquisition.
+ */
+static
+VOID
+NTAPI
+PushLockControlledThread(
+    _In_ PVOID Parameter)
+{
+    PPUSH_LOCK_THREAD_CONTEXT Context;
+    PPUSH_LOCK_TEST_STATE State;
+    NTSTATUS Status;
+
+    Context = (PPUSH_LOCK_THREAD_CONTEXT)Parameter;
+    State = Context->State;
+
+    /* ReadyEvent reports only that the thread is running. It may still be held
+       behind StartGate and hasn't yet attempted to acquire the push lock. */
+    KeSetEvent(&Context->ReadyEvent, IO_NO_INCREMENT, FALSE);
+
+    if (Context->StartGate != NULL)
+    {
+        Status = KeWaitForSingleObject(Context->StartGate,
+                                       Executive,
+                                       KernelMode,
+                                       FALSE,
+                                       NULL);
+        if (Status != STATUS_SUCCESS)
+        {
+            PushLockRecordViolation(State);
+            KeSetEvent(&Context->DoneEvent, IO_NO_INCREMENT, FALSE);
+            return;
+        }
+    }
+
+    KeEnterCriticalRegion();
+
+    PushLockAcquire(&State->Lock, Context->Mode);
+    PushLockEnterProtectedRegion(State, Context->Mode);
+
+    /* Publish acquisition only after updating the ownership counters,
+       so the controlling thread can inspect a consistent protected
+       state after this event is signaled */
+    KeSetEvent(&Context->AcquiredEvent, IO_NO_INCREMENT, FALSE);
+
+    /* Remain inside the protected region until the test has inspected the lock
+       word and waiter chain for this acquisition */
+    Status = KeWaitForSingleObject(&Context->ReleaseEvent,
+                                   Executive,
+                                   KernelMode,
+                                   FALSE,
+                                   NULL);
+    if (Status != STATUS_SUCCESS)
+    {
+        PushLockRecordViolation(State);
+    }
+
+    PushLockLeaveProtectedRegion(State, Context->Mode);
+    PushLockRelease(&State->Lock, Context->Mode, Context->ReleaseKind);
+
+    KeLeaveCriticalRegion();
+
+    KeSetEvent(&Context->DoneEvent, IO_NO_INCREMENT, FALSE);
+}
+
+static
+BOOLEAN
+PushLockStartControlledThread(
+    _Inout_ PPUSH_LOCK_THREAD_CONTEXT Context,
+    _Out_ PKTHREAD *Thread)
+{
+    NTSTATUS Status;
+
+    *Thread = KmtStartThread(PushLockControlledThread, Context);
+    if (*Thread == NULL)
+    {
+        ok(FALSE, "Could not create push-lock test thread\n");
+        return FALSE;
+    }
+
+    /* Don't examine the queue until the worker has started.
+       N.B. ReadyEvent doesn't imply that acquisition or queue
+            insertion has completed. */
+    Status = PushLockWaitForEvent(&Context->ReadyEvent);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+
+    return Status == STATUS_SUCCESS;
+}
+
+static
+VOID
+PushLockReleaseAndFinishThread(
+    _In_opt_ PKTHREAD Thread,
+    _Inout_ PPUSH_LOCK_THREAD_CONTEXT Context)
+{
+    NTSTATUS Status;
+
+    if (Thread == NULL)
+    {
+        return;
+    }
+
+    KeSetEvent(&Context->ReleaseEvent, IO_NO_INCREMENT, FALSE);
+
+    Status = PushLockWaitForEvent(&Context->DoneEvent);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+
+    KmtFinishThread(Thread, NULL);
+}
+
+/*
+ * Wait blocks are inserted in the newest-first manner. Once list optimization completes,
+ * Head->Last points to the oldest waiter and Previous links point toward newer
+ * waiters. The oldest block's Next field isn't a list terminator and isn't
+ * inspected.
+ *
+ * ExpectedNewestFirst describes the expected waiter modes starting at the
+ * wait block stored in the push lock and ending with the oldest waiter.
+ *
+ * The lock must remain owned while the chain is examined. InProgress is
+ * returned while an expected waiter hasn't yet been inserted or while list
+ * optimization is still in progress.
+ */
+static
+PUSH_LOCK_WAIT_CHAIN_STATE
+PushLockValidateWaitChain(
+    _In_ PEX_PUSH_LOCK PushLock,
+    _In_reads_(ExpectedCount) const PUSH_LOCK_MODE *ExpectedNewestFirst,
+    _In_ ULONG ExpectedCount,
+    _Out_opt_ PEX_PUSH_LOCK_WAIT_BLOCK *OldestWaitBlock)
+{
+    EX_PUSH_LOCK Value;
+    EX_PUSH_LOCK CurrentValue;
+    PVOID Seen[PUSH_LOCK_MAX_WAITERS];
+    PUSH_LOCK_MODE ActualNewestFirst[PUSH_LOCK_MAX_WAITERS];
+    PEX_PUSH_LOCK_WAIT_BLOCK Head;
+    PEX_PUSH_LOCK_WAIT_BLOCK Current;
+    PEX_PUSH_LOCK_WAIT_BLOCK Previous;
+    PEX_PUSH_LOCK_WAIT_BLOCK Last;
+    ULONG ActualCount;
+    ULONG Index;
+    ULONG SeenIndex;
+    LONG Flags;
+
+    if (ExpectedCount == 0 || ExpectedCount > PUSH_LOCK_MAX_WAITERS)
+    {
+        return PushLockWaitChainInvalid;
+    }
+
+    Value = PushLockReadValue(PushLock);
+
+    if (!PushLockValueIsPlausible(Value))
+    {
+        return PushLockWaitChainInvalid;
+    }
+
+    /* The tests keep an owner in place while constructing the queue.
+       Waiting may still be clear until the expected waiter is inserted,
+       and Waking remains set while the list links are being optimized. */
+    if (!Value.Locked)
+    {
+        return PushLockWaitChainInvalid;
+    }
+
+    if (!Value.Waiting || Value.Waking)
+    {
+        return PushLockWaitChainInProgress;
+    }
+
+    Head = (PEX_PUSH_LOCK_WAIT_BLOCK)(Value.Value & ~EX_PUSH_LOCK_PTR_BITS);
+    if (!MmIsAddressValid(Head))
+    {
+        return PushLockWaitChainInvalid;
+    }
+
+    Last = Head->Last;
+    if (Last == NULL)
+        goto CheckForConcurrentChange;
+
+    if (((ULONG_PTR)Last & EX_PUSH_LOCK_PTR_BITS) != 0 || !MmIsAddressValid(Last))
+    {
+        return PushLockWaitChainInvalid;
+    }
+
+    RtlZeroMemory(Seen, sizeof(Seen));
+
+    Current = Head;
+    Previous = NULL;
+    ActualCount = 0;
+
+    for (Index = 0; Index < PUSH_LOCK_MAX_WAITERS; Index++)
+    {
+        if (Current == NULL)
+        {
+            return PushLockWaitChainInvalid;
+        }
+
+        if (!MmIsAddressValid(Current))
+        {
+            return PushLockWaitChainInvalid;
+        }
+
+        if (((ULONG_PTR)Current & EX_PUSH_LOCK_PTR_BITS) != 0)
+        {
+            return PushLockWaitChainInvalid;
+        }
+
+        for (SeenIndex = 0; SeenIndex < ActualCount; SeenIndex++)
+        {
+            if (Seen[SeenIndex] == Current)
+            {
+                return PushLockWaitChainInvalid;
+            }
+        }
+
+        Seen[ActualCount] = Current;
+
+        /* Previous links are built by ExpOptimizePushLockList. If the
+           push lock value changed while examining them, retry after the
+           concurrent insertion/optimization completes. */
+        if (Current->Previous != Previous)
+        {
+            goto CheckForConcurrentChange;
+        }
+
+        Flags = Current->Flags;
+
+        /* WAIT is the wake/sleep handshake bit and may already be clear.
+           EXCLUSIVE records the acquisition mode. No other flag bits are
+           valid for these wait blocks. */
+        if (Flags & ~(EX_PUSH_LOCK_FLAGS_EXCLUSIVE | EX_PUSH_LOCK_FLAGS_WAIT))
+        {
+            return PushLockWaitChainInvalid;
+        }
+
+        ActualNewestFirst[ActualCount] = Flags & EX_PUSH_LOCK_FLAGS_EXCLUSIVE
+                                             ? PushLockModeExclusive
+                                             : PushLockModeShared;
+
+        ActualCount++;
+
+        if (Current == Last)
+        {
+            break;
+        }
+
+        Previous = Current;
+        Current = Current->Next;
+    }
+
+    if (Current != Last)
+        return PushLockWaitChainInvalid;
+
+    /* Make sure the lock word didn't change while the non-atomic wait block
+       links were being examined */
+    CurrentValue = PushLockReadValue(PushLock);
+    if (CurrentValue.Value != Value.Value)
+    {
+        return PushLockWaitChainInProgress;
+    }
+
+    /* A shorter chain means that not all expected waiters have been queued yet.
+       Additional waiters are invalid because the tests construct the queue in
+       controlled steps. */
+    if (ActualCount < ExpectedCount)
+    {
+        return PushLockWaitChainInProgress;
+    }
+
+    if (ActualCount > ExpectedCount)
+    {
+        return PushLockWaitChainInvalid;
+    }
+
+    for (Index = 0; Index < ExpectedCount; Index++)
+    {
+        /* EXCLUSIVE is the persistent mode bit, so the stable chain must
+           match the acquisition modes requested by the test */
+        if (ActualNewestFirst[Index] != ExpectedNewestFirst[Index])
+        {
+            return PushLockWaitChainInvalid;
+        }
+    }
+
+    if (OldestWaitBlock != NULL)
+    {
+        *OldestWaitBlock = Last;
+    }
+
+    return PushLockWaitChainStable;
+
+CheckForConcurrentChange:
+
+    CurrentValue = PushLockReadValue(PushLock);
+    if (CurrentValue.Value != Value.Value)
+    {
+        return PushLockWaitChainInProgress;
+    }
+
+    return PushLockWaitChainInvalid;
+}
+
+/*
+ * ExpectedNewestFirst describes the expected mode of each waiter,
+ * starting with the wait block encoded in the push lock and ending
+ * with the oldest wait block.
+ */
+static
+BOOLEAN
+PushLockWaitForStableWaitChain(
+    _In_ PEX_PUSH_LOCK PushLock,
+    _In_reads_(ExpectedCount) const PUSH_LOCK_MODE *ExpectedNewestFirst,
+    _In_ ULONG ExpectedCount,
+    _Out_opt_ PEX_PUSH_LOCK_WAIT_BLOCK *OldestWaitBlock)
+{
+    PUSH_LOCK_WAIT_CHAIN_STATE ChainState;
+    ULONG Elapsed;
+
+    /* Queue insertion and list optimization are separate operations. Poll until
+       the waiter chain reaches the backward linked form required by the
+       structural checks below. */
+    for (Elapsed = 0;
+         Elapsed < PUSH_LOCK_TIMEOUT_MS;
+         Elapsed += PUSH_LOCK_POLL_INTERVAL_MS)
+    {
+        ChainState = PushLockValidateWaitChain(PushLock,
+                                               ExpectedNewestFirst,
+                                               ExpectedCount,
+                                               OldestWaitBlock);
+
+        if (ChainState == PushLockWaitChainStable)
+        {
+            return TRUE;
+        }
+
+        if (ChainState == PushLockWaitChainInvalid)
+        {
+            return FALSE;
+        }
+
+        PushLockDelay();
+    }
+
+    return FALSE;
+}
+
+/* Verify the exact lock word encodings used by uncontended operations. */
+static
+VOID
+TestPushLockUncontended(
+    _In_ PUSH_LOCK_RELEASE_KIND ReleaseKind)
+{
+    PUSH_LOCK_TEST_STATE State;
+    EX_PUSH_LOCK Value;
+    ULONG Count;
+
+    PushLockInitializeState(&State);
+    ok_eq_ulongptr(State.Lock.Value, 0);
+
+    KeEnterCriticalRegion();
+
+    /* An uncontended exclusive acquisition is represented by the Locked bit alone */
+    ExfAcquirePushLockExclusive(&State.Lock);
+    ok_eq_ulongptr(PushLockReadValue(&State.Lock).Value, EX_PUSH_LOCK_LOCK);
+
+    PushLockRelease(&State.Lock, PushLockModeExclusive, ReleaseKind);
+    ok_eq_ulongptr(PushLockReadValue(&State.Lock).Value, 0);
+
+    /* In the uncontended shared form, the lock word contains Locked plus one
+       EX_PUSH_LOCK_SHARE_INC for each shared acquisition */
+    for (Count = 1; Count <= 4; Count++)
+    {
+        ExfAcquirePushLockShared(&State.Lock);
+        Value = PushLockReadValue(&State.Lock);
+        ok_eq_ulongptr(Value.Value, EX_PUSH_LOCK_LOCK + Count * EX_PUSH_LOCK_SHARE_INC);
+    }
+
+    /* Verify every intermediate shared count, including the transition from the
+       final shared owner back to the zero lock word */
+    for (Count = 4; Count > 0; Count--)
+    {
+        PushLockRelease(&State.Lock, PushLockModeShared, ReleaseKind);
+        Value = PushLockReadValue(&State.Lock);
+
+        if (Count == 1)
+        {
+            ok_eq_ulongptr(Value.Value, 0);
+        }
+        else
+        {
+            ok_eq_ulongptr(Value.Value,
+                           EX_PUSH_LOCK_LOCK + (Count - 1) * EX_PUSH_LOCK_SHARE_INC);
+        }
+    }
+
+    KeLeaveCriticalRegion();
+}
+
+/*
+ * Queue one exclusive waiter followed by two shared waiters. The oldest
+ * exclusive waiter must be selected alone. After it releases, the two readers
+ * may acquire together.
+ */
+static
+VOID
+TestPushLockWaiterSelection(VOID)
+{
+    static const PUSH_LOCK_MODE Modes[] = {
+        PushLockModeExclusive,
+        PushLockModeShared,
+        PushLockModeShared
+    };
+    static const PUSH_LOCK_MODE ExpectedOne[] = {PushLockModeExclusive};
+    static const PUSH_LOCK_MODE ExpectedTwo[] = {
+        PushLockModeShared,
+        PushLockModeExclusive
+    };
+    static const PUSH_LOCK_MODE ExpectedThree[] = {
+        PushLockModeShared,
+        PushLockModeShared,
+        PushLockModeExclusive
+    };
+    static const PUSH_LOCK_MODE ExpectedReaders[] = {
+        PushLockModeShared,
+        PushLockModeShared
+    };
+    const PUSH_LOCK_MODE *Expected[] = {
+        ExpectedOne,
+        ExpectedTwo,
+        ExpectedThree
+    };
+    PUSH_LOCK_TEST_STATE State;
+    PUSH_LOCK_THREAD_CONTEXT Contexts[RTL_NUMBER_OF(Modes)];
+    PKTHREAD Threads[RTL_NUMBER_OF(Modes)] = {NULL};
+    NTSTATUS Status;
+    ULONG Started;
+    ULONG Index;
+
+    PushLockInitializeState(&State);
+    Started = 0;
+
+    /* Hold the lock while constructing the waiter chain. Starting each waiter
+       separately makes the newest-to-oldest order deterministic. */
+
+    KeEnterCriticalRegion();
+
+    ExfAcquirePushLockExclusive(&State.Lock);
+
+    /* The resulting chains are:
+        o exclusive
+        o shared -> exclusive
+        o shared -> shared -> exclusive
+       where the leftmost entry is the newest waiter */
+
+    for (Index = 0; Index < RTL_NUMBER_OF(Modes); Index++)
+    {
+        PushLockInitializeThreadContext(&Contexts[Index],
+                                        &State,
+                                        Modes[Index],
+                                        PushLockReleaseSpecific);
+
+        if (!PushLockStartControlledThread(&Contexts[Index], &Threads[Index]))
+        {
+            if (Threads[Index] != NULL)
+            {
+                Started++;
+            }
+            break;
+        }
+
+        Started++;
+
+        ok(PushLockWaitForStableWaitChain(&State.Lock, Expected[Index], Index + 1, NULL),
+           "Wait chain did not stabilize after waiter %lu\n", Index);
+    }
+
+    /* The oldest waiter is exclusive, so releasing the owner must select only
+       that waiter and leave both shared waiters queued */
+    ExfReleasePushLockExclusive(&State.Lock);
+
+    KeLeaveCriticalRegion();
+
+    if (Started == RTL_NUMBER_OF(Modes))
+    {
+        Status = PushLockWaitForEvent(&Contexts[0].AcquiredEvent);
+        ok_eq_hex(Status, STATUS_SUCCESS);
+
+        ok_eq_long(KeReadStateEvent(&Contexts[1].AcquiredEvent), 0);
+        ok_eq_long(KeReadStateEvent(&Contexts[2].AcquiredEvent), 0);
+
+        /* Once the x waiter owns the lock, the two newer s waiters must
+           still form the complete remaining wait chain */
+        ok(PushLockWaitForStableWaitChain(&State.Lock, ExpectedReaders,
+               RTL_NUMBER_OF(ExpectedReaders), NULL),
+           "Reader wait chain is invalid while the writer owns the lock\n");
+
+        /* Releasing the oldest x waiter permits the remaining s batch to acquire together */
+        PushLockReleaseAndFinishThread(Threads[0], &Contexts[0]);
+        Threads[0] = NULL;
+
+        Status = PushLockWaitForEvent(&Contexts[1].AcquiredEvent);
+        ok_eq_hex(Status, STATUS_SUCCESS);
+        Status = PushLockWaitForEvent(&Contexts[2].AcquiredEvent);
+        ok_eq_hex(Status, STATUS_SUCCESS);
+
+        ok_eq_long(State.ActiveReaders, 2);
+        ok_eq_long(State.ActiveWriters, 0);
+        ok_eq_ulongptr(PushLockReadValue(&State.Lock).Value,
+                       EX_PUSH_LOCK_LOCK + 2 * EX_PUSH_LOCK_SHARE_INC);
+    }
+
+    for (Index = 0; Index < Started; Index++)
+    {
+        if (Threads[Index] != NULL)
+        {
+            PushLockReleaseAndFinishThread(Threads[Index], &Contexts[Index]);
+            Threads[Index] = NULL;
+        }
+    }
+
+    ok_eq_long(State.ActiveReaders, 0);
+    ok_eq_long(State.ActiveWriters, 0);
+    ok_eq_long(State.Violations, 0);
+    ok_eq_ulongptr(PushLockReadValue(&State.Lock).Value, 0);
+}
+
+/*
+ * When an x waiter is queued behind several s acquisitions, the
+ * oldest wait block stores the number of outstanding shares.
+ * A newer s waiter must remain queued until the x waiter has acquired and
+ * released the lock.
+ */
+static
+VOID
+TestPushLockSharedOwnerDrain(
+    _In_ PUSH_LOCK_RELEASE_KIND ReleaseKind)
+{
+    /*
+     * shared
+     * shared
+     * shared
+     *   |
+     *   v
+     * exclusive waiter     <- oldest, ShareCount = 3
+     *   |
+     *   v
+     * shared waiter        <- newest
+     *   |
+     *   v
+     * release share        ShareCount = 2, nobody wakes
+     * release share        ShareCount = 1, nobody wakes
+     * release share        ShareCount = 0
+     *   |
+     *   v
+     * exclusive wakes      shared MUST remain queued
+     *   |
+     *   v
+     * exclusive releases
+     *   |
+     *   v
+     * shared wakes
+     */
+    static const PUSH_LOCK_MODE ExpectedExclusive[] = {PushLockModeExclusive};
+    static const PUSH_LOCK_MODE ExpectedBoth[] = {PushLockModeShared, PushLockModeExclusive};
+    static const PUSH_LOCK_MODE ExpectedShared[] = {PushLockModeShared};
+    PUSH_LOCK_TEST_STATE State;
+    PUSH_LOCK_THREAD_CONTEXT ExclusiveContext;
+    PUSH_LOCK_THREAD_CONTEXT SharedContext;
+    PKTHREAD ExclusiveThread;
+    PKTHREAD SharedThread;
+    PEX_PUSH_LOCK_WAIT_BLOCK OldestWaitBlock;
+    EX_PUSH_LOCK Value;
+    NTSTATUS Status;
+    BOOLEAN Success;
+    ULONG Count;
+
+    PushLockInitializeState(&State);
+    ExclusiveThread = NULL;
+    SharedThread = NULL;
+    OldestWaitBlock = NULL;
+
+    PushLockInitializeThreadContext(&ExclusiveContext,
+                                    &State,
+                                    PushLockModeExclusive,
+                                    PushLockReleaseSpecific);
+
+    PushLockInitializeThreadContext(&SharedContext,
+                                    &State,
+                                    PushLockModeShared,
+                                    PushLockReleaseSpecific);
+
+    KeEnterCriticalRegion();
+
+    /* 3 shared acquisitions force the 1st x waiter to use
+       MultipleShared and store the outstanding count in its wait block */
+    for (Count = 0; Count < 3; Count++)
+    {
+        ExfAcquirePushLockShared(&State.Lock);
+    }
+
+    if (!PushLockStartControlledThread(&ExclusiveContext, &ExclusiveThread))
+    {
+        goto Cleanup;
+    }
+
+    Success = PushLockWaitForStableWaitChain(&State.Lock,
+                                             ExpectedExclusive,
+                                             RTL_NUMBER_OF(ExpectedExclusive),
+                                             &OldestWaitBlock);
+    ok(Success, "Exclusive waiter did not reach a stable wait state\n");
+    if (!Success)
+    {
+        goto Cleanup;
+    }
+
+    /* Queue an s waiter after the x waiter. Since Waiting is already set,
+       it must queue instead of joining the current s owners */
+    if (!PushLockStartControlledThread(&SharedContext, &SharedThread))
+    {
+        goto Cleanup;
+    }
+
+    Success = PushLockWaitForStableWaitChain(&State.Lock,
+                                             ExpectedBoth,
+                                             RTL_NUMBER_OF(ExpectedBoth),
+                                             &OldestWaitBlock);
+    ok(Success, "Exclusive/shared wait chain did not stabilize\n");
+    if (!Success)
+    {
+        goto Cleanup;
+    }
+
+    Value = PushLockReadValue(&State.Lock);
+    ok(Value.Locked, "Push lock is not locked\n");
+    ok(Value.Waiting, "Push lock has no waiters\n");
+    ok(!Value.Waking, "Push lock is waking\n");
+    ok(Value.MultipleShared, "MultipleShared is not set\n");
+
+    if (OldestWaitBlock != NULL)
+    {
+        ok_eq_long(OldestWaitBlock->ShareCount, 3);
+        ok(OldestWaitBlock->Flags & EX_PUSH_LOCK_FLAGS_EXCLUSIVE, "Oldest waiter is not exclusive\n");
+    }
+
+    /* The first 2 releases only decrement the saved shared count.
+       Neither waiter may acquire while an existing s owner remains. */
+    for (Count = 3; Count > 1; Count--)
+    {
+        PushLockRelease(&State.Lock, PushLockModeShared, ReleaseKind);
+
+        if (OldestWaitBlock != NULL)
+        {
+            ok_eq_long(OldestWaitBlock->ShareCount, Count - 1);
+        }
+
+        Value = PushLockReadValue(&State.Lock);
+        ok(Value.Locked, "Push lock is not locked while shares remain\n");
+        ok(Value.Waiting, "Push lock has no waiters while shares remain\n");
+        ok(Value.MultipleShared, "MultipleShared is not set while shares remain\n");
+
+        ok_eq_long(KeReadStateEvent(&ExclusiveContext.AcquiredEvent), 0);
+        ok_eq_long(KeReadStateEvent(&SharedContext.AcquiredEvent), 0);
+    }
+
+    /* The final s release must select the oldest x waiter.
+       The newer s waiter must remain queued behind it. */
+    PushLockRelease(&State.Lock, PushLockModeShared, ReleaseKind);
+
+    KeLeaveCriticalRegion();
+
+    Status = PushLockWaitForEvent(&ExclusiveContext.AcquiredEvent);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+
+    if (Status != STATUS_SUCCESS)
+    {
+        /* Allow either waiter to finish if the expected handoff failed.
+           Signaling both avoids making cleanup depend on which one acquired. */
+        KeSetEvent(&ExclusiveContext.ReleaseEvent, IO_NO_INCREMENT, FALSE);
+        KeSetEvent(&SharedContext.ReleaseEvent, IO_NO_INCREMENT, FALSE);
+
+        PushLockReleaseAndFinishThread(ExclusiveThread, &ExclusiveContext);
+        PushLockReleaseAndFinishThread(SharedThread, &SharedContext);
+        return;
+    }
+
+    ok_eq_long(KeReadStateEvent(&SharedContext.AcquiredEvent), 0);
+    ok_eq_long(State.ActiveWriters, 1);
+    ok_eq_long(State.ActiveReaders, 0);
+
+    /* While the x waiter owns the lock, the newer s waiter must still be
+       the complete remaining wait chain */
+    Success = PushLockWaitForStableWaitChain(&State.Lock,
+                                             ExpectedShared,
+                                             RTL_NUMBER_OF(ExpectedShared),
+                                             NULL);
+    ok(Success, "Shared waiter did not remain queued behind the exclusive owner\n");
+
+    /* Releasing the x owner now permits the remaining s waiter to acquire */
+    PushLockReleaseAndFinishThread(ExclusiveThread, &ExclusiveContext);
+    ExclusiveThread = NULL;
+
+    Status = PushLockWaitForEvent(&SharedContext.AcquiredEvent);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+
+    if (Status == STATUS_SUCCESS)
+    {
+        ok_eq_long(State.ActiveWriters, 0);
+        ok_eq_long(State.ActiveReaders, 1);
+    }
+
+    PushLockReleaseAndFinishThread(SharedThread, &SharedContext);
+    SharedThread = NULL;
+
+    ok_eq_long(State.ActiveReaders, 0);
+    ok_eq_long(State.ActiveWriters, 0);
+    ok_eq_long(State.Violations, 0);
+    ok_eq_ulongptr(PushLockReadValue(&State.Lock).Value, 0);
+
+    return;
+
+Cleanup:
+
+    /* Let any successfully started waiter leave immediately after acquiring,
+       regardless of how far queue construction progressed */
+    if (ExclusiveThread != NULL)
+    {
+        KeSetEvent(&ExclusiveContext.ReleaseEvent, IO_NO_INCREMENT, FALSE);
+    }
+
+    if (SharedThread != NULL)
+    {
+        KeSetEvent(&SharedContext.ReleaseEvent, IO_NO_INCREMENT, FALSE);
+    }
+
+    for (Count = 0; Count < 3; Count++)
+    {
+        PushLockRelease(&State.Lock, PushLockModeShared, ReleaseKind);
+    }
+
+    KeLeaveCriticalRegion();
+
+    PushLockReleaseAndFinishThread(ExclusiveThread, &ExclusiveContext);
+    PushLockReleaseAndFinishThread(SharedThread, &SharedContext);
+}
+
+/*
+ * TLA counter example: 1 waiter is already queued while another waiter is
+ * allowed to arrive as the final shared owner releases.
+ * A black box test can't stop the release routine between its load and cmpxchg,
+ * so this only stresses the window...
+ */
+static
+VOID
+TestPushLockWaiterArrivalDuringRelease(VOID)
+{
+    static const PUSH_LOCK_MODE ExpectedOldest[] = {PushLockModeExclusive};
+    PUSH_LOCK_TEST_STATE State;
+    PUSH_LOCK_THREAD_CONTEXT OldestContext;
+    PUSH_LOCK_THREAD_CONTEXT NewestContext;
+    PKTHREAD OldestThread;
+    PKTHREAD NewestThread;
+    KEVENT StartGate;
+    PUSH_LOCK_RELEASE_KIND ReleaseKind;
+    ULONG Iteration;
+
+    for (Iteration = 0; Iteration < PUSH_LOCK_RACE_ITERATIONS; Iteration++)
+    {
+        PushLockInitializeState(&State);
+        OldestThread = NULL;
+        NewestThread = NULL;
+        KeInitializeEvent(&StartGate, NotificationEvent, FALSE);
+
+        KeEnterCriticalRegion();
+        ExfAcquirePushLockShared(&State.Lock);
+
+        PushLockInitializeThreadContext(&OldestContext,
+                                        &State,
+                                        PushLockModeExclusive,
+                                        PushLockReleaseSpecific);
+        if (!PushLockStartControlledThread(&OldestContext, &OldestThread))
+        {
+            ExfReleasePushLockShared(&State.Lock);
+            KeLeaveCriticalRegion();
+            PushLockReleaseAndFinishThread(OldestThread, &OldestContext);
+            continue;
+        }
+
+        ok(PushLockWaitForStableWaitChain(&State.Lock, ExpectedOldest,
+               RTL_NUMBER_OF(ExpectedOldest), NULL),
+           "Oldest waiter did not stabilize at iteration %lu\n",
+           Iteration);
+
+        PushLockInitializeThreadContext(&NewestContext,
+                                        &State,
+                                        PushLockModeExclusive,
+                                        PushLockReleaseSpecific);
+        NewestContext.StartGate = &StartGate;
+
+        if (!PushLockStartControlledThread(&NewestContext, &NewestThread))
+        {
+            KeSetEvent(&StartGate, IO_NO_INCREMENT, FALSE);
+            ExfReleasePushLockShared(&State.Lock);
+            KeLeaveCriticalRegion();
+            PushLockReleaseAndFinishThread(OldestThread, &OldestContext);
+            PushLockReleaseAndFinishThread(NewestThread, &NewestContext);
+            continue;
+        }
+
+        /* Don't hold either waiter after acquisition. The test is interested in
+           completion of the entire queue, not in inspecting an intermediate owner... */
+        KeSetEvent(&OldestContext.ReleaseEvent, IO_NO_INCREMENT, FALSE);
+        KeSetEvent(&NewestContext.ReleaseEvent, IO_NO_INCREMENT, FALSE);
+
+        /* Exercise the same arrival window through both the s specific and
+           generic release */
+        ReleaseKind = (Iteration & 1)
+                          ? PushLockReleaseGeneric
+                          : PushLockReleaseSpecific;
+
+        /* Make the new waiter ready immediately before the final shared release.
+           The scheduler may insert it before or during the release. This can't
+           force the exact load/CAS interleaving, but repeatedly exposes the
+           implementation to the execution found by the tla */
+        KeSetEvent(&StartGate, IO_NO_INCREMENT, FALSE);
+        PushLockRelease(&State.Lock, PushLockModeShared, ReleaseKind);
+
+        KeLeaveCriticalRegion();
+
+        PushLockReleaseAndFinishThread(OldestThread, &OldestContext);
+        PushLockReleaseAndFinishThread(NewestThread, &NewestContext);
+
+        ok_eq_long(KeReadStateEvent(&OldestContext.AcquiredEvent), 1);
+        ok_eq_long(KeReadStateEvent(&NewestContext.AcquiredEvent), 1);
+        ok_eq_long(State.Violations, 0);
+        ok_eq_ulongptr(PushLockReadValue(&State.Lock).Value, 0);
+    }
+}
+
+/*
+ * The contention workers use fixed roles and a deterministic release pattern.
+ * 2 writers and 4 readers start together, repeatedly validate protected data,
+ * adn use both the generic and mode specific releases.
+ */
+static
+VOID
+NTAPI
+PushLockContentionThread(
+    _In_ PVOID Parameter)
+{
+    PPUSH_LOCK_THREAD_CONTEXT Context;
+    PPUSH_LOCK_TEST_STATE State;
+    PUSH_LOCK_RELEASE_KIND ReleaseKind;
+    NTSTATUS Status;
+    ULONG Iteration;
+
+    Context = Parameter;
+    State = Context->State;
+
+    KeSetEvent(&Context->ReadyEvent, IO_NO_INCREMENT, FALSE);
+
+    Status = KeWaitForSingleObject(Context->StartGate,
+                                   Executive,
+                                   KernelMode,
+                                   FALSE,
+                                   NULL);
+    if (Status != STATUS_SUCCESS)
+    {
+        PushLockRecordViolation(State);
+        KeSetEvent(&Context->DoneEvent, IO_NO_INCREMENT, FALSE);
+        return;
+    }
+
+    for (Iteration = 0; Iteration < Context->Iterations; Iteration++)
+    {
+        /* Alternate release per worker and iteration so every role uses
+           both the generic and mode specific release functions */
+        ReleaseKind = ((Iteration + Context->Index) & 1)
+                          ? PushLockReleaseGeneric
+                          : PushLockReleaseSpecific;
+
+        KeEnterCriticalRegion();
+
+        PushLockAcquire(&State->Lock, Context->Mode);
+        /* The ownership counters and protected value checks validate the
+           exclusion contract without relying on the internal push lock fields */
+        PushLockEnterProtectedRegion(State, Context->Mode);
+
+        if (Context->Mode == PushLockModeExclusive)
+        {
+            PushLockWriteProtectedValue(State);
+        }
+        else
+        {
+            PushLockReadProtectedValue(State);
+        }
+
+        PushLockLeaveProtectedRegion(State, Context->Mode);
+        PushLockRelease(&State->Lock, Context->Mode, ReleaseKind);
+
+        KeLeaveCriticalRegion();
+
+        InterlockedIncrement(&State->CompletedOperations);
+
+        /* Occasionally sample the encoded lock state and yield to increase useful nterleavings */
+        if ((Iteration & 0x3f) == 0)
+        {
+            PushLockSampleState(State);
+            YieldProcessor();
+        }
+    }
+
+    KeSetEvent(&Context->DoneEvent, IO_NO_INCREMENT, FALSE);
+}
+
+static
+VOID
+TestPushLockContention(VOID)
+{
+    PUSH_LOCK_TEST_STATE State;
+    PUSH_LOCK_THREAD_CONTEXT Contexts[PUSH_LOCK_CONTENTION_THREADS];
+    PKTHREAD Threads[PUSH_LOCK_CONTENTION_THREADS] = {NULL};
+    KEVENT StartGate;
+    NTSTATUS Status;
+    ULONG Index;
+    ULONG Started;
+    ULONG WriterCount;
+    ULONG ReaderCount;
+
+    PushLockInitializeState(&State);
+    KeInitializeEvent(&StartGate, NotificationEvent, FALSE);
+
+    Started = 0;
+    WriterCount = 0;
+    ReaderCount = 0;
+
+    for (Index = 0; Index < PUSH_LOCK_CONTENTION_THREADS; Index++)
+    {
+        PUSH_LOCK_MODE Mode;
+
+        /* Threads 0 and 3 are writers; the remaining 4 are readers */
+        Mode = ((Index % 3) == 0) ? PushLockModeExclusive : PushLockModeShared;
+
+        if (Mode == PushLockModeExclusive)
+        {
+            WriterCount++;
+        }
+        else
+        {
+            ReaderCount++;
+        }
+
+        PushLockInitializeThreadContext(&Contexts[Index],
+                                        &State,
+                                        Mode,
+                                        PushLockReleaseSpecific);
+        Contexts[Index].StartGate = &StartGate;
+        Contexts[Index].Index = Index;
+        Contexts[Index].Iterations = PUSH_LOCK_CONTENTION_ITERATIONS;
+
+        Threads[Index] = KmtStartThread(PushLockContentionThread,
+                                        &Contexts[Index]);
+        if (Threads[Index] == NULL)
+        {
+            ok(FALSE, "Could not create contention thread %lu\n", Index);
+            break;
+        }
+
+        Started++;
+
+        Status = PushLockWaitForEvent(&Contexts[Index].ReadyEvent);
+        ok_eq_hex(Status, STATUS_SUCCESS);
+
+        if (Status != STATUS_SUCCESS)
+        {
+            break;
+        }
+    }
+
+    /* Release all successfully created workers together so their first
+       acquisitions contend on the same initially unlocked push lock */
+    KeSetEvent(&StartGate, IO_NO_INCREMENT, FALSE);
+
+    for (Index = 0; Index < Started; Index++)
+    {
+        Status = PushLockWaitForEvent(&Contexts[Index].DoneEvent);
+        ok_eq_hex(Status, STATUS_SUCCESS);
+        KmtFinishThread(Threads[Index], NULL);
+    }
+
+    ok_eq_long(State.ActiveReaders, 0);
+    ok_eq_long(State.ActiveWriters, 0);
+    ok_eq_long(State.Violations, 0);
+    ok_eq_long(State.CompletedOperations,
+               (LONG)(Started * PUSH_LOCK_CONTENTION_ITERATIONS));
+
+    if (Started == PUSH_LOCK_CONTENTION_THREADS)
+    {
+        ok_eq_long(State.ExclusiveAcquisitions,
+                   (LONG)(WriterCount * PUSH_LOCK_CONTENTION_ITERATIONS));
+        ok_eq_long(State.SharedAcquisitions,
+                   (LONG)(ReaderCount * PUSH_LOCK_CONTENTION_ITERATIONS));
+    }
+
+    ok_eq_ulongptr(PushLockReadValue(&State.Lock).Value, 0);
+}
+
+START_TEST(ExPushLock)
+{
+    TestPushLockUncontended(PushLockReleaseSpecific);
+    TestPushLockUncontended(PushLockReleaseGeneric);
+
+    TestPushLockWaiterSelection();
+
+    TestPushLockSharedOwnerDrain(PushLockReleaseSpecific);
+    TestPushLockSharedOwnerDrain(PushLockReleaseGeneric);
+
+    TestPushLockWaiterArrivalDuringRelease();
+    TestPushLockContention();
+}

--- a/ntoskrnl/ex/pushlock.c
+++ b/ntoskrnl/ex/pushlock.c
@@ -812,96 +812,104 @@ ExfReleasePushLock(PEX_PUSH_LOCK PushLock)
     EX_PUSH_LOCK OldValue = *PushLock, NewValue, WakeValue;
     PEX_PUSH_LOCK_WAIT_BLOCK WaitBlock, LastWaitBlock;
 
-    /* Sanity check */
+    /* The caller must hold the push lock */
     ASSERT(OldValue.Locked);
 
-    /* Start main loop */
     while (TRUE)
     {
-        /* Check if someone is waiting on the lock */
+        /*
+         * Without waiters, the upper bits contain the shared acquisition count.
+         * Drop one shared acquisition, or clear the lock word when releasing the
+         * final owner.
+         *
+         * A waiter may be inserted before the CMPXCHG completes. If that happens,
+         * continue using the value returned by the failed operation.
+         */
         if (!OldValue.Waiting)
         {
-            /* Check if it's shared */
             if (OldValue.Shared > 1)
             {
-                /* Write the Old Value but decrease share count */
                 NewValue = OldValue;
                 NewValue.Shared--;
             }
             else
             {
-                /* Simply clear the lock */
                 NewValue.Value = 0;
             }
 
-            /* Write the New Value */
             NewValue.Ptr = InterlockedCompareExchangePointer(&PushLock->Ptr,
                                                              NewValue.Ptr,
                                                              OldValue.Ptr);
             if (NewValue.Value == OldValue.Value) return;
 
-            /* Did it enter a wait state? */
             OldValue = NewValue;
         }
         else
         {
-            /* Ok, we do know someone is waiting on it. Are there more then one? */
+            /*
+             * Once waiters are queued, the upper bits hold a wait block pointer.
+             * If multiple shared owners existed when the first waiter was queued,
+             * their remaining count is stored in the oldest exclusive wait block,
+             * and MultipleShared marks that representation.
+             *
+             * If this call releases one of those shared owners, only the final
+             * shared release continues to unlock the push lock.
+             */
             if (OldValue.MultipleShared)
             {
-                /* Get the wait block */
                 WaitBlock = (PEX_PUSH_LOCK_WAIT_BLOCK)(OldValue.Value &
                                                        ~EX_PUSH_LOCK_PTR_BITS);
 
-                /* Loop until we find the last wait block */
+                /*
+                 * The push lock points to the newest wait block. Last contains
+                 * the oldest block once the list has been optimized; otherwise
+                 * follow Next until a wait block with Last set is found.
+                 */
                 while (TRUE)
                 {
-                    /* Get the last wait block */
                     LastWaitBlock = WaitBlock->Last;
-
-                    /* Did it exist? */
                     if (LastWaitBlock)
                     {
-                        /* Choose it */
                         WaitBlock = LastWaitBlock;
                         break;
                     }
 
-                    /* Keep searching */
                     WaitBlock = WaitBlock->Next;
                 }
 
-                /* Make sure the Share Count is above 0 */
+                /*
+                 * A generic release may reach this path after the saved shared
+                 * acquisition count has already been exhausted.
+                 */
                 if (WaitBlock->ShareCount > 0)
                 {
-                    /* This shouldn't be an exclusive wait block */
+                    /* The outstanding shared count is stored in the oldest exclusive waiter */
                     ASSERT(WaitBlock->Flags & EX_PUSH_LOCK_FLAGS_EXCLUSIVE);
 
-                    /* Do the decrease and check if the lock isn't shared anymore */
                     if (InterlockedDecrement(&WaitBlock->ShareCount) > 0) return;
                 }
             }
 
             /*
-             * If nobody was waiting on the block, then we possibly reduced the number
-             * of times the pushlock was shared, and we unlocked it.
-             * If someone was waiting, and more then one person is waiting, then we
-             * reduced the number of times the pushlock is shared in the wait block.
-             * Therefore, at this point, we can now 'satisfy' the wait.
+             * The final owner must clear Locked and MultipleShared. If no wakeup is
+             * in progress, it must also set Waking and process the wait list. A new
+             * waiter may be inserted while this update is being attempted, so both
+             * cases use CMPXCHG.
              */
             for (;;)
             {
-                /* Now we need to see if it's waking */
                 if (OldValue.Waking)
                 {
-                    /* Remove the lock and multiple shared bits */
+                    /*
+                     * Another thread owns wakeup. Leave Waking set and
+                     * clear only the ownership state.
+                     */
                     NewValue.Value = OldValue.Value;
                     NewValue.MultipleShared = FALSE;
                     NewValue.Locked = FALSE;
 
-                    /* Sanity check */
                     ASSERT(NewValue.Waking && !NewValue.Locked && !NewValue.MultipleShared);
 
-                    /* Write the new value */
                     NewValue.Ptr = InterlockedCompareExchangePointer(&PushLock->Ptr,
                                                                      NewValue.Ptr,
                                                                      OldValue.Ptr);
@@ -909,25 +917,26 @@ ExfReleasePushLock(PEX_PUSH_LOCK PushLock)
                 }
                 else
                 {
-                    /* Remove the lock and multiple shared bits */
+                    /*
+                     * No thread is responsible for wakeup yet. Clear the ownership state
+                     * and set Waking in the same atomic update so this thread becomes
+                     * responsible for processing the wait list.
+                     */
                     NewValue.Value = OldValue.Value;
                     NewValue.MultipleShared = FALSE;
                     NewValue.Locked = FALSE;
 
-                    /* It's not already waking, so add the wake bit */
                     NewValue.Waking = TRUE;
 
-                    /* Sanity check */
                     ASSERT(NewValue.Waking && !NewValue.Locked && !NewValue.MultipleShared);
 
-                    /* Write the new value */
                     WakeValue = NewValue;
                     NewValue.Ptr = InterlockedCompareExchangePointer(&PushLock->Ptr,
                                                                      NewValue.Ptr,
                                                                      OldValue.Ptr);
                     if (NewValue.Value == OldValue.Value)
                     {
-                        /* The write was successful. The pushlock is Unlocked and Waking */
+                        /* Wake the waiters after the state update succeeds */
                         ExfWakePushLock(PushLock, WakeValue);
                         return;
                     }
@@ -965,86 +974,94 @@ ExfReleasePushLockShared(PEX_PUSH_LOCK PushLock)
     EX_PUSH_LOCK OldValue = *PushLock, NewValue, WakeValue;
     PEX_PUSH_LOCK_WAIT_BLOCK WaitBlock, LastWaitBlock;
 
-    /* Check if someone is waiting on the lock */
+    /* The caller must hold the push lock */
+    ASSERT(OldValue.Locked);
+
+    /*
+     * Without waiters, the upper bits contain the shared acquisition count.
+     * Drop one shared acquisition, or clear the lock word when releasing the
+     * final owner.
+     *
+     * A waiter may be inserted before the CMPXCHG completes. If that happens,
+     * continue using the value returned by the failed operation.
+     */
     while (!OldValue.Waiting)
     {
-        /* Check if it's shared */
         if (OldValue.Shared > 1)
         {
-            /* Write the Old Value but decrease share count */
             NewValue = OldValue;
             NewValue.Shared--;
         }
         else
         {
-            /* Simply clear the lock */
             NewValue.Value = 0;
         }
 
-        /* Write the New Value */
         NewValue.Ptr = InterlockedCompareExchangePointer(&PushLock->Ptr,
                                                          NewValue.Ptr,
                                                          OldValue.Ptr);
         if (NewValue.Value == OldValue.Value) return;
 
-        /* Did it enter a wait state? */
         OldValue = NewValue;
     }
 
-    /* Ok, we do know someone is waiting on it. Are there more then one? */
+    /*
+     * Once waiters are queued, the upper bits hold a wait block pointer.
+     * If multiple shared owners existed when the first waiter was queued,
+     * their remaining count is stored in the oldest exclusive wait block,
+     * and MultipleShared marks that representation.
+     *
+     * Only the final shared release continues to unlock the push lock.
+     */
     if (OldValue.MultipleShared)
     {
-        /* Get the wait block */
         WaitBlock = (PEX_PUSH_LOCK_WAIT_BLOCK)(OldValue.Value &
                                                ~EX_PUSH_LOCK_PTR_BITS);
 
-        /* Loop until we find the last wait block */
+        /*
+         * The push lock points to the newest wait block. Last contains the
+         * oldest block once the list has been optimized; otherwise follow
+         * Next until a wait block with Last set is found.
+         */
         while (TRUE)
         {
-            /* Get the last wait block */
             LastWaitBlock = WaitBlock->Last;
-
-            /* Did it exist? */
             if (LastWaitBlock)
             {
-                /* Choose it */
                 WaitBlock = LastWaitBlock;
                 break;
             }
 
-            /* Keep searching */
             WaitBlock = WaitBlock->Next;
         }
 
-        /* Sanity checks */
+        /* The oldest exclusive waiter stores the remaining shared acquisitions */
         ASSERT(WaitBlock->ShareCount > 0);
         ASSERT(WaitBlock->Flags & EX_PUSH_LOCK_FLAGS_EXCLUSIVE);
 
-        /* Do the decrease and check if the lock isn't shared anymore */
         if (InterlockedDecrement(&WaitBlock->ShareCount) > 0) return;
     }
 
     /*
-     * If nobody was waiting on the block, then we possibly reduced the number
-     * of times the pushlock was shared, and we unlocked it.
-     * If someone was waiting, and more then one person is waiting, then we
-     * reduced the number of times the pushlock is shared in the wait block.
-     * Therefore, at this point, we can now 'satisfy' the wait.
+     * The final owner must clear Locked and MultipleShared. If no wakeup is
+     * in progress, it must also set Waking and process the wait list. A new
+     * waiter may be inserted while this update is being attempted, so both
+     * cases use CMPXCHG.
      */
     for (;;)
     {
-        /* Now we need to see if it's waking */
         if (OldValue.Waking)
         {
-            /* Remove the lock and multiple shared bits */
+            /*
+             * Another thread owns wakeup. Leave Waking set and
+             * clear only the ownership state.
+             */
             NewValue.Value = OldValue.Value;
             NewValue.MultipleShared = FALSE;
             NewValue.Locked = FALSE;
 
-            /* Sanity check */
             ASSERT(NewValue.Waking && !NewValue.Locked && !NewValue.MultipleShared);
 
-            /* Write the new value */
             NewValue.Ptr = InterlockedCompareExchangePointer(&PushLock->Ptr,
                                                              NewValue.Ptr,
                                                              OldValue.Ptr);
@@ -1052,25 +1069,26 @@ ExfReleasePushLockShared(PEX_PUSH_LOCK PushLock)
         }
         else
         {
-            /* Remove the lock and multiple shared bits */
+            /*
+             * No thread is responsible for wakeup yet. Clear the ownership state
+             * and set Waking in the same atomic update so this thread becomes
+             * responsible for processing the wait list.
+             */
             NewValue.Value = OldValue.Value;
             NewValue.MultipleShared = FALSE;
             NewValue.Locked = FALSE;
 
-            /* It's not already waking, so add the wake bit */
             NewValue.Waking = TRUE;
 
-            /* Sanity check */
             ASSERT(NewValue.Waking && !NewValue.Locked && !NewValue.MultipleShared);
 
-            /* Write the new value */
             WakeValue = NewValue;
             NewValue.Ptr = InterlockedCompareExchangePointer(&PushLock->Ptr,
                                                              NewValue.Ptr,
                                                              OldValue.Ptr);
             if (NewValue.Value == OldValue.Value)
             {
-                /* The write was successful. The pushlock is Unlocked and Waking */
+                /* Wake the waiters after the state update succeeds */
                 ExfWakePushLock(PushLock, WakeValue);
                 return;
             }

--- a/ntoskrnl/ex/pushlock.c
+++ b/ntoskrnl/ex/pushlock.c
@@ -925,12 +925,19 @@ ExfReleasePushLock(PEX_PUSH_LOCK PushLock)
                     NewValue.Ptr = InterlockedCompareExchangePointer(&PushLock->Ptr,
                                                                      NewValue.Ptr,
                                                                      OldValue.Ptr);
-                    if (NewValue.Value != OldValue.Value) continue;
-
-                    /* The write was successful. The pushlock is Unlocked and Waking */
-                    ExfWakePushLock(PushLock, WakeValue);
-                    return;
+                    if (NewValue.Value == OldValue.Value)
+                    {
+                        /* The write was successful. The pushlock is Unlocked and Waking */
+                        ExfWakePushLock(PushLock, WakeValue);
+                        return;
+                    }
                 }
+
+                /*
+                 * The failed CMPXCHG returned the current lock value, use it for
+                 * the next attempt.
+                 */
+                OldValue = NewValue;
             }
         }
     }
@@ -1061,12 +1068,19 @@ ExfReleasePushLockShared(PEX_PUSH_LOCK PushLock)
             NewValue.Ptr = InterlockedCompareExchangePointer(&PushLock->Ptr,
                                                              NewValue.Ptr,
                                                              OldValue.Ptr);
-            if (NewValue.Value != OldValue.Value) continue;
-
-            /* The write was successful. The pushlock is Unlocked and Waking */
-            ExfWakePushLock(PushLock, WakeValue);
-            return;
+            if (NewValue.Value == OldValue.Value)
+            {
+                /* The write was successful. The pushlock is Unlocked and Waking */
+                ExfWakePushLock(PushLock, WakeValue);
+                return;
+            }
         }
+
+        /*
+         * The failed CMPXCHG returned the current lock value, use it for
+         * the next attempt.
+         */
+        OldValue = NewValue;
     }
 }
 


### PR DESCRIPTION
This PR proposes three related changes:
1. Kernel tests for push lock
2. A fix for a livelock in `ExfReleasePushLock()` and `ExfReleasePushLockShared()` when another waiter is inserted during a
contended release
3. Improvements to the comments in the modified functions (since the old comments were of little practical value)

<details>
  <summary>Explanation</summary>
  
  A bounded TLA+ model found a legal execution in which the release loop repeatedly performs cmpxchg using an obsolete OldValue.

The failed cmpxchg returns the current push lock value, but the contended release loop doesn't assign that value back to OldValue before retrying. If another waiter was inserted between the original read and the cmpxcg, every subsequent attempt uses the same obsolete comparison value and fails again. The releasing thread can remain inside the release routine indefinitely while all queued waiters remain blocked.

Each of 3 modeled threads independently chooses shared or exclusive acquisition. The release progress property is:
```
ReleaseProgress ==
    \A t \in Threads:
        pc[t] \in ReleaseLabels ~> pc[t] \notin ReleaseLabels
```
So in other words, whenever a thread enters the release state machine, it must eventually leave it.

In ExfReleasePushLock, the Waking branch performs the cpmxchg and returns on success:

```
NewValue.Ptr = InterlockedCompareExchangePointer(&PushLock->Ptr, NewValue.Ptr, OldValue.Ptr);
if (NewValue.Value == OldValue.Value) return;
```

Adn the other branch retries directly on failure:

```
NewValue.Ptr = InterlockedCompareExchangePointer(&PushLock->Ptr, NewValue.Ptr, OldValue.Ptr);
if (NewValue.Value != OldValue.Value) continue;
```

Neither updates OldValue before the next inner loop iteration, the same pattern is present in ExfReleasePushLockShared. (By comparison, ExfReleasePushLockExclusive explicitly executes OldValue = NewValue before retrying.)

The corresponding model action is:

```
release_contended_cas:
    CurrentValue := pushlock;
    if (CurrentValue = OldValue) {
        pushlock := NewValue;

        if (~WasWaking) {
release_wake_call:
            call wake_pushlock(WakeValue);
        };

release_contended_return:
        OldValue := defaultInitValue ||
        NewValue := defaultInitValue ||
        CurrentValue := defaultInitValue ||
        WakeValue := defaultInitValue ||
        OldestWaiter := defaultInitValue ||
        OwnerDropped := defaultInitValue ||
        WasWaking := defaultInitValue;
release_contended_return_done:
        return;
    } else {
release_contended_retry:
        NewValue := defaultInitValue ||
        CurrentValue := defaultInitValue ||
        WakeValue := defaultInitValue ||
        WasWaking := defaultInitValue;
    };
```

CurrentValue represents the current value returned by a failed cmpxchg. OldValue is deliberately not changed in release_contended_retry, matching the current implementation.

TLC explored the 3 thread model and reported a temporal property violation after "generating 3,407,906 states and finding 1,213,986 distinct states". The counter example ends in a cycle from State 53 through "State 57 and then returns to State 53:
```
pushlock.queue = <<t3, t2>>
OldValue[t1].queue = <<t2>>

blocked = {t2, t3}

pc[t1] = release_drop_owner
pc[t2] = exclusive_queue_block
pc[t3] = exclusive_queue_block
```

The execution is:
1. t1 owns the push lock in shared mode.
2. t2 queues as an exclusive waiter.
3. t1 begins releasing the lock and reads an OldValue whose queue contains only t2: `OldValue[t1].queue = <<t2>>`
4. Before t1 performs its release cmxchg, t3 inserts itself as a newer waiter: `pushlock.queue = <<t3, t2>>`
5. t1 performs the release cmpxchg using its old value:
```
expected queue = <<t2>>
actual queue = <<t3, t2>>
```
6. The failed operation returns the actual current value:
```
CurrentValue[t1].queue = <<t3, t2>>
```
In State 56, CurrentValue[t1] contains the current push lock value, while OldValue[t1] still contains the obsolete queue containing only t2.
7. release_contended_retry clears CurrentValue but doesn't update OldValue.

The model then returns to release_loop with:
```
pushlock.queue = <<t3, t2>>
OldValue[t1].queue = <<t2>>
blocked = {t2, t3}
```

TLC reports:
```
State 57: <release_contended_retry ...>

Back to state 53: <release_loop ...>
```
  
</details>

<details>
  <summary>Without the fix applied</summary>
  
  ```
(modules\rostests\kmtests\kmtest_drv\kmtest_drv.c:377) DriverIoControl. Starting test ExPushLock
Break instruction exception - code 80000003 (first chance)
kmtest_drv!TestPushLockWaiterArrivalDuringRelease+0x1f8:
fffff880`74d83d88 cc              int     3

kd> dv /t
struct _KTHREAD * NewestThread = 0xfffffa80`291a2bc0
struct _KTHREAD * OldestThread = 0xfffffa80`291a1bc0
PUSH_LOCK_RELEASE_KIND ReleaseKind = PushLockReleaseSpecific (0n0)
struct PUSH_LOCK_THREAD_CONTEXT OldestContext = struct PUSH_LOCK_THREAD_CONTEXT
struct _KEVENT StartGate = struct _KEVENT
unsigned long Iteration = 0
struct PUSH_LOCK_THREAD_CONTEXT NewestContext = struct PUSH_LOCK_THREAD_CONTEXT
PUSH_LOCK_MODE [1] ExpectedOldest = PUSH_LOCK_MODE [1]
struct PUSH_LOCK_TEST_STATE State = struct PUSH_LOCK_TEST_STATE
kd> ?? &State.Lock
struct _EX_PUSH_LOCK * 0xfffff880`74fb4590
   +0x000 Locked           : 0y1
   +0x000 Waiting          : 0y1
   +0x000 Waking           : 0y0
   +0x000 MultipleShared   : 0y0
   +0x000 Shared           : 0y111111111111111111111000100000000111010100100111111110110101 (0xfffff8807527fb5)
   +0x000 Value            : 0xfffff880`7527fb53
   +0x000 Ptr              : 0xfffff880`7527fb53 Void

kd> eq nt!ExpForceReleasePushLockTarget fffff880`74fb4590
kd> ed nt!ExpReleasePushLockSharedRetryCount 0
kd> ed nt!ExpForceReleasePushLockSharedRetry 1
kd> g

Break instruction exception - code 80000003 (first chance)
nt!DbgBreakPoint:
fffff800`005a7e20 cc              int     3
kd> dd nt!ExpReleasePushLockSharedRetryCount L1
fffff800`00647d10  000003e8

kd> kv
 # Child-SP          RetAddr               : Args to Child                                                           : Call Site
00 fffff880`74fb4448 fffff800`00439e17     : fffff880`74fb4590 fffff800`00647d00 00000000`00000000 00000000`00000000 : nt!DbgBreakPoint [C:\Dev\reactos\output-VS-amd64-sln\sdk\lib\rtl\asm\debug_asm_rtl_asm.asm @ 484] 
01 fffff880`74fb4450 fffff880`74d82784     : fffff880`74fb4590 00000000`00000000 00000001`00000001 00000000`00000286 : nt!ExfReleasePushLockShared+0x427 [C:\Dev\reactos\ntoskrnl\ex\pushlock.c @ 1086] 
02 fffff880`74fb4500 fffff880`74d83dad     : fffff880`74fb4590 fffff880`00000000 fffff880`00000000 00000000`00000000 : kmtest_drv!PushLockRelease+0x44 [C:\Dev\reactos\modules\rostests\kmtests\ntos_ex\ExPushLock.c @ 221] 
03 fffff880`74fb4530 fffff880`74d845e0     : fffff880`00000001 fffffa80`291a9401 00000000`00000000 00000000`00000000 : kmtest_drv!TestPushLockWaiterArrivalDuringRelease+0x21d [C:\Dev\reactos\modules\rostests\kmtests\ntos_ex\ExPushLock.c @ 1002] 
04 fffff880`74fb4700 fffff880`74d5c806     : fffff880`74eaafd0 fffff880`74eaaf9f 00000000`00000179 fffff880`74fb4818 : kmtest_drv!Test_ExPushLock+0x30 [C:\Dev\reactos\modules\rostests\kmtests\ntos_ex\ExPushLock.c @ 1194] 
05 fffff880`74fb4730 fffff800`004866bf     : fffffa80`291a71f0 fffffa80`292ade60 00000000`00000000 fffff800`00478d91 : kmtest_drv!DriverIoControl+0x356 [C:\Dev\reactos\modules\rostests\kmtests\kmtest_drv\kmtest_drv.c @ 378] 
06 fffff880`74fb4850 fffff800`0047c2fc     : fffffa80`291a71f0 fffffa80`292ade60 fffffa80`291ce040 00000000`00000000 : nt!IofCallDriver+0xdf [C:\Dev\reactos\ntoskrnl\io\iomgr\irp.c @ 1288] 
07 fffff880`74fb48b0 fffff800`0047b7e3     : fffffa80`291a71f0 fffffa80`292ade60 fffffa80`291a9c20 00000000`00000000 : nt!IopPerformSynchronousRequest+0x6c [C:\Dev\reactos\ntoskrnl\io\iomgr\iofunc.c @ 142] 
08 fffff880`74fb4920 fffff800`0047c9f4     : 00000000`000002f4 00000000`00000000 00000000`00000000 00000000`00000000 : nt!IopDeviceFsIoControl+0xac3 [C:\Dev\reactos\ntoskrnl\io\iomgr\iofunc.c @ 648] 
09 fffff880`74fb4a40 fffff800`0058e5f7     : 00000000`000002f4 00000000`00000000 00000000`00000000 00000000`00000000 : nt!NtDeviceIoControlFile+0x84 [C:\Dev\reactos\ntoskrnl\io\iomgr\iofunc.c @ 1453] 
0a fffff880`74fb4ab0 000007ff`b705b081     : 000007ff`b60393c2 00000000`00000000 00000000`00000000 00000000`00000000 : nt!KiSystemCallEntry64+0xe0 (TrapFrame @ fffff880`74fb4b30) [C:\Dev\reactos\output-VS-amd64-sln\ntoskrnl\asm\trap_ntoskrnl_asm.asm @ 3269] 
0b 00000000`0012fcb8 000007ff`b60393c2     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : ntdll!NtDeviceIoControlFile+0xa
0c 00000000`0012fcc0 00000000`00000000     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`0012fd30 : kernel32!DeviceIoControl+0x2a2
```
Retry counter reached 1000 and execution is still inside ExfReleasePushLockShared. Without OldValue = NewValue it keeps retrying and makes no progress.
  
</details>

<details>
  <summary>With the fix applied</summary>
  
  ```
ExPushLock.c:936: Push lock race target: FFFFF880751DF590, Iteration O
ExPushLock.c:336: Push lock race target: FFFFF880751DF590, Iteration 1
ExPushLock: 1100 tests executed (0 marked as todo, 0 failures), 0 skipped.
```

```
kd> bc *
kd> ed nt!ExpReleasePushLockRetryCount 0
kd> ed nt!ExpReleasePushLockSharedRetryCount 0
kd> ed nt!ExpForceReleasePushLockRetry 0
kd> ed nt!ExpForceReleasePushLockSharedRetry 0
kd> eq nt!ExpForceReleasePushLockTarget 0

kd> g
Break instruction exception - code 80000003 (first chance)
kmtest_drv!TestPushLockWaiterArrivalDuringRelease+0x1f8:
fffff880`74d83d88 cc              int     3

kd> dv /t
struct _KTHREAD * NewestThread = 0xfffffa80`291a0bc0
struct _KTHREAD * OldestThread = 0xfffffa80`2919fbc0
PUSH_LOCK_RELEASE_KIND ReleaseKind = PushLockReleaseSpecific (0n0)
struct PUSH_LOCK_THREAD_CONTEXT OldestContext = struct PUSH_LOCK_THREAD_CONTEXT
struct _KEVENT StartGate = struct _KEVENT
unsigned long Iteration = 0
struct PUSH_LOCK_THREAD_CONTEXT NewestContext = struct PUSH_LOCK_THREAD_CONTEXT
PUSH_LOCK_MODE [1] ExpectedOldest = PUSH_LOCK_MODE [1]
struct PUSH_LOCK_TEST_STATE State = struct PUSH_LOCK_TEST_STATE
kd> ?? &State.Lock
struct _EX_PUSH_LOCK * 0xfffff880`751df590
   +0x000 Locked           : 0y1
   +0x000 Waiting          : 0y1
   +0x000 Waking           : 0y0
   +0x000 MultipleShared   : 0y0
   +0x000 Shared           : 0y111111111111111111111000100000000111010100100110100110110101 (0xfffff88075269b5)
   +0x000 Value            : 0xfffff880`75269b53
   +0x000 Ptr              : 0xfffff880`75269b53 Void
kd> dx &State.Lock
&State.Lock                 : 0xfffff880751df590 [Type: _EX_PUSH_LOCK *]
    [+0x000 ( 0: 0)] Locked           : 0x1 [Type: unsigned __int64]
    [+0x000 ( 1: 1)] Waiting          : 0x1 [Type: unsigned __int64]
    [+0x000 ( 2: 2)] Waking           : 0x0 [Type: unsigned __int64]
    [+0x000 ( 3: 3)] MultipleShared   : 0x0 [Type: unsigned __int64]
    [+0x000 (63: 4)] Shared           : 0xfffff88075269b5 [Type: unsigned __int64]
    [+0x000] Value            : 0xfffff88075269b53 [Type: unsigned __int64]
    [+0x000] Ptr              : 0xfffff88075269b53 [Type: void *]

kd> bc *
kd> eq nt!ExpForceReleasePushLockTarget fffff880`751df590
kd> ed nt!ExpReleasePushLockSharedRetryCount 0
kd> ed nt!ExpForceReleasePushLockSharedRetry 1
kd> ba w4 nt!ExpReleasePushLockSharedRetryCount
kd> bl
     0 e Disable Clear  fffff800`00647d10 w 4 0001 (0001) nt!ExpReleasePushLockSharedRetryCount
kd> g

Breakpoint 0 hit
nt!ExfReleasePushLockShared+0x411:
fffff800`00439e01 488b442420      mov     rax,qword ptr [rsp+20h]

kd> dd nt!ExpReleasePushLockSharedRetryCount L1
fffff800`00647d10  00000001
kd> dd nt!ExpForceReleasePushLockSharedRetry L1
fffff800`00647d00  00000000

kd> kv
 # Child-SP          RetAddr               : Args to Child                                                           : Call Site
00 fffff880`751df450 fffff880`74d82784     : fffff880`751df590 00000000`00000000 00000001`00000001 00000000`00000286 : nt!ExfReleasePushLockShared+0x411 [C:\Dev\reactos\ntoskrnl\ex\pushlock.c @ 1083] 
01 fffff880`751df500 fffff880`74d83dad     : fffff880`751df590 fffff880`00000000 fffff880`00000000 00000000`00000000 : kmtest_drv!PushLockRelease+0x44 [C:\Dev\reactos\modules\rostests\kmtests\ntos_ex\ExPushLock.c @ 221] 
02 fffff880`751df530 fffff880`74d845e0     : fffff880`00000001 fffffa80`291a5d01 00000000`00000000 00000000`00000000 : kmtest_drv!TestPushLockWaiterArrivalDuringRelease+0x21d [C:\Dev\reactos\modules\rostests\kmtests\ntos_ex\ExPushLock.c @ 1002] 
03 fffff880`751df700 fffff880`74d5c806     : fffff880`74eaafd0 fffff880`74eaaf9f 00000000`00000179 fffff880`751df818 : kmtest_drv!Test_ExPushLock+0x30 [C:\Dev\reactos\modules\rostests\kmtests\ntos_ex\ExPushLock.c @ 1194] 
04 fffff880`751df730 fffff800`004866af     : fffffa80`291a52e0 fffffa80`29254c90 00000000`00000000 fffff800`00478d81 : kmtest_drv!DriverIoControl+0x356 [C:\Dev\reactos\modules\rostests\kmtests\kmtest_drv\kmtest_drv.c @ 378] 
05 fffff880`751df850 fffff800`0047c2ec     : fffffa80`291a52e0 fffffa80`29254c90 fffffa80`2929fc20 00000000`00000000 : nt!IofCallDriver+0xdf [C:\Dev\reactos\ntoskrnl\io\iomgr\irp.c @ 1288] 
06 fffff880`751df8b0 fffff800`0047b7d3     : fffffa80`291a52e0 fffffa80`29254c90 fffffa80`291a5ef0 00000000`00000000 : nt!IopPerformSynchronousRequest+0x6c [C:\Dev\reactos\ntoskrnl\io\iomgr\iofunc.c @ 142] 
07 fffff880`751df920 fffff800`0047c9e4     : 00000000`000002f4 00000000`00000000 00000000`00000000 00000000`00000000 : nt!IopDeviceFsIoControl+0xac3 [C:\Dev\reactos\ntoskrnl\io\iomgr\iofunc.c @ 648] 
08 fffff880`751dfa40 fffff800`0058e5e7     : 00000000`000002f4 00000000`00000000 00000000`00000000 00000000`00000000 : nt!NtDeviceIoControlFile+0x84 [C:\Dev\reactos\ntoskrnl\io\iomgr\iofunc.c @ 1453] 
09 fffff880`751dfab0 000007ff`b705b081     : 000007ff`b60393c2 00000000`00000000 00000000`00000000 00000000`00000000 : nt!KiSystemCallEntry64+0xe0 (TrapFrame @ fffff880`751dfb30) [C:\Dev\reactos\output-VS-amd64-sln\ntoskrnl\asm\trap_ntoskrnl_asm.asm @ 3269] 
0a 00000000`0012fcb8 000007ff`b60393c2     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : ntdll!NtDeviceIoControlFile+0xa
0b 00000000`0012fcc0 00000000`00000000     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`0012fd30 : kernel32!DeviceIoControl+0x2a2

kd> bc *
kd> g

Break instruction exception - code 80000003 (first chance)
kmtest_drv!TestPushLockWaiterArrivalDuringRelease+0x1f8:
fffff880`74d83d88 cc              int     3

kd> dv /t
struct _KTHREAD * NewestThread = 0xfffffa80`2919fbc0
struct _KTHREAD * OldestThread = 0xfffffa80`291a0bc0
PUSH_LOCK_RELEASE_KIND ReleaseKind = PushLockReleaseGeneric (0n1)
struct PUSH_LOCK_THREAD_CONTEXT OldestContext = struct PUSH_LOCK_THREAD_CONTEXT
struct _KEVENT StartGate = struct _KEVENT
unsigned long Iteration = 1
struct PUSH_LOCK_THREAD_CONTEXT NewestContext = struct PUSH_LOCK_THREAD_CONTEXT
PUSH_LOCK_MODE [1] ExpectedOldest = PUSH_LOCK_MODE [1]
struct PUSH_LOCK_TEST_STATE State = struct PUSH_LOCK_TEST_STATE
kd> ?? &State.Lock
struct _EX_PUSH_LOCK * 0xfffff880`751df590
   +0x000 Locked           : 0y1
   +0x000 Waiting          : 0y1
   +0x000 Waking           : 0y0
   +0x000 MultipleShared   : 0y0
   +0x000 Shared           : 0y111111111111111111111000100000000111010100100010001110110101 (0xfffff88075223b5)
   +0x000 Value            : 0xfffff880`75223b53
   +0x000 Ptr              : 0xfffff880`75223b53 Void

kd> eq nt!ExpForceReleasePushLockTarget fffff880`751df590
kd> ed nt!ExpReleasePushLockRetryCount 0
kd> ed nt!ExpForceReleasePushLockRetry 1
kd> ba w4 nt!ExpReleasePushLockRetryCount
kd> bl
     0 e Disable Clear  fffff800`00647d14 w 4 0001 (0001) nt!ExpReleasePushLockRetryCount
kd> g

Breakpoint 0 hit
nt!ExfReleasePushLock+0x3ef:
fffff800`0043976f 488b442420      mov     rax,qword ptr [rsp+20h]
kd> dd nt!ExpReleasePushLockRetryCount L1
fffff800`00647d14  00000001
kd> dd nt!ExpForceReleasePushLockRetry L1
fffff800`00647d04  00000000
kd> kv
 # Child-SP          RetAddr               : Args to Child                                                           : Call Site
00 fffff880`751df450 fffff880`74d82763     : fffff880`751df590 00000000`00000000 00000001`00000001 00000000`00000286 : nt!ExfReleasePushLock+0x3ef [C:\Dev\reactos\ntoskrnl\ex\pushlock.c @ 932] 
01 fffff880`751df500 fffff880`74d83dad     : fffff880`751df590 fffff880`00000000 fffff880`00000001 00000000`00000001 : kmtest_drv!PushLockRelease+0x23 [C:\Dev\reactos\modules\rostests\kmtests\ntos_ex\ExPushLock.c @ 213] 
02 fffff880`751df530 fffff880`74d845e0     : fffff880`00000001 fffffa80`291a5d01 00000000`00000000 00000000`00000000 : kmtest_drv!TestPushLockWaiterArrivalDuringRelease+0x21d [C:\Dev\reactos\modules\rostests\kmtests\ntos_ex\ExPushLock.c @ 1002] 
03 fffff880`751df700 fffff880`74d5c806     : fffff880`74eaafd0 fffff880`74eaaf9f 00000000`00000179 fffff880`751df818 : kmtest_drv!Test_ExPushLock+0x30 [C:\Dev\reactos\modules\rostests\kmtests\ntos_ex\ExPushLock.c @ 1194] 
04 fffff880`751df730 fffff800`004866af     : fffffa80`291a52e0 fffffa80`29254c90 00000000`00000000 fffff800`00478d81 : kmtest_drv!DriverIoControl+0x356 [C:\Dev\reactos\modules\rostests\kmtests\kmtest_drv\kmtest_drv.c @ 378] 
05 fffff880`751df850 fffff800`0047c2ec     : fffffa80`291a52e0 fffffa80`29254c90 fffffa80`2929fc20 00000000`00000000 : nt!IofCallDriver+0xdf [C:\Dev\reactos\ntoskrnl\io\iomgr\irp.c @ 1288] 
06 fffff880`751df8b0 fffff800`0047b7d3     : fffffa80`291a52e0 fffffa80`29254c90 fffffa80`291a5ef0 00000000`00000000 : nt!IopPerformSynchronousRequest+0x6c [C:\Dev\reactos\ntoskrnl\io\iomgr\iofunc.c @ 142] 
07 fffff880`751df920 fffff800`0047c9e4     : 00000000`000002f4 00000000`00000000 00000000`00000000 00000000`00000000 : nt!IopDeviceFsIoControl+0xac3 [C:\Dev\reactos\ntoskrnl\io\iomgr\iofunc.c @ 648] 
08 fffff880`751dfa40 fffff800`0058e5e7     : 00000000`000002f4 00000000`00000000 00000000`00000000 00000000`00000000 : nt!NtDeviceIoControlFile+0x84 [C:\Dev\reactos\ntoskrnl\io\iomgr\iofunc.c @ 1453] 
09 fffff880`751dfab0 000007ff`b705b081     : 000007ff`b60393c2 00000000`00000000 00000000`00000000 00000000`00000000 : nt!KiSystemCallEntry64+0xe0 (TrapFrame @ fffff880`751dfb30) [C:\Dev\reactos\output-VS-amd64-sln\ntoskrnl\asm\trap_ntoskrnl_asm.asm @ 3269] 
0a 00000000`0012fcb8 000007ff`b60393c2     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : ntdll!NtDeviceIoControlFile+0xa
0b 00000000`0012fcc0 00000000`00000000     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`0012fd30 : kernel32!DeviceIoControl+0x2a2
kd> bc *
kd> eq nt!ExpForceReleasePushLockTarget 0
kd> g
```
  
</details>

<details>
  <summary>Test results</summary>
  
  <img width="760" height="500" alt="ExPushLock ReactOS" src="https://github.com/user-attachments/assets/c936f569-766e-4498-b32c-df416a34695d" />
  <img width="1337" height="487" alt="ExPushLock Windows Server 2003" src="https://github.com/user-attachments/assets/4507d407-784c-484e-a862-53162bae7e1d" />

</details>