### PR TITLE
Add .vs folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ modules/[Aa][Hh][Kk]_[Tt]ests
 .idea
 .project
 .settings
+.vs
 .vscode
 sdk/tools/winesync/winesync.cfg


### PR DESCRIPTION
Visual Studio IDE (in my case the 2026 Community Edition IDE) creates a folder for workspace user settings as soon as you open a project directory with Open > Folder in the context menu. Ignore it, this prevents people from accidentaly sharing their VS dir to master.