### PR TITLE
[MOUNTMGR][KMTEST] Preserve persisted volume links on arrival

### DIFF
--- a/drivers/storage/mountmgr/symlink.c
+++ b/drivers/storage/mountmgr/symlink.c
@@ -314,7 +314,8 @@ SymbolicLinkNamesFromUniqueIdCount(IN PWSTR ValueName,
     UNICODE_STRING ValueNameString;
     PMOUNTDEV_UNIQUE_ID UniqueId = Context;
 
-    if (ValueName[0] != L'#' || ValueType != REG_BINARY ||
+    /* Entries beginning with '#' only suppress drive-letter assignment. */
+    if (ValueName[0] == L'#' || ValueType != REG_BINARY ||
         (UniqueId->UniqueIdLength != ValueLength))
     {
         return STATUS_SUCCESS;
@@ -352,7 +353,8 @@ SymbolicLinkNamesFromUniqueIdQuery(IN PWSTR ValueName,
     /* Unicode strings table */
     PUNICODE_STRING ReturnString = EntryContext;
 
-    if (ValueName[0] != L'#' || ValueType != REG_BINARY ||
+    /* Entries beginning with '#' only suppress drive-letter assignment. */
+    if (ValueName[0] == L'#' || ValueType != REG_BINARY ||
         (UniqueId->UniqueIdLength != ValueLength))
     {
         return STATUS_SUCCESS;

--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(example)
 add_subdirectory(fltmgr)
 add_subdirectory(hidparse)
 add_subdirectory(kernel32)
+add_subdirectory(mountmgr)
 add_subdirectory(ntos_cc)
 add_subdirectory(ntos_io)
 add_subdirectory(ntos_mm)
@@ -166,6 +167,7 @@ list(APPEND KMTEST_SOURCE
     hidparse/HidP_user.c
     kernel32/FileAttributes_user.c
     kernel32/FindFile_user.c
+    mountmgr/MountMgrVolume_user.c
     ntos_cc/CcCopyRead_user.c
     ntos_cc/CcCopyWrite_user.c
     ntos_cc/CcMapData_user.c
@@ -205,6 +207,7 @@ add_dependencies(kmtest_drivers
     iohelper_drv
     ioreadwrite_drv
     kernel32_drv
+    MountMgrVolume_drv
     mmmaplockedpagesspecifycache_drv
     ntcreatesection_drv
     poirp_drv

--- a/modules/rostests/kmtests/kmtest/testlist.c
+++ b/modules/rostests/kmtests/kmtest/testlist.c
@@ -21,6 +21,7 @@ KMT_TESTFUNC Test_HidPDescription;
 KMT_TESTFUNC Test_IoCreateFile;
 KMT_TESTFUNC Test_IoDeviceObject;
 KMT_TESTFUNC Test_IoReadWrite;
+KMT_TESTFUNC Test_MountMgrVolume;
 KMT_TESTFUNC Test_MmMapLockedPagesSpecifyCache;
 KMT_TESTFUNC Test_NtCreateSection;
 KMT_TESTFUNC Test_NtSystemDebugControl;
@@ -57,6 +58,7 @@ const KMT_TEST TestList[] =
     { "IoCreateFile",                 Test_IoCreateFile },
     { "IoDeviceObject",               Test_IoDeviceObject },
     { "IoReadWrite",                  Test_IoReadWrite },
+    { "MountMgrVolume",               Test_MountMgrVolume },
     { "MmMapLockedPagesSpecifyCache", Test_MmMapLockedPagesSpecifyCache },
     { "NtCreateSection",              Test_NtCreateSection },
     { "NtSystemDebugControl",         Test_NtSystemDebugControl },

--- a/modules/rostests/kmtests/mountmgr/CMakeLists.txt
+++ b/modules/rostests/kmtests/mountmgr/CMakeLists.txt
@@ -1,0 +1,13 @@
+
+include_directories(../include)
+
+list(APPEND MOUNTMGRVOLUME_DRV_SOURCE
+    ../kmtest_drv/kmtest_standalone.c
+    MountMgrVolume_drv.c)
+
+add_library(MountMgrVolume_drv MODULE ${MOUNTMGRVOLUME_DRV_SOURCE})
+set_module_type(MountMgrVolume_drv kernelmodedriver)
+target_link_libraries(MountMgrVolume_drv kmtest_printf ${PSEH_LIB})
+add_importlibs(MountMgrVolume_drv ntoskrnl hal)
+target_compile_definitions(MountMgrVolume_drv PRIVATE KMT_STANDALONE_DRIVER)
+add_rostests_file(TARGET MountMgrVolume_drv)

--- a/modules/rostests/kmtests/mountmgr/MountMgrVolume.h
+++ b/modules/rostests/kmtests/mountmgr/MountMgrVolume.h
@@ -1,0 +1,22 @@
+/*
+ * PROJECT:     ReactOS kernel-mode tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Shared definitions for the MountMgr persisted-link regression test
+ * COPYRIGHT:   Copyright 2026 Alejandro Sánchez <alesangreat@gmail.com>
+ */
+
+#pragma once
+
+#define MOUNTMGR_VOLUME_QUERY_INFO 1
+
+#define MOUNTMGR_TEST_DEVICE_NAME_CCH   96
+#define MOUNTMGR_TEST_VOLUME_NAME_CCH   64
+#define MOUNTMGR_TEST_SENTINEL_NAME_CCH 64
+
+typedef struct _MOUNTMGR_VOLUME_TEST_INFO
+{
+    GUID UniqueId;
+    WCHAR DeviceName[MOUNTMGR_TEST_DEVICE_NAME_CCH];
+    WCHAR VolumeName[MOUNTMGR_TEST_VOLUME_NAME_CCH];
+    WCHAR SentinelName[MOUNTMGR_TEST_SENTINEL_NAME_CCH];
+} MOUNTMGR_VOLUME_TEST_INFO, *PMOUNTMGR_VOLUME_TEST_INFO;

--- a/modules/rostests/kmtests/mountmgr/MountMgrVolume_drv.c
+++ b/modules/rostests/kmtests/mountmgr/MountMgrVolume_drv.c
@@ -1,0 +1,282 @@
+/*
+ * PROJECT:     ReactOS kernel-mode tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Synthetic mountdev used to exercise MountMgr persisted-link recovery
+ * COPYRIGHT:   Copyright 2026 Alejandro Sánchez <alesangreat@gmail.com>
+ */
+
+#include <kmt_test.h>
+#include <mountdev.h>
+#include <mountmgr.h>
+
+#include "MountMgrVolume.h"
+
+#define NDEBUG
+#include <debug.h>
+
+static PDEVICE_OBJECT FakeDeviceObject;
+static UNICODE_STRING FakeDeviceName;
+static MOUNTMGR_VOLUME_TEST_INFO TestInfo;
+
+static const UNICODE_STRING DevicePrefix = RTL_CONSTANT_STRING(L"\\Device\\MountMgrTest-");
+static const UNICODE_STRING VolumePrefix = RTL_CONSTANT_STRING(L"\\??\\Volume");
+static const UNICODE_STRING SentinelPrefix = RTL_CONSTANT_STRING(L"#MountMgrTest-");
+
+static KMT_IRP_HANDLER MountDevIrpHandler;
+static KMT_MESSAGE_HANDLER QueryInfoHandler;
+
+static
+NTSTATUS
+BuildTestName(
+    _Out_writes_bytes_(BufferSize) PWCHAR Buffer,
+    _In_ SIZE_T BufferSize,
+    _In_ PCUNICODE_STRING Prefix,
+    _In_ PCUNICODE_STRING Suffix,
+    _Out_opt_ PUNICODE_STRING Result)
+{
+    SIZE_T Length = Prefix->Length + Suffix->Length;
+
+    if (Length + sizeof(UNICODE_NULL) > BufferSize)
+        return STATUS_BUFFER_TOO_SMALL;
+
+    RtlCopyMemory(Buffer, Prefix->Buffer, Prefix->Length);
+    RtlCopyMemory((PUCHAR)Buffer + Prefix->Length, Suffix->Buffer, Suffix->Length);
+    Buffer[Length / sizeof(WCHAR)] = UNICODE_NULL;
+
+    if (Result)
+    {
+        Result->Buffer = Buffer;
+        Result->Length = (USHORT)Length;
+        Result->MaximumLength = (USHORT)(Length + sizeof(UNICODE_NULL));
+    }
+
+    return STATUS_SUCCESS;
+}
+
+static
+NTSTATUS
+CompleteNameQuery(
+    _Inout_ PIRP Irp,
+    _In_ ULONG OutputLength)
+{
+    ULONG RequiredLength;
+    PMOUNTDEV_NAME Name = Irp->AssociatedIrp.SystemBuffer;
+
+    if (OutputLength < FIELD_OFFSET(MOUNTDEV_NAME, Name))
+        return STATUS_BUFFER_TOO_SMALL;
+
+    Name->NameLength = FakeDeviceName.Length;
+    Irp->IoStatus.Information = FIELD_OFFSET(MOUNTDEV_NAME, Name);
+
+    RequiredLength = FIELD_OFFSET(MOUNTDEV_NAME, Name) + FakeDeviceName.Length;
+    if (OutputLength < RequiredLength)
+        return STATUS_BUFFER_OVERFLOW;
+
+    RtlCopyMemory(Name->Name, FakeDeviceName.Buffer, FakeDeviceName.Length);
+    Irp->IoStatus.Information = RequiredLength;
+    return STATUS_SUCCESS;
+}
+
+static
+NTSTATUS
+CompleteUniqueIdQuery(
+    _Inout_ PIRP Irp,
+    _In_ ULONG OutputLength)
+{
+    ULONG RequiredLength;
+    PMOUNTDEV_UNIQUE_ID UniqueId = Irp->AssociatedIrp.SystemBuffer;
+
+    if (OutputLength < FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId))
+        return STATUS_BUFFER_TOO_SMALL;
+
+    UniqueId->UniqueIdLength = sizeof(TestInfo.UniqueId);
+    Irp->IoStatus.Information = FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId);
+
+    RequiredLength = FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId) + sizeof(TestInfo.UniqueId);
+    if (OutputLength < RequiredLength)
+        return STATUS_BUFFER_OVERFLOW;
+
+    RtlCopyMemory(UniqueId->UniqueId, &TestInfo.UniqueId, sizeof(TestInfo.UniqueId));
+    Irp->IoStatus.Information = RequiredLength;
+    return STATUS_SUCCESS;
+}
+
+static
+NTSTATUS
+MountDevIrpHandler(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _Inout_ PIRP Irp,
+    _In_ PIO_STACK_LOCATION IoStackLocation)
+{
+    NTSTATUS Status;
+    ULONG IoControlCode;
+    ULONG OutputLength;
+
+    ok_eq_pointer(DeviceObject, FakeDeviceObject);
+
+    IoControlCode = IoStackLocation->Parameters.DeviceIoControl.IoControlCode;
+    OutputLength = IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength;
+    Irp->IoStatus.Information = 0;
+
+    switch (IoControlCode)
+    {
+        case IOCTL_MOUNTDEV_QUERY_DEVICE_NAME:
+            Status = CompleteNameQuery(Irp, OutputLength);
+            break;
+
+        case IOCTL_MOUNTDEV_QUERY_UNIQUE_ID:
+            Status = CompleteUniqueIdQuery(Irp, OutputLength);
+            break;
+
+        case IOCTL_MOUNTDEV_QUERY_STABLE_GUID:
+        case IOCTL_MOUNTDEV_QUERY_SUGGESTED_LINK_NAME:
+            Status = STATUS_NOT_SUPPORTED;
+            break;
+
+        case IOCTL_MOUNTDEV_LINK_CREATED:
+        case IOCTL_MOUNTDEV_LINK_DELETED:
+            Status = STATUS_SUCCESS;
+            break;
+
+        default:
+            Status = STATUS_INVALID_DEVICE_REQUEST;
+            break;
+    }
+
+    Irp->IoStatus.Status = Status;
+    IoCompleteRequest(Irp, IO_NO_INCREMENT);
+    return Status;
+}
+
+static
+NTSTATUS
+QueryInfoHandler(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ ULONG ControlCode,
+    _Inout_updates_bytes_opt_(*OutLength) PVOID Buffer,
+    _In_ SIZE_T InLength,
+    _Inout_ PSIZE_T OutLength)
+{
+    UNREFERENCED_PARAMETER(DeviceObject);
+
+    if (ControlCode != MOUNTMGR_VOLUME_QUERY_INFO || InLength != 0)
+        return STATUS_INVALID_PARAMETER;
+
+    if (!Buffer || *OutLength < sizeof(TestInfo))
+    {
+        *OutLength = sizeof(TestInfo);
+        return STATUS_BUFFER_TOO_SMALL;
+    }
+
+    RtlCopyMemory(Buffer, &TestInfo, sizeof(TestInfo));
+    *OutLength = sizeof(TestInfo);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+TestEntry(
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_ PCUNICODE_STRING RegistryPath,
+    _Out_ PCWSTR *DeviceName,
+    _Inout_ INT *Flags)
+{
+    NTSTATUS Status;
+    UNICODE_STRING GuidString;
+
+    UNREFERENCED_PARAMETER(RegistryPath);
+    UNREFERENCED_PARAMETER(Flags);
+
+    *DeviceName = L"MountMgrVolume";
+    RtlZeroMemory(&TestInfo, sizeof(TestInfo));
+
+    Status = ExUuidCreate(&TestInfo.UniqueId);
+    if (!NT_SUCCESS(Status))
+        return Status;
+
+    Status = RtlStringFromGUID(&TestInfo.UniqueId, &GuidString);
+    if (!NT_SUCCESS(Status))
+        return Status;
+
+    Status = BuildTestName(TestInfo.DeviceName,
+                           sizeof(TestInfo.DeviceName),
+                           &DevicePrefix,
+                           &GuidString,
+                           &FakeDeviceName);
+    if (NT_SUCCESS(Status))
+    {
+        Status = BuildTestName(TestInfo.VolumeName,
+                               sizeof(TestInfo.VolumeName),
+                               &VolumePrefix,
+                               &GuidString,
+                               NULL);
+    }
+    if (NT_SUCCESS(Status))
+    {
+        Status = BuildTestName(TestInfo.SentinelName,
+                               sizeof(TestInfo.SentinelName),
+                               &SentinelPrefix,
+                               &GuidString,
+                               NULL);
+    }
+
+    RtlFreeUnicodeString(&GuidString);
+    if (!NT_SUCCESS(Status))
+        return Status;
+
+    Status = IoCreateDevice(DriverObject,
+                            0,
+                            &FakeDeviceName,
+                            FILE_DEVICE_UNKNOWN,
+                            FILE_DEVICE_SECURE_OPEN,
+                            FALSE,
+                            &FakeDeviceObject);
+    if (!NT_SUCCESS(Status))
+        return Status;
+
+    FakeDeviceObject->Flags |= DO_BUFFERED_IO;
+    FakeDeviceObject->Flags &= ~DO_DEVICE_INITIALIZING;
+
+    Status = KmtRegisterIrpHandler(IRP_MJ_DEVICE_CONTROL,
+                                   FakeDeviceObject,
+                                   MountDevIrpHandler);
+    if (!NT_SUCCESS(Status))
+        goto Failure;
+
+    Status = KmtRegisterMessageHandler(MOUNTMGR_VOLUME_QUERY_INFO,
+                                       NULL,
+                                       QueryInfoHandler);
+    if (!NT_SUCCESS(Status))
+    {
+        KmtUnregisterIrpHandler(IRP_MJ_DEVICE_CONTROL,
+                                FakeDeviceObject,
+                                MountDevIrpHandler);
+        goto Failure;
+    }
+
+    return STATUS_SUCCESS;
+
+Failure:
+    IoDeleteDevice(FakeDeviceObject);
+    FakeDeviceObject = NULL;
+    return Status;
+}
+
+VOID
+TestUnload(
+    _In_ PDRIVER_OBJECT DriverObject)
+{
+    UNREFERENCED_PARAMETER(DriverObject);
+
+    KmtUnregisterMessageHandler(MOUNTMGR_VOLUME_QUERY_INFO,
+                                NULL,
+                                QueryInfoHandler);
+
+    if (FakeDeviceObject)
+    {
+        KmtUnregisterIrpHandler(IRP_MJ_DEVICE_CONTROL,
+                                FakeDeviceObject,
+                                MountDevIrpHandler);
+        IoDeleteDevice(FakeDeviceObject);
+        FakeDeviceObject = NULL;
+    }
+}

--- a/modules/rostests/kmtests/mountmgr/MountMgrVolume_user.c
+++ b/modules/rostests/kmtests/mountmgr/MountMgrVolume_user.c
@@ -1,0 +1,355 @@
+/*
+ * PROJECT:     ReactOS kernel-mode tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Regression test for MountMgr recovery of persisted symbolic links
+ * COPYRIGHT:   Copyright 2026 Alejandro Sánchez <alesangreat@gmail.com>
+ */
+
+#include <kmt_test.h>
+#include <mountmgr.h>
+
+#include "MountMgrVolume.h"
+
+#define MAX_MATCHING_VALUES 32
+#define MAX_VALUE_NAME_CCH  128
+#define CLEANUP_BUFFER_SIZE 4096
+
+static const WCHAR MountedDevicesKey[] = L"SYSTEM\\MountedDevices";
+static const WCHAR VolumePrefix[] = L"\\??\\Volume{";
+
+typedef struct _MATCHING_VALUES
+{
+    DWORD Count;
+    DWORD StoredCount;
+    DWORD VolumeCount;
+    DWORD SentinelCount;
+    WCHAR Names[MAX_MATCHING_VALUES][MAX_VALUE_NAME_CCH];
+} MATCHING_VALUES, *PMATCHING_VALUES;
+
+static
+BOOL
+IsVolumeValueName(
+    _In_ PCWSTR ValueName)
+{
+    return wcsncmp(ValueName,
+                   VolumePrefix,
+                   RTL_NUMBER_OF(VolumePrefix) - 1) == 0;
+}
+
+static
+BOOL
+ContainsValueName(
+    _In_ const MATCHING_VALUES *Values,
+    _In_ PCWSTR ValueName)
+{
+    DWORD Index;
+
+    for (Index = 0; Index < Values->StoredCount; ++Index)
+    {
+        if (wcscmp(Values->Names[Index], ValueName) == 0)
+            return TRUE;
+    }
+
+    return FALSE;
+}
+
+static
+LONG
+EnumerateMatchingValues(
+    _In_ HKEY Key,
+    _In_ const GUID *UniqueId,
+    _Out_ PMATCHING_VALUES Values)
+{
+    DWORD Index;
+
+    ZeroMemory(Values, sizeof(*Values));
+
+    for (Index = 0; ; ++Index)
+    {
+        LONG Error;
+        DWORD Type;
+        DWORD NameLength = MAX_VALUE_NAME_CCH;
+        DWORD DataLength = 512;
+        WCHAR Name[MAX_VALUE_NAME_CCH];
+        BYTE Data[512];
+
+        Error = RegEnumValueW(Key,
+                              Index,
+                              Name,
+                              &NameLength,
+                              NULL,
+                              &Type,
+                              Data,
+                              &DataLength);
+        if (Error == ERROR_NO_MORE_ITEMS)
+            return ERROR_SUCCESS;
+
+        if (Error == ERROR_MORE_DATA)
+            continue;
+
+        if (Error != ERROR_SUCCESS)
+            return Error;
+
+        if (Type != REG_BINARY || DataLength != sizeof(*UniqueId) ||
+            memcmp(Data, UniqueId, sizeof(*UniqueId)) != 0)
+        {
+            continue;
+        }
+
+        ++Values->Count;
+        if (Name[0] == L'#')
+            ++Values->SentinelCount;
+        if (IsVolumeValueName(Name))
+            ++Values->VolumeCount;
+
+        if (Values->StoredCount < MAX_MATCHING_VALUES)
+        {
+            wcscpy(Values->Names[Values->StoredCount], Name);
+            ++Values->StoredCount;
+        }
+    }
+}
+
+static
+BOOL
+DeleteMountPointByName(
+    _In_ HANDLE MountMgrHandle,
+    _In_ PCWSTR SymbolicName,
+    _In_ const GUID *UniqueId)
+{
+    BOOL Ret;
+    BYTE Output[CLEANUP_BUFFER_SIZE];
+    BYTE *Input;
+    DWORD BytesReturned;
+    DWORD InputLength;
+    ULONG NameBytes;
+    PMOUNTMGR_MOUNT_POINT Point;
+
+    NameBytes = (ULONG)(wcslen(SymbolicName) * sizeof(WCHAR));
+    InputLength = sizeof(MOUNTMGR_MOUNT_POINT) + NameBytes + sizeof(*UniqueId);
+    Input = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, InputLength);
+    if (!Input)
+        return FALSE;
+
+    Point = (PMOUNTMGR_MOUNT_POINT)Input;
+    Point->SymbolicLinkNameOffset = sizeof(MOUNTMGR_MOUNT_POINT);
+    Point->SymbolicLinkNameLength = (USHORT)NameBytes;
+    Point->UniqueIdOffset = Point->SymbolicLinkNameOffset + NameBytes;
+    Point->UniqueIdLength = sizeof(*UniqueId);
+
+    CopyMemory(Input + Point->SymbolicLinkNameOffset, SymbolicName, NameBytes);
+    CopyMemory(Input + Point->UniqueIdOffset, UniqueId, sizeof(*UniqueId));
+
+    Ret = DeviceIoControl(MountMgrHandle,
+                          IOCTL_MOUNTMGR_DELETE_POINTS,
+                          Input,
+                          InputLength,
+                          Output,
+                          sizeof(Output),
+                          &BytesReturned,
+                          NULL);
+
+    HeapFree(GetProcessHeap(), 0, Input);
+    return Ret;
+}
+
+static
+BOOL
+SendArrivalNotification(
+    _In_ HANDLE MountMgrHandle,
+    _In_ PCWSTR DeviceName)
+{
+    BOOL Ret;
+    DWORD BytesReturned;
+    DWORD InputLength;
+    ULONG DeviceNameBytes;
+    PMOUNTMGR_TARGET_NAME Target;
+
+    DeviceNameBytes = (ULONG)(wcslen(DeviceName) * sizeof(WCHAR));
+    InputLength = FIELD_OFFSET(MOUNTMGR_TARGET_NAME, DeviceName) + DeviceNameBytes;
+    Target = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, InputLength);
+    if (!Target)
+        return FALSE;
+
+    Target->DeviceNameLength = (USHORT)DeviceNameBytes;
+    CopyMemory(Target->DeviceName, DeviceName, DeviceNameBytes);
+
+    Ret = DeviceIoControl(MountMgrHandle,
+                          IOCTL_MOUNTMGR_VOLUME_ARRIVAL_NOTIFICATION,
+                          Target,
+                          InputLength,
+                          NULL,
+                          0,
+                          &BytesReturned,
+                          NULL);
+
+    HeapFree(GetProcessHeap(), 0, Target);
+    return Ret;
+}
+
+static
+VOID
+CleanupFixture(
+    _In_ HKEY Key,
+    _In_ HANDLE MountMgrHandle,
+    _In_ const MOUNTMGR_VOLUME_TEST_INFO *Info)
+{
+    DWORD Index;
+    LONG Error;
+    MATCHING_VALUES Values;
+
+    Error = EnumerateMatchingValues(Key, &Info->UniqueId, &Values);
+    if (Error == ERROR_SUCCESS)
+    {
+        for (Index = 0; Index < Values.StoredCount; ++Index)
+        {
+            if (MountMgrHandle != INVALID_HANDLE_VALUE)
+                DeleteMountPointByName(MountMgrHandle, Values.Names[Index], &Info->UniqueId);
+
+            RegDeleteValueW(Key, Values.Names[Index]);
+        }
+    }
+
+    /* These names may have been registry-only and therefore absent from MountMgr memory. */
+    RegDeleteValueW(Key, Info->SentinelName);
+    RegDeleteValueW(Key, Info->VolumeName);
+}
+
+START_TEST(MountMgrVolume)
+{
+    BOOL Ret;
+    DWORD Error;
+    DWORD InfoLength;
+    HKEY Key = NULL;
+    HANDLE MountMgrHandle = INVALID_HANDLE_VALUE;
+    MATCHING_VALUES Before, After, Remaining;
+    MOUNTMGR_VOLUME_TEST_INFO Info;
+    BOOLEAN HaveInfo = FALSE;
+    BOOLEAN FixtureWritten = FALSE;
+
+    ZeroMemory(&Info, sizeof(Info));
+
+    Error = KmtLoadAndOpenDriver(L"MountMgrVolume", FALSE);
+    ok_eq_int(Error, ERROR_SUCCESS);
+    if (Error != ERROR_SUCCESS)
+        return;
+
+    InfoLength = sizeof(Info);
+    Error = KmtSendBufferToDriver(MOUNTMGR_VOLUME_QUERY_INFO,
+                                  &Info,
+                                  0,
+                                  &InfoLength);
+    ok_eq_int(Error, ERROR_SUCCESS);
+    ok_eq_ulong(InfoLength, sizeof(Info));
+    if (Error != ERROR_SUCCESS || InfoLength != sizeof(Info))
+        goto Cleanup;
+
+    HaveInfo = TRUE;
+    ok(Info.DeviceName[0] != UNICODE_NULL, "Synthetic device name is empty\n");
+    ok(Info.VolumeName[0] != UNICODE_NULL, "Synthetic volume name is empty\n");
+    ok(Info.SentinelName[0] == L'#', "Sentinel does not begin with '#': %ls\n", Info.SentinelName);
+
+    MountMgrHandle = CreateFileW(MOUNTMGR_DOS_DEVICE_NAME,
+                                 GENERIC_READ | GENERIC_WRITE,
+                                 FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                 NULL,
+                                 OPEN_EXISTING,
+                                 0,
+                                 NULL);
+    ok(MountMgrHandle != INVALID_HANDLE_VALUE,
+       "Unable to open MountMgr: %lu\n", GetLastError());
+    if (MountMgrHandle == INVALID_HANDLE_VALUE)
+        goto Cleanup;
+
+    Error = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+                          MountedDevicesKey,
+                          0,
+                          KEY_QUERY_VALUE | KEY_SET_VALUE,
+                          &Key);
+    ok_eq_long(Error, ERROR_SUCCESS);
+    if (Error != ERROR_SUCCESS)
+        goto Cleanup;
+
+    /* A fresh GUID must not already exist in MountedDevices. */
+    Error = EnumerateMatchingValues(Key, &Info.UniqueId, &Before);
+    ok_eq_long(Error, ERROR_SUCCESS);
+    ok_eq_ulong(Before.Count, 0);
+    if (Error != ERROR_SUCCESS || Before.Count != 0)
+        goto Cleanup;
+
+    Error = RegSetValueExW(Key,
+                           Info.SentinelName,
+                           0,
+                           REG_BINARY,
+                           (const BYTE *)&Info.UniqueId,
+                           sizeof(Info.UniqueId));
+    ok_eq_long(Error, ERROR_SUCCESS);
+    if (Error != ERROR_SUCCESS)
+        goto Cleanup;
+    FixtureWritten = TRUE;
+
+    Error = RegSetValueExW(Key,
+                           Info.VolumeName,
+                           0,
+                           REG_BINARY,
+                           (const BYTE *)&Info.UniqueId,
+                           sizeof(Info.UniqueId));
+    ok_eq_long(Error, ERROR_SUCCESS);
+    if (Error != ERROR_SUCCESS)
+        goto Cleanup;
+
+    Error = EnumerateMatchingValues(Key, &Info.UniqueId, &Before);
+    ok_eq_long(Error, ERROR_SUCCESS);
+    ok_eq_ulong(Before.Count, 2);
+    ok_eq_ulong(Before.VolumeCount, 1);
+    ok_eq_ulong(Before.SentinelCount, 1);
+    ok(ContainsValueName(&Before, Info.VolumeName),
+       "Persisted volume link was not found before arrival\n");
+    ok(ContainsValueName(&Before, Info.SentinelName),
+       "No-drive-letter sentinel was not found before arrival\n");
+    if (Error != ERROR_SUCCESS || Before.Count != 2)
+        goto Cleanup;
+
+    Ret = SendArrivalNotification(MountMgrHandle, Info.DeviceName);
+    ok(Ret == TRUE, "Volume arrival notification failed: %lu\n", GetLastError());
+    if (!Ret)
+        goto Cleanup;
+
+    Error = EnumerateMatchingValues(Key, &Info.UniqueId, &After);
+    ok_eq_long(Error, ERROR_SUCCESS);
+    if (Error != ERROR_SUCCESS)
+        goto Cleanup;
+
+    /*
+     * The persisted Volume GUID is a real symbolic link and the '#' value is
+     * only a no-drive-letter sentinel. MountMgr must reuse the former and
+     * must not manufacture another Volume GUID for the same UniqueId.
+     */
+    ok_eq_ulong(After.Count, 2);
+    ok_eq_ulong(After.VolumeCount, 1);
+    ok_eq_ulong(After.SentinelCount, 1);
+    ok(ContainsValueName(&After, Info.VolumeName),
+       "Persisted volume link disappeared during arrival\n");
+    ok(ContainsValueName(&After, Info.SentinelName),
+       "No-drive-letter sentinel disappeared during arrival\n");
+
+Cleanup:
+    if (Key && HaveInfo && FixtureWritten)
+    {
+        CleanupFixture(Key, MountMgrHandle, &Info);
+
+        Error = EnumerateMatchingValues(Key, &Info.UniqueId, &Remaining);
+        ok_eq_long(Error, ERROR_SUCCESS);
+        if (Error == ERROR_SUCCESS)
+            ok_eq_ulong(Remaining.Count, 0);
+    }
+
+    if (Key)
+        RegCloseKey(Key);
+
+    if (MountMgrHandle != INVALID_HANDLE_VALUE)
+        CloseHandle(MountMgrHandle);
+
+    KmtCloseDriver();
+    KmtUnloadDriver();
+}


### PR DESCRIPTION
## Purpose

Fix [CORE-18139](https://jira.reactos.org/browse/CORE-18139), where MountMgr can fail to reuse a persisted Volume GUID symbolic link when a matching `#...` no-drive-letter sentinel exists for the same unique ID, causing an extra Volume GUID to be manufactured during volume arrival.

## Proposed changes

- Ignore `#...` no-drive-letter sentinel entries when counting and recovering persisted symbolic-link names for a mountdev unique ID.
- Preserve the existing persisted Volume GUID during volume arrival instead of creating a duplicate.
- Add a standalone `MountMgrVolume` kmtest with a synthetic mountdev that seeds one Volume GUID plus one `#` sentinel and exercises `IOCTL_MOUNTMGR_VOLUME_ARRIVAL_NOTIFICATION`.
- Verify cleanup removes all test-specific `MountedDevices` values.

## Testing

- Rebased onto current `origin/master` (`51fcee37bc` at test time).
- Final targeted remote build passed for `mountmgr MountMgrVolume_drv kmtest` (i386, GCC, Debug, `ENABLE_ROSTESTS=1`).
- Runtime FAIL-before: the same regression test against the pre-fix `mountmgr.sys` reports the expected duplicate state: `After.Count = 3` instead of 2 and `After.VolumeCount = 2` instead of 1 (2 failures).
- Runtime PASS-after: with the production fix, `MountMgrVolume` reports 0 failures and 0 skipped.
- The A/B used byte-identical `kmtest.exe` and `MountMgrVolume_drv.sys`; only `mountmgr.sys` differed between baseline and fix.
- Both runtime images were rebuilt from the same byte-identical base image and payload FAT chains were verified before boot.
- `git diff --check origin/master..HEAD` is clean.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
