### PR TITLE
[NTOS:KE/x86] Fix CPU vendor retrieval order

### DIFF
--- a/ntoskrnl/ke/i386/cpu.c
+++ b/ntoskrnl/ke/i386/cpu.c
@@ -111,10 +111,14 @@ VOID
 NTAPI
 KiSetProcessorType(VOID)
 {
+    PKPRCB Prcb = KeGetCurrentPrcb();
     CPU_INFO CpuInfo;
     CPU_SIGNATURE CpuSignature;
     BOOLEAN ExtendModel;
     ULONG Stepping, Type;
+
+    /* Get the CPU vendor string */
+    KiGetCpuVendorString(Prcb->VendorString);
 
     /* Do CPUID 1 now */
     KiCpuId(&CpuInfo, 1);
@@ -153,9 +157,9 @@ KiSetProcessorType(VOID)
     }
 
     /* Save them in the PRCB */
-    KeGetCurrentPrcb()->CpuID = TRUE;
-    KeGetCurrentPrcb()->CpuType = (UCHAR)Type;
-    KeGetCurrentPrcb()->CpuStep = (USHORT)Stepping;
+    Prcb->CpuID = TRUE;
+    Prcb->CpuType = (UCHAR)Type;
+    Prcb->CpuStep = (USHORT)Stepping;
 }
 
 CODE_SEG("INIT")
@@ -170,9 +174,6 @@ KiGetFeatureBits(VOID)
     UCHAR Ccr1;
     BOOLEAN ExtendedCPUID = TRUE;
     ULONG CpuFeatures = 0;
-
-    /* Get the CPU vendor string */
-    KiGetCpuVendorString(Prcb->VendorString);
 
     /* Get the Vendor ID */
     Vendor = KiGetCpuVendor();


### PR DESCRIPTION
## Purpose

Move call to KiGetCpuVendorString from KiGetFeatureBits to KiSetProcessorType. The latter is called before KiGetFeatureBits and calls KiGetCpuVendor, which expects the vendor string to be set up. This new order matches what we do for x64 and makes more sense.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109378,109381
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109379,109382