### PR TITLE
[COMCTL32] Clamp child height when cyIntegral is zero

### DIFF
--- a/dll/win32/comctl32/rebar.c
+++ b/dll/win32/comctl32/rebar.c
@@ -469,7 +469,15 @@ static int round_child_height(const REBAR_BAND *lpBand, int cyHeight)
 {
     int cy = 0;
     if (lpBand->cyIntegral == 0)
+#ifdef __REACTOS__ /* Import fix from Wine-11.15 */
+    {
+        cyHeight = max(cyHeight, (int)lpBand->cyMinChild);
+        cyHeight = min(cyHeight, (int)lpBand->cyMaxChild);
         return cyHeight;
+    }
+#else
+        return cyHeight;
+#endif
     cy = max(cyHeight - (int)lpBand->cyMinChild, 0);
     cy = lpBand->cyMinChild + (cy/lpBand->cyIntegral) * lpBand->cyIntegral;
     cy = min(cy, lpBand->cyMaxChild);


### PR DESCRIPTION
## Purpose

This PR imports an [upstream fix](https://gitlab.winehq.org/wine/wine/-/commit/36f5ab876f67d1467317a834594fdff7860e6aba) from WINE 11.15.

<img width="676" height="490" alt="image" src="https://github.com/user-attachments/assets/f8f4be6e-d82b-4ae0-ac6a-dde7339a4334" />

JIRA issue: [CORE-17940](https://jira.reactos.org/browse/CORE-17940)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: