### PR TITLE
[DEVMGR] Fix use-after-free in the UI code

### DIFF
--- a/dll/win32/devmgr/devmgmt/DeviceView.cpp
+++ b/dll/win32/devmgr/devmgmt/DeviceView.cpp
@@ -404,15 +404,15 @@ unsigned int __stdcall CDeviceView::RefreshThread(void *Param)
     // Empty the treeview
     This->EmptyDeviceView();
 
-    // Re-add the root node to the tree
-    if (This->AddRootDevice() == false)
-        return 0;
-
     // Refresh the devices only if requested
     if (ThreadData->ScanForChanges)
     {
         This->RefreshDeviceList();
     }
+
+    // Re-add the root node to the tree
+    if (This->AddRootDevice() == false)
+        return 0;
 
     // display the type of view the user wants
     switch (This->m_ViewType)


### PR DESCRIPTION
## Purpose

The `CDeviceView::RefreshDeviceList` destroys the `m_RootNode` object and replaces it with a new one while TreeView still holds a reference to the now-destroyed old one. This makes event-handlers to be called using the old pointer, which in turn makes `Node` in `CDeviceView::BuildActionMenuForNode` return an invalid value for `CNode::GetNodeType()` that hides the "Add Hardware" option from context menu.

JIRA issue: [CORE-19770](https://jira.reactos.org/browse/CORE-19770)

## Proposed changes

Instead of adding the TreeView root node and then calling `RefreshDeviceList`, we can change the order so the root node is always added to the TreeView after `RefreshDeviceList` recreated the `m_RootNode`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: