### PR TITLE
[NTOS:EX] Prevent shared acquisition from stealing a contended push lock

### DIFF
--- a/ntoskrnl/ex/pushlock.c
+++ b/ntoskrnl/ex/pushlock.c
@@ -652,21 +652,17 @@ ExfAcquirePushLockShared(PEX_PUSH_LOCK PushLock)
     /* Start main loop */
     for (;;)
     {
-        /* Check if it's unlocked or if it's waiting without any sharers */
-        if (!(OldValue.Locked) || (!(OldValue.Waiting) && (OldValue.Shared > 0)))
+        /*
+         * Check if shared ownership can be acquired directly.
+         * We don't let a shared acquirer steal a contended but unlocked
+         * push lock, since such an acquisition is represented only by
+         * setting Locked and would exclude other shared acquirers.
+         */
+        if (!OldValue.Waiting && (!OldValue.Locked || OldValue.Shared > 0))
         {
-            /* Check if anyone is waiting on it */
-            if (!OldValue.Waiting)
-            {
-                /* Increase the share count and lock it */
-                NewValue.Value = OldValue.Value | EX_PUSH_LOCK_LOCK;
-                NewValue.Shared++;
-            }
-            else
-            {
-                /* Simply set the lock bit */
-                NewValue.Value = OldValue.Value | EX_PUSH_LOCK_LOCK;
-            }
+            /* Acquire shared ownership */
+            NewValue.Value = OldValue.Value | EX_PUSH_LOCK_LOCK;
+            NewValue.Shared++;
 
             /* Sanity check */
             ASSERT(NewValue.Locked);


### PR DESCRIPTION
Currently push locks allow an arriving thread to steal a contended lock while the previous owner is waking waiters. Doing so for a shared acquisition has an undesirable side effect. When a shared acquirer steals a contended but temporarily unlocked push lock, its ownership is represented only by setting the Locked bit rather than incrementing the shared count. As a result, the acquisition effectively behaves as exclusive (ie, subsequent shared acquirers queue until that owner releases the lock). This can deadlock users which rely on multiple shared owners entering concurrently in SMP configuration.

Proposed fix:

Do not allow shared acquisitions to steal the lock while Waiting is set. The existing waiter/waker part of the algorithm already handles this state correctly.
