### PR TITLE
[NTOS:EX] Fix shared push lock list optimization

### DIFF
--- a/ntoskrnl/ex/pushlock.c
+++ b/ntoskrnl/ex/pushlock.c
@@ -213,8 +213,13 @@ ExfWakePushLock(PEX_PUSH_LOCK PushLock,
 /*++
  * @name ExpOptimizePushLockList
  *
- *     The ExpOptimizePushLockList routine optimizes the list of waiters
- *     associated to a pushlock's wait block.
+ *     The ExpOptimizePushLockList routine completes the links in a push
+ *     lock waiter chain.
+ *
+ *     Wait blocks are inserted at the head using their Next link. This
+ *     routine fills the corresponding Previous links and caches the tail
+ *     pointer in the new head, allowing the wakeup to traverse the
+ *     chain without first scanning it from the head.
  *
  * @param PushLock
  *        Pointer to a pushlock whose waiter list needs to be optimized.
@@ -247,7 +252,11 @@ ExpOptimizePushLockList(PEX_PUSH_LOCK PushLock,
     /* Start main loop */
     for (;;)
     {
-        /* Check if we've been unlocked */
+        /*
+         * A release may have cleared Locked while this thread owned
+         * Waking. In that case, retain responsibility for the chain
+         * and proceed directly to wakeup.
+         */
         if (!OldValue.Locked)
         {
             /* Wake us up and leave */
@@ -255,34 +264,38 @@ ExpOptimizePushLockList(PEX_PUSH_LOCK PushLock,
             break;
         }
 
-        /* Get the wait block */
+        /* Start at the waiter chain head encoded in the lock value. */
         WaitBlock = (PEX_PUSH_LOCK_WAIT_BLOCK)(OldValue.Value &
                                                ~EX_PUSH_LOCK_PTR_BITS);
 
-        /* Loop the blocks */
         FirstWaitBlock = WaitBlock;
+
+        /*
+         * Follow Next links until reaching an already completed part
+         * of the chain. Complete the reverse links along the way.
+         */
         while (TRUE)
         {
-            /* Get the last wait block */
             LastWaitBlock = WaitBlock->Last;
             if (LastWaitBlock)
             {
-                /* Set this as the new last block, we're done */
+                /* Cache the chain tail in the current head. */
                 FirstWaitBlock->Last = LastWaitBlock;
                 break;
             }
 
-            /* Save the block */
             PreviousWaitBlock = WaitBlock;
 
-            /* Get the next block */
             WaitBlock = WaitBlock->Next;
 
-            /* Save the previous */
+            /* Link the older waiter back toward the chain head. */
             WaitBlock->Previous = PreviousWaitBlock;
         }
 
-        /* Remove the wake bit */
+        /*
+         * Release responsibility for the waiter chain now that its
+         * reverse links and cached tail are complete.
+         */
         NewValue.Value = OldValue.Value &~ EX_PUSH_LOCK_WAKING;
 
         /* Sanity checks */
@@ -294,10 +307,13 @@ ExpOptimizePushLockList(PEX_PUSH_LOCK PushLock,
                                                          NewValue.Ptr,
                                                          OldValue.Ptr);
 
-        /* If we updated correctly, leave */
+        /* If waking was cleared successfully, we're done */
         if (NewValue.Value == OldValue.Value) break;
 
-        /* Update value */
+        /*
+         * A waiter was inserted or the lock was released. Retry from
+         * the current lock value while keeping Waking ownership.
+         */
         OldValue = NewValue;
     }
 }
@@ -518,7 +534,7 @@ ExfAcquirePushLockExclusive(PEX_PUSH_LOCK PushLock)
             /* Check if there is already a waiter */
             if (OldValue.Waiting)
             {
-                /* Nobody is the last waiter yet */
+                /* The tail pointer is filled in when the wait list is linked */
                 WaitBlock->Last = NULL;
 
                 /* We are an exclusive waiter */
@@ -540,7 +556,7 @@ ExfAcquirePushLockExclusive(PEX_PUSH_LOCK PushLock)
             }
             else
             {
-                /* We are the first waiter, so loop the wait block */
+                /* The first waiter is both the head and the tail */
                 WaitBlock->Last = WaitBlock;
 
                 /* Set the share count */
@@ -709,7 +725,7 @@ ExfAcquirePushLockShared(PEX_PUSH_LOCK PushLock)
                 WaitBlock->Next = (PEX_PUSH_LOCK_WAIT_BLOCK)(
                                    OldValue.Value &~ EX_PUSH_LOCK_PTR_BITS);
 
-                /* Nobody is the last waiter yet */
+                /* The tail pointer is filled in when the wait list is linked */
                 WaitBlock->Last = NULL;
 
                 /* Point to ours */
@@ -724,7 +740,7 @@ ExfAcquirePushLockShared(PEX_PUSH_LOCK PushLock)
             }
             else
             {
-                /* We are the first waiter, so loop the wait block */
+                /* The first waiter is both the head and the tail */
                 WaitBlock->Last = WaitBlock;
 
                 /* Point to our wait block */

--- a/ntoskrnl/ex/pushlock.c
+++ b/ntoskrnl/ex/pushlock.c
@@ -644,7 +644,7 @@ VOID
 FASTCALL
 ExfAcquirePushLockShared(PEX_PUSH_LOCK PushLock)
 {
-    EX_PUSH_LOCK OldValue = *PushLock, NewValue;
+    EX_PUSH_LOCK OldValue = *PushLock, NewValue, TempValue;
     BOOLEAN NeedWake;
     EX_PUSH_LOCK_WAIT_BLOCK Block;
     PEX_PUSH_LOCK_WAIT_BLOCK WaitBlock = &Block;
@@ -736,6 +736,7 @@ ExfAcquirePushLockShared(PEX_PUSH_LOCK PushLock)
 #endif
 
             /* Write the new value */
+            TempValue = NewValue;
             NewValue.Ptr = InterlockedCompareExchangePointer(&PushLock->Ptr,
                                                              NewValue.Ptr,
                                                              OldValue.Ptr);
@@ -746,14 +747,11 @@ ExfAcquirePushLockShared(PEX_PUSH_LOCK PushLock)
                 continue;
             }
 
-            /* Update the value now */
-            OldValue = NewValue;
-
             /* Check if the pushlock needed waking */
             if (NeedWake)
             {
                 /* Scan the Waiters and Wake PushLocks */
-                ExpOptimizePushLockList(PushLock, OldValue);
+                ExpOptimizePushLockList(PushLock, TempValue);
             }
 
             /* Set up the Wait Gate */

--- a/ntoskrnl/ex/pushlock.c
+++ b/ntoskrnl/ex/pushlock.c
@@ -219,21 +219,30 @@ ExfWakePushLock(PEX_PUSH_LOCK PushLock,
  * @param PushLock
  *        Pointer to a pushlock whose waiter list needs to be optimized.
  *
- * @param OldValue
- *        Last known value of the pushlock before this routine was called.
+ * @param InitialValue
+ *        Last known value of the pushlock installed by the caller when
+ *        it inserted a new wait block and set the Waking bit.
  *
  * @return None.
  *
- * @remarks At the end of the optimization, the pushlock will also be wakened.
+ * @remarks If the pushlock remains locked, this routine completes
+ *          the wait block links and clears Waking. If the lock has
+ *          been released, the pushlock will be wakened.
  *
  *--*/
 VOID
 FASTCALL
 ExpOptimizePushLockList(PEX_PUSH_LOCK PushLock,
-                        EX_PUSH_LOCK OldValue)
+                        EX_PUSH_LOCK InitialValue)
 {
     PEX_PUSH_LOCK_WAIT_BLOCK WaitBlock, LastWaitBlock, PreviousWaitBlock, FirstWaitBlock;
-    EX_PUSH_LOCK NewValue;
+    EX_PUSH_LOCK OldValue, NewValue;
+
+    ASSERT(InitialValue.Locked);
+    ASSERT(InitialValue.Waiting);
+    ASSERT(InitialValue.Waking);
+
+    OldValue = InitialValue;
 
     /* Start main loop */
     for (;;)

--- a/ntoskrnl/ex/pushlock.c
+++ b/ntoskrnl/ex/pushlock.c
@@ -213,8 +213,13 @@ ExfWakePushLock(PEX_PUSH_LOCK PushLock,
 /*++
  * @name ExpOptimizePushLockList
  *
- *     The ExpOptimizePushLockList routine optimizes the list of waiters
- *     associated to a pushlock's wait block.
+ *     The ExpOptimizePushLockList routine completes the links in a push
+ *     lock waiter chain.
+ *
+ *     Wait blocks are inserted at the head using their Next link. This
+ *     routine fills the corresponding Previous links and caches the tail
+ *     pointer in the new head, allowing the wakeup to traverse the
+ *     chain without first scanning it from the head.
  *
  * @param PushLock
  *        Pointer to a pushlock whose waiter list needs to be optimized.
@@ -247,7 +252,11 @@ ExpOptimizePushLockList(PEX_PUSH_LOCK PushLock,
     /* Start main loop */
     for (;;)
     {
-        /* Check if we've been unlocked */
+        /*
+         * A release may have cleared Locked while this thread owned
+         * Waking. In that case, retain responsibility for the chain
+         * and proceed directly to wakeup.
+         */
         if (!OldValue.Locked)
         {
             /* Wake us up and leave */
@@ -255,34 +264,38 @@ ExpOptimizePushLockList(PEX_PUSH_LOCK PushLock,
             break;
         }
 
-        /* Get the wait block */
+        /* Start at the waiter chain head encoded in the lock value. */
         WaitBlock = (PEX_PUSH_LOCK_WAIT_BLOCK)(OldValue.Value &
                                                ~EX_PUSH_LOCK_PTR_BITS);
 
-        /* Loop the blocks */
         FirstWaitBlock = WaitBlock;
+
+        /*
+         * Follow Next links until reaching an already completed part
+         * of the chain. Complete the reverse links along the way.
+         */
         while (TRUE)
         {
-            /* Get the last wait block */
             LastWaitBlock = WaitBlock->Last;
             if (LastWaitBlock)
             {
-                /* Set this as the new last block, we're done */
+                /* Cache the chain tail in the current head. */
                 FirstWaitBlock->Last = LastWaitBlock;
                 break;
             }
 
-            /* Save the block */
             PreviousWaitBlock = WaitBlock;
 
-            /* Get the next block */
             WaitBlock = WaitBlock->Next;
 
-            /* Save the previous */
+            /* Link the older waiter back toward the chain head. */
             WaitBlock->Previous = PreviousWaitBlock;
         }
 
-        /* Remove the wake bit */
+        /*
+         * Release responsibility for the waiter chain now that its
+         * reverse links and cached tail are complete.
+         */
         NewValue.Value = OldValue.Value &~ EX_PUSH_LOCK_WAKING;
 
         /* Sanity checks */
@@ -294,10 +307,13 @@ ExpOptimizePushLockList(PEX_PUSH_LOCK PushLock,
                                                          NewValue.Ptr,
                                                          OldValue.Ptr);
 
-        /* If we updated correctly, leave */
+        /* Waking was cleared successfully */
         if (NewValue.Value == OldValue.Value) break;
 
-        /* Update value */
+        /*
+         * A waiter was inserted or the lock was released. Retry from
+         * the current lock value while keeping Waking ownership.
+         */
         OldValue = NewValue;
     }
 }
@@ -518,7 +534,7 @@ ExfAcquirePushLockExclusive(PEX_PUSH_LOCK PushLock)
             /* Check if there is already a waiter */
             if (OldValue.Waiting)
             {
-                /* Nobody is the last waiter yet */
+                /* The tail pointer is filled in when the wait list is linked */
                 WaitBlock->Last = NULL;
 
                 /* We are an exclusive waiter */
@@ -540,7 +556,7 @@ ExfAcquirePushLockExclusive(PEX_PUSH_LOCK PushLock)
             }
             else
             {
-                /* We are the first waiter, so loop the wait block */
+                /* The first waiter is both the head and the tail */
                 WaitBlock->Last = WaitBlock;
 
                 /* Set the share count */
@@ -709,7 +725,7 @@ ExfAcquirePushLockShared(PEX_PUSH_LOCK PushLock)
                 WaitBlock->Next = (PEX_PUSH_LOCK_WAIT_BLOCK)(
                                    OldValue.Value &~ EX_PUSH_LOCK_PTR_BITS);
 
-                /* Nobody is the last waiter yet */
+                /* The tail pointer is filled in when the wait list is linked */
                 WaitBlock->Last = NULL;
 
                 /* Point to ours */
@@ -724,7 +740,7 @@ ExfAcquirePushLockShared(PEX_PUSH_LOCK PushLock)
             }
             else
             {
-                /* We are the first waiter, so loop the wait block */
+                /* The first waiter is both the head and the tail */
                 WaitBlock->Last = WaitBlock;
 
                 /* Point to our wait block */


### PR DESCRIPTION
When a shared acquisition queues behind existing waiters while Waking bit is clear, it inserts a new wait block and sets Waking in the same CMPXCHG. CMPXCHG returns the previous lock value and overwrites NewValue. The existing code subsequently copies that returned value to OldValue and passes it to ExpOptimizePushLockList.

As a result, ExpOptimizePushLockList initially receives the pre enqueue wait block head with Waking clear, rather than the value installed by the successful enqueue. It eventually obtains the current value after its CMPXCHG fails, but only after an unnecessary chain walk and failed exchange.

Changes:
- Preserve the shared acquisition's installed lock value before the CMPXCHG and pass that value to ExpOptimizePushLockList.
- Rename ExpOptimizePushLockList argument to InitialValue and document its required state.
- Correct ExpOptimizePushLockList remarks to distinguish clearing Waking from entering the wakeup.
- Rewrite some comments because ExpOptimizePushLockList is currently hard to understand from its comments, and several comments are misleading.