### PR TITLE
[NTOS:SE] Adapt the logon session database into a hash table

### DIFF
--- a/ntoskrnl/se/srm.c
+++ b/ntoskrnl/se/srm.c
@@ -4,7 +4,7 @@
  * PURPOSE:     Security Reference Monitor Server
  * COPYRIGHT:   Copyright Timo Kreuzer <timo.kreuzer@reactos.org>
  *              Copyright Pierre Schweitzer <pierre@reactos.org>
- *              Copyright 2021 George Bișoc <george.bisoc@reactos.org>
+ *              Copyright 2021-2026 George Bișoc <george.bisoc@reactos.org>
  */
 
 /* INCLUDES *******************************************************************/
@@ -60,8 +60,19 @@ ULONG SepAdtMaxListLength = 0x3000;
 UCHAR SeAuditingState[POLICY_AUDIT_EVENT_TYPE_COUNT];
 
 KGUARDED_MUTEX SepRmDbLock;
-PSEP_LOGON_SESSION_REFERENCES SepLogonSessions = NULL;
 PSEP_LOGON_SESSION_TERMINATED_NOTIFICATION SepLogonNotifications = NULL;
+
+/*
+ * The logon session database is a hash table comprised of 16 hash buckets.
+ * Each bucket is a single-list of SEP_LOGON_SESSION_REFERENCES structures,
+ * that is simply indexed by a session logon ID modulo the number of buckets.
+ *
+ * !logonsession command extension from WinDBG strictly expects nt!SepLogonSessions
+ * symbol to follow this mechanism.
+ */
+#define MAX_LOGON_SESSION_LISTS_IN_ARRAY      16
+static PSEP_LOGON_SESSION_REFERENCES _SepLogonSessions[MAX_LOGON_SESSION_LISTS_IN_ARRAY] = {NULL};
+PSEP_LOGON_SESSION_REFERENCES* const SepLogonSessions = _SepLogonSessions;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
@@ -377,7 +388,8 @@ SepRmInsertLogonSessionIntoToken(
     /* Acquire the database lock */
     KeAcquireGuardedMutex(&SepRmDbLock);
 
-    for (LogonSession = SepLogonSessions;
+    /* Retrieve the hash bucket and loop over it */
+    for (LogonSession = SepLogonSessions[Token->AuthenticationId.LowPart % MAX_LOGON_SESSION_LISTS_IN_ARRAY];
          LogonSession != NULL;
          LogonSession = LogonSession->Next)
     {
@@ -458,7 +470,8 @@ SepRmRemoveLogonSessionFromToken(
     /* Acquire the database lock */
     KeAcquireGuardedMutex(&SepRmDbLock);
 
-    for (LogonSession = SepLogonSessions;
+    /* Retrieve the hash bucket and loop over it */
+    for (LogonSession = SepLogonSessions[Token->AuthenticationId.LowPart % MAX_LOGON_SESSION_LISTS_IN_ARRAY];
          LogonSession != NULL;
          LogonSession = LogonSession->Next)
     {
@@ -512,7 +525,7 @@ NTSTATUS
 SepRmCreateLogonSession(
     _In_ PLUID LogonLuid)
 {
-    PSEP_LOGON_SESSION_REFERENCES CurrentSession, NewSession;
+    PSEP_LOGON_SESSION_REFERENCES *LogonSession, CurrentSession, NewSession;
     NTSTATUS Status;
     PAGED_CODE();
 
@@ -538,8 +551,15 @@ SepRmCreateLogonSession(
     /* Acquire the database lock */
     KeAcquireGuardedMutex(&SepRmDbLock);
 
+    /*
+     * Cache the previous session from the hash bucket, the newly created
+     * session will keep hold of the previous session and the hash bucket
+     * gets a new assigned session.
+     */
+    LogonSession = &SepLogonSessions[LogonLuid->LowPart % MAX_LOGON_SESSION_LISTS_IN_ARRAY];
+
     /* Loop all existing sessions */
-    for (CurrentSession = SepLogonSessions;
+    for (CurrentSession = *LogonSession;
          CurrentSession != NULL;
          CurrentSession = CurrentSession->Next)
     {
@@ -552,8 +572,8 @@ SepRmCreateLogonSession(
     }
 
     /* Insert the new session */
-    NewSession->Next = SepLogonSessions;
-    SepLogonSessions = NewSession;
+    NewSession->Next = *LogonSession;
+    *LogonSession = NewSession;
 
     Status = STATUS_SUCCESS;
 
@@ -590,7 +610,7 @@ NTSTATUS
 SepRmDeleteLogonSession(
     _In_ PLUID LogonLuid)
 {
-    PSEP_LOGON_SESSION_REFERENCES SessionToDelete;
+    PSEP_LOGON_SESSION_REFERENCES SessionToDelete, *LogonSession;
     NTSTATUS Status;
     PAGED_CODE();
 
@@ -600,8 +620,11 @@ SepRmDeleteLogonSession(
     /* Acquire the database lock */
     KeAcquireGuardedMutex(&SepRmDbLock);
 
+    /* Retrieve the hash bucket, the database will have this session pulled away down below */
+    LogonSession = &SepLogonSessions[LogonLuid->LowPart % MAX_LOGON_SESSION_LISTS_IN_ARRAY];
+
     /* Loop over the existing logon sessions */
-    for (SessionToDelete = SepLogonSessions;
+    for (SessionToDelete = *LogonSession;
          SessionToDelete != NULL;
          SessionToDelete = SessionToDelete->Next)
     {
@@ -667,6 +690,9 @@ SepRmDeleteLogonSession(
         ObfDereferenceDeviceMap(SessionToDelete->pDeviceMap);
     }
 
+    /* Unlink the session from the bucket list */
+    *LogonSession = SessionToDelete->Next;
+
     /* If we're here then we've deleted the logon session successfully */
     DPRINT("SepRmDeleteLogonSession(): Logon session deleted with success!\n");
     Status = STATUS_SUCCESS;
@@ -705,8 +731,8 @@ SepRmReferenceLogonSession(
     /* Acquire the database lock */
     KeAcquireGuardedMutex(&SepRmDbLock);
 
-    /* Loop all existing sessions */
-    for (CurrentSession = SepLogonSessions;
+    /* Retrieve the hash bucket and loop over it */
+    for (CurrentSession = SepLogonSessions[LogonLuid->LowPart % MAX_LOGON_SESSION_LISTS_IN_ARRAY];
          CurrentSession != NULL;
          CurrentSession = CurrentSession->Next)
     {
@@ -1018,8 +1044,8 @@ SepRmDereferenceLogonSession(
     /* Acquire the database lock */
     KeAcquireGuardedMutex(&SepRmDbLock);
 
-    /* Loop all existing sessions */
-    for (CurrentSession = SepLogonSessions;
+    /* Retrieve the hash bucket and walk over it */
+    for (CurrentSession = SepLogonSessions[LogonLuid->LowPart % MAX_LOGON_SESSION_LISTS_IN_ARRAY];
          CurrentSession != NULL;
          CurrentSession = CurrentSession->Next)
     {
@@ -1367,8 +1393,8 @@ SeGetLogonIdDeviceMap(
     /* Acquire the database lock */
     KeAcquireGuardedMutex(&SepRmDbLock);
 
-    /* Loop all existing sessions */
-    for (CurrentSession = SepLogonSessions;
+    /* Retrieve the hash bucket and loop over it */
+    for (CurrentSession = SepLogonSessions[LogonId->LowPart % MAX_LOGON_SESSION_LISTS_IN_ARRAY];
          CurrentSession != NULL;
          CurrentSession = CurrentSession->Next)
     {
@@ -1519,8 +1545,8 @@ SeMarkLogonSessionForTerminationNotification(
     /* Acquire the database lock */
     KeAcquireGuardedMutex(&SepRmDbLock);
 
-    /* Loop over the existing logon sessions */
-    for (SessionToMark = SepLogonSessions;
+    /* Retrieve the hash bucket and loop over it */
+    for (SessionToMark = SepLogonSessions[LogonId->LowPart % MAX_LOGON_SESSION_LISTS_IN_ARRAY];
          SessionToMark != NULL;
          SessionToMark = SessionToMark->Next)
     {


### PR DESCRIPTION
Right now `nt!SepLogonSessions` in ROS is a mere pointer list of `_SEP_LOGON_SESSION_REFERENCES` structures. The WinDBG `!logonsession` command expects it to be a hash table, composed as an array of lists. Consequently this command doesn't work if you debug ROS, it simply causes the debugger to spam the logger with garbage into an infinite loop.

So in order to fix this, we gotta make this database construct behave as what WinDBG would strictly expect.

<img width="2089" height="1188" alt="Screenshot 2026-08-17 233016" src="https://github.com/user-attachments/assets/af8d507b-5173-4f3c-a94b-7fa301bc0f65" />

JIRA Issue: [CORE-20344](https://jira.reactos.org/browse/CORE-20344)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109606,109608
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109607,109609