### PR TITLE
[RAPPS] Remove readonly flag from the downloaded database file

### DIFF
--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -967,6 +967,11 @@ CDownloadManager::PerformDownloadAndInstall(const DownloadInfo &Info)
         {
             if (CopyFileW(LocalFilePath, Path, FALSE))
             {
+                // Remove the readonly flag in case we are copying from a read-only medium
+                DWORD attr = GetFileAttributesW(Path);
+                if (attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_READONLY))
+                    SetFileAttributesW(Path, attr & ~FILE_ATTRIBUTE_READONLY);
+
                 goto run;
             }
             else


### PR DESCRIPTION


## Purpose

Remove readonly flag from the downloaded database file

JIRA issue: [CORE-20743](https://jira.reactos.org/browse/CORE-20743)

