### PR TITLE
[PORTCLS] Debug more data fields from the audio miniport's Filter Descriptor

### DIFF
--- a/drivers/wdm/audio/backpln/portcls/undoc.cpp
+++ b/drivers/wdm/audio/backpln/portcls/undoc.cpp
@@ -509,6 +509,7 @@ PcCaptureFormat(
     return STATUS_NOT_IMPLEMENTED;
 }
 
+#if DBG
 VOID
 DumpAutomationTable(
     IN PPCAUTOMATION_TABLE AutomationTable,
@@ -545,7 +546,7 @@ DumpAutomationTable(
             ASSERT(PropertyItem);
 
             // display all properties associated
-            for(Index = 0; Index < AutomationTable->PropertyCount; Index++)
+            for (Index = 0; Index < AutomationTable->PropertyCount; Index++)
             {
                 // convert to printable string
                 RtlStringFromGUID(*PropertyItem->Set, &GuidString);
@@ -573,7 +574,7 @@ DumpAutomationTable(
             // sanity check
             ASSERT(EventItem);
 
-            for(Index = 0; Index < AutomationTable->EventCount; Index++)
+            for (Index = 0; Index < AutomationTable->EventCount; Index++)
             {
                 // convert to printable string
                 RtlStringFromGUID(*EventItem->Set, &GuidString);
@@ -601,7 +602,7 @@ DumpAutomationTable(
             // sanity check
             ASSERT(MethodItem);
 
-            for(Index = 0; Index < AutomationTable->MethodCount; Index++)
+            for (Index = 0; Index < AutomationTable->MethodCount; Index++)
             {
                 // convert to printable string
                 RtlStringFromGUID(*MethodItem->Set, &GuidString);
@@ -627,6 +628,7 @@ DumpFilterDescriptor(
 {
     ULONG Index;
     WCHAR Buffer[30];
+    UNICODE_STRING GuidString;
     PPCPIN_DESCRIPTOR PinDescriptor;
     PPCNODE_DESCRIPTOR NodeDescriptor;
 
@@ -648,10 +650,26 @@ DumpFilterDescriptor(
             // sanity check
             ASSERT(PinDescriptor);
 
-            for(Index = 0; Index < FilterDescription->PinCount; Index++)
+            for (Index = 0; Index < FilterDescription->PinCount; Index++)
             {
                // print prefix
                _swprintf(Buffer, L"PinIndex %lu", Index);
+
+               DPRINT("PinIndex %lu\n", Index);
+               DPRINT("DataFlow %lu, Communication %lu\n",
+                   PinDescriptor->KsPinDescriptor.DataFlow, PinDescriptor->KsPinDescriptor.Communication);
+               if (PinDescriptor->KsPinDescriptor.Category)
+               {
+                   RtlStringFromGUID(*PinDescriptor->KsPinDescriptor.Category, &GuidString);
+                   DPRINT("Category %S\n", GuidString.Buffer);
+                   RtlFreeUnicodeString(&GuidString);
+               }
+               if (PinDescriptor->KsPinDescriptor.Name)
+               {
+                   RtlStringFromGUID(*PinDescriptor->KsPinDescriptor.Name, &GuidString);
+                   DPRINT("Name %S\n", GuidString.Buffer);
+                   RtlFreeUnicodeString(&GuidString);
+               }
 
                // dump automation table
                DumpAutomationTable((PPCAUTOMATION_TABLE)PinDescriptor->AutomationTable, Buffer, L"    ");
@@ -666,6 +684,8 @@ DumpFilterDescriptor(
         }
     }
 
+    DPRINT("=====================================================================\n");
+
     if (FilterDescription->Nodes)
     {
         if (FilterDescription->NodeSize >= sizeof(PCNODE_DESCRIPTOR))
@@ -676,10 +696,24 @@ DumpFilterDescriptor(
             // sanity check
             ASSERT(NodeDescriptor);
 
-            for(Index = 0; Index < FilterDescription->NodeCount; Index++)
+            for (Index = 0; Index < FilterDescription->NodeCount; Index++)
             {
                 // print prefix
                 _swprintf(Buffer, L"NodeIndex %lu", Index);
+
+                DPRINT("NodeIndex %lu\n", Index);
+                if (NodeDescriptor->Type)
+                {
+                    RtlStringFromGUID(*NodeDescriptor->Type, &GuidString);
+                    DPRINT("Type %S\n", GuidString.Buffer);
+                    RtlFreeUnicodeString(&GuidString);
+                }
+                if (NodeDescriptor->Name)
+                {
+                    RtlStringFromGUID(*NodeDescriptor->Name, &GuidString);
+                    DPRINT("Name %S\n", GuidString.Buffer);
+                    RtlFreeUnicodeString(&GuidString);
+                }
 
                 // dump automation table
                 DumpAutomationTable((PPCAUTOMATION_TABLE)NodeDescriptor->AutomationTable, Buffer, L"    ");
@@ -699,18 +733,19 @@ DumpFilterDescriptor(
     if (FilterDescription->ConnectionCount)
     {
         DPRINT("------ Start of Nodes Connections ----------------\n");
-        for(Index = 0; Index < FilterDescription->ConnectionCount; Index++)
+        for (Index = 0; Index < FilterDescription->ConnectionCount; Index++)
         {
-            DPRINT1("Index %ld FromPin %ld FromNode %ld -> ToPin %ld ToNode %ld\n", Index,
-                                                                                    FilterDescription->Connections[Index].FromNodePin,
-                                                                                    FilterDescription->Connections[Index].FromNode,
-                                                                                    FilterDescription->Connections[Index].ToNodePin,
-                                                                                    FilterDescription->Connections[Index].ToNode);
+            DPRINT("Index %lu FromNode %ld FromPin %ld -> ToNode %ld ToPin %ld\n", Index,
+                                                                                   FilterDescription->Connections[Index].FromNode,
+                                                                                   FilterDescription->Connections[Index].FromNodePin,
+                                                                                   FilterDescription->Connections[Index].ToNode,
+                                                                                   FilterDescription->Connections[Index].ToNodePin);
         }
-        DPRINT("------ End of Nodes Connections----------------\n");
+        DPRINT("------ End of Nodes Connections ----------------\n");
     }
-    DPRINT1("======================\n");
+    DPRINT("======================\n");
 }
+#endif // DBG
 
 NTSTATUS
 NTAPI
@@ -755,7 +790,9 @@ PcCreateSubdeviceDescriptor(
     RtlCopyMemory(Descriptor->Interfaces, InterfaceGuids, sizeof(GUID) * InterfaceCount);
     Descriptor->InterfaceCount = InterfaceCount;
 
-    //DumpFilterDescriptor(FilterDescription);
+#if DBG
+    DumpFilterDescriptor(FilterDescription);
+#endif
 
     // are any property sets supported by the portcls
     if (FilterPropertiesCount)


### PR DESCRIPTION
## Purpose

Debug more members of `PCFILTER_DESCRIPTOR` and its sub-items (`PCPIN_DESCRIPTOR`, `PCNODE_DESCRIPTOR` and `PCCONNECTION_DESCRIPTOR`). This allows to achieve the following things:
1) Actually debug more contents from the internal Filter Descriptor's definition of any audio miniport driver, including proprietary ones (e. g., Intel AC97, Realtek HD Audio codec etc.), and therefore to learn better how the Filters, Pins, Nodes and Connections are organized inside it.
2) Hence the proper debugging of them is also very useful and helpful for developing new audio miniport drivers both for Windows and ReactOS as well (as an example, it helps a lot to develop a new generic HD audio miniport driver for ReactOS personally for me in my older #8683 PR).

JIRA issue: None

## Proposed changes

- Debug `DataFlow`, `Communication`, `Category` and `Name` fields of all Pins and Nodes inside Filter Descriptor in particular. This allows to see the actual names and types for the audio-related items, to know whether the Pin or Node is of an input, output or bridge type and which is its actual purpose (for example, which thing the Node should do: Volume, Mute, Mux control etc. and with which external physical or virtual device the Pin is associated: WaveOut, WaveIn, Topology Speaker, Microphone, Headphones device etc.).
- Reorganize debug output of the Connections list: first debug `FromNode` and `ToNode`, and only then `FromPin` and `ToPin` fields of `PCCONNECTION_DESCRIPTOR`. This follows the original sequence of the members in the structure as it's defined at MSDN and improves readability and understandability of the Connections list in general (at least personally for me).
- Wrap debug-only functions into an `#if DBG` condition, to ensure they are enabled only for debug builds, but not for release ones.
- Enable the call of the main `DumpFilterDescriptor()` debug routine inside `PcCreateSubdeviceDescriptor()` (which actually converts audio miniport's Filter Descriptor to the understandable format for the system PortCls driver), to make it possible to debug it at all. Mute some `DPTINT`s (debug prints) appropriately, so now debug output is printed ONLY in case when `NDEBUG` is NOT defined (so hence it's possible to get it by either disabling `#define NDEBUG` line at the top, or modifying it to `#define YDEBUG` instead). Since no any other debug prints are currently added in this source file (undoc.cpp), nothing else will be printed except the Filter Descriptor's contents.
- Fix code formatting for all related `for()` loops a little bit. Add one space between the `for` keyword and the condition of the loop iteration.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: