### PR TITLE
[CMD] Handle overlong DATE and TIME input as one line

### DIFF
--- a/base/shell/cmd/console.c
+++ b/base/shell/cmd/console.c
@@ -78,38 +78,93 @@ VOID ConInKey(PINPUT_RECORD lpBuffer)
     while (TRUE);
 }
 
-VOID ConInString(LPWSTR lpInput, DWORD dwLength)
+BOOL ConInString(LPWSTR lpInput, DWORD dwLength)
 {
-    DWORD dwOldMode;
+    DWORD dwOldMode = 0;
     DWORD dwRead = 0;
+    DWORD dwDiscarded;
     HANDLE hFile;
+    BOOL bConsole;
+    BOOL bSuccess;
+    BOOL bTruncated = FALSE;
+    CHAR ch;
 
     LPWSTR p;
     PCHAR pBuf;
+    PCHAR pCr;
+    PCHAR pLf;
 
-    pBuf = (PCHAR)cmd_alloc(dwLength - 1);
+    if (!lpInput || dwLength < 2)
+        return FALSE;
 
     ZeroMemory(lpInput, dwLength * sizeof(WCHAR));
+
+    pBuf = (PCHAR)cmd_alloc(dwLength - 1);
+    if (!pBuf)
+        return FALSE;
     hFile = GetStdHandle(STD_INPUT_HANDLE);
-    GetConsoleMode(hFile, &dwOldMode);
+    bConsole = GetConsoleMode(hFile, &dwOldMode);
 
-    SetConsoleMode(hFile, ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT);
+    if (bConsole)
+        SetConsoleMode(hFile, ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT);
 
-    ReadFile(hFile, (PVOID)pBuf, dwLength - 1, &dwRead, NULL);
+    bSuccess = ReadFile(hFile, (PVOID)pBuf, dwLength - 1, &dwRead, NULL);
 
-    MultiByteToWideChar(InputCodePage, 0, pBuf, dwRead, lpInput, dwLength - 1);
+    /*
+     * If the input buffer filled up before a line terminator was read,
+     * consume the rest of that logical line. Otherwise, callers that retry
+     * after invalid input would see every remaining chunk as a new entry.
+     */
+    pCr = bSuccess ? memchr(pBuf, '\r', dwRead) : NULL;
+    pLf = bSuccess ? memchr(pBuf, '\n', dwRead) : NULL;
+
+    if (bSuccess && dwRead == dwLength - 1)
+    {
+        if (!pCr && !pLf)
+        {
+            if (ReadFile(hFile, &ch, 1, &dwDiscarded, NULL) && dwDiscarded)
+            {
+                if (ch == '\r')
+                {
+                    /* Consume the LF from the normal CR/LF line ending. */
+                    ReadFile(hFile, &ch, 1, &dwDiscarded, NULL);
+                }
+                else if (ch != '\n')
+                {
+                    bTruncated = TRUE;
+                    do
+                    {
+                        if (!ReadFile(hFile, &ch, 1, &dwDiscarded, NULL) || !dwDiscarded)
+                            break;
+                    }
+                    while (ch != '\n');
+                }
+            }
+        }
+        else if (pCr == pBuf + dwRead - 1)
+        {
+            /* The CR exactly filled the buffer; consume its trailing LF. */
+            ReadFile(hFile, &ch, 1, &dwDiscarded, NULL);
+        }
+    }
+
+    if (bSuccess)
+        MultiByteToWideChar(InputCodePage, 0, pBuf, dwRead, lpInput, dwLength - 1);
     cmd_free(pBuf);
 
     for (p = lpInput; *p; p++)
     {
-        if (*p == L'\r') // Terminate at the carriage-return.
+        if (*p == L'\r' || *p == L'\n')
         {
             *p = L'\0';
             break;
         }
     }
 
-    SetConsoleMode(hFile, dwOldMode);
+    if (bConsole)
+        SetConsoleMode(hFile, dwOldMode);
+
+    return !bTruncated;
 }
 
 

--- a/base/shell/cmd/console.c
+++ b/base/shell/cmd/console.c
@@ -78,21 +78,66 @@ VOID ConInKey(PINPUT_RECORD lpBuffer)
     while (TRUE);
 }
 
+static
+BOOL
+ConInHandleFullBuffer(
+    _In_ HANDLE hFile,
+    _In_reads_(Length) PCHAR Buffer,
+    _In_ DWORD Length)
+{
+    DWORD dwDiscarded;
+    PCHAR pCr;
+    PCHAR pLf;
+    CHAR ch;
+
+    pCr = memchr(Buffer, '\r', Length);
+    pLf = memchr(Buffer, '\n', Length);
+
+    if (pCr || pLf)
+    {
+        if (pCr == Buffer + Length - 1)
+        {
+            /* The CR exactly filled the buffer; consume its trailing LF. */
+            ReadFile(hFile, &ch, 1, &dwDiscarded, NULL);
+        }
+
+        return FALSE;
+    }
+
+    if (!ReadFile(hFile, &ch, 1, &dwDiscarded, NULL) || !dwDiscarded)
+        return FALSE;
+
+    if (ch == '\r')
+    {
+        /* Consume the LF from the normal CR/LF line ending. */
+        ReadFile(hFile, &ch, 1, &dwDiscarded, NULL);
+        return FALSE;
+    }
+
+    if (ch == '\n')
+        return FALSE;
+
+    do
+    {
+        if (!ReadFile(hFile, &ch, 1, &dwDiscarded, NULL) || !dwDiscarded)
+            break;
+    }
+    while (ch != '\n');
+
+    return TRUE;
+}
+
 BOOL ConInString(LPWSTR lpInput, DWORD dwLength)
 {
     DWORD dwOldMode = 0;
     DWORD dwRead = 0;
-    DWORD dwDiscarded;
     HANDLE hFile;
     BOOL bConsole;
     BOOL bSuccess;
     BOOL bTruncated = FALSE;
-    CHAR ch;
 
     LPWSTR p;
     PCHAR pBuf;
-    PCHAR pCr;
-    PCHAR pLf;
 
     if (!lpInput || dwLength < 2)
         return FALSE;
@@ -111,42 +156,12 @@ BOOL ConInString(LPWSTR lpInput, DWORD dwLength)
     bSuccess = ReadFile(hFile, (PVOID)pBuf, dwLength - 1, &dwRead, NULL);
 
     /*
-     * If the input buffer filled up before a line terminator was read,
-     * consume the rest of that logical line. Otherwise, callers that retry
-     * after invalid input would see every remaining chunk as a new entry.
+     * A full buffer may end exactly at the line terminator or may contain
+     * only the first chunk of a longer line. Drain the logical line here so
+     * callers that retry do not see each remaining chunk as a new entry.
      */
-    pCr = bSuccess ? memchr(pBuf, '\r', dwRead) : NULL;
-    pLf = bSuccess ? memchr(pBuf, '\n', dwRead) : NULL;
-
     if (bSuccess && dwRead == dwLength - 1)
-    {
-        if (!pCr && !pLf)
-        {
-            if (ReadFile(hFile, &ch, 1, &dwDiscarded, NULL) && dwDiscarded)
-            {
-                if (ch == '\r')
-                {
-                    /* Consume the LF from the normal CR/LF line ending. */
-                    ReadFile(hFile, &ch, 1, &dwDiscarded, NULL);
-                }
-                else if (ch != '\n')
-                {
-                    bTruncated = TRUE;
-                    do
-                    {
-                        if (!ReadFile(hFile, &ch, 1, &dwDiscarded, NULL) || !dwDiscarded)
-                            break;
-                    }
-                    while (ch != '\n');
-                }
-            }
-        }
-        else if (pCr == pBuf + dwRead - 1)
-        {
-            /* The CR exactly filled the buffer; consume its trailing LF. */
-            ReadFile(hFile, &ch, 1, &dwDiscarded, NULL);
-        }
-    }
+        bTruncated = ConInHandleFullBuffer(hFile, pBuf, dwRead);
 
     if (bSuccess)
         MultiByteToWideChar(InputCodePage, 0, pBuf, dwRead, lpInput, dwLength - 1);

--- a/base/shell/cmd/console.h
+++ b/base/shell/cmd/console.h
@@ -18,7 +18,7 @@ VOID ConInDisable (VOID);
 VOID ConInEnable (VOID);
 VOID ConInFlush (VOID);
 VOID ConInKey (PINPUT_RECORD);
-VOID ConInString (LPTSTR, DWORD);
+BOOL ConInString (LPTSTR, DWORD);
 
 
 VOID ConOutChar(TCHAR);

--- a/base/shell/cmd/date.c
+++ b/base/shell/cmd/date.c
@@ -179,6 +179,7 @@ INT cmd_date(LPTSTR param)
     INT argc;
     INT i;
     BOOL bPrompt = TRUE;
+    BOOL bLineComplete;
     INT nDateString = -1;
     TCHAR szDate[40];
 
@@ -220,14 +221,14 @@ INT cmd_date(LPTSTR param)
         if (nDateString == -1)
         {
             PromptDateString();
-            ConInString(szDate, ARRAYSIZE(szDate));
+            bLineComplete = ConInString(szDate, ARRAYSIZE(szDate));
 
             TRACE("\'%s\'\n", debugstr_aw(szDate));
 
             while (*szDate && szDate[_tcslen(szDate) - 1] < _T(' '))
                 szDate[_tcslen(szDate) - 1] = _T('\0');
 
-            if (ParseDate(szDate))
+            if (bLineComplete && ParseDate(szDate))
             {
                 freep(arg);
                 return 0;

--- a/base/shell/cmd/time.c
+++ b/base/shell/cmd/time.c
@@ -134,6 +134,7 @@ INT cmd_time(LPTSTR param)
     LPTSTR* arg;
     INT argc;
     INT i;
+    BOOL bLineComplete;
     INT nTimeString = -1;
     TCHAR szTime[40];
 
@@ -177,14 +178,14 @@ INT cmd_time(LPTSTR param)
         if (nTimeString == -1)
         {
             ConOutResPuts(STRING_TIME_HELP2);
-            ConInString(szTime, ARRAYSIZE(szTime));
+            bLineComplete = ConInString(szTime, ARRAYSIZE(szTime));
 
             TRACE("\'%s\'\n", debugstr_aw(szTime));
 
             while (*szTime && szTime[_tcslen(szTime) - 1] < _T(' '))
                 szTime[_tcslen(szTime) - 1] = _T('\0');
 
-            if (ParseTime(szTime))
+            if (bLineComplete && ParseTime(szTime))
             {
                 freep(arg);
                 return 0;

--- a/modules/rostests/apitests/cmd/cmd.c
+++ b/modules/rostests/apitests/cmd/cmd.c
@@ -498,6 +498,113 @@ static void DoTestEntry(const TEST_ENTRY *pEntry)
     }
 }
 
+static BOOL
+RunLongInputCommand(PCSTR Builtin,
+                    SIZE_T MarkerCount,
+                    PCHAR Output,
+                    SIZE_T OutputSize,
+                    PINT ExitCode)
+{
+    CHAR InputName[64];
+    CHAR CommandLine[256];
+    FILE *File;
+    SIZE_T i;
+    SIZE_T Read;
+    BOOL Success = FALSE;
+
+    sprintf(InputName, "cmd-long-input-%lu.tmp", GetCurrentProcessId());
+
+    File = fopen(InputName, "wb");
+    if (!File)
+    {
+        skip("Could not create %s\n", InputName);
+        return FALSE;
+    }
+
+    for (i = 0; i < MarkerCount; ++i)
+        fputc('#', File);
+    fputs("\r\n\r\n", File);
+    if (ferror(File))
+    {
+        skip("Could not write %s\n", InputName);
+        fclose(File);
+        DeleteFileA(InputName);
+        return FALSE;
+    }
+    fclose(File);
+
+    sprintf(CommandLine,
+            "%s invalid < %s 2>&1",
+            Builtin, InputName);
+    File = _popen(CommandLine, "r");
+    if (!File)
+    {
+        skip("_popen failed for %s\n", Builtin);
+        DeleteFileA(InputName);
+        return FALSE;
+    }
+
+    Read = fread(Output, 1, OutputSize - 1, File);
+    Output[Read] = '\0';
+    if (ferror(File))
+        skip("Could not read output for %s\n", Builtin);
+    else
+        Success = TRUE;
+
+    *ExitCode = _pclose(File);
+    DeleteFileA(InputName);
+    return Success;
+}
+
+static VOID
+NormalizeLongInputOutput(PCHAR Output)
+{
+    PCHAR Src = Output;
+    PCHAR Dst = Output;
+
+    while (*Src)
+    {
+        if (*Src != '#')
+            *Dst++ = *Src;
+        ++Src;
+    }
+    *Dst = '\0';
+}
+
+START_TEST(long_input)
+{
+    static const PCSTR Builtins[] = { "date", "time" };
+    SIZE_T i;
+
+    for (i = 0; i < ARRAYSIZE(Builtins); ++i)
+    {
+        CHAR ShortOutput[2048];
+        CHAR LongOutput[2048];
+        INT ShortExitCode;
+        INT LongExitCode;
+
+        if (!RunLongInputCommand(Builtins[i], 1,
+                                 ShortOutput, ARRAYSIZE(ShortOutput),
+                                 &ShortExitCode) ||
+            !RunLongInputCommand(Builtins[i], 120,
+                                 LongOutput, ARRAYSIZE(LongOutput),
+                                 &LongExitCode))
+        {
+            continue;
+        }
+
+        NormalizeLongInputOutput(ShortOutput);
+        NormalizeLongInputOutput(LongOutput);
+
+        ok(ShortExitCode == LongExitCode,
+           "%s: exit codes differ: %d vs %d\n",
+           Builtins[i], ShortExitCode, LongExitCode);
+        ok(strcmp(ShortOutput, LongOutput) == 0,
+           "%s: long input was handled differently\nshort: '%s'\nlong: '%s'\n",
+           Builtins[i], ShortOutput, LongOutput);
+    }
+}
+
 START_TEST(exit)
 {
     SIZE_T i;

--- a/modules/rostests/apitests/cmd/testlist.c
+++ b/modules/rostests/apitests/cmd/testlist.c
@@ -6,6 +6,7 @@ extern void func_cd(void);
 extern void func_echo(void);
 extern void func_exit(void);
 extern void func_fc(void);
+extern void func_long_input(void);
 extern void func_pushd(void);
 
 const struct test winetest_testlist[] =
@@ -15,6 +16,7 @@ const struct test winetest_testlist[] =
     { "echo", func_echo },
     { "exit", func_exit },
     { "fc", func_fc },
+    { "long_input", func_long_input },
     { "pushd", func_pushd },
     { 0, 0 }
 };


### PR DESCRIPTION
## Purpose

Fix CORE-20733, where the `DATE` and `TIME` commands can treat a single overlong input line as several separate attempts because the remaining chunks stay pending on stdin.

JIRA issue: [CORE-20733](https://jira.reactos.org/browse/CORE-20733)

## Proposed changes

- Make `ConInString()` consume the remainder of an overlong logical input line instead of leaving subsequent chunks for the next prompt.
- Return whether the input line was complete so `DATE` and `TIME` reject a truncated value once instead of parsing its prefix.
- Preserve the existing EOF behavior for redirected input.
- Add a `cmd_apitest` regression test comparing short and overlong input behavior for both commands.

## Testing

- Rebased onto current `master` (`c1827c0631` at test time).
- `ninja cmd cmd_apitest` completed successfully.
- `cmd_apitest.exe long_input`: 4 tests, 0 failures with the fix.
- The same test produces failures for both `DATE` and `TIME` without the production fix.
- Boundary battery: 28/28 cases passed across input lengths 1, 37-41, 77-81 and 119-121 for both commands.
- The regression semantics were also checked against Windows Server 2003 SP2 `cmd.exe` 5.2.3790.3959 and Windows 11, both yielding the expected single logical-line behavior.
- `git diff --check origin/master...HEAD` is clean.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
### Final validation after readability cleanup

Final head: `5744b1e0990c9667101825765d0bed9c91e35848`.

- The full PR diff passes the mechanical readability gate and `git diff --check`.
- `cmd_apitest.exe long_input`: 4 tests, 0 failures on the final head.
- Boundary battery: 28/28 cases passed (14 lengths across both DATE and TIME), with exactly one rejection per invalid logical input line.
- Build-farm run `32433562549`: SUCCESS for targets `cmd cmd_apitest` from this exact SHA; the artifact contains a clean `source-status.txt`.

The readability-only refactor moved the full-buffer handling into `ConInHandleFullBuffer()` so `ConInString()` now reads as linear orchestration without changing the tested semantics.