### PR TITLE
[NTDLL_WINETEST][ADVAPI32] Fix build when building with Win8 dll exports

### DIFF
--- a/dll/win32/advapi32/advapi32.spec
+++ b/dll/win32/advapi32/advapi32.spec
@@ -495,6 +495,8 @@
 @ stdcall RegDeleteKeyW(long wstr)
 @ stdcall -version=0x600+ RegDeleteTreeA(long str)
 @ stdcall -version=0x600+ RegDeleteTreeW(long wstr)
+@ stdcall -version=0x600+ RegDeleteKeyValueA(long wstr wstr)
+@ stdcall -version=0x600+ RegDeleteKeyValueW(long wstr wstr)
 @ stdcall RegDeleteValueA(long str)
 @ stdcall RegDeleteValueW(long wstr)
 @ stdcall RegDisablePredefinedCache()

--- a/modules/rostests/winetests/ntdll/CMakeLists.txt
+++ b/modules/rostests/winetests/ntdll/CMakeLists.txt
@@ -66,6 +66,6 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 endif()
 
 set_module_type(ntdll_winetest win32cui)
-add_importlibs(ntdll_winetest user32 ole32 advapi32 msvcrt kernel32 ntdll)
+add_importlibs(ntdll_winetest user32 psapi ole32 advapi32 msvcrt kernel32 ntdll)
 add_rostests_file(TARGET ntdll_winetest)
 target_compile_definitions(ntdll_winetest PRIVATE wcsnicmp=_wcsnicmp)


### PR DESCRIPTION
## Purpose

Fix build of ntdll_winetest when compiling with `-DDLL_EXPORT_VERSION=0x602`.

JIRA issue: None

## Proposed changes

- Export RegDeleteKeyValueA and RegDeleteKeyValueW in advapi32
- Link ntdll_winetest against psapi for EnumProcesses

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: