### PR TITLE
[NTGDI] Revert 3D Screensaver BAD Hack

### DIFF
--- a/win32ss/gdi/ntgdi/gdiobj.c
+++ b/win32ss/gdi/ntgdi/gdiobj.c
@@ -479,13 +479,6 @@ ENTRY_ReferenceEntryByHandle(HGDIOBJ hobj, FLONG fl)
 {
     ULONG ulIndex, cNewRefs, cOldRefs;
     PENTRY pentry;
-    PTHREADINFO pti = PsGetCurrentThreadWin32Thread();
-
-    /* HACK: This may be a hack but it fixes CORE-5601.
-     * Allow a window that is moving or resizing to have access to all of its child
-     * windows dc's even if the dc belongs to another process i.e. 3D Screensaver */
-    if (pti && pti->TIF_flags & TIF_MOVESIZETRACKING)
-        fl = GDIOBJFLAG_IGNOREPID;
 
     /* Get the handle index and check if its too big */
     ulIndex = GDI_HANDLE_GET_INDEX(hobj);


### PR DESCRIPTION
CORE-20720

## Purpose

_This reverts commit https://github.com/reactos/reactos/commit/ad6cb32._

JIRA issue: [CORE-20720](https://jira.reactos.org/browse/CORE-20720)

## Proposed changes

_Revert HACK that allowed a window that was moving or resizing to have access to all of its child windows DC's._

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: