### PR TITLE
**PROPOSAL** [BOOTDATA] Move the "Live Environment" boot entries first in the boot menu

### DIFF
--- a/boot/bootdata/bootcd.ini
+++ b/boot/bootdata/bootcd.ini
@@ -7,29 +7,18 @@ TitleText=ReactOS Boot Media
 MinimalUI=Yes
 
 [Operating Systems]
-Setup="ReactOS Setup (Text Mode)"
 LiveImg="ReactOS Live Environment (Graphics Mode)"
 LiveImg_RamDisk="ReactOS Live Environment - RamDisk"
+Setup="ReactOS Setup (Text Mode)"
 ==
 ;; The entries below are for testing and development:
-Setup_Debug="Setup (Debug)"
-Setup_Screen="Setup (Screen Debug)"
 LiveImg_Debug="Live (Debug)"
 LiveImg_VBoxDebug="Live (VBox Debug)"
 LiveImg_Screen="Live (Screen Debug)"
 ;; The following entry is an example template:
 ;LiveImg_LogFile="Live (Log file)"
-
-[Setup]
-BootType=ReactOSSetup
-
-[Setup_Debug]
-BootType=ReactOSSetup
-Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /NOGUIBOOT /SIFOPTIONSOVERRIDE
-
-[Setup_Screen]
-BootType=ReactOSSetup
-Options=/DEBUG /DEBUGPORT=SCREEN /SIFOPTIONSOVERRIDE
+Setup_Debug="Setup (Debug)"
+Setup_Screen="Setup (Screen Debug)"
 
 [LiveImg]
 BootType=Windows2003
@@ -61,3 +50,14 @@ Options=/DEBUG /DEBUGPORT=SCREEN /SOS /FASTDETECT /MININT
 ;BootType=Windows2003
 ;SystemPath=\reactos
 ;Options=/DEBUG /DEBUGPORT=FILE:\Device\HarddiskX\PartitionY\debug.log /SOS /FASTDETECT /MININT
+
+[Setup]
+BootType=ReactOSSetup
+
+[Setup_Debug]
+BootType=ReactOSSetup
+Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /NOGUIBOOT /SIFOPTIONSOVERRIDE
+
+[Setup_Screen]
+BootType=ReactOSSetup
+Options=/DEBUG /DEBUGPORT=SCREEN /SIFOPTIONSOVERRIDE

--- a/boot/bootdata/floppy_pc98.ini
+++ b/boot/bootdata/floppy_pc98.ini
@@ -7,31 +7,16 @@ TitleText=ReactOS CD-ROM Boot
 MinimalUI=Yes
 
 [Operating Systems]
-Setup="ReactOS Setup (Text Mode)"
 LiveImg="ReactOS Live Environment (Graphics Mode)"
+Setup="ReactOS Setup (Text Mode)"
 ==
 ;; The entries below are for testing and development:
-Setup_Debug="Setup (Debug)"
-Setup_Screen="Setup (Screen Debug)"
 LiveImg_Debug="Live (Debug)"
 LiveImg_Screen="Live (Screen Debug)"
 ;; The following entry is an example template:
 ;LiveImg_LogFile="Live (Log file)"
-
-[Setup]
-BootType=ReactOSSetup
-SystemPath=multi(0)disk(0)cdrom(0)\
-Options=/HAL=halpc98.dll
-
-[Setup_Debug]
-BootType=ReactOSSetup
-SystemPath=multi(0)disk(0)cdrom(0)\
-Options=/HAL=halpc98.dll /DEBUG /DEBUGPORT=COM1 /BAUDRATE=9600 /NOGUIBOOT /SIFOPTIONSOVERRIDE
-
-[Setup_Screen]
-BootType=ReactOSSetup
-SystemPath=multi(0)disk(0)cdrom(0)\
-Options=/HAL=halpc98.dll /DEBUG /DEBUGPORT=SCREEN /SIFOPTIONSOVERRIDE
+Setup_Debug="Setup (Debug)"
+Setup_Screen="Setup (Screen Debug)"
 
 [LiveImg]
 BootType=Windows2003
@@ -52,3 +37,18 @@ Options=/HAL=halpc98.dll /DEBUG /DEBUGPORT=SCREEN /SOS /MININT
 ;BootType=Windows2003
 ;SystemPath=multi(0)disk(0)cdrom(0)\reactos
 ;Options=/HAL=halpc98.dll /DEBUG /DEBUGPORT=FILE:\Device\HarddiskX\PartitionY\debug.log /SOS /MININT
+
+[Setup]
+BootType=ReactOSSetup
+SystemPath=multi(0)disk(0)cdrom(0)\
+Options=/HAL=halpc98.dll
+
+[Setup_Debug]
+BootType=ReactOSSetup
+SystemPath=multi(0)disk(0)cdrom(0)\
+Options=/HAL=halpc98.dll /DEBUG /DEBUGPORT=COM1 /BAUDRATE=9600 /NOGUIBOOT /SIFOPTIONSOVERRIDE
+
+[Setup_Screen]
+BootType=ReactOSSetup
+SystemPath=multi(0)disk(0)cdrom(0)\
+Options=/HAL=halpc98.dll /DEBUG /DEBUGPORT=SCREEN /SIFOPTIONSOVERRIDE


### PR DESCRIPTION
## Purpose & Suggestion for discussion:

Promote the all-in-one ReactOS "Live Environment" by moving its boot entries first in the boot menu.

The menu would now look like this:
```
ReactOS Live Environment (Graphics Mode)
ReactOS Live Environment - RamDisk
ReactOS Setup (Text Mode)
-------------------------------------------
Live (Debug)
Live (VBox Debug)
Live (Screen Debug)
Setup (Debug)
Setup (Screen Debug)
```

Please give your thoughts in comments.
