### PR TITLE
[FREELDR:UEFI] Simplify Reboot() fallback code

### DIFF
--- a/boot/freeldr/freeldr/arch/uefi/uefildr.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefildr.c
@@ -123,10 +123,8 @@ VOID __cdecl Reboot(VOID)
     /* Fallback dead-loop if runtime services are missing or fail to respond */
     for (;;)
     {
-#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64))
+#if defined(_M_IX86) || defined(_M_AMD64)
         __halt();
-#elif defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
-        __asm__ __volatile__("hlt");
 #else
         /* Fallback placeholder loop for other platforms */
         NOTHING;


### PR DESCRIPTION
## Purpose / Proposed changes

Addendum to commit 2a74f5e794 (PR #9092)

- The `__halt()` intrinsic is also defined for GCC-based builds, see: sdk/include/vcruntime/mingw32/intrin_x86.h

- The `_M_IX86` and `_M_AMD64` defines are also defined for GCC-based builds, see: sdk/include/reactos/msvctarget.h

JIRA issue: [CORE-11954](https://jira.reactos.org/browse/CORE-11954)