### PR TITLE
[SDK:ARBITER] Implement OrderingList Support and rename default callbacks

### DIFF
--- a/drivers/bus/pcix/arb/ar_busno.c
+++ b/drivers/bus/pcix/arb/ar_busno.c
@@ -54,7 +54,7 @@ arbusno_Initializer(IN PVOID Instance)
     Arbiter->CommonInstance.ScoreRequirement = arbusno_ScoreRequirement;
 #endif
 
-    Status = ArbInitializeArbiterInstance(&Arbiter->CommonInstance,
+    Status = ArbiterLibInitializeInstance(&Arbiter->CommonInstance,
                                           FdoExtension->FunctionalDeviceObject,
                                           CmResourceTypeBusNumber,
                                           Arbiter->InstanceName,

--- a/drivers/bus/pcix/arb/ar_memio.c
+++ b/drivers/bus/pcix/arb/ar_memio.c
@@ -121,11 +121,11 @@ ario_ApplyBrokenVideoHack(IN PPCI_FDO_EXTENSION FdoExtension)
     CommonInstance = &PciArbiter->CommonInstance;
 
     /* Free the two lists, enabling full VGA access */
-    ArbFreeOrderingList(&CommonInstance->OrderingList);
-    ArbFreeOrderingList(&CommonInstance->ReservedList);
+    ArbiterLibFreeOrderingList(&CommonInstance->OrderingList);
+    ArbiterLibFreeOrderingList(&CommonInstance->ReservedList);
 
     /* Build the ordering for broken video PCI access */
-    Status = ArbBuildAssignmentOrdering(CommonInstance,
+    Status = ArbiterLibDefaultAssignmentOrdering(CommonInstance,
                                         L"Pci",
                                         L"BrokenVideo",
                                         NULL);

--- a/ntoskrnl/io/pnpmgr/arb/arbbus.c
+++ b/ntoskrnl/io/pnpmgr/arb/arbbus.c
@@ -108,7 +108,7 @@ IopArbBusNumberInitialize(VOID)
     IopRootBusNumberArbiter.UnpackResource = IopArbBusNumberUnpackResource;
     IopRootBusNumberArbiter.ScoreRequirement = IopArbBusNumberScoreRequirement;
 
-    Status = ArbInitializeArbiterInstance(&IopRootBusNumberArbiter,
+    Status = ArbiterLibInitializeInstance(&IopRootBusNumberArbiter,
                                           NULL,
                                           CmResourceTypeBusNumber,
                                           IopRootBusNumberArbiter.Name,

--- a/ntoskrnl/io/pnpmgr/arb/arbdma.c
+++ b/ntoskrnl/io/pnpmgr/arb/arbdma.c
@@ -114,7 +114,7 @@ IopArbDmaInitialize(VOID)
     IopRootDmaArbiter.UnpackResource = IopArbDmaUnpackResource;
     IopRootDmaArbiter.ScoreRequirement = IopArbDmaScoreRequirement;
 
-    Status = ArbInitializeArbiterInstance(&IopRootDmaArbiter,
+    Status = ArbiterLibInitializeInstance(&IopRootDmaArbiter,
                                           NULL,
                                           CmResourceTypeDma,
                                           IopRootDmaArbiter.Name,

--- a/ntoskrnl/io/pnpmgr/arb/arbirq.c
+++ b/ntoskrnl/io/pnpmgr/arb/arbirq.c
@@ -158,7 +158,7 @@ IopArbIrqInitialize(VOID)
     IopRootIrqArbiter.UnpackResource = IopArbIrqUnpackResource;
     IopRootIrqArbiter.ScoreRequirement = IopArbIrqScoreRequirement;
 
-    Status = ArbInitializeArbiterInstance(&IopRootIrqArbiter,
+    Status = ArbiterLibInitializeInstance(&IopRootIrqArbiter,
                                           NULL,
                                           CmResourceTypeInterrupt,
                                           IopRootIrqArbiter.Name,

--- a/ntoskrnl/io/pnpmgr/arb/arbmem.c
+++ b/ntoskrnl/io/pnpmgr/arb/arbmem.c
@@ -98,7 +98,7 @@ IopArbMemInitialize(VOID)
     IopRootMemArbiter.UnpackResource = IopArbMemUnpackResource;
     IopRootMemArbiter.ScoreRequirement = IopArbMemScoreRequirement;
 
-    Status = ArbInitializeArbiterInstance(&IopRootMemArbiter,
+    Status = ArbiterLibInitializeInstance(&IopRootMemArbiter,
                                           NULL,
                                           CmResourceTypeMemory,
                                           IopRootMemArbiter.Name,

--- a/ntoskrnl/io/pnpmgr/arb/arbport.c
+++ b/ntoskrnl/io/pnpmgr/arb/arbport.c
@@ -98,7 +98,7 @@ IopArbPortInitialize(VOID)
     IopRootPortArbiter.UnpackResource = IopPortMemUnpackResource;
     IopRootPortArbiter.ScoreRequirement = IopPortMemScoreRequirement;
 
-    Status = ArbInitializeArbiterInstance(&IopRootPortArbiter,
+    Status = ArbiterLibInitializeInstance(&IopRootPortArbiter,
                                           NULL,
                                           CmResourceTypePort,
                                           IopRootPortArbiter.Name,

--- a/sdk/lib/drivers/arbiter/CMakeLists.txt
+++ b/sdk/lib/drivers/arbiter/CMakeLists.txt
@@ -2,7 +2,8 @@
 add_definitions(-D_NTSYSTEM_)
 
 list(APPEND SOURCE
-    arbiter.c)
+    arbiter.c
+    ordering.c)
 
 add_library(arbiter ${SOURCE})
 add_dependencies(arbiter bugcodes xdk)

--- a/sdk/lib/drivers/arbiter/arbiter.c
+++ b/sdk/lib/drivers/arbiter/arbiter.c
@@ -17,16 +17,18 @@
 #define ARBITER_SIG  'sbrA'
 #define TAG_ARBITER  'ibrA'
 
-/* 
- * TODO: ArbTestAllocation-ArbQueryConflict have some signature rewrites
- * that need to happen when we retarget to vista.
- */
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbTestAllocation(
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+ArbiterLibTestAllocation(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_TEST_ALLOCATION_PARAMETERS Parameters)
+#else
+ArbiterLibTestAllocation(
     _In_ PARBITER_INSTANCE Arbiter,
     _Inout_ PLIST_ENTRY ArbitrationList)
+#endif
 {
     PAGED_CODE();
 
@@ -37,9 +39,15 @@ ArbTestAllocation(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbRetestAllocation(
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+ArbiterLibRetestAllocation(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_RETEST_ALLOCATION_PARAMETERS Parameters)
+#else
+ArbiterLibRetestAllocation(
     _In_ PARBITER_INSTANCE Arbiter,
     _Inout_ PLIST_ENTRY ArbitrationList)
+#endif
 {
     PAGED_CODE();
 
@@ -50,9 +58,15 @@ ArbRetestAllocation(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbBootAllocation(
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+ArbiterLibBootAllocation(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_BOOT_ALLOCATION_PARAMETERS Parameters)
+#else
+ArbiterLibBootAllocation(
     _In_ PARBITER_INSTANCE Arbiter,
     _Inout_ PLIST_ENTRY ArbitrationList)
+#endif
 {
     PAGED_CODE();
 
@@ -63,10 +77,16 @@ ArbBootAllocation(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbAddReserved(
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+ArbiterLibAddReserved(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_ADD_RESERVED_PARAMETERS Parameters)
+#else
+ArbiterLibAddReserved(
     _In_ PARBITER_INSTANCE Arbiter,
     _In_opt_ PIO_RESOURCE_DESCRIPTOR Requirement,
     _In_opt_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource)
+#endif
 {
     PAGED_CODE();
 
@@ -77,12 +97,18 @@ ArbAddReserved(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbQueryConflict(
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+ArbiterLibQueryConflict(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_QUERY_CONFLICT_PARAMETERS Parameters)
+#else
+ArbiterLibQueryConflict(
     _In_ PARBITER_INSTANCE Arbiter,
     _In_ PDEVICE_OBJECT PhysicalDeviceObject,
     _In_ PIO_RESOURCE_DESCRIPTOR ConflictingResource,
     _Out_ PULONG ConflictCount,
     _Out_ PARBITER_CONFLICT_INFO *Conflicts)
+#endif
 {
     PAGED_CODE();
 
@@ -94,7 +120,7 @@ ArbQueryConflict(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbInitializeRangeList(
+ArbiterLibInitializeRangeList(
     _In_ PARBITER_INSTANCE Arbiter,
     _In_ ULONG ResourceCount,
     _In_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resources,
@@ -110,7 +136,7 @@ ArbInitializeRangeList(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbCommitAllocation(
+ArbiterLibCommitAllocation(
     _In_ PARBITER_INSTANCE Arbiter)
 {
     PAGED_CODE();
@@ -122,7 +148,7 @@ ArbCommitAllocation(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbRollbackAllocation(
+ArbiterLibRollbackAllocation(
     _In_ PARBITER_INSTANCE Arbiter)
 {
     PAGED_CODE();
@@ -134,7 +160,7 @@ ArbRollbackAllocation(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbStartArbiter(
+ArbiterLibStartArbiter(
     _In_ PARBITER_INSTANCE Arbiter,
     _In_ PCM_RESOURCE_LIST StartResources)
 {
@@ -147,7 +173,7 @@ ArbStartArbiter(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbPreprocessEntry(
+ArbiterLibPreprocessEntry(
     _In_ PARBITER_INSTANCE Arbiter,
     _Inout_ PARBITER_ALLOCATION_STATE ArbState)
 {
@@ -160,7 +186,7 @@ ArbPreprocessEntry(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbAllocateEntry(
+ArbiterLibAllocateEntry(
     _In_ PARBITER_INSTANCE Arbiter,
     _Inout_ PARBITER_ALLOCATION_STATE ArbState)
 {
@@ -173,7 +199,7 @@ ArbAllocateEntry(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbSortArbitrationList(
+ArbiterLibSortArbitrationList(
     _Inout_ PLIST_ENTRY ArbitrationList)
 {
     PAGED_CODE();
@@ -185,7 +211,7 @@ ArbSortArbitrationList(
 CODE_SEG("PAGE")
 BOOLEAN
 NTAPI
-ArbGetNextAllocationRange(
+ArbiterLibGetNextAllocationRange(
     _In_ PARBITER_INSTANCE Arbiter,
     _Inout_ PARBITER_ALLOCATION_STATE ArbState)
 {
@@ -198,7 +224,7 @@ ArbGetNextAllocationRange(
 CODE_SEG("PAGE")
 BOOLEAN
 NTAPI
-ArbFindSuitableRange(
+ArbiterLibFindSuitableRange(
     _In_ PARBITER_INSTANCE Arbiter,
     _Inout_ PARBITER_ALLOCATION_STATE ArbState)
 {
@@ -211,7 +237,7 @@ ArbFindSuitableRange(
 CODE_SEG("PAGE")
 VOID
 NTAPI
-ArbAddAllocation(
+ArbiterLibAddAllocation(
     _In_ PARBITER_INSTANCE Arbiter,
     _Inout_ PARBITER_ALLOCATION_STATE ArbState)
 {
@@ -223,7 +249,7 @@ ArbAddAllocation(
 CODE_SEG("PAGE")
 VOID
 NTAPI
-ArbBacktrackAllocation(
+ArbiterLibBacktrackAllocation(
     _In_ PARBITER_INSTANCE Arbiter,
     _Inout_ PARBITER_ALLOCATION_STATE ArbState)
 {
@@ -235,7 +261,7 @@ ArbBacktrackAllocation(
 CODE_SEG("PAGE")
 VOID
 NTAPI
-ArbConfirmAllocation(
+ArbiterLibConfirmAllocation(
     _In_ PARBITER_INSTANCE Arbiter,
     _Inout_ PARBITER_ALLOCATION_STATE ArbState)
 {
@@ -247,7 +273,7 @@ ArbConfirmAllocation(
 CODE_SEG("PAGE")
 BOOLEAN
 NTAPI
-ArbOverrideConflict(
+ArbiterLibOverrideConflict(
     _In_ PARBITER_INSTANCE Arbiter,
     _Inout_ PARBITER_ALLOCATION_STATE ArbState)
 {
@@ -260,7 +286,7 @@ ArbOverrideConflict(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbArbiterHandler(
+ArbiterLibHandler(
     _In_ PVOID Context,
     _In_ ARBITER_ACTION Action,
     _Inout_ PARBITER_PARAMETERS Parameters)
@@ -272,88 +298,9 @@ ArbArbiterHandler(
 }
 
 CODE_SEG("PAGE")
-NTSTATUS
-NTAPI
-ArbInitializeOrderingList(
-    _Out_ PARBITER_ORDERING_LIST OrderingList)
-{
-    PAGED_CODE();
-
-    UNIMPLEMENTED;
-    return STATUS_NOT_IMPLEMENTED;
-}
-
-CODE_SEG("PAGE")
 VOID
 NTAPI
-ArbFreeOrderingList(
-    _Inout_ PARBITER_ORDERING_LIST OrderingList)
-{
-    PAGED_CODE();
-
-    UNIMPLEMENTED;
-}
-
-CODE_SEG("PAGE")
-NTSTATUS
-NTAPI
-ArbCopyOrderingList(
-    _Out_ PARBITER_ORDERING_LIST Destination,
-    _In_ PARBITER_ORDERING_LIST Source)
-{
-    PAGED_CODE();
-
-    UNIMPLEMENTED;
-    return STATUS_NOT_IMPLEMENTED;
-}
-
-CODE_SEG("PAGE")
-NTSTATUS
-NTAPI
-ArbAddOrdering(
-    _Inout_ PARBITER_ORDERING_LIST OrderingList,
-    _In_ UINT64 Start,
-    _In_ UINT64 End)
-{
-    PAGED_CODE();
-
-    UNIMPLEMENTED;
-    return STATUS_NOT_IMPLEMENTED;
-}
-
-CODE_SEG("PAGE")
-NTSTATUS
-NTAPI
-ArbPruneOrdering(
-    _Inout_ PARBITER_ORDERING_LIST OrderingList,
-    _In_ UINT64 Start,
-    _In_ UINT64 End)
-{
-    PAGED_CODE();
-
-    UNIMPLEMENTED;
-    return STATUS_NOT_IMPLEMENTED;
-}
-
-CODE_SEG("PAGE")
-NTSTATUS
-NTAPI
-ArbBuildAssignmentOrdering(
-    _Inout_ PARBITER_INSTANCE Arbiter,
-    _In_ PCWSTR AllocationOrderName,
-    _In_ PCWSTR ReservedResourcesName,
-    _In_opt_ PARB_TRANSLATE_ORDERING TranslateOrderingFunction)
-{
-    PAGED_CODE();
-
-    UNIMPLEMENTED;
-    return STATUS_SUCCESS;
-}
-
-CODE_SEG("PAGE")
-VOID
-NTAPI
-ArbDeleteArbiterInstance(
+ArbiterLibDeleteInstance(
     _In_ PARBITER_INSTANCE Arbiter)
 {
     PAGED_CODE();
@@ -397,7 +344,7 @@ ArbDeleteArbiterInstance(
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbInitializeArbiterInstance(
+ArbiterLibInitializeInstance(
     _Inout_ PARBITER_INSTANCE Arbiter,
     _In_ PDEVICE_OBJECT BusDeviceObject,
     _In_ CM_RESOURCE_TYPE ResourceType,
@@ -409,7 +356,7 @@ ArbInitializeArbiterInstance(
 
     PAGED_CODE();
 
-    DPRINT("ArbInitializeArbiterInstance: '%S'\n", ArbiterName);
+    DPRINT("ArbiterLibInitializeInstance: '%S'\n", ArbiterName);
 
     ASSERT(Arbiter->UnpackRequirement != NULL);
     ASSERT(Arbiter->PackResource != NULL);
@@ -472,51 +419,51 @@ ArbInitializeArbiterInstance(
     RtlInitializeRangeList(Arbiter->PossibleAllocation);
 
     if (!Arbiter->TestAllocation)
-        Arbiter->TestAllocation = ArbTestAllocation;
+        Arbiter->TestAllocation = ArbiterLibTestAllocation;
     if (!Arbiter->RetestAllocation)
-        Arbiter->RetestAllocation = ArbRetestAllocation;
+        Arbiter->RetestAllocation = ArbiterLibRetestAllocation;
     if (!Arbiter->CommitAllocation)
-        Arbiter->CommitAllocation = ArbCommitAllocation;
+        Arbiter->CommitAllocation = ArbiterLibCommitAllocation;
     if (!Arbiter->RollbackAllocation)
-        Arbiter->RollbackAllocation = ArbRollbackAllocation;
+        Arbiter->RollbackAllocation = ArbiterLibRollbackAllocation;
     if (!Arbiter->BootAllocation)
-        Arbiter->BootAllocation = ArbBootAllocation;
+        Arbiter->BootAllocation = ArbiterLibBootAllocation;
     if (!Arbiter->AddReserved)
-        Arbiter->AddReserved = ArbAddReserved;
+        Arbiter->AddReserved = ArbiterLibAddReserved;
     if (!Arbiter->QueryConflict)
-        Arbiter->QueryConflict = ArbQueryConflict;
+        Arbiter->QueryConflict = ArbiterLibQueryConflict;
     if (!Arbiter->StartArbiter)
-        Arbiter->StartArbiter = ArbStartArbiter;
+        Arbiter->StartArbiter = ArbiterLibStartArbiter;
     if (!Arbiter->PreprocessEntry)
-        Arbiter->PreprocessEntry = ArbPreprocessEntry;
+        Arbiter->PreprocessEntry = ArbiterLibPreprocessEntry;
     if (!Arbiter->AllocateEntry)
-        Arbiter->AllocateEntry = ArbAllocateEntry;
+        Arbiter->AllocateEntry = ArbiterLibAllocateEntry;
     if (!Arbiter->GetNextAllocationRange)
-        Arbiter->GetNextAllocationRange = ArbGetNextAllocationRange;
+        Arbiter->GetNextAllocationRange = ArbiterLibGetNextAllocationRange;
     if (!Arbiter->FindSuitableRange)
-        Arbiter->FindSuitableRange = ArbFindSuitableRange;
+        Arbiter->FindSuitableRange = ArbiterLibFindSuitableRange;
     if (!Arbiter->AddAllocation)
-        Arbiter->AddAllocation = ArbAddAllocation;
+        Arbiter->AddAllocation = ArbiterLibAddAllocation;
     if (!Arbiter->BacktrackAllocation)
-        Arbiter->BacktrackAllocation = ArbBacktrackAllocation;
+        Arbiter->BacktrackAllocation = ArbiterLibBacktrackAllocation;
     if (!Arbiter->OverrideConflict)
-        Arbiter->OverrideConflict = ArbOverrideConflict;
+        Arbiter->OverrideConflict = ArbiterLibOverrideConflict;
 #if (NTDDI_VERSION >= NTDDI_VISTA)
     if (!Arbiter->InitializeRangeList)
-        Arbiter->InitializeRangeList = ArbInitializeRangeList;
+        Arbiter->InitializeRangeList = ArbiterLibInitializeRangeList;
 #endif
 
-    Status = ArbBuildAssignmentOrdering(Arbiter, OrderName, OrderName, TranslateOrderingFunction);
+    Status = ArbiterLibDefaultAssignmentOrdering(Arbiter, OrderName, OrderName, TranslateOrderingFunction);
     if (!NT_SUCCESS(Status))
     {
-        DPRINT1("ArbInitializeArbiterInstance: ArbBuildAssignmentOrdering failed, Status %X\n", Status);
+        DPRINT1("ArbiterLibInitializeInstance: ArbiterLibDefaultAssignmentOrdering failed, Status %X\n", Status);
         goto Failure;
     }
 
     return STATUS_SUCCESS;
 
 Failure:
-    DPRINT1("ArbInitializeArbiterInstance: '%S' failed, Status %X\n", ArbiterName, Status);
-    ArbDeleteArbiterInstance(Arbiter);
+    DPRINT1("ArbiterLibInitializeInstance: '%S' failed, Status %X\n", ArbiterName, Status);
+    ArbiterLibDeleteInstance(Arbiter);
     return Status;
 }

--- a/sdk/lib/drivers/arbiter/arbiter.c
+++ b/sdk/lib/drivers/arbiter/arbiter.c
@@ -1,5 +1,5 @@
 /*
- * PROJECT:     ReactOS Arbitrartion Library
+ * PROJECT:     ReactOS Arbitration Library
  * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Generic Arbiter Library
  * COPYRIGHT:   Copyright 2026 Justin Miller <justin.miller@reactos.org>
@@ -15,7 +15,6 @@
 #include <debug.h>
 
 #define ARBITER_SIG  'sbrA'
-#define TAG_ARBITER  'ibrA'
 
 CODE_SEG("PAGE")
 NTSTATUS
@@ -325,6 +324,9 @@ ArbiterLibDeleteInstance(
         Arbiter->AllocationStack = NULL;
         Arbiter->AllocationStackMaxSize = 0;
     }
+
+    ArbiterLibFreeOrderingList(&Arbiter->OrderingList);
+    ArbiterLibFreeOrderingList(&Arbiter->ReservedList);
 
 #if (NTDDI_VERSION >= NTDDI_VISTA)
     if (Arbiter->TransactionEvent)

--- a/sdk/lib/drivers/arbiter/arbiter.h
+++ b/sdk/lib/drivers/arbiter/arbiter.h
@@ -294,11 +294,143 @@ typedef struct _ARBITER_INSTANCE
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
-ArbInitializeArbiterInstance(
+ArbiterLibInitializeInstance(
     _Inout_ PARBITER_INSTANCE Arbiter,
     _In_ PDEVICE_OBJECT BusDeviceObject,
     _In_ CM_RESOURCE_TYPE ResourceType,
     _In_ PCWSTR ArbiterName,
     _In_ PCWSTR OrderName,
     _In_ PARB_TRANSLATE_ORDERING TranslateOrderingFunction
+);
+
+CODE_SEG("PAGE")
+VOID
+NTAPI
+ArbiterLibDeleteInstance(
+    _In_ PARBITER_INSTANCE Arbiter
+);
+
+/* The generic dispatch entry point (installed as ARBITER_INTERFACE.ArbiterHandler). */
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibHandler(
+    _In_ PVOID Context,
+    _In_ ARBITER_ACTION Action,
+    _Inout_ PARBITER_PARAMETERS Parameters
+);
+
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibTestAllocation(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_TEST_ALLOCATION_PARAMETERS Parameters
+);
+
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibRetestAllocation(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_RETEST_ALLOCATION_PARAMETERS Parameters
+);
+
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibBootAllocation(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_BOOT_ALLOCATION_PARAMETERS Parameters
+);
+
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibQueryConflict(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_QUERY_CONFLICT_PARAMETERS Parameters
+);
+#else
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibTestAllocation(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PLIST_ENTRY ArbitrationList
+);
+
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibRetestAllocation(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PLIST_ENTRY ArbitrationList
+);
+
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibBootAllocation(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PLIST_ENTRY ArbitrationList
+);
+
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibQueryConflict(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _In_ PDEVICE_OBJECT PhysicalDeviceObject,
+    _In_ PIO_RESOURCE_DESCRIPTOR ConflictingResource,
+    _Out_ PULONG ConflictCount,
+    _Out_ PARBITER_CONFLICT_INFO *Conflicts
+);
+#endif
+
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibCommitAllocation(
+    _In_ PARBITER_INSTANCE Arbiter
+);
+
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibRollbackAllocation(
+    _In_ PARBITER_INSTANCE Arbiter
+);
+
+CODE_SEG("PAGE")
+BOOLEAN
+NTAPI
+ArbiterLibGetNextAllocationRange(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_ALLOCATION_STATE ArbState
+);
+
+CODE_SEG("PAGE")
+BOOLEAN
+NTAPI
+ArbiterLibFindSuitableRange(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_ALLOCATION_STATE ArbState
+);
+
+CODE_SEG("PAGE")
+VOID
+NTAPI
+ArbiterLibAddAllocation(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_ALLOCATION_STATE ArbState
+);
+
+CODE_SEG("PAGE")
+VOID
+NTAPI
+ArbiterLibBacktrackAllocation(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_ALLOCATION_STATE ArbState
 );

--- a/sdk/lib/drivers/arbiter/arbiter.h
+++ b/sdk/lib/drivers/arbiter/arbiter.h
@@ -1,11 +1,13 @@
 /*
- * PROJECT:     ReactOS Arbitrartion Library
+ * PROJECT:     ReactOS Arbitration Library
  * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Generic Arbiter Library
  * COPYRIGHT:   Copyright 2026 Justin Miller <justin.miller@reactos.org>
  */
 
 #pragma once
+
+#define TAG_ARBITER  'ibrA'
 
 typedef struct _ARBITER_ALTERNATIVE
 {
@@ -310,6 +312,32 @@ ArbiterLibDeleteInstance(
     _In_ PARBITER_INSTANCE Arbiter
 );
 
+CODE_SEG("PAGE")
+VOID
+NTAPI
+ArbiterLibFreeOrderingList(
+    _Inout_ PARBITER_ORDERING_LIST OrderingList
+);
+
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibAddOrdering(
+    _Inout_ PARBITER_ORDERING_LIST OrderingList,
+    _In_ UINT64 Start,
+    _In_ UINT64 End
+);
+
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibDefaultAssignmentOrdering(
+    _Inout_ PARBITER_INSTANCE Arbiter,
+    _In_ PCWSTR AllocationOrderName,
+    _In_ PCWSTR ReservedResourcesName,
+    _In_opt_ PARB_TRANSLATE_ORDERING TranslateOrderingFunction
+);
+
 /* The generic dispatch entry point (installed as ARBITER_INTERFACE.ArbiterHandler). */
 CODE_SEG("PAGE")
 NTSTATUS
@@ -352,7 +380,9 @@ ArbiterLibQueryConflict(
     _In_ PARBITER_INSTANCE Arbiter,
     _Inout_ PARBITER_QUERY_CONFLICT_PARAMETERS Parameters
 );
-#else
+
+#else // (NTDDI_VERSION < NTDDI_VISTA)
+
 CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
@@ -387,7 +417,7 @@ ArbiterLibQueryConflict(
     _Out_ PULONG ConflictCount,
     _Out_ PARBITER_CONFLICT_INFO *Conflicts
 );
-#endif
+#endif // (NTDDI_VERSION >= NTDDI_VISTA)
 
 CODE_SEG("PAGE")
 NTSTATUS

--- a/sdk/lib/drivers/arbiter/ordering.c
+++ b/sdk/lib/drivers/arbiter/ordering.c
@@ -1,0 +1,358 @@
+/*
+ * PROJECT:     ReactOS Arbitration Library
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Ordering lists and the registry assignment ordering
+ * COPYRIGHT:   Copyright 2026 Justin Miller <justin.miller@reactos.org>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include <ntifs.h>
+#include <ndk/rtlfuncs.h>
+#include "arbiter.h"
+
+#define NDEBUG
+#include <debug.h>
+
+#define ARBITER_ORDERING_GRANULARITY  16
+#define ARBITER_ORDERING_LIMIT        1024
+
+#define ARBP_POLICY_ROOT   L"\\Registry\\Machine\\System\\CurrentControlSet\\Control\\Arbiters\\"
+#define ARBP_LONGEST_SUBKEY L"ReservedResources"
+
+/* ORDERING LISTS *************************************************************/
+
+/* Set up an empty ordering array at its starting capacity. */
+CODE_SEG("PAGE")
+static
+NTSTATUS
+ArbpCreateOrderingList(
+    _Out_ PARBITER_ORDERING_LIST OrderingList)
+{
+    PAGED_CODE();
+
+    OrderingList->Orderings = ExAllocatePoolWithTag(PagedPool,
+                                                    ARBITER_ORDERING_GRANULARITY * sizeof(ARBITER_ORDERING),
+                                                    TAG_ARBITER);
+    if (OrderingList->Orderings == NULL)
+    {
+        OrderingList->Count = 0;
+        OrderingList->Maximum = 0;
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    OrderingList->Count = 0;
+    OrderingList->Maximum = ARBITER_ORDERING_GRANULARITY;
+    return STATUS_SUCCESS;
+}
+
+CODE_SEG("PAGE")
+VOID
+NTAPI
+ArbiterLibFreeOrderingList(
+    _Inout_ PARBITER_ORDERING_LIST OrderingList)
+{
+    PAGED_CODE();
+
+    if (OrderingList->Orderings != NULL)
+        ExFreePoolWithTag(OrderingList->Orderings, TAG_ARBITER);
+
+    OrderingList->Orderings = NULL;
+    OrderingList->Count = 0;
+    OrderingList->Maximum = 0;
+}
+
+/* Append one [Start, End] window (both bounds inclusive) at the tail
+ * (= lowest preference so far). */
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibAddOrdering(
+    _Inout_ PARBITER_ORDERING_LIST OrderingList,
+    _In_ UINT64 Start,
+    _In_ UINT64 End)
+{
+    PAGED_CODE();
+
+    if (End < Start)
+        return STATUS_INVALID_PARAMETER;
+
+    /* Double the array capacity when it fills up, up to the sanity cap. */
+    if (OrderingList->Count == OrderingList->Maximum)
+    {
+        ULONG NewMaximum;
+        PARBITER_ORDERING NewArray;
+
+        NewMaximum = OrderingList->Maximum ? (ULONG)OrderingList->Maximum * 2
+                                           : ARBITER_ORDERING_GRANULARITY;
+        if (NewMaximum > ARBITER_ORDERING_LIMIT)
+            return STATUS_INSUFFICIENT_RESOURCES;
+
+        NewArray = ExAllocatePoolWithTag(PagedPool,
+                                         NewMaximum * sizeof(ARBITER_ORDERING),
+                                         TAG_ARBITER);
+        if (NewArray == NULL)
+            return STATUS_INSUFFICIENT_RESOURCES;
+
+        if (OrderingList->Orderings != NULL)
+        {
+            RtlCopyMemory(NewArray, OrderingList->Orderings,
+                          OrderingList->Count * sizeof(ARBITER_ORDERING));
+            ExFreePoolWithTag(OrderingList->Orderings, TAG_ARBITER);
+        }
+
+        OrderingList->Maximum = (UINT16)NewMaximum;
+        OrderingList->Orderings = NewArray;
+    }
+
+    OrderingList->Orderings[OrderingList->Count].Start = Start;
+    OrderingList->Orderings[OrderingList->Count].End = End;
+    OrderingList->Count++;
+    return STATUS_SUCCESS;
+}
+
+/* REGISTRY-DESCRIBED RANGES **************************************************/
+
+/*
+ * An arbiter refines its allocation policy from HKLM\...\Control\Arbiters.
+ * Each value there is a REG_RESOURCE_REQUIREMENTS_LIST whose descriptors give
+ * [MinimumAddress, MaximumAddress] ranges, filtered by the arbiter's resource
+ * This can get written to by chipset drivers.
+ */
+
+typedef VOID
+(NTAPI *PARB_RANGE_CALLBACK)(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _In_opt_ PVOID Context,
+    _In_ ULONGLONG Start,
+    _In_ ULONGLONG End);
+
+/* Open one subkey of the Arbiters policy key by composing its full path. */
+CODE_SEG("PAGE")
+static
+NTSTATUS
+ArbpOpenPolicySubkey(
+    _In_ PCWSTR SubkeyName,
+    _Out_ PHANDLE KeyHandle)
+{
+    WCHAR PathBuffer[sizeof(ARBP_POLICY_ROOT ARBP_LONGEST_SUBKEY) / sizeof(WCHAR)];
+    UNICODE_STRING KeyPath;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    NTSTATUS Status;
+
+    PAGED_CODE();
+
+    RtlInitEmptyUnicodeString(&KeyPath, PathBuffer, sizeof(PathBuffer));
+    Status = RtlAppendUnicodeToString(&KeyPath, ARBP_POLICY_ROOT);
+    if (NT_SUCCESS(Status))
+        Status = RtlAppendUnicodeToString(&KeyPath, SubkeyName);
+    if (!NT_SUCCESS(Status))
+        return Status;
+
+    InitializeObjectAttributes(&ObjectAttributes, &KeyPath,
+                               OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE, NULL, NULL);
+    return ZwOpenKey(KeyHandle, KEY_READ, &ObjectAttributes);
+}
+
+/* Read one value into a freshly-allocated KEY_VALUE_FULL_INFORMATION. */
+CODE_SEG("PAGE")
+static
+NTSTATUS
+ArbpReadPolicyValue(
+    _In_ HANDLE KeyHandle,
+    _In_ PCWSTR ValueName,
+    _Out_ PKEY_VALUE_FULL_INFORMATION *Value)
+{
+    UNICODE_STRING NameString;
+    PKEY_VALUE_FULL_INFORMATION Buffer;
+    ULONG Size = 0;
+    ULONG ResultLength = 0;
+    NTSTATUS Status;
+
+    PAGED_CODE();
+
+    RtlInitUnicodeString(&NameString, ValueName);
+
+    /* Size probe: only a buffer-size result means the value is readable. */
+    Status = ZwQueryValueKey(KeyHandle, &NameString, KeyValueFullInformationAlign64,
+                             NULL, 0, &Size);
+    if (Status != STATUS_BUFFER_TOO_SMALL && Status != STATUS_BUFFER_OVERFLOW)
+        return NT_SUCCESS(Status) ? STATUS_UNSUCCESSFUL : Status;
+
+    Buffer = ExAllocatePoolWithTag(PagedPool, Size, TAG_ARBITER);
+    if (Buffer == NULL)
+        return STATUS_INSUFFICIENT_RESOURCES;
+
+    Status = ZwQueryValueKey(KeyHandle, &NameString, KeyValueFullInformationAlign64,
+                             Buffer, Size, &ResultLength);
+
+    if (NT_SUCCESS(Status) &&
+        ((ULONGLONG)Buffer->DataOffset + Buffer->DataLength > ResultLength))
+    {
+        Status = STATUS_UNSUCCESSFUL;
+    }
+
+    if (!NT_SUCCESS(Status))
+    {
+        ExFreePoolWithTag(Buffer, TAG_ARBITER);
+        return Status;
+    }
+
+    *Value = Buffer;
+    return STATUS_SUCCESS;
+}
+
+/* Does a policy descriptor apply to this arbiter's resource type? */
+CODE_SEG("PAGE")
+static
+BOOLEAN
+ArbpDescriptorMatchesArbiter(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _In_ UCHAR DescriptorType)
+{
+    PAGED_CODE();
+
+    if (DescriptorType == (UCHAR)Arbiter->ResourceType)
+        return TRUE;
+
+    /* Large-memory descriptors also satisfy the plain memory arbiter. */
+    return (DescriptorType == CmResourceTypeMemoryLarge &&
+            Arbiter->ResourceType == CmResourceTypeMemory);
+}
+
+/*
+ * Walk the policy ranges stored under HKLM\...\Control\Arbiters\<Subkey>,
+ * This is used by machine-specific policy tables.
+ */
+CODE_SEG("PAGE")
+static
+NTSTATUS
+ArbpForEachRegistryRange(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _In_ PCWSTR Subkey,
+    _In_ PCWSTR ValueName,
+    _In_ PARB_RANGE_CALLBACK Callback,
+    _In_opt_ PVOID Context)
+{
+    HANDLE KeyHandle;
+    PKEY_VALUE_FULL_INFORMATION Value = NULL;
+    NTSTATUS Status;
+
+    PAGED_CODE();
+
+    if (!NT_SUCCESS(ArbpOpenPolicySubkey(Subkey, &KeyHandle)))
+        return STATUS_SUCCESS;
+
+    Status = ArbpReadPolicyValue(KeyHandle, ValueName, &Value);
+
+    /* Follow a REG_SZ indirection to the named sibling value. */
+    if (NT_SUCCESS(Status) && Value->Type == REG_SZ)
+    {
+        PWSTR TargetName = (PWSTR)((PUCHAR)Value + Value->DataOffset);
+        ULONG TargetChars = Value->DataLength / sizeof(WCHAR);
+        PKEY_VALUE_FULL_INFORMATION Target = NULL;
+
+        if (TargetChars != 0 &&
+            TargetName[TargetChars - 1] == UNICODE_NULL &&
+            NT_SUCCESS(ArbpReadPolicyValue(KeyHandle, TargetName, &Target)))
+        {
+            ExFreePoolWithTag(Value, TAG_ARBITER);
+            Value = Target;
+        }
+    }
+
+    if (NT_SUCCESS(Status) &&
+        Value->Type == REG_RESOURCE_REQUIREMENTS_LIST &&
+        Value->DataLength >= sizeof(IO_RESOURCE_REQUIREMENTS_LIST))
+    {
+        PIO_RESOURCE_REQUIREMENTS_LIST Requirements;
+        PIO_RESOURCE_LIST Alternative;
+        PUCHAR DataEnd;
+        ULONG Index;
+
+        Requirements = (PIO_RESOURCE_REQUIREMENTS_LIST)((PUCHAR)Value + Value->DataOffset);
+        DataEnd = (PUCHAR)Requirements + Value->DataLength;
+        Alternative = &Requirements->List[0];
+
+        for (Index = 0; Index < Alternative->Count; ++Index)
+        {
+            PIO_RESOURCE_DESCRIPTOR Descriptor = &Alternative->Descriptors[Index];
+
+            /* Never trust the stored Count past the actual value data. */
+            if ((PUCHAR)(Descriptor + 1) > DataEnd)
+                break;
+
+            if (ArbpDescriptorMatchesArbiter(Arbiter, Descriptor->Type))
+            {
+                Callback(Arbiter, Context,
+                         (ULONGLONG)Descriptor->u.Generic.MinimumAddress.QuadPart,
+                         (ULONGLONG)Descriptor->u.Generic.MaximumAddress.QuadPart);
+            }
+        }
+    }
+
+    if (Value != NULL)
+        ExFreePoolWithTag(Value, TAG_ARBITER);
+    ZwClose(KeyHandle);
+    return STATUS_SUCCESS;
+}
+
+/* Prepend a registry-described preferred range ahead of the full-range default. */
+CODE_SEG("PAGE")
+static
+VOID
+NTAPI
+ArbpAddOrderingCallback(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _In_opt_ PVOID Context,
+    _In_ ULONGLONG Start,
+    _In_ ULONGLONG End)
+{
+    PAGED_CODE();
+    UNREFERENCED_PARAMETER(Context);
+    ArbiterLibAddOrdering(&Arbiter->OrderingList, Start, End);
+}
+
+/*
+ * Build the arbiter's allocation ordering.  The registry-described preferred
+ * ranges (AllocationOrder\<AllocationOrderName>) the engine walks the
+ * list in index order, so index 0 is the most-preferred window. If one isnt
+ * found its followed by a full-range fallback so the arbiter can always search the whole space
+ *
+ * Both ordering lists are (re)created here: callers may rebuild an existing
+ * ordering against a different policy table (see pcix ario_ApplyBrokenVideoHack).
+ */
+CODE_SEG("PAGE")
+NTSTATUS
+NTAPI
+ArbiterLibDefaultAssignmentOrdering(
+    _Inout_ PARBITER_INSTANCE Arbiter,
+    _In_ PCWSTR AllocationOrderName,
+    _In_ PCWSTR ReservedResourcesName,
+    _In_opt_ PARB_TRANSLATE_ORDERING TranslateOrderingFunction)
+{
+    NTSTATUS Status;
+
+    PAGED_CODE();
+
+    UNREFERENCED_PARAMETER(ReservedResourcesName);
+    UNREFERENCED_PARAMETER(TranslateOrderingFunction);
+
+    ArbiterLibFreeOrderingList(&Arbiter->OrderingList);
+    ArbiterLibFreeOrderingList(&Arbiter->ReservedList);
+
+    Status = ArbpCreateOrderingList(&Arbiter->OrderingList);
+    if (!NT_SUCCESS(Status))
+        return Status;
+    Status = ArbpCreateOrderingList(&Arbiter->ReservedList);
+    if (!NT_SUCCESS(Status))
+    {
+        ArbiterLibFreeOrderingList(&Arbiter->OrderingList);
+        return Status;
+    }
+
+    ArbpForEachRegistryRange(Arbiter, L"AllocationOrder", AllocationOrderName,
+                             ArbpAddOrderingCallback, NULL);
+
+    return ArbiterLibAddOrdering(&Arbiter->OrderingList, 0, 0xFFFFFFFFFFFFFFFFULL);
+}


### PR DESCRIPTION
Okay first chunk of implementing the arbiter library, 
This implements the arbiter ordering list.

When you have a PCI device let's say and it provides a wide range of placements that satisfies it, Arbiter has some functionality to apply some "preferred rule-sets" even before these assignments start happening. While windows can Rebalance PNP, there are some quirks that the kernel can't immediately see right away. So this was more for some BIOSes to have a static set of rules and avoid rebalancing too many times per boot as this was expensive, and couldn't account for ALL of these quirks.
Honestly if you are super bored and care that much about these things you can pull up BIOSINFO.inf on different installs of pre-vista windows and see what kind of vendor hooks exists, There's a lot. Vista prebakes this.
I imagine the other "ports" have their own, PC-98 that probably should be checked but that's a little bit out of scope.

Currently Windows 11 has a few of these rules that remain to this day. Summarized:
- Ports: prefer 0x500–0xFFFF (above the legacy ISA area) first; then fall back through progressively more haunted windows — 0x200–0x2FF (game port), 0x300–0x36F (prototype cards), 0x378 (LPT), 0x2E8/0x3E8 (COM4/COM3), 0x1F0 (IDE), 0x3B0–0x3CF (VGA), and only at the very end 0x100–0x3FF.
- IRQs: 9, 8, 7, 11, 10, 2, 3, 5, 4, … with 15, 13, 14, 6, 12, 1 at the end. hand out the typically-free IRQs first and touch IDE (14/15), floppy (6), PS/2 mouse (12), and keyboard (1)
- Memory: prefer everything above 1MB (0x100000+), fall back to the UMB/adapter areas (0xF0000, 0x80000–0xBFFFF) last.
- Or for some more obscure things: vga hacks, COM1 and COM2.

Not everything is implemented in this PR for these policies but instead I'm trying to provide some context instead of leaving you to review something isn't clear what it's for. The ReservedResources half (the quirk tables like BrokenVideo) will come later.

Good to note
https://www.vergiliusproject.com/kernels/x64/windows-vista/sp2/_ARBITER_ORDERING
https://www.vergiliusproject.com/kernels/x64/windows-vista/sp2/_ARBITER_ORDERING_LIST


## Testbot runs (Filled in by Devs)

N/A Deadcode