### PR TITLE
[SHELL32_APITEST] Fix and extend ShellState API tests

### DIFF
--- a/modules/rostests/apitests/shell32/ShellState.cpp
+++ b/modules/rostests/apitests/shell32/ShellState.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "shelltest.h"
+#include "shell32_apitest_sub.h"
 
 #define NDEBUG
 #include <debug.h>
@@ -14,6 +15,7 @@
 #include <strsafe.h>
 #include <shlwapi.h>
 #include <shlwapi_undoc.h>
+#include <versionhelpers.h>
 
 /* [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer] */
 /* The contents of RegValue ShellState. */
@@ -23,9 +25,15 @@ typedef struct REGSHELLSTATE
     SHELLSTATE ss;
 } REGSHELLSTATE, *PREGSHELLSTATE;
 
-static void dump(const char *name, const void *ptr, size_t siz)
+static const LPCWSTR s_pszExplorer =
+    L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer";
+static const LPCWSTR s_pszShellState =
+    L"ShellState";
+
+static ULONG dump(const char *name, const void *ptr, size_t siz)
 {
     char buf[256], sz[16];
+    ULONG ret = 0;
 
     StringCbCopyA(buf, sizeof(buf), name);
     StringCbCatA(buf, sizeof(buf), ": ");
@@ -33,11 +41,14 @@ static void dump(const char *name, const void *ptr, size_t siz)
     const BYTE *pb = reinterpret_cast<const BYTE *>(ptr);
     while (siz--)
     {
+        if (*pb)
+            ret++;
         StringCbPrintfA(sz, sizeof(sz), "%02X ", *pb++);
         StringCbCatA(buf, sizeof(buf), sz);
     }
 
     trace("%s\n", buf);
+    return ret;
 }
 
 static int read_key(REGSHELLSTATE *prss)
@@ -45,8 +56,6 @@ static int read_key(REGSHELLSTATE *prss)
     HKEY hKey;
     LONG result;
     DWORD cb;
-    static const LPCWSTR s_pszExplorer =
-        L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer";
 
     memset(prss, 0, sizeof(*prss));
 
@@ -61,10 +70,9 @@ static int read_key(REGSHELLSTATE *prss)
     }
 
     cb = sizeof(*prss);
-    result = RegQueryValueExW(hKey, L"ShellState", NULL, NULL, reinterpret_cast<LPBYTE>(prss), &cb);
+    result = RegQueryValueExW(hKey, s_pszShellState, NULL, NULL, reinterpret_cast<LPBYTE>(prss), &cb);
     RegCloseKey(hKey);
 
-    ok(result == ERROR_SUCCESS, "result was %ld\n", result);
     if (result != ERROR_SUCCESS)
     {
         skip("RegQueryValueEx failed: %ld\n", result);
@@ -152,8 +160,350 @@ static int read_advanced_key(SHELLSTATE* pss)
 
 static int dump_pss(SHELLSTATE *pss)
 {
-    dump("SHELLSTATE", pss, sizeof(*pss));
+    dump("SHELLSTATE KEY", pss, sizeof(*pss));
     return 0;
+}
+
+static HWND start_sub(void)
+{
+    int retries = 50;
+    WCHAR s_szSubProgram[MAX_PATH]; // shell32_apitest_sub.exe
+    if (!FindSubProgram(s_szSubProgram, _countof(s_szSubProgram)))
+    {
+        trace("shell32_apitest_sub.exe not found\n");
+        return 0;
+    }
+
+    // Close the SUB_CLASSNAME windows
+    DoWaitForWindow(SUB_CLASSNAME, SUB_CLASSNAME, TRUE, TRUE);
+
+    // Execute sub program
+    HINSTANCE hinst = ShellExecuteW(NULL, NULL, s_szSubProgram, L"----", NULL, SW_HIDE);
+    if ((INT_PTR)hinst <= 32)
+    {
+        trace("Unable to run shell32_apitest_sub.exe.\n");
+        return 0;
+    }
+
+Retry:
+    HWND s_hSubWnd = DoWaitForWindow(SUB_CLASSNAME, SUB_CLASSNAME, FALSE, FALSE);
+    if (!s_hSubWnd)
+    {
+        if (--retries > 0)
+        {
+            Sleep(100);
+            goto Retry;
+        }
+        trace("Unable to find sub-program window.\n");
+        return 0;
+    }
+
+    return s_hSubWnd;
+}
+
+static void stop_sub(HWND s_hSubWnd)
+{
+    PostMessageW(s_hSubWnd, WM_COMMAND, IDNO, 0); // Finish
+    DoWaitForWindow(SUB_CLASSNAME, SUB_CLASSNAME, TRUE, TRUE); // Close sub-windows
+}
+
+static LONG del_state_key()
+{
+    HKEY hKey;
+    LONG res = RegOpenKeyExW(HKEY_CURRENT_USER, s_pszExplorer, 0, KEY_SET_VALUE, &hKey);
+    if (res != ERROR_SUCCESS || !hKey)
+    {
+        trace("RegOpenKeyEx failed: %ld, skipping default values test\n", res);
+        return res;
+    }
+
+    res = RegDeleteValueW(hKey, s_pszShellState);
+    RegCloseKey(hKey);
+    return res;
+}
+
+static LONG state_key_exists()
+{
+    HKEY hKey;
+    LONG res = RegOpenKeyExW(HKEY_CURRENT_USER, s_pszExplorer, 0, KEY_QUERY_VALUE, &hKey);
+    if (res != ERROR_SUCCESS || !hKey)
+    {
+        trace("RegOpenKeyEx failed: %ld, skipping default values test\n", res);
+        return res;
+    }
+
+    res = RegQueryValueExW(hKey, s_pszShellState, NULL, NULL, NULL, NULL);
+    RegCloseKey(hKey);
+    return res;
+}
+
+static void process_test(SHELLSTATE *pss)
+{
+    SHELLSTATE bak, ss1, ss2;
+    SHELLSTATE_SUB sub;
+    LONG result;
+    COPYDATASTRUCT copyData = { ID_SHSTATE, sizeof(sub), &sub };
+
+    // Backup current state
+    memset(&bak, 0, sizeof(bak));
+    SHGetSetSettings(&bak, MAXDWORD, FALSE);
+
+    memset(&ss1, 0, sizeof(ss1));
+    SHGetSetSettings(&ss1, MAXDWORD, FALSE);
+
+    // Test 1: Read one field, then write another
+    HWND s_hSubWnd = start_sub();
+    if (!s_hSubWnd)
+    {
+        skip("Skipping read/write value test 1\n");
+        goto Cleanup;
+    }
+
+    memset(&sub, 0, sizeof(sub));
+
+    sub.dwMask = SSF_DOUBLECLICKINWEBVIEW;
+    sub.bSet = FALSE;
+    SendMessageW(s_hSubWnd, WM_COPYDATA, 0, (LPARAM)&copyData);
+
+    sub.ss.fNoConfirmRecycle = !ss1.fNoConfirmRecycle;
+    ss1.fNoConfirmRecycle = sub.ss.fNoConfirmRecycle;
+    sub.dwMask = SSF_NOCONFIRMRECYCLE;
+    sub.bSet = TRUE;
+    SendMessageW(s_hSubWnd, WM_COPYDATA, 0, (LPARAM)&copyData);
+
+    memset(&ss2, 0, sizeof(ss2));
+    SHGetSetSettings(&ss2, MAXDWORD, FALSE);
+
+#define CHECK_BITS(x) ok(ss1.x == ss2.x, "ss2.%s expected %d, was %d\n", #x, (int)ss1.x, (int)ss2.x)
+    CHECK_BITS(fNoConfirmRecycle);
+    CHECK_BITS(fDoubleClickInWebView);
+    CHECK_BITS(fDesktopHTML);
+    CHECK_BITS(fWin95Classic);
+    CHECK_BITS(lParamSort);
+    CHECK_BITS(iSortDirection);
+    CHECK_BITS(fStartPanelOn);
+    CHECK_BITS(fShowCompColor);
+    CHECK_BITS(fShowAttribCol);
+    CHECK_BITS(fShowInfoTip);
+
+    stop_sub(s_hSubWnd);
+
+    // Test 2: Only write a field
+    s_hSubWnd = start_sub();
+    if (!s_hSubWnd)
+    {
+        skip("Skipping write value test 2\n");
+        goto Cleanup;
+    }
+
+    memset(&sub, 0, sizeof(sub));
+
+    sub.ss.fNoConfirmRecycle = !ss1.fNoConfirmRecycle;
+    ss1.fNoConfirmRecycle = sub.ss.fNoConfirmRecycle;
+    sub.dwMask = SSF_NOCONFIRMRECYCLE;
+    sub.bSet = TRUE;
+    SendMessageW(s_hSubWnd, WM_COPYDATA, 0, (LPARAM)&copyData);
+
+    memset(&ss2, 0, sizeof(ss2));
+    SHGetSetSettings(&ss2, MAXDWORD, FALSE);
+
+    CHECK_BITS(fNoConfirmRecycle);
+    CHECK_BITS(fDoubleClickInWebView);
+    CHECK_BITS(fDesktopHTML);
+    CHECK_BITS(fWin95Classic);
+    CHECK_BITS(lParamSort);
+    CHECK_BITS(iSortDirection);
+    CHECK_BITS(fStartPanelOn);
+    CHECK_BITS(fShowCompColor);
+    CHECK_BITS(fShowAttribCol);
+    CHECK_BITS(fShowInfoTip);
+
+    stop_sub(s_hSubWnd);
+
+    // Test 3: Write another one
+    ss1.fNoConfirmRecycle = 0;
+    SHGetSetSettings(&ss1, SSF_NOCONFIRMRECYCLE, TRUE);
+    ss1.fNoConfirmRecycle = 1;
+    ss1.fDoubleClickInWebView = 1;
+    SHGetSetSettings(&ss1, SSF_NOCONFIRMRECYCLE | SSF_DOUBLECLICKINWEBVIEW, TRUE);
+
+    s_hSubWnd = start_sub();
+    if (!s_hSubWnd)
+    {
+        skip("Skipping write value test 3\n");
+        goto Cleanup;
+    }
+
+    memset(&sub, 0, sizeof(sub));
+
+    sub.ss.fDoubleClickInWebView = !ss1.fDoubleClickInWebView;
+    ss1.fDoubleClickInWebView = sub.ss.fDoubleClickInWebView;
+    sub.dwMask = SSF_DOUBLECLICKINWEBVIEW;
+    sub.bSet = TRUE;
+    SendMessageW(s_hSubWnd, WM_COPYDATA, 0, (LPARAM)&copyData);
+
+    memset(&ss2, 0, sizeof(ss2));
+    SHGetSetSettings(&ss2, MAXDWORD, FALSE);
+
+    CHECK_BITS(fNoConfirmRecycle);
+    CHECK_BITS(fDoubleClickInWebView);
+    CHECK_BITS(fDesktopHTML);
+    CHECK_BITS(fWin95Classic);
+    CHECK_BITS(lParamSort);
+    CHECK_BITS(iSortDirection);
+    CHECK_BITS(fStartPanelOn);
+    CHECK_BITS(fShowCompColor);
+    CHECK_BITS(fShowAttribCol);
+    CHECK_BITS(fShowInfoTip);
+
+    stop_sub(s_hSubWnd);
+
+    // Test 4: Check default state values
+    ss1.fNoConfirmRecycle = 1;
+    ss1.fDoubleClickInWebView = 0;
+    ss1.fDesktopHTML = 1;
+    ss1.fWin95Classic = 1;
+    ss1.fStartPanelOn = 0;
+    ss1.fShowCompColor = 0;
+    ss1.fShowAttribCol = 1;
+    ss1.fShowInfoTip = 0;
+    SHGetSetSettings(&ss1, MAXDWORD, TRUE);
+
+    // ShellState key is expected to always exist at this point (we have set the state above)
+    result = del_state_key();
+    ok(result == ERROR_SUCCESS, "del_state_key failed: %ld\n", result);
+    if (result != ERROR_SUCCESS)
+    {
+        skip("Skipping default values test\n");
+        goto Cleanup;
+    }
+
+    s_hSubWnd = start_sub();
+    if (!s_hSubWnd)
+    {
+        skip("Skipping default values test\n");
+        goto Cleanup;
+    }
+
+    memset(&sub, 0, sizeof(sub));
+
+    sub.dwMask = SSF_NOCONFIRMRECYCLE;
+    sub.bGetSet = TRUE;
+    SendMessageW(s_hSubWnd, WM_COPYDATA, 0, (LPARAM)&copyData);
+
+    memset(&ss2, 0, sizeof(ss2));
+    SHGetSetSettings(&ss2, MAXDWORD, FALSE);
+
+#define CHECK_TRUE(x) ok(ss2.x, "ss2.%s expected to be TRUE\n", #x)
+#define CHECK_FALSE(x) ok(!ss2.x, "ss2.%s expected to be FALSE\n", #x)
+    if (GetNTVersion() < _WIN32_WINNT_WIN8)
+        CHECK_FALSE(fNoConfirmRecycle); // Different between Windows versions
+    else
+        CHECK_TRUE(fNoConfirmRecycle);
+    CHECK_TRUE(fDoubleClickInWebView);
+    CHECK_FALSE(fDesktopHTML);
+    CHECK_FALSE(fWin95Classic);
+    if (IsReactOS())
+        CHECK_FALSE(fStartPanelOn); // CORE-12158: Disabled intentionally, as no Modern Start menu yet
+    else
+        CHECK_TRUE(fStartPanelOn);
+    CHECK_BITS(fShowCompColor); // Keeps the state
+    CHECK_FALSE(fShowAttribCol);
+    CHECK_BITS(fShowInfoTip); // Keeps the state
+
+    stop_sub(s_hSubWnd);
+
+    // Test 5: Check when the registry key is created
+    result = del_state_key();
+    ok(result == ERROR_SUCCESS, "del_state_key failed: %ld\n", result);
+    if (result != ERROR_SUCCESS)
+    {
+        skip("Skipping registry key test\n");
+        goto Cleanup;
+    }
+
+    s_hSubWnd = start_sub();
+    if (!s_hSubWnd)
+    {
+        skip("Skipping default values test\n");
+        goto Cleanup;
+    }
+
+    memset(&sub, 0, sizeof(sub));
+
+    // Just get the field
+    sub.dwMask = SSF_DOUBLECLICKINWEBVIEW;
+    sub.bSet = FALSE;
+    SendMessageW(s_hSubWnd, WM_COPYDATA, 0, (LPARAM)&copyData);
+
+    stop_sub(s_hSubWnd);
+
+    result = state_key_exists();
+    if (GetNTVersion() < _WIN32_WINNT_WIN7)
+    {
+        ok(result == ERROR_FILE_NOT_FOUND, "There should be no registry key: %ld\n", result);
+    }
+    else
+    {
+        trace("state_key_exists(): %ld\n", result); // This may be random
+    }
+    if (result == ERROR_SUCCESS)
+        del_state_key();
+
+    s_hSubWnd = start_sub();
+    if (!s_hSubWnd)
+    {
+        skip("Skipping default values test\n");
+        goto Cleanup;
+    }
+
+    memset(&sub, 0, sizeof(sub));
+
+    // Set the field to expected default value
+    sub.ss.fDoubleClickInWebView = 1;
+    sub.dwMask = SSF_DOUBLECLICKINWEBVIEW;
+    sub.bSet = TRUE;
+    SendMessageW(s_hSubWnd, WM_COPYDATA, 0, (LPARAM)&copyData);
+
+    stop_sub(s_hSubWnd);
+
+    result = state_key_exists();
+    if (GetNTVersion() < _WIN32_WINNT_WIN7)
+    {
+        ok(result == ERROR_FILE_NOT_FOUND, "There should be no registry key: %ld\n", result);
+    }
+    else
+    {
+        trace("state_key_exists(): %ld\n", result); // This may be random
+    }
+    if (result == ERROR_SUCCESS)
+        del_state_key();
+
+    s_hSubWnd = start_sub();
+    if (!s_hSubWnd)
+    {
+        skip("Skipping default values test\n");
+        goto Cleanup;
+    }
+
+    memset(&sub, 0, sizeof(sub));
+
+    // Set the field to different value
+    sub.ss.fDoubleClickInWebView = 0;
+    sub.dwMask = SSF_DOUBLECLICKINWEBVIEW;
+    sub.bSet = TRUE;
+    SendMessageW(s_hSubWnd, WM_COPYDATA, 0, (LPARAM)&copyData);
+
+    stop_sub(s_hSubWnd);
+
+    result = state_key_exists();
+    ok(result == ERROR_SUCCESS, "Registry state value expected: %ld\n", result);
+
+Cleanup:
+    // Restore current state
+    SHGetSetSettings(&bak, MAXDWORD, TRUE);
+
+    return;
 }
 
 START_TEST(ShellState)
@@ -162,8 +512,10 @@ START_TEST(ShellState)
     REGSHELLSTATE rss;
     SHELLSTATE ss, *pss;
     SHELLFLAGSTATE FlagState;
+    BOOL GotReg = TRUE;
     LPBYTE pb;
     int ret;
+    ULONG c1, c2;
 
     trace("GetVersion(): 0x%08lX\n", GetVersion());
 
@@ -201,7 +553,8 @@ START_TEST(ShellState)
     ret = read_key(&rss);
     if (ret)
     {
-        return;
+        GotReg = FALSE;
+        goto SkipReg;
     }
 
     dump_pss(pss);
@@ -243,6 +596,7 @@ START_TEST(ShellState)
     DUMP_BOOL(pss->fShowStatusBar);
 #endif
 
+SkipReg:
 #define SSF_MASK \
     (SSF_SHOWALLOBJECTS | SSF_SHOWEXTENSIONS | SSF_NOCONFIRMRECYCLE | SSF_SHOWSYSFILES | \
      SSF_SHOWCOMPCOLOR | SSF_DOUBLECLICKINWEBVIEW | SSF_DESKTOPHTML | \
@@ -254,6 +608,8 @@ START_TEST(ShellState)
     /* Get the settings */
     memset(&ss, 0, sizeof(ss));
     SHGetSetSettings(&ss, SSF_MASK, FALSE);
+    if (GotReg)
+    {
 #define CHECK_REG_FLAG(x) ok(pss->x == ss.x, "ss.%s expected %d, was %d\n", #x, (int)pss->x, (int)ss.x)
     CHECK_REG_FLAG(fShowAllObjects);
     CHECK_REG_FLAG(fShowExtensions);
@@ -276,6 +632,14 @@ START_TEST(ShellState)
 #if NTDDI_VERSION >= NTDDI_WIN8     // for future use
     CHECK_REG_FLAG(fShowStatusBar);
 #endif
+    }
+    c1 = dump("SHELLSTATE SSF_MASK", &ss, sizeof(ss));
+
+    memset(&ss, 0, sizeof(ss));
+    SHGetSetSettings(&ss, MAXDWORD, FALSE);
+    c2 = dump("SHELLSTATE MAXDWORD", &ss, sizeof(ss));
+
+    ok(c2 >= c1, "Set bytes in MAXDWORD state expected to be greater than %u, was %u\n", c1, c2);
 
     /* Get the flag settings */
     memset(&FlagState, 0, sizeof(FlagState));
@@ -298,6 +662,16 @@ START_TEST(ShellState)
     CHECK_FLAG(fAutoCheckSelect);
     CHECK_FLAG(fIconsOnly);
 #endif
+    c1 = dump("SHELLFLAGSTATE SSF_MASK", &FlagState, sizeof(FlagState));
+
+    memset(&FlagState, 0, sizeof(FlagState));
+    SHGetSettings(&FlagState, MAXDWORD);
+    c2 = dump("SHELLFLAGSTATE MAXDWORD", &FlagState, sizeof(FlagState));
+
+    ok(c2 >= c1, "Set bytes in MAXDWORD flags expected to be greater than %u, was %u\n", c1, c2);
+
+    /* Inter-process tests */
+    process_test(pss);
 
     /* Structure alignment tests */
 #if 1

--- a/modules/rostests/apitests/shell32/ShellState.cpp
+++ b/modules/rostests/apitests/shell32/ShellState.cpp
@@ -4,6 +4,7 @@
  * PURPOSE:         Test for SHELLSTATE
  * PROGRAMMERS:     Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
+
 #include "shelltest.h"
 
 #define NDEBUG
@@ -230,20 +231,20 @@ START_TEST(ShellState)
     DUMP_LONG(pss->lParamSort);
     DUMP_LONG(pss->iSortDirection);
     DUMP_LONG(pss->version);
-    DUMP_LONG(pss->lParamSort);
-    DUMP_LONG(pss->iSortDirection);
-    DUMP_LONG(pss->version);
     DUMP_BOOL(pss->fSepProcess);
     DUMP_BOOL(pss->fStartPanelOn);
     DUMP_BOOL(pss->fShowStartPage);
-#if NTDDI_VERSION >= 0x06000000     // for future use
+#if NTDDI_VERSION >= NTDDI_VISTA    // for future use
+    DUMP_BOOL(pss->fAutoCheckSelect);
     DUMP_BOOL(pss->fIconsOnly);
     DUMP_BOOL(pss->fShowTypeOverlay);
+#endif
+#if NTDDI_VERSION >= NTDDI_WIN8     // for future use
     DUMP_BOOL(pss->fShowStatusBar);
 #endif
 
 #define SSF_MASK \
-    (SSF_SHOWALLOBJECTS | SSF_SHOWEXTENSIONS | SSF_NOCONFIRMRECYCLE | \
+    (SSF_SHOWALLOBJECTS | SSF_SHOWEXTENSIONS | SSF_NOCONFIRMRECYCLE | SSF_SHOWSYSFILES | \
      SSF_SHOWCOMPCOLOR | SSF_DOUBLECLICKINWEBVIEW | SSF_DESKTOPHTML | \
      SSF_WIN95CLASSIC | SSF_DONTPRETTYPATH | SSF_SHOWATTRIBCOL | \
      SSF_MAPNETDRVBUTTON | SSF_SHOWINFOTIP | SSF_HIDEICONS)
@@ -257,8 +258,7 @@ START_TEST(ShellState)
     CHECK_REG_FLAG(fShowAllObjects);
     CHECK_REG_FLAG(fShowExtensions);
     CHECK_REG_FLAG(fNoConfirmRecycle);
-    if (GetNTVersion() != _WIN32_WINNT_VISTA)
-        CHECK_REG_FLAG(fShowSysFiles);    // No use, test is broken on Vista
+    CHECK_REG_FLAG(fShowSysFiles);
     CHECK_REG_FLAG(fShowCompColor);
     CHECK_REG_FLAG(fDoubleClickInWebView);
     CHECK_REG_FLAG(fDesktopHTML);
@@ -268,9 +268,13 @@ START_TEST(ShellState)
     CHECK_REG_FLAG(fMapNetDrvBtn);
     CHECK_REG_FLAG(fShowInfoTip);
     CHECK_REG_FLAG(fHideIcons);
-#if NTDDI_VERSION >= 0x06000000     // for future use
+#if NTDDI_VERSION >= NTDDI_VISTA    // for future use
     CHECK_REG_FLAG(fAutoCheckSelect);
     CHECK_REG_FLAG(fIconsOnly);
+    CHECK_REG_FLAG(fShowTypeOverlay);
+#endif
+#if NTDDI_VERSION >= NTDDI_WIN8     // for future use
+    CHECK_REG_FLAG(fShowStatusBar);
 #endif
 
     /* Get the flag settings */
@@ -280,7 +284,7 @@ START_TEST(ShellState)
     CHECK_FLAG(fShowAllObjects);
     CHECK_FLAG(fShowExtensions);
     CHECK_FLAG(fNoConfirmRecycle);
-    CHECK_FLAG(fShowSysFiles);    // No use
+    CHECK_FLAG(fShowSysFiles);
     CHECK_FLAG(fShowCompColor);
     CHECK_FLAG(fDoubleClickInWebView);
     CHECK_FLAG(fDesktopHTML);
@@ -290,11 +294,12 @@ START_TEST(ShellState)
     CHECK_FLAG(fMapNetDrvBtn);
     CHECK_FLAG(fShowInfoTip);
     CHECK_FLAG(fHideIcons);
-#if NTDDI_VERSION >= 0x06000000     // for future use
+#if NTDDI_VERSION >= NTDDI_VISTA    // for future use
     CHECK_FLAG(fAutoCheckSelect);
     CHECK_FLAG(fIconsOnly);
 #endif
 
+    /* Structure alignment tests */
 #if 1
     #define DO_IT(x) x
 #else

--- a/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
+++ b/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
@@ -5,7 +5,7 @@
  * COPYRIGHT:   Copyright 2020-2024 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
-// This program is used in SHChangeNotify and ShellExecCmdLine testcases.
+// This program is used in SHChangeNotify, ShellExecCmdLine, and ShellState testcases.
 
 #include "shelltest.h"
 #include "shell32_apitest_sub.h"
@@ -308,6 +308,29 @@ static INT_PTR OnShellNotify(HWND hwnd, WPARAM wParam, LPARAM lParam)
     return TRUE;
 }
 
+static LRESULT OnCopyData(HWND hwnd, LPARAM lParam)
+{
+    COPYDATASTRUCT *cds = (COPYDATASTRUCT*)lParam;
+
+    if (!cds || hwnd != 0 || cds->dwData != ID_SHSTATE)
+        return 0;
+
+    PSHELLSTATE_SUB sub = (PSHELLSTATE_SUB)cds->lpData;
+    if (sub->bGetSet && sub->dwMask == SSF_NOCONFIRMRECYCLE)
+    {
+        SHGetSetSettings(&sub->ss, sub->dwMask, FALSE);
+        // Flip the flag
+        sub->ss.fNoConfirmRecycle = !sub->ss.fNoConfirmRecycle;
+        SHGetSetSettings(&sub->ss, sub->dwMask, TRUE);
+        // Flip back
+        sub->ss.fNoConfirmRecycle = !sub->ss.fNoConfirmRecycle;
+        SHGetSetSettings(&sub->ss, sub->dwMask, TRUE);
+        return 1;
+    }
+    SHGetSetSettings(&sub->ss, sub->dwMask, sub->bSet);
+    return 1;
+}
+
 static LRESULT CALLBACK SubWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
@@ -321,6 +344,9 @@ static LRESULT CALLBACK SubWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARA
 
         case WM_SHELL_NOTIFY:
             return OnShellNotify(hwnd, wParam, lParam);
+
+        case WM_COPYDATA:
+            return OnCopyData((HWND)wParam, lParam);
 
         case WM_DESTROY:
             OnDestroy(hwnd);

--- a/modules/rostests/apitests/shell32/shell32_apitest_sub.h
+++ b/modules/rostests/apitests/shell32/shell32_apitest_sub.h
@@ -12,6 +12,16 @@
 
 #define NUM_STAGE 10
 
+#define ID_SHSTATE 0xFEEDDEAF
+
+typedef struct SHELLSTATE_SUB
+{
+    SHELLSTATE ss;
+    DWORD dwMask;
+    BOOL bSet;
+    BOOL bGetSet;
+} SHELLSTATE_SUB, *PSHELLSTATE_SUB;
+
 static inline BOOL FindSubProgram(LPWSTR pszSubProgram, DWORD cchSubProgram)
 {
     GetModuleFileNameW(NULL, pszSubProgram, cchSubProgram);


### PR DESCRIPTION
First commit fixes broken stuff in the test, second one extends the coverage.

Primary reason for this is to cover what exactly have been fixed by 4fecc908e7d (#9293).

### Commit 1: Fix fShowSysFiles test (trivial)

- There was a missing SSF_SHOWSYSFILES flag in the mask
- Also remove duplicate tests, add some missing, fix NTDDI constants

### Commit 2: Extend the coverage

- Skip registry tests if the key is missing, but keep testing
- Add tests for different bitmasks and compare amount of set bytes
- Add inter-process tests (using shell32_apitest_sub) that verify shell behavior, especially covering parts that were recently fixed in 4fecc908e7d (#9293)

All tests are confirmed to pass on Windows 2003, Vista, 7, 8.1 and 10.

JIRA issues: [CORE-12822](https://jira.reactos.org/browse/CORE-12822), [CORE-20585](https://jira.reactos.org/browse/CORE-20585)

## Test output on Windows

There are 2 test runs for each, on first run I rename `ShellState` value to see results without it, on the second run I let it read the registry value contents.

<details>
  <summary>Server 2003 R2 (Service Pack 2)</summary>

```
ShellState.cpp:516: GetVersion(): 0x0ECE0205
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000005
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00000ECE
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:77: Tests skipped: RegQueryValueEx failed: 2
ShellState.cpp:49: SHELLSTATE SSF_MASK: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 02 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 33 08 00 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 33 08 00 00

ShellState: 66 tests executed (0 marked as todo, 0 failures), 1 skipped.

ShellState.cpp:516: GetVersion(): 0x0ECE0205
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000005
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00000ECE
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:49: SHELLSTATE KEY: 33 08 00 00 00 00 00 00 00 00 00 00 00 00 00
00 01 00 00 00 0D 00 00 00 00 00 00 00 02 00 00 00
ShellState.cpp:563: pss->fShowAllObjects: 1
ShellState.cpp:564: pss->fShowExtensions: 1
ShellState.cpp:565: pss->fNoConfirmRecycle: 0
ShellState.cpp:566: pss->fShowSysFiles: 0
ShellState.cpp:567: pss->fShowCompColor: 1
ShellState.cpp:568: pss->fDoubleClickInWebView: 1
ShellState.cpp:569: pss->fDesktopHTML: 0
ShellState.cpp:570: pss->fWin95Classic: 0
ShellState.cpp:571: pss->fDontPrettyPath: 0
ShellState.cpp:572: pss->fShowAttribCol: 0
ShellState.cpp:573: pss->fMapNetDrvBtn: 0
ShellState.cpp:574: pss->fShowInfoTip: 1
ShellState.cpp:575: pss->fHideIcons: 0
ShellState.cpp:576: pss->fWebView: 0
ShellState.cpp:577: pss->fFilter: 0
ShellState.cpp:578: pss->fShowSuperHidden: 0
ShellState.cpp:579: pss->fNoNetCrawling: 0
ShellState.cpp:580: pss->lParamSort: 0x00000000
ShellState.cpp:581: pss->iSortDirection: 0x00000001
ShellState.cpp:582: pss->version: 0x0000000D
ShellState.cpp:583: pss->fSepProcess: 0
ShellState.cpp:584: pss->fStartPanelOn: 1
ShellState.cpp:585: pss->fShowStartPage: 0
ShellState.cpp:49: SHELLSTATE SSF_MASK: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 02 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 33 08 00 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 33 08 00 00

ShellState: 80 tests executed (0 marked as todo, 0 failures), 0 skipped.
```
</details>

<details>
  <summary>Windows Vista (RTM)</summary>

```
ShellState.cpp:516: GetVersion(): 0x17700006
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000006
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000000
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00001770
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:77: Tests skipped: RegQueryValueEx failed: 2
ShellState.cpp:49: SHELLSTATE SSF_MASK: 38 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 38 28 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 22 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 38 08 00 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 38 28 00 00

ShellState: 66 tests executed (0 marked as todo, 0 failures), 1 skipped.

ShellState.cpp:516: GetVersion(): 0x17700006
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000006
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000000
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00001770
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:49: SHELLSTATE KEY: 38 28 00 00 00 00 00 00 00 00 00 00 00 00 00
00 01 00 00 00 12 00 00 00 00 00 00 00 22 00 00 00
ShellState.cpp:563: pss->fShowAllObjects: 0
ShellState.cpp:564: pss->fShowExtensions: 0
ShellState.cpp:565: pss->fNoConfirmRecycle: 0
ShellState.cpp:566: pss->fShowSysFiles: 1
ShellState.cpp:567: pss->fShowCompColor: 1
ShellState.cpp:568: pss->fDoubleClickInWebView: 1
ShellState.cpp:569: pss->fDesktopHTML: 0
ShellState.cpp:570: pss->fWin95Classic: 0
ShellState.cpp:571: pss->fDontPrettyPath: 0
ShellState.cpp:572: pss->fShowAttribCol: 0
ShellState.cpp:573: pss->fMapNetDrvBtn: 0
ShellState.cpp:574: pss->fShowInfoTip: 1
ShellState.cpp:575: pss->fHideIcons: 0
ShellState.cpp:576: pss->fWebView: 1
ShellState.cpp:577: pss->fFilter: 0
ShellState.cpp:578: pss->fShowSuperHidden: 0
ShellState.cpp:579: pss->fNoNetCrawling: 0
ShellState.cpp:580: pss->lParamSort: 0x00000000
ShellState.cpp:581: pss->iSortDirection: 0x00000001
ShellState.cpp:582: pss->version: 0x00000012
ShellState.cpp:583: pss->fSepProcess: 0
ShellState.cpp:584: pss->fStartPanelOn: 1
ShellState.cpp:585: pss->fShowStartPage: 0
ShellState.cpp:49: SHELLSTATE SSF_MASK: 38 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 38 28 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 22 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 38 08 00 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 38 28 00 00

ShellState: 80 tests executed (0 marked as todo, 0 failures), 0 skipped.
```
</details>

<details>
  <summary>Windows 7 (RTM)</summary>

```
ShellState.cpp:516: GetVersion(): 0x1DB00106
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000006
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000001
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00001DB0
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:77: Tests skipped: RegQueryValueEx failed: 2
ShellState.cpp:49: SHELLSTATE SSF_MASK: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 33 A8 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 22 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 33 08 00 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 33 88 00 00
ShellState.cpp:444: state_key_exists(): 0
ShellState.cpp:473: state_key_exists(): 2

ShellState: 64 tests executed (0 marked as todo, 0 failures), 1 skipped.

ShellState.cpp:516: GetVersion(): 0x1DB00106
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000006
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000001
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00001DB0
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:49: SHELLSTATE KEY: 33 A8 00 00 00 00 00 00 00 00 00 00 00 00 00
00 01 00 00 00 12 00 00 00 00 00 00 00 22 00 00 00
ShellState.cpp:563: pss->fShowAllObjects: 1
ShellState.cpp:564: pss->fShowExtensions: 1
ShellState.cpp:565: pss->fNoConfirmRecycle: 0
ShellState.cpp:566: pss->fShowSysFiles: 0
ShellState.cpp:567: pss->fShowCompColor: 1
ShellState.cpp:568: pss->fDoubleClickInWebView: 1
ShellState.cpp:569: pss->fDesktopHTML: 0
ShellState.cpp:570: pss->fWin95Classic: 0
ShellState.cpp:571: pss->fDontPrettyPath: 0
ShellState.cpp:572: pss->fShowAttribCol: 0
ShellState.cpp:573: pss->fMapNetDrvBtn: 0
ShellState.cpp:574: pss->fShowInfoTip: 1
ShellState.cpp:575: pss->fHideIcons: 0
ShellState.cpp:576: pss->fWebView: 1
ShellState.cpp:577: pss->fFilter: 0
ShellState.cpp:578: pss->fShowSuperHidden: 1
ShellState.cpp:579: pss->fNoNetCrawling: 0
ShellState.cpp:580: pss->lParamSort: 0x00000000
ShellState.cpp:581: pss->iSortDirection: 0x00000001
ShellState.cpp:582: pss->version: 0x00000012
ShellState.cpp:583: pss->fSepProcess: 0
ShellState.cpp:584: pss->fStartPanelOn: 1
ShellState.cpp:585: pss->fShowStartPage: 0
ShellState.cpp:49: SHELLSTATE SSF_MASK: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 33 A8 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 22 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 33 08 00 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 33 88 00 00
ShellState.cpp:444: state_key_exists(): 2
ShellState.cpp:473: state_key_exists(): 2

ShellState: 78 tests executed (0 marked as todo, 0 failures), 0 skipped.
```
</details>

<details>
  <summary>Windows 8.1</summary>

```
ShellState.cpp:516: GetVersion(): 0x23F00206
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000006
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x000023F0
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:77: Tests skipped: RegQueryValueEx failed: 2
ShellState.cpp:49: SHELLSTATE SSF_MASK: 3C 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 3C 28 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 62 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 3C 08 00 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 3C 08 00 00
ShellState.cpp:444: state_key_exists(): 2
ShellState.cpp:473: state_key_exists(): 2

ShellState: 64 tests executed (0 marked as todo, 0 failures), 1 skipped.

ShellState.cpp:516: GetVersion(): 0x23F00206
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000006
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x000023F0
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:49: SHELLSTATE KEY: 3C 28 00 00 00 00 00 00 00 00 00 00 00 00 00
00 01 00 00 00 13 00 00 00 00 00 00 00 62 00 00 00
ShellState.cpp:563: pss->fShowAllObjects: 0
ShellState.cpp:564: pss->fShowExtensions: 0
ShellState.cpp:565: pss->fNoConfirmRecycle: 1
ShellState.cpp:566: pss->fShowSysFiles: 1
ShellState.cpp:567: pss->fShowCompColor: 1
ShellState.cpp:568: pss->fDoubleClickInWebView: 1
ShellState.cpp:569: pss->fDesktopHTML: 0
ShellState.cpp:570: pss->fWin95Classic: 0
ShellState.cpp:571: pss->fDontPrettyPath: 0
ShellState.cpp:572: pss->fShowAttribCol: 0
ShellState.cpp:573: pss->fMapNetDrvBtn: 0
ShellState.cpp:574: pss->fShowInfoTip: 1
ShellState.cpp:575: pss->fHideIcons: 0
ShellState.cpp:576: pss->fWebView: 1
ShellState.cpp:577: pss->fFilter: 0
ShellState.cpp:578: pss->fShowSuperHidden: 0
ShellState.cpp:579: pss->fNoNetCrawling: 0
ShellState.cpp:580: pss->lParamSort: 0x00000000
ShellState.cpp:581: pss->iSortDirection: 0x00000001
ShellState.cpp:582: pss->version: 0x00000013
ShellState.cpp:583: pss->fSepProcess: 0
ShellState.cpp:584: pss->fStartPanelOn: 1
ShellState.cpp:585: pss->fShowStartPage: 0
ShellState.cpp:49: SHELLSTATE SSF_MASK: 3C 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 3C 28 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 62 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 3C 08 00 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 3C 08 00 00
ShellState.cpp:444: state_key_exists(): 0
ShellState.cpp:473: state_key_exists(): 2

ShellState: 78 tests executed (0 marked as todo, 0 failures), 0 skipped.
```
</details>

<details>
  <summary>Windows 10 (22H2 19045.7548)</summary>

```
ShellState.cpp:516: GetVersion(): 0x23F00206
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000006
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x000023F0
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:77: Tests skipped: RegQueryValueEx failed: 2
ShellState.cpp:49: SHELLSTATE SSF_MASK: 3C 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 3C 28 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00 6A 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 3C 08 00 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 3C 28 00 00
ShellState.cpp:444: state_key_exists(): 0
ShellState.cpp:473: state_key_exists(): 2

ShellState: 64 tests executed (0 marked as todo, 0 failures), 1 skipped.

ShellState.cpp:516: GetVersion(): 0x23F00206
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000006
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x000023F0
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:49: SHELLSTATE KEY: 3C 28 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 13 00 00 00 00 00 00 00 6A 00 00 00
ShellState.cpp:563: pss->fShowAllObjects: 0
ShellState.cpp:564: pss->fShowExtensions: 0
ShellState.cpp:565: pss->fNoConfirmRecycle: 1
ShellState.cpp:566: pss->fShowSysFiles: 1
ShellState.cpp:567: pss->fShowCompColor: 1
ShellState.cpp:568: pss->fDoubleClickInWebView: 1
ShellState.cpp:569: pss->fDesktopHTML: 0
ShellState.cpp:570: pss->fWin95Classic: 0
ShellState.cpp:571: pss->fDontPrettyPath: 0
ShellState.cpp:572: pss->fShowAttribCol: 0
ShellState.cpp:573: pss->fMapNetDrvBtn: 0
ShellState.cpp:574: pss->fShowInfoTip: 1
ShellState.cpp:575: pss->fHideIcons: 0
ShellState.cpp:576: pss->fWebView: 1
ShellState.cpp:577: pss->fFilter: 0
ShellState.cpp:578: pss->fShowSuperHidden: 0
ShellState.cpp:579: pss->fNoNetCrawling: 0
ShellState.cpp:580: pss->lParamSort: 0x00000000
ShellState.cpp:581: pss->iSortDirection: 0x00000001
ShellState.cpp:582: pss->version: 0x00000013
ShellState.cpp:583: pss->fSepProcess: 0
ShellState.cpp:584: pss->fStartPanelOn: 1
ShellState.cpp:585: pss->fShowStartPage: 0
ShellState.cpp:49: SHELLSTATE SSF_MASK: 3C 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 3C 28 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00 6A 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 3C 08 00 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 3C 28 00 00
ShellState.cpp:444: state_key_exists(): 0
ShellState.cpp:473: state_key_exists(): 2

ShellState: 78 tests executed (0 marked as todo, 0 failures), 0 skipped.
```
</details>

## Test output on ReactOS

<details>
  <summary>0.4.17-dev-202-g60c8612 (before Doug's hackfix)</summary>

```
ShellState.cpp:516: GetVersion(): 0x0ECE0205
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000005
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00000ECE
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:77: Tests skipped: RegQueryValueEx failed: 2
ShellState.cpp:49: SHELLSTATE SSF_MASK: 23 00 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 33 0A 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 33 AA 23 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 33 0A 22 00
ShellState.cpp:310: Test failed: ss2.fDoubleClickInWebView expected -1, was 0
ShellState.cpp:314: Test failed: ss2.iSortDirection expected 1, was 0
ShellState.cpp:347: Test failed: ss2.fNoConfirmRecycle expected -1, was 0
ShellState.cpp:352: Test failed: ss2.iSortDirection expected 1, was 0
ShellState.cpp:405: Test failed: ss2.fStartPanelOn expected to be TRUE
ShellState.cpp:407: Test failed: ss2.fShowAttribCol expected to be FALSE

ShellState: 66 tests executed (0 marked as todo, 6 failures), 1 skipped.

ShellState.cpp:516: GetVersion(): 0x0ECE0205
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000005
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00000ECE
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:49: SHELLSTATE KEY: 33 0A 00 00 00 00 00 00 00 00 00 00 00 00 00
00 01 00 00 00 0D 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:563: pss->fShowAllObjects: 1
ShellState.cpp:564: pss->fShowExtensions: 1
ShellState.cpp:565: pss->fNoConfirmRecycle: 0
ShellState.cpp:566: pss->fShowSysFiles: 0
ShellState.cpp:567: pss->fShowCompColor: 1
ShellState.cpp:568: pss->fDoubleClickInWebView: 1
ShellState.cpp:569: pss->fDesktopHTML: 0
ShellState.cpp:570: pss->fWin95Classic: 0
ShellState.cpp:571: pss->fDontPrettyPath: 0
ShellState.cpp:572: pss->fShowAttribCol: 1
ShellState.cpp:573: pss->fMapNetDrvBtn: 0
ShellState.cpp:574: pss->fShowInfoTip: 1
ShellState.cpp:575: pss->fHideIcons: 0
ShellState.cpp:576: pss->fWebView: 0
ShellState.cpp:577: pss->fFilter: 0
ShellState.cpp:578: pss->fShowSuperHidden: 0
ShellState.cpp:579: pss->fNoNetCrawling: 0
ShellState.cpp:580: pss->lParamSort: 0x00000000
ShellState.cpp:581: pss->iSortDirection: 0x00000001
ShellState.cpp:582: pss->version: 0x0000000D
ShellState.cpp:583: pss->fSepProcess: 0
ShellState.cpp:584: pss->fStartPanelOn: 0
ShellState.cpp:585: pss->fShowStartPage: 0
ShellState.cpp:619: Test failed: ss.fShowAttribCol expected -1, was 0
ShellState.cpp:49: SHELLSTATE SSF_MASK: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 33 A8 23 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 33 08 22 00
ShellState.cpp:282: Test failed: ss2.iSortDirection expected 1, was 0
ShellState.cpp:310: Test failed: ss2.fDoubleClickInWebView expected -1, was 0
ShellState.cpp:314: Test failed: ss2.iSortDirection expected 1, was 0
ShellState.cpp:347: Test failed: ss2.fNoConfirmRecycle expected -1, was 0
ShellState.cpp:352: Test failed: ss2.iSortDirection expected 1, was 0
ShellState.cpp:405: Test failed: ss2.fStartPanelOn expected to be TRUE
ShellState.cpp:407: Test failed: ss2.fShowAttribCol expected to be FALSE

ShellState: 80 tests executed (0 marked as todo, 8 failures), 0 skipped.
```
</details>

<details>
  <summary>0.4.17-dev-203-g39ad1b6 (after Doug's hackfix)</summary>

```
ShellState.cpp:516: GetVersion(): 0x0ECE0205
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000005
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00000ECE
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:77: Tests skipped: RegQueryValueEx failed: 2
ShellState.cpp:49: SHELLSTATE SSF_MASK: 23 00 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 33 0A 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 33 AA 23 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 33 0A 22 00
ShellState.cpp:282: Test failed: ss2.iSortDirection expected 1, was 0
ShellState.cpp:310: Test failed: ss2.fDoubleClickInWebView expected -1, was 0
ShellState.cpp:314: Test failed: ss2.iSortDirection expected 1, was 0
ShellState.cpp:347: Test failed: ss2.fNoConfirmRecycle expected -1, was 0
ShellState.cpp:352: Test failed: ss2.iSortDirection expected 1, was 0
ShellState.cpp:405: Test failed: ss2.fStartPanelOn expected to be TRUE
ShellState.cpp:407: Test failed: ss2.fShowAttribCol expected to be FALSE
ShellState.cpp:440: Test failed: There should be no registry key: 0
ShellState.cpp:469: Test failed: There should be no registry key: 0

ShellState: 66 tests executed (0 marked as todo, 9 failures), 1 skipped.

ShellState.cpp:516: GetVersion(): 0x0ECE0205
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000005
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00000ECE
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:49: SHELLSTATE KEY: 33 0A 00 00 00 00 00 00 00 00 00 00 00 00 00
00 01 00 00 00 0D 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:563: pss->fShowAllObjects: 1
ShellState.cpp:564: pss->fShowExtensions: 1
ShellState.cpp:565: pss->fNoConfirmRecycle: 0
ShellState.cpp:566: pss->fShowSysFiles: 0
ShellState.cpp:567: pss->fShowCompColor: 1
ShellState.cpp:568: pss->fDoubleClickInWebView: 1
ShellState.cpp:569: pss->fDesktopHTML: 0
ShellState.cpp:570: pss->fWin95Classic: 0
ShellState.cpp:571: pss->fDontPrettyPath: 0
ShellState.cpp:572: pss->fShowAttribCol: 1
ShellState.cpp:573: pss->fMapNetDrvBtn: 0
ShellState.cpp:574: pss->fShowInfoTip: 1
ShellState.cpp:575: pss->fHideIcons: 0
ShellState.cpp:576: pss->fWebView: 0
ShellState.cpp:577: pss->fFilter: 0
ShellState.cpp:578: pss->fShowSuperHidden: 0
ShellState.cpp:579: pss->fNoNetCrawling: 0
ShellState.cpp:580: pss->lParamSort: 0x00000000
ShellState.cpp:581: pss->iSortDirection: 0x00000001
ShellState.cpp:582: pss->version: 0x0000000D
ShellState.cpp:583: pss->fSepProcess: 0
ShellState.cpp:584: pss->fStartPanelOn: 0
ShellState.cpp:585: pss->fShowStartPage: 0
ShellState.cpp:619: Test failed: ss.fShowAttribCol expected -1, was 0
ShellState.cpp:49: SHELLSTATE SSF_MASK: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 33 A8 23 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 33 08 22 00
ShellState.cpp:282: Test failed: ss2.iSortDirection expected 1, was 0
ShellState.cpp:310: Test failed: ss2.fDoubleClickInWebView expected -1, was 0
ShellState.cpp:314: Test failed: ss2.iSortDirection expected 1, was 0
ShellState.cpp:347: Test failed: ss2.fNoConfirmRecycle expected -1, was 0
ShellState.cpp:352: Test failed: ss2.iSortDirection expected 1, was 0
ShellState.cpp:405: Test failed: ss2.fStartPanelOn expected to be TRUE
ShellState.cpp:407: Test failed: ss2.fShowAttribCol expected to be FALSE
ShellState.cpp:440: Test failed: There should be no registry key: 0
ShellState.cpp:469: Test failed: There should be no registry key: 0

ShellState: 80 tests executed (0 marked as todo, 10 failures), 0 skipped.
```
</details>

<details>
  <summary>0.4.17-dev-556-g4fecc90 (after Whindmar's fix)</summary>

```
ShellState.cpp:516: GetVersion(): 0x0ECE0205
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000005
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00000ECE
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:77: Tests skipped: RegQueryValueEx failed: 2
ShellState.cpp:49: SHELLSTATE SSF_MASK: 23 00 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 33 0A 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 33 AA 23 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 33 0A 22 00
ShellState.cpp:309: Test failed: ss2.fNoConfirmRecycle expected 0, was -1
ShellState.cpp:348: Test failed: ss2.fDoubleClickInWebView expected 0, was -1
ShellState.cpp:405: Test failed: ss2.fStartPanelOn expected to be TRUE
ShellState.cpp:407: Test failed: ss2.fShowAttribCol expected to be FALSE
ShellState.cpp:440: Test failed: There should be no registry key: 0
ShellState.cpp:469: Test failed: There should be no registry key: 0

ShellState: 66 tests executed (0 marked as todo, 6 failures), 1 skipped.

ShellState.cpp:516: GetVersion(): 0x0ECE0205
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000005
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00000ECE
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:49: SHELLSTATE KEY: 33 0A 00 00 00 00 00 00 00 00 00 00 00 00 00
00 01 00 00 00 0D 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:563: pss->fShowAllObjects: 1
ShellState.cpp:564: pss->fShowExtensions: 1
ShellState.cpp:565: pss->fNoConfirmRecycle: 0
ShellState.cpp:566: pss->fShowSysFiles: 0
ShellState.cpp:567: pss->fShowCompColor: 1
ShellState.cpp:568: pss->fDoubleClickInWebView: 1
ShellState.cpp:569: pss->fDesktopHTML: 0
ShellState.cpp:570: pss->fWin95Classic: 0
ShellState.cpp:571: pss->fDontPrettyPath: 0
ShellState.cpp:572: pss->fShowAttribCol: 1
ShellState.cpp:573: pss->fMapNetDrvBtn: 0
ShellState.cpp:574: pss->fShowInfoTip: 1
ShellState.cpp:575: pss->fHideIcons: 0
ShellState.cpp:576: pss->fWebView: 0
ShellState.cpp:577: pss->fFilter: 0
ShellState.cpp:578: pss->fShowSuperHidden: 0
ShellState.cpp:579: pss->fNoNetCrawling: 0
ShellState.cpp:580: pss->lParamSort: 0x00000000
ShellState.cpp:581: pss->iSortDirection: 0x00000001
ShellState.cpp:582: pss->version: 0x0000000D
ShellState.cpp:583: pss->fSepProcess: 0
ShellState.cpp:584: pss->fStartPanelOn: 0
ShellState.cpp:585: pss->fShowStartPage: 0
ShellState.cpp:619: Test failed: ss.fShowAttribCol expected -1, was 0
ShellState.cpp:49: SHELLSTATE SSF_MASK: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 33 A8 23 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 33 08 22 00
ShellState.cpp:309: Test failed: ss2.fNoConfirmRecycle expected 0, was -1
ShellState.cpp:348: Test failed: ss2.fDoubleClickInWebView expected 0, was -1
ShellState.cpp:405: Test failed: ss2.fStartPanelOn expected to be TRUE
ShellState.cpp:407: Test failed: ss2.fShowAttribCol expected to be FALSE
ShellState.cpp:440: Test failed: There should be no registry key: 0
ShellState.cpp:469: Test failed: There should be no registry key: 0

ShellState: 80 tests executed (0 marked as todo, 7 failures), 0 skipped.
```
</details>

<details>
  <summary>After Whindmar's fix and reverting the Doug's hackfix</summary>

```
ShellState.cpp:516: GetVersion(): 0x0ECE0205
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000005
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00000ECE
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:77: Tests skipped: RegQueryValueEx failed: 2
ShellState.cpp:49: SHELLSTATE SSF_MASK: 23 00 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 33 0A 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 33 AA 23 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 33 0A 22 00
ShellState.cpp:309: Test failed: ss2.fNoConfirmRecycle expected 0, was -1
ShellState.cpp:348: Test failed: ss2.fDoubleClickInWebView expected 0, was -1
ShellState.cpp:405: Test failed: ss2.fStartPanelOn expected to be TRUE
ShellState.cpp:407: Test failed: ss2.fShowAttribCol expected to be FALSE

ShellState: 66 tests executed (0 marked as todo, 4 failures), 1 skipped.

ShellState.cpp:516: GetVersion(): 0x0ECE0205
ShellState.cpp:520: osinfo.dwMajorVersion: 0x00000005
ShellState.cpp:521: osinfo.dwMinorVersion: 0x00000002
ShellState.cpp:522: osinfo.dwBuildNumber: 0x00000ECE
ShellState.cpp:523: osinfo.dwPlatformId: 0x00000002
ShellState.cpp:525: WINVER: 0x0502
ShellState.cpp:526: _WIN32_WINNT: 0x0502
ShellState.cpp:527: _WIN32_IE: 0x0603
ShellState.cpp:528: NTDDI_VERSION: 0x05020100
ShellState.cpp:533: __MINGW32__: 0x00000001
ShellState.cpp:541: sizeof(SHELLSTATE): 32
ShellState.cpp:542: __alignof(SHELLSTATE): 1
ShellState.cpp:543: sizeof(SHELLFLAGSTATE): 4
ShellState.cpp:544: sizeof(CABINETSTATE): 12
ShellState.cpp:49: SHELLSTATE KEY: 33 0A 00 00 00 00 00 00 00 00 00 00 00 00 00
00 01 00 00 00 0D 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:563: pss->fShowAllObjects: 1
ShellState.cpp:564: pss->fShowExtensions: 1
ShellState.cpp:565: pss->fNoConfirmRecycle: 0
ShellState.cpp:566: pss->fShowSysFiles: 0
ShellState.cpp:567: pss->fShowCompColor: 1
ShellState.cpp:568: pss->fDoubleClickInWebView: 1
ShellState.cpp:569: pss->fDesktopHTML: 0
ShellState.cpp:570: pss->fWin95Classic: 0
ShellState.cpp:571: pss->fDontPrettyPath: 0
ShellState.cpp:572: pss->fShowAttribCol: 1
ShellState.cpp:573: pss->fMapNetDrvBtn: 0
ShellState.cpp:574: pss->fShowInfoTip: 1
ShellState.cpp:575: pss->fHideIcons: 0
ShellState.cpp:576: pss->fWebView: 0
ShellState.cpp:577: pss->fFilter: 0
ShellState.cpp:578: pss->fShowSuperHidden: 0
ShellState.cpp:579: pss->fNoNetCrawling: 0
ShellState.cpp:580: pss->lParamSort: 0x00000000
ShellState.cpp:581: pss->iSortDirection: 0x00000001
ShellState.cpp:582: pss->version: 0x0000000D
ShellState.cpp:583: pss->fSepProcess: 0
ShellState.cpp:584: pss->fStartPanelOn: 0
ShellState.cpp:585: pss->fShowStartPage: 0
ShellState.cpp:619: Test failed: ss.fShowAttribCol expected -1, was 0
ShellState.cpp:49: SHELLSTATE SSF_MASK: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLSTATE MAXDWORD: 33 08 00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
ShellState.cpp:49: SHELLFLAGSTATE SSF_MASK: 33 A8 23 00
ShellState.cpp:49: SHELLFLAGSTATE MAXDWORD: 33 08 22 00
ShellState.cpp:309: Test failed: ss2.fNoConfirmRecycle expected 0, was -1
ShellState.cpp:348: Test failed: ss2.fDoubleClickInWebView expected 0, was -1
ShellState.cpp:405: Test failed: ss2.fStartPanelOn expected to be TRUE
ShellState.cpp:407: Test failed: ss2.fShowAttribCol expected to be FALSE

ShellState: 80 tests executed (0 marked as todo, 5 failures), 0 skipped.
```
</details>

## Test summary on ReactOS builds

- 0.4.17-dev-202-g60c8612 (before Doug's hackfix)
  - `ShellState: 80 tests executed (0 marked as todo, 8 failures), 0 skipped.`
- 0.4.17-dev-203-g39ad1b6 (after Doug's hackfix)
  - `ShellState: 80 tests executed (0 marked as todo, 10 failures), 0 skipped.`
- 0.4.17-dev-556-g4fecc90 (after Whindmar's fix)
  - `ShellState: 80 tests executed (0 marked as todo, 7 failures), 0 skipped.`
- After Whindmar's fix and reverting the Doug's hackfix
  - `ShellState: 80 tests executed (0 marked as todo, 5 failures), 0 skipped.`

As you can see by test results, the hackfix needs to be reverted. I'm going to do this after merging these tests.

## Testbot runs

- [ ] KVM x86:
- [ ] KVM x64: