### PR TITLE
[WININET_WINETEST] Bound waits in http test

### DIFF
--- a/modules/rostests/winetests/wininet/http.c
+++ b/modules/rostests/winetests/wininet/http.c
@@ -116,12 +116,15 @@ static DWORD req_error;
 static BOOL is_ie7plus = TRUE;
 
 #ifdef __REACTOS__
-/* Fail infinite waits before rosautotest's process-activity watchdog and report the stalled object. */
+/* Fail infinite waits before rosautotest's process-activity watchdog and
+ * report the stalled object. */
 #define WININET_TEST_WAIT_TIMEOUT (2 * 60 * 1000u)
 
-static DWORD wait_for_single_object_(HANDLE object, DWORD timeout, const char *object_name, unsigned line)
+static DWORD wait_for_single_object_(HANDLE object, DWORD timeout,
+                                     const char *object_name, unsigned line)
 {
-    DWORD effective_timeout = timeout == INFINITE ? WININET_TEST_WAIT_TIMEOUT : timeout;
+    DWORD effective_timeout =
+        timeout == INFINITE ? WININET_TEST_WAIT_TIMEOUT : timeout;
     DWORD result = WaitForSingleObject(object, effective_timeout);
 
     if (timeout != INFINITE || result == WAIT_OBJECT_0)

--- a/modules/rostests/winetests/wininet/http.c
+++ b/modules/rostests/winetests/wininet/http.c
@@ -115,6 +115,33 @@ static HANDLE complete_event, conn_close_event, conn_wait_event, server_req_rec_
 static DWORD req_error;
 static BOOL is_ie7plus = TRUE;
 
+#ifdef __REACTOS__
+/* Fail infinite waits before rosautotest's process-activity watchdog and report the stalled object. */
+#define WININET_TEST_WAIT_TIMEOUT (2 * 60 * 1000u)
+
+static DWORD wait_for_single_object_(HANDLE object, DWORD timeout, const char *object_name, unsigned line)
+{
+    DWORD effective_timeout = timeout == INFINITE ? WININET_TEST_WAIT_TIMEOUT : timeout;
+    DWORD result = WaitForSingleObject(object, effective_timeout);
+
+    if (timeout != INFINITE || result == WAIT_OBJECT_0)
+        return result;
+
+    if (result == WAIT_TIMEOUT)
+        ok_(__FILE__, line)(FALSE, "Timed out waiting for %s after %u ms\n",
+                            object_name, WININET_TEST_WAIT_TIMEOUT);
+    else
+        ok_(__FILE__, line)(FALSE, "WaitForSingleObject(%s) failed: %lu, error %lu\n",
+                            object_name, result, GetLastError());
+
+    fflush(stdout);
+    ExitProcess(1);
+}
+
+#define WaitForSingleObject(object, timeout) \
+    wait_for_single_object_((object), (timeout), #object, __LINE__)
+#endif
+
 #define TESTF_REDIRECT      0x01
 #define TESTF_COMPRESSED    0x02
 #define TESTF_CHUNKED       0x04
@@ -7995,12 +8022,6 @@ static void test_cert_string(void)
 START_TEST(http)
 {
     HMODULE hdll;
-
-    if (!winetest_interactive)
-    {
-        win_skip("Skipping wininet:http due to hang ROSTESTS-357\n");
-        return;
-    }
 
     hdll = GetModuleHandleA("wininet.dll");
 


### PR DESCRIPTION
## Purpose

Fix [ROSTESTS-354](https://jira.reactos.org/browse/ROSTESTS-354), where `wininet:http` contains infinite waits that can leave regression-test processes hanging indefinitely when an asynchronous/network operation never completes.

This also allows the non-interactive `http` test to run again instead of being skipped as a workaround for [ROSTESTS-357](https://jira.reactos.org/browse/ROSTESTS-357).

## Proposed changes

- Add a ReactOS-only 120-second wait wrapper for the events that were previously waited on with `INFINITE`.
- Report the specific event that timed out or failed, then fail that winetest process instead of leaving it blocked indefinitely.
- Keep the deadline below `rosautotest`'s process-activity watchdog so the test can provide a more specific diagnostic first.
- Leave already finite waits unchanged.
- Preserve Wine/non-ReactOS behavior behind `#ifdef __REACTOS__`.
- Remove the non-interactive `wininet:http` skip added for ROSTESTS-357 now that these waits are bounded.

## Testing

- `ninja wininet_winetest`: builds and links successfully.
- `git diff --check origin/master...HEAD`: clean.
- Normal host-side smoke runs of the ReactOS-built `wininet_winetest.exe http` completed the full test instead of hanging (4108 and 4102 checks respectively). Two host certificate/locale expectation failures were observed in both runs and are unrelated to this change.
- Forced timeout validation: temporarily reduced the new deadline to 1 ms, rebuilt, and ran `http`. The process exited by itself with code 1 and reported `Timed out waiting for complete_event after 1 ms`; the external runner timeout did not fire. The source was then restored exactly to the committed 120-second value and rebuilt successfully.
### Final validation after readability cleanup

Final head: `62c3a2f453040b86a450b4b0c6e17cbd0f146d08`.

- Build-farm run `32433569150`: SUCCESS for `wininet_winetest`, with clean `source-status.txt`.
- The exact build-farm `wininet_winetest.exe` was injected into a real ReactOS guest and run headless under QEMU with user-mode networking.
- Guest serial: `WININET_RUNTIME_BEGIN`, then `http: 4066 tests executed (0 marked as todo, 65 failures), 2 skipped.`, followed by `WININET_RUNTIME_END`.
- QEMU exited with code 0 after guest shutdown; no bugcheck/assertion and no `Timed out waiting` diagnostic occurred.

The 65 functional WinInet failures are not claimed as passes; they are separate from the scope of this PR. The relevant ROSTESTS-354/357 result is that the formerly skipped/non-interactive `http` test now traverses its full suite inside ReactOS and terminates instead of hanging indefinitely.