### PR TITLE
[WIN32K:NTGDI] Add missing DC unlock in NtGdiFlushUserBatch

### DIFF
--- a/win32ss/gdi/ntgdi/gdibatch.c
+++ b/win32ss/gdi/ntgdi/gdibatch.c
@@ -512,7 +512,14 @@ NtGdiFlushUserBatch(VOID)
            ULONG Size;
            // Process Gdi Batch!
            Size = GdiFlushUserBatch(pDC, (PGDIBATCHHDR) pHdr);
-           if (!Size) break;
+           if (!Size)
+           {
+               if (pDC)
+               {
+                   DC_UnlockDc(pDC);
+               }
+               break;
+           }
            pHdr += Size;
        }
 


### PR DESCRIPTION
## Purpose

Add missing DC unlock in NtGdiFlushUserBatch

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
