### PR TITLE
[WIN32U_APITEST][NTUSER] Fix NtUserSBGetParms BSOD

### DIFF
--- a/modules/rostests/apitests/win32u/CMakeLists.txt
+++ b/modules/rostests/apitests/win32u/CMakeLists.txt
@@ -69,6 +69,7 @@ list(APPEND SOURCE
     ntuser/NtUserGetTitleBarInfo.c
     ntuser/NtUserProcessConnect.c
     ntuser/NtUserRedrawWindow.c
+    ntuser/NtUserSBGetParms.c
     ntuser/NtUserScrollDC.c
     ntuser/NtUserSelectPalette.c
     ntuser/NtUserSetTimer.c

--- a/modules/rostests/apitests/win32u/ntuser/NtUserSBGetParms.c
+++ b/modules/rostests/apitests/win32u/ntuser/NtUserSBGetParms.c
@@ -1,0 +1,82 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Test for NtUserSBGetParms
+ * COPYRIGHT:   Copyright 2026 Max Korostil <mrmks04@yandex.ru>
+ */
+
+#include <apitest.h>
+#include <wincon.h>
+
+#include "../win32nt.h"
+
+START_TEST(NtUserSBGetParms)
+{
+    BOOL ret;
+    DWORD error;
+    SBDATA sbData;
+    SCROLLINFO si;
+    HWND hWnd = GetConsoleWindow();
+    
+    // 1
+    SetLastError(0);
+    ret = NtUserSBGetParms(hWnd, SB_CTL, &sbData, &si);
+    error = GetLastError();
+
+    ok_int(ret, TRUE);
+    ok_int(error, ERROR_SUCCESS);
+
+    // 2
+    SetLastError(0);
+    ret = NtUserSBGetParms(hWnd, SB_CTL, &sbData, NULL);
+    error = GetLastError();
+
+    ok_int(ret, FALSE);
+    ok_int(error, ERROR_NOACCESS);
+
+    // 3
+    SetLastError(0);
+    ret = NtUserSBGetParms(hWnd, SB_CTL, &sbData, (LPSCROLLINFO)(ULONG_PTR)0xDEADBEEF);
+    error = GetLastError();
+
+    ok_int(ret, FALSE);
+    ok_int(error, ERROR_NOACCESS);
+    
+    // 4
+    SetLastError(0);
+    ret = NtUserSBGetParms(hWnd, SB_CTL, NULL, &si);
+    error = GetLastError();
+
+    ok_int(ret, FALSE);
+    ok_int(error, ERROR_NOACCESS);
+
+    // 5
+    SetLastError(0);
+    ret = NtUserSBGetParms(hWnd, SB_CTL, (PSBDATA)(ULONG_PTR)0xDEADBEEF, &si);
+    error = GetLastError();
+
+    ok_int(ret, FALSE);
+    ok_int(error, ERROR_NOACCESS);
+
+    // 6
+    SetLastError(0);
+    ret = NtUserSBGetParms(NULL, SB_CTL, &sbData, &si);
+    error = GetLastError();
+
+    ok_int(ret, FALSE);
+    ok_int(error, ERROR_INVALID_WINDOW_HANDLE);
+
+    // 7
+    ret = NtUserSBGetParms(hWnd, SB_CTL, &sbData, (LPSCROLLINFO)MAXULONG_PTR);
+    error = GetLastError();
+
+    ok_int(ret, FALSE);
+    ok_int(error, ERROR_NOACCESS);
+
+    // 8
+    ret = NtUserSBGetParms(hWnd, SB_CTL, (PSBDATA)(ULONG_PTR)MAXULONG_PTR, &si);
+    error = GetLastError();
+
+    ok_int(ret, FALSE);
+    ok_int(error, ERROR_NOACCESS);
+}

--- a/modules/rostests/apitests/win32u/testlist.c
+++ b/modules/rostests/apitests/win32u/testlist.c
@@ -64,6 +64,7 @@ extern void func_NtUserGetThreadState(void);
 extern void func_NtUserGetTitleBarInfo(void);
 extern void func_NtUserProcessConnect(void);
 extern void func_NtUserRedrawWindow(void);
+extern void func_NtUserSBGetParms(void);
 extern void func_NtUserScrollDC(void);
 extern void func_NtUserSelectPalette(void);
 extern void func_NtUserSetTimer(void);
@@ -138,6 +139,7 @@ const struct test winetest_testlist[] =
     { "NtUserGetTitleBarInfo", func_NtUserGetTitleBarInfo },
     { "NtUserProcessConnect", func_NtUserProcessConnect },
     { "NtUserRedrawWindow", func_NtUserRedrawWindow },
+    { "NtUserSBGetParms", func_NtUserSBGetParms },
     { "NtUserScrollDC", func_NtUserScrollDC },
     { "NtUserSelectPalette", func_NtUserSelectPalette },
     { "NtUserSetTimer", func_NtUserSetTimer },

--- a/win32ss/user/ntuser/scrollbar.c
+++ b/win32ss/user/ntuser/scrollbar.c
@@ -1207,9 +1207,11 @@ NtUserSBGetParms(
 
    _SEH2_TRY
    {
+      ProbeForWrite(lpsi, sizeof(SCROLLINFO), 1);      
+      ProbeForRead(pSBData, sizeof(SBDATA), 1);
+
       RtlCopyMemory(&psi, lpsi, sizeof(SCROLLINFO));
-      if (pSBData)
-         RtlCopyMemory(&SBDataSafe, pSBData, sizeof(SBDATA));
+      RtlCopyMemory(&SBDataSafe, pSBData, sizeof(SBDATA));
    }
    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
    {
@@ -1243,8 +1245,8 @@ NtUserSBGetParms(
    _SEH2_END
 
 Exit:
-   TRACE("Leave NtUserGetScrollInfo, ret=%i\n", Ret);
    UserLeave();
+   TRACE("Leave NtUserGetScrollInfo, ret=%i\n", Ret);   
    return Ret;
 }
 


### PR DESCRIPTION
Fix NtUserSBGetParms BSOD.
Add unit test.

JIRA issue: [CORE-18128](https://jira.reactos.org/browse/CORE-18128)

Test result:

Windows
<img width="665" height="328" alt="windows" src="https://github.com/user-attachments/assets/cb7ad05f-d460-406e-bdb0-4164fcdc600c" />

ReactOS
<img width="663" height="160" alt="reactos" src="https://github.com/user-attachments/assets/80e35c2a-85aa-43c5-9086-6c7a666236be" />
