### PR TITLE
[FREELDR] Fix AMD64 builds on GCC/Clang

### DIFF
--- a/boot/freeldr/freeldr/include/mm.h
+++ b/boot/freeldr/freeldr/include/mm.h
@@ -21,13 +21,8 @@
 
 extern char __ImageBase;
 #ifdef __GNUC__
-  #ifdef _M_AMD64
-    /* .text/.data/.rdata, and .bss */
-    #define FREELDR_SECTION_COUNT 2
-  #else
-    /* .text/.data/.rdata, .edata and .bss */
-    #define FREELDR_SECTION_COUNT 3
-  #endif
+/* .text/.data/.rdata, .edata and .bss */
+#define FREELDR_SECTION_COUNT 3
 #else
 #ifdef _M_AMD64
 /* .text, .rdata/.edata, .pdata and .data/.bss */


### PR DESCRIPTION
## Purpose

FreeLoader builds for AMD64 on GCC/Clang fail to boot with `FREELDR_IMAGE_CORRUPTION` bugcheck.

This is because those compilers (on latest RosBE/CI at least) generate an .edata section which is guarded against in the FreeLoader `mm.h`

## Proposed changes

This simple patch undoes the guard and restores it to 3 sections.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: