### PR TITLE
[SHELL32] Ignore click event for disabled menu items

### DIFF
--- a/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
@@ -853,6 +853,10 @@ HRESULT CMenuToolbarBase::MenuBarMouseDown(INT iIndex, BOOL isLButton)
 
     GetButton(iIndex, &btn);
 
+    // Ignore disabled items
+    if (!(btn.fsState & TBSTATE_ENABLED))
+        return S_OK;
+
     if ((m_initFlags & SMINIT_VERTICAL)
         || m_popupBar
         || m_cancelingPopup)
@@ -874,6 +878,10 @@ HRESULT CMenuToolbarBase::MenuBarMouseUp(INT iIndex, BOOL isLButton)
         return S_OK;
 
     GetButton(iIndex, &btn);
+
+    // Ignore disabled items
+    if (!(btn.fsState & TBSTATE_ENABLED))
+        return S_OK;
 
     if (isLButton)
         return ProcessClick(btn.idCommand);


### PR DESCRIPTION
## Purpose

This PR makes CMenuToolbarBase ignore click events for shellmenu items without `TBSTATE_ENABLED` flag, so when you click on a placeholder menu item in start menu (like "(Empty)" items) it doesn't close the menu.

JIRA issue: [CORE-11755](https://jira.reactos.org/browse/CORE-11755)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: