### PR TITLE
[FREELDR] Implement PCI bus detection on UEFI

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/hwpci.c
+++ b/boot/freeldr/freeldr/arch/i386/hwpci.c
@@ -73,6 +73,70 @@ GetPciIrqRoutingTable(VOID)
     return NULL;
 }
 
+ULONG
+PciReadConfigDword(
+    _In_ UCHAR Bus,
+    _In_ UCHAR Device,
+    _In_ UCHAR Function,
+    _In_ UCHAR Register)
+{
+    PCI_TYPE1_CFG_BITS Cfg;
+
+    Cfg.u.AsULONG = 0;
+    Cfg.u.bits.Enable = 1;
+    Cfg.u.bits.BusNumber = Bus;
+    Cfg.u.bits.DeviceNumber = Device;
+    Cfg.u.bits.FunctionNumber = Function;
+    Cfg.u.bits.RegisterNumber = Register & ~3;
+
+    WRITE_PORT_ULONG(PCI_TYPE1_ADDRESS_PORT, Cfg.u.AsULONG);
+    return READ_PORT_ULONG((PULONG)PCI_TYPE1_DATA_PORT);
+}
+
+BOOLEAN
+PciScanFunction(
+    _In_ UCHAR Bus,
+    _In_ UCHAR Device,
+    _In_ UCHAR Function,
+    _Inout_updates_(PCI_MAX_BUSES) BOOLEAN *ScannedBuses,
+    _Inout_updates_(PCI_MAX_BUSES) UCHAR *PendingBuses,
+    _Inout_ ULONG *PendingCount)
+{
+    ULONG VendorDevice, HeaderTypeDword, BridgeBusNumbers;
+    UCHAR HeaderType, SecondaryBus, SubordinateBus, b;
+
+    VendorDevice = PciReadConfigDword(Bus, Device, Function, 0x00);
+    if ((VendorDevice & 0xFFFF) == 0xFFFF)
+        return FALSE;
+
+    HeaderTypeDword = PciReadConfigDword(Bus, Device, Function, 0x0C);
+    HeaderType = (UCHAR)((HeaderTypeDword >> 16) & 0xFF);
+
+    if ((HeaderType & PCI_HEADER_TYPE_MASK) == PCI_HEADER_TYPE_BRIDGE)
+    {
+        BridgeBusNumbers = PciReadConfigDword(Bus, Device, Function, 0x18);
+        SecondaryBus = (UCHAR)((BridgeBusNumbers >> 8) & 0xFF);
+        SubordinateBus = (UCHAR)((BridgeBusNumbers >> 16) & 0xFF);
+
+        if (SecondaryBus != 0 && SecondaryBus != Bus && SubordinateBus >= SecondaryBus)
+        {
+            for (b = SecondaryBus; b <= SubordinateBus; b++)
+            {
+                if (!ScannedBuses[b] && (*PendingCount < PCI_MAX_BUSES))
+                {
+                    ScannedBuses[b] = TRUE;
+                    PendingBuses[(*PendingCount)++] = b;
+                }
+
+                if (b == 255)
+                    break; /* avoid UCHAR wraparound */
+            }
+        }
+    }
+
+    return TRUE;
+}
+
 #ifndef UEFIBOOT
 BOOLEAN
 PcFindPciBios(PPCI_REGISTRY_INFO BusData)

--- a/boot/freeldr/freeldr/arch/i386/hwpci.c
+++ b/boot/freeldr/freeldr/arch/i386/hwpci.c
@@ -103,7 +103,8 @@ PciScanFunction(
     _Inout_ ULONG *PendingCount)
 {
     ULONG VendorDevice, HeaderTypeDword, BridgeBusNumbers;
-    UCHAR HeaderType, SecondaryBus, SubordinateBus, b;
+    UCHAR HeaderType, SecondaryBus, SubordinateBus;
+    USHORT b;
 
     VendorDevice = PciReadConfigDword(Bus, Device, Function, 0x00);
     if ((VendorDevice & 0xFFFF) == 0xFFFF)
@@ -120,16 +121,13 @@ PciScanFunction(
 
         if (SecondaryBus != 0 && SecondaryBus != Bus && SubordinateBus >= SecondaryBus)
         {
-            for (b = SecondaryBus; b <= SubordinateBus; b++)
+            for (b = SecondaryBus; b <= SubordinateBus && b < PCI_MAX_BUSES; b++)
             {
                 if (!ScannedBuses[b] && (*PendingCount < PCI_MAX_BUSES))
                 {
                     ScannedBuses[b] = TRUE;
-                    PendingBuses[(*PendingCount)++] = b;
+                    PendingBuses[(*PendingCount)++] = (UCHAR)b;
                 }
-
-                if (b == 255)
-                    break; /* avoid UCHAR wraparound */
             }
         }
     }

--- a/boot/freeldr/freeldr/arch/i386/hwpci.c
+++ b/boot/freeldr/freeldr/arch/i386/hwpci.c
@@ -73,6 +73,7 @@ GetPciIrqRoutingTable(VOID)
     return NULL;
 }
 
+#ifndef UEFIBOOT
 BOOLEAN
 PcFindPciBios(PPCI_REGISTRY_INFO BusData)
 {
@@ -107,6 +108,7 @@ PcFindPciBios(PPCI_REGISTRY_INFO BusData)
 
     return FALSE;
 }
+#endif
 
 static
 VOID

--- a/boot/freeldr/freeldr/arch/uefi/uefihw.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefihw.c
@@ -26,14 +26,6 @@ extern PCM_FRAMEBUF_DEVICE_DATA FrameBufferData;
 BOOLEAN AcpiPresent = FALSE;
 static EFI_EVENT IdleTimerEvent = NULL;
 
-#define PCI_MAX_BUSES 256
-#define PCI_MAX_DEVICES 32
-#define PCI_MAX_FUNCTIONS 8
-
-#define PCI_HEADER_TYPE_MASK 0x7F
-#define PCI_HEADER_TYPE_BRIDGE 0x01
-#define PCI_HEADER_TYPE_MULTIFUNC 0x80
-
 /* FUNCTIONS *****************************************************************/
 
 VOID
@@ -331,72 +323,6 @@ DetectInternal(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
 }
 
 static
-ULONG
-UefiPciReadConfigDword(
-    _In_ UCHAR Bus,
-    _In_ UCHAR Device,
-    _In_ UCHAR Function,
-    _In_ UCHAR Register)
-{
-    PCI_TYPE1_CFG_BITS Cfg;
-
-    Cfg.u.AsULONG = 0;
-    Cfg.u.bits.Enable = 1;
-    Cfg.u.bits.BusNumber = Bus;
-    Cfg.u.bits.DeviceNumber = Device;
-    Cfg.u.bits.FunctionNumber = Function;
-    Cfg.u.bits.RegisterNumber = Register & ~3;
-
-    WRITE_PORT_ULONG(PCI_TYPE1_ADDRESS_PORT, Cfg.u.AsULONG);
-    return READ_PORT_ULONG((PULONG)PCI_TYPE1_DATA_PORT);
-}
-
-static
-BOOLEAN
-UefiScanPciFunction(
-    _In_ UCHAR Bus,
-    _In_ UCHAR Device,
-    _In_ UCHAR Function,
-    _Inout_updates_(PCI_MAX_BUSES) BOOLEAN *ScannedBuses,
-    _Inout_updates_(PCI_MAX_BUSES) UCHAR *PendingBuses,
-    _Inout_ ULONG *PendingCount)
-{
-    ULONG VendorDevice, HeaderTypeDword, BridgeBusNumbers;
-    UCHAR HeaderType, SecondaryBus, SubordinateBus, b;
-
-    VendorDevice = UefiPciReadConfigDword(Bus, Device, Function, 0x00);
-    if ((VendorDevice & 0xFFFF) == 0xFFFF)
-        return FALSE;
-
-    HeaderTypeDword = UefiPciReadConfigDword(Bus, Device, Function, 0x0C);
-    HeaderType = (UCHAR)((HeaderTypeDword >> 16) & 0xFF);
-
-    if ((HeaderType & PCI_HEADER_TYPE_MASK) == PCI_HEADER_TYPE_BRIDGE)
-    {
-        BridgeBusNumbers = UefiPciReadConfigDword(Bus, Device, Function, 0x18);
-        SecondaryBus = (UCHAR)((BridgeBusNumbers >> 8) & 0xFF);
-        SubordinateBus = (UCHAR)((BridgeBusNumbers >> 16) & 0xFF);
-
-        if (SecondaryBus != 0 && SecondaryBus != Bus && SubordinateBus >= SecondaryBus)
-        {
-            for (b = SecondaryBus; b <= SubordinateBus; b++)
-            {
-                if (!ScannedBuses[b] && (*PendingCount < PCI_MAX_BUSES))
-                {
-                    ScannedBuses[b] = TRUE;
-                    PendingBuses[(*PendingCount)++] = b;
-                }
-
-                if (b == 255)
-                    break; /* avoid UCHAR wraparound */
-            }
-        }
-    }
-
-    return TRUE;
-}
-
-static
 BOOLEAN
 UefiFindPciBios(
     _Out_ PPCI_REGISTRY_INFO BusData)
@@ -459,7 +385,7 @@ UefiFindPciBios(
 
         for (Device = 0; Device < PCI_MAX_DEVICES; Device++)
         {
-            if (!UefiScanPciFunction(Bus, (UCHAR)Device, 0,
+            if (!PciScanFunction(Bus, (UCHAR)Device, 0,
                                       ScannedBuses, PendingBuses, &PendingCount))
             {
                 continue;
@@ -469,13 +395,13 @@ UefiFindPciBios(
             if (Bus > HighestBus)
                 HighestBus = Bus;
 
-            HeaderTypeDword = UefiPciReadConfigDword(Bus, (UCHAR)Device, 0, 0x0C);
+            HeaderTypeDword = PciReadConfigDword(Bus, (UCHAR)Device, 0, 0x0C);
             if (!((HeaderTypeDword >> 16) & PCI_HEADER_TYPE_MULTIFUNC))
                 continue;
 
             for (Function = 1; Function < PCI_MAX_FUNCTIONS; Function++)
             {
-                if (UefiScanPciFunction(Bus, (UCHAR)Device, (UCHAR)Function,
+                if (PciScanFunction(Bus, (UCHAR)Device, (UCHAR)Function,
                                          ScannedBuses, PendingBuses, &PendingCount))
                 {
                     AnyFound = TRUE;

--- a/boot/freeldr/freeldr/arch/uefi/uefihw.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefihw.c
@@ -344,7 +344,7 @@ UefiFindPciBios(
     Mcfg = (PMCFG_TABLE)UefiFindAcpiTable(MCFG_SIGNATURE);
     if ((Mcfg != NULL) && (Mcfg->Header.Length >= sizeof(MCFG_TABLE)))
     {
-        McfgCount = (Mcfg->Header.Length - sizeof(MCFG_TABLE)) / sizeof(MCFG_ALLOCATION) + 1;
+        McfgCount = (Mcfg->Header.Length - FIELD_OFFSET(MCFG_TABLE, Allocation)) / sizeof(MCFG_ALLOCATION);
         HighestMcfgBus = 0;
 
         for (McfgIndex = 0; McfgIndex < McfgCount; McfgIndex++)

--- a/boot/freeldr/freeldr/arch/uefi/uefihw.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefihw.c
@@ -386,7 +386,7 @@ UefiFindPciBios(
         for (Device = 0; Device < PCI_MAX_DEVICES; Device++)
         {
             if (!PciScanFunction(Bus, (UCHAR)Device, 0,
-                                      ScannedBuses, PendingBuses, &PendingCount))
+                                 ScannedBuses, PendingBuses, &PendingCount))
             {
                 continue;
             }

--- a/boot/freeldr/freeldr/arch/uefi/uefihw.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefihw.c
@@ -402,7 +402,7 @@ UefiFindPciBios(
             for (Function = 1; Function < PCI_MAX_FUNCTIONS; Function++)
             {
                 if (PciScanFunction(Bus, (UCHAR)Device, (UCHAR)Function,
-                                         ScannedBuses, PendingBuses, &PendingCount))
+                                    ScannedBuses, PendingBuses, &PendingCount))
                 {
                     AnyFound = TRUE;
                 }

--- a/boot/freeldr/freeldr/arch/uefi/uefihw.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefihw.c
@@ -401,6 +401,11 @@ BOOLEAN
 UefiFindPciBios(
     _Out_ PPCI_REGISTRY_INFO BusData)
 {
+    PMCFG_TABLE Mcfg;
+    PMCFG_ALLOCATION Alloc;
+    ULONG McfgCount, McfgIndex;
+    UCHAR HighestMcfgBus;
+    BOOLEAN FoundMcfgSegment0 = FALSE;
     BOOLEAN ScannedBuses[PCI_MAX_BUSES];
     UCHAR PendingBuses[PCI_MAX_BUSES];
     ULONG PendingCount = 0;
@@ -409,9 +414,42 @@ UefiFindPciBios(
     ULONG Device, Function, HeaderTypeDword;
     BOOLEAN AnyFound = FALSE;
 
+    /* Prefer MCFG since it lists each segment's bus range directly */
+    Mcfg = (PMCFG_TABLE)UefiFindAcpiTable(MCFG_SIGNATURE);
+    if ((Mcfg != NULL) && (Mcfg->Header.Length >= sizeof(MCFG_TABLE)))
+    {
+        McfgCount = (Mcfg->Header.Length - sizeof(MCFG_TABLE)) / sizeof(MCFG_ALLOCATION) + 1;
+        HighestMcfgBus = 0;
+
+        for (McfgIndex = 0; McfgIndex < McfgCount; McfgIndex++)
+        {
+            Alloc = &Mcfg->Allocation[McfgIndex];
+
+            if (Alloc->PciSegmentGroup != 0)
+                continue;
+
+            if (Alloc->EndBusNumber < Alloc->StartBusNumber)
+                continue; /* malformed entry */
+
+            FoundMcfgSegment0 = TRUE;
+            if (Alloc->EndBusNumber > HighestMcfgBus)
+                HighestMcfgBus = Alloc->EndBusNumber;
+        }
+
+        if (FoundMcfgSegment0)
+        {
+            BusData->MajorRevision = 3;
+            BusData->MinorRevision = 0;
+            BusData->NoBuses = HighestMcfgBus + 1;
+            BusData->HardwareMechanism = 1;
+
+            TRACE("UEFI PCI: %u bus(es) found via MCFG\n", BusData->NoBuses);
+            return TRUE;
+        }
+    }
+
     RtlZeroMemory(ScannedBuses, sizeof(ScannedBuses));
 
-    /* Seed the queue with bus 0 */
     ScannedBuses[0] = TRUE;
     PendingBuses[PendingCount++] = 0;
 

--- a/boot/freeldr/freeldr/arch/uefi/uefihw.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefihw.c
@@ -26,6 +26,14 @@ extern PCM_FRAMEBUF_DEVICE_DATA FrameBufferData;
 BOOLEAN AcpiPresent = FALSE;
 static EFI_EVENT IdleTimerEvent = NULL;
 
+#define PCI_MAX_BUSES 256
+#define PCI_MAX_DEVICES 32
+#define PCI_MAX_FUNCTIONS 8
+
+#define PCI_HEADER_TYPE_MASK 0x7F
+#define PCI_HEADER_TYPE_BRIDGE 0x01
+#define PCI_HEADER_TYPE_MULTIFUNC 0x80
+
 /* FUNCTIONS *****************************************************************/
 
 VOID
@@ -322,6 +330,147 @@ DetectInternal(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
     /* FIXME: Detect more devices */
 }
 
+static
+ULONG
+UefiPciReadConfigDword(
+    _In_ UCHAR Bus,
+    _In_ UCHAR Device,
+    _In_ UCHAR Function,
+    _In_ UCHAR Register)
+{
+    PCI_TYPE1_CFG_BITS Cfg;
+
+    Cfg.u.AsULONG = 0;
+    Cfg.u.bits.Enable = 1;
+    Cfg.u.bits.BusNumber = Bus;
+    Cfg.u.bits.DeviceNumber = Device;
+    Cfg.u.bits.FunctionNumber = Function;
+    Cfg.u.bits.RegisterNumber = Register & ~3;
+
+    WRITE_PORT_ULONG(PCI_TYPE1_ADDRESS_PORT, Cfg.u.AsULONG);
+    return READ_PORT_ULONG((PULONG)PCI_TYPE1_DATA_PORT);
+}
+
+static
+BOOLEAN
+UefiScanPciFunction(
+    _In_ UCHAR Bus,
+    _In_ UCHAR Device,
+    _In_ UCHAR Function,
+    _Inout_updates_(PCI_MAX_BUSES) BOOLEAN *ScannedBuses,
+    _Inout_updates_(PCI_MAX_BUSES) UCHAR *PendingBuses,
+    _Inout_ ULONG *PendingCount)
+{
+    ULONG VendorDevice, HeaderTypeDword, BridgeBusNumbers;
+    UCHAR HeaderType, SecondaryBus, SubordinateBus, b;
+
+    VendorDevice = UefiPciReadConfigDword(Bus, Device, Function, 0x00);
+    if ((VendorDevice & 0xFFFF) == 0xFFFF)
+        return FALSE;
+
+    HeaderTypeDword = UefiPciReadConfigDword(Bus, Device, Function, 0x0C);
+    HeaderType = (UCHAR)((HeaderTypeDword >> 16) & 0xFF);
+
+    if ((HeaderType & PCI_HEADER_TYPE_MASK) == PCI_HEADER_TYPE_BRIDGE)
+    {
+        BridgeBusNumbers = UefiPciReadConfigDword(Bus, Device, Function, 0x18);
+        SecondaryBus = (UCHAR)((BridgeBusNumbers >> 8) & 0xFF);
+        SubordinateBus = (UCHAR)((BridgeBusNumbers >> 16) & 0xFF);
+
+        if (SecondaryBus != 0 && SecondaryBus != Bus && SubordinateBus >= SecondaryBus)
+        {
+            for (b = SecondaryBus; b <= SubordinateBus; b++)
+            {
+                if (!ScannedBuses[b] && (*PendingCount < PCI_MAX_BUSES))
+                {
+                    ScannedBuses[b] = TRUE;
+                    PendingBuses[(*PendingCount)++] = b;
+                }
+
+                if (b == 255)
+                    break; /* avoid UCHAR wraparound */
+            }
+        }
+    }
+
+    return TRUE;
+}
+
+static
+BOOLEAN
+UefiFindPciBios(
+    _Out_ PPCI_REGISTRY_INFO BusData)
+{
+    BOOLEAN ScannedBuses[PCI_MAX_BUSES];
+    UCHAR PendingBuses[PCI_MAX_BUSES];
+    ULONG PendingCount = 0;
+    ULONG QueueHead = 0;
+    UCHAR Bus, HighestBus = 0;
+    ULONG Device, Function, HeaderTypeDword;
+    BOOLEAN AnyFound = FALSE;
+
+    RtlZeroMemory(ScannedBuses, sizeof(ScannedBuses));
+
+    /* Seed the queue with bus 0 */
+    ScannedBuses[0] = TRUE;
+    PendingBuses[PendingCount++] = 0;
+
+    while (QueueHead < PendingCount)
+    {
+        Bus = PendingBuses[QueueHead++];
+
+        for (Device = 0; Device < PCI_MAX_DEVICES; Device++)
+        {
+            if (!UefiScanPciFunction(Bus, (UCHAR)Device, 0,
+                                      ScannedBuses, PendingBuses, &PendingCount))
+            {
+                continue;
+            }
+
+            AnyFound = TRUE;
+            if (Bus > HighestBus)
+                HighestBus = Bus;
+
+            HeaderTypeDword = UefiPciReadConfigDword(Bus, (UCHAR)Device, 0, 0x0C);
+            if (!((HeaderTypeDword >> 16) & PCI_HEADER_TYPE_MULTIFUNC))
+                continue;
+
+            for (Function = 1; Function < PCI_MAX_FUNCTIONS; Function++)
+            {
+                if (UefiScanPciFunction(Bus, (UCHAR)Device, (UCHAR)Function,
+                                         ScannedBuses, PendingBuses, &PendingCount))
+                {
+                    AnyFound = TRUE;
+                }
+            }
+        }
+    }
+
+    for (Bus = PCI_MAX_BUSES - 1; Bus > HighestBus; Bus--)
+    {
+        if (ScannedBuses[Bus])
+        {
+            HighestBus = Bus;
+            break;
+        }
+    }
+
+    if (!AnyFound)
+    {
+        WARN("No PCI devices found\n");
+        return FALSE;
+    }
+
+    BusData->MajorRevision = 3;
+    BusData->MinorRevision = 0;
+    BusData->NoBuses = HighestBus + 1;
+    BusData->HardwareMechanism = 1;
+
+    TRACE("UEFI PCI probe: %u bus(es) found\n", BusData->NoBuses);
+
+    return TRUE;
+}
+
 PCONFIGURATION_COMPONENT_DATA
 UefiHwDetect(
     _In_opt_ PCSTR Options)
@@ -344,7 +493,9 @@ UefiHwDetect(
 
     /* Detect buses */
     DetectInternal(SystemKey, &BusNumber);
-    // TODO: DetectPciBios
+#if defined(_M_IX86) || defined(_M_AMD64)
+    DetectPciBios(SystemKey, &BusNumber, UefiFindPciBios);
+#endif
     DetectAcpiBios(SystemKey, &BusNumber);
 
     TRACE("DetectHardware() Done\n");

--- a/boot/freeldr/freeldr/include/arch/pc/hardware.h
+++ b/boot/freeldr/freeldr/include/arch/pc/hardware.h
@@ -63,6 +63,14 @@ typedef struct _PCI_TYPE1_CFG_BITS
     } u;
 } PCI_TYPE1_CFG_BITS, *PPCI_TYPE1_CFG_BITS;
 
+#define PCI_MAX_BUSES 256
+#define PCI_MAX_DEVICES 32
+#define PCI_MAX_FUNCTIONS 8
+
+#define PCI_HEADER_TYPE_MASK 0x7F
+#define PCI_HEADER_TYPE_BRIDGE 0x01
+#define PCI_HEADER_TYPE_MULTIFUNC 0x80
+
 typedef
 PCM_PARTIAL_RESOURCE_LIST
 (*GET_HARDDISK_CONFIG_DATA)(UCHAR DriveNumber, ULONG* pSize);
@@ -93,6 +101,22 @@ DetectPciBios(
     _In_ PCONFIGURATION_COMPONENT_DATA SystemKey,
     _Inout_ PULONG BusNumber,
     _In_ FIND_PCI_BIOS MachFindPciBios);
+
+ULONG
+PciReadConfigDword(
+    _In_ UCHAR Bus,
+    _In_ UCHAR Device,
+    _In_ UCHAR Function,
+    _In_ UCHAR Register);
+
+BOOLEAN
+PciScanFunction(
+    _In_ UCHAR Bus,
+    _In_ UCHAR Device,
+    _In_ UCHAR Function,
+    _Inout_updates_(PCI_MAX_BUSES) BOOLEAN *ScannedBuses,
+    _Inout_updates_(PCI_MAX_BUSES) UCHAR *PendingBuses,
+    _Inout_ ULONG *PendingCount);
 
 /* i386pnp.S */
 ULONG_PTR __cdecl PnpBiosSupported(VOID);

--- a/boot/freeldr/freeldr/uefi.cmake
+++ b/boot/freeldr/freeldr/uefi.cmake
@@ -26,11 +26,14 @@ list(APPEND UEFILDR_ARC_SOURCE
 
 if(ARCH STREQUAL "i386")
     list(APPEND UEFILDR_ARC_SOURCE
-        arch/i386/i386idt.c)
+        arch/i386/i386idt.c
+        arch/i386/hwpci.c)
     list(APPEND UEFILDR_COMMON_ASM_SOURCE
         arch/uefi/i386/uefiasm.S
         arch/i386/i386trap.S)
 elseif(ARCH STREQUAL "amd64")
+    list(APPEND UEFILDR_ARC_SOURCE
+        arch/i386/hwpci.c)
     list(APPEND UEFILDR_COMMON_ASM_SOURCE
         arch/uefi/amd64/uefiasm.S)
 elseif(ARCH STREQUAL "arm")

--- a/sdk/include/reactos/drivers/acpi/acpi.h
+++ b/sdk/include/reactos/drivers/acpi/acpi.h
@@ -41,6 +41,7 @@ typedef struct _ACPI_BIOS_MULTI_NODE
 #define SRAT_SIGNATURE 'TARS'
 #define WDRT_SIGNATURE 'TRDW'
 #define BGRT_SIGNATURE  0x54524742      	// "BGRT"
+#define MCFG_SIGNATURE 'GFCM'
 
 //
 // FADT Flags
@@ -264,5 +265,21 @@ typedef struct _BGRT_TABLE
     ULONG OffsetX;
     ULONG OffsetY;
 } BGRT_TABLE, *PBGRT_TABLE;
+
+typedef struct _MCFG_ALLOCATION
+{
+    ULONGLONG BaseAddress;
+    USHORT PciSegmentGroup;
+    UCHAR StartBusNumber;
+    UCHAR EndBusNumber;
+    ULONG Reserved;
+} MCFG_ALLOCATION, *PMCFG_ALLOCATION;
+
+typedef struct _MCFG_TABLE
+{
+    DESCRIPTION_HEADER Header;
+    ULONGLONG Reserved;
+    MCFG_ALLOCATION Allocation[ANYSIZE_ARRAY];
+} MCFG_TABLE, *PMCFG_TABLE;
 
 /* EOF */


### PR DESCRIPTION
## Purpose

UEFI boot skipped PCI bus detection entirely, so the kernel got zero PCI buses reported. Add UEFI-native detection: 
MCFG when present, config space probing with bridge walking as fallback.

JIRA issue: [CORE-20760](https://jira.reactos.org/browse/CORE-20760)

## Proposed changes
- Add `UefiFindPciBios` in `uefihw.c` 
- Add two helpers (`PciReadConfigDword`, `PciScanFunction`) to `hwpci.c`, add their signatures to `hardware.h` and add some defines too.
- Prefer ACPI MCFG for bus count and fall back to CF8/CFC probing with bridge walking
- Add `MCFG_TABLE`/`MCFG_ALLOCATION` to `acpi.h`

## TODO
- [ ] Should be tested on real hardware (with and without MCFG)

## Testbot runs (Filled in by Devs)
- [ ] KVM x86:
- [ ] KVM x64: