### PR TITLE
[ATAPI] Translate SCSI UNMAP to ATA DSM TRIM

### DIFF
--- a/drivers/storage/ide/atapi/atapi.h
+++ b/drivers/storage/ide/atapi/atapi.h
@@ -905,6 +905,10 @@ AtaDeviceQueueEvent(
 /* satl.c *********************************************************************/
 
 BOOLEAN
+AtaDevCanUseDsmTrim(
+    _In_ PATAPORT_DEVICE_EXTENSION DevExt);
+
+BOOLEAN
 AtaReqDmaTransferToPioTransfer(
     _In_ PATA_DEVICE_REQUEST Request);
 

--- a/drivers/storage/ide/atapi/ioctl.c
+++ b/drivers/storage/ide/atapi/ioctl.c
@@ -234,7 +234,7 @@ AtaPdoQueryStorageDeviceTrimProperty(
     TrimDescriptor = Irp->AssociatedIrp.SystemBuffer;
     TrimDescriptor->Version = sizeof(*TrimDescriptor);
     TrimDescriptor->Size = sizeof(*TrimDescriptor);
-    TrimDescriptor->TrimEnabled = AtaDevHasTrimFunction(&DevExt->IdentifyDeviceData);
+    TrimDescriptor->TrimEnabled = AtaDevCanUseDsmTrim(DevExt);
 
     Irp->IoStatus.Information = sizeof(*TrimDescriptor);
     return STATUS_SUCCESS;
@@ -404,8 +404,8 @@ AtaPdoHandleStorageManageDataSetAttributes(
 {
     PAGED_CODE();
 
-    // TODO: Implement
-    return Irp->IoStatus.Status;
+    /* Let classpnp fall back to translating DSM trim requests to SCSI UNMAP. */
+    return STATUS_NOT_SUPPORTED;
 }
 
 static

--- a/drivers/storage/ide/atapi/satl.c
+++ b/drivers/storage/ide/atapi/satl.c
@@ -34,7 +34,67 @@ static const UCHAR AtapReadWriteCommandMap[12][2] =
     { 0,                                  0                             }, // DMA
 };
 
+#define ATA_DSM_TRIM_FEATURE             0x01
+#define ATA_DSM_BLOCK_SIZE               512
+#define ATA_DSM_RANGE_SIZE               8
+#define ATA_DSM_RANGES_PER_BLOCK         (ATA_DSM_BLOCK_SIZE / ATA_DSM_RANGE_SIZE)
+#define ATA_DSM_MAX_RANGE_SECTORS        0xFFFFUL
+#define ATA_DSM_MAX_UNMAP_LBA_COUNT      (ATA_DSM_RANGES_PER_BLOCK * ATA_DSM_MAX_RANGE_SECTORS)
+
 /* FUNCTIONS ******************************************************************/
+
+BOOLEAN
+AtaDevCanUseDsmTrim(
+    _In_ PATAPORT_DEVICE_EXTENSION DevExt)
+{
+    return AtaDevHasTrimFunction(&DevExt->IdentifyDeviceData) &&
+           (DevExt->Device.DeviceFlags & DEVICE_LBA48) &&
+           !(DevExt->Device.DeviceFlags & (DEVICE_PIO_ONLY |
+                                           DEVICE_PIO_FOR_LBA48_XFER));
+}
+
+static
+USHORT
+AtaReqReadBe16(
+    _In_reads_(2) const UCHAR *Buffer)
+{
+    return ((USHORT)Buffer[0] << 8) | Buffer[1];
+}
+
+static
+ULONG
+AtaReqReadBe32(
+    _In_reads_(4) const UCHAR *Buffer)
+{
+    return ((ULONG)Buffer[0] << 24) |
+           ((ULONG)Buffer[1] << 16) |
+           ((ULONG)Buffer[2] << 8) |
+           Buffer[3];
+}
+
+static
+ULONG64
+AtaReqReadBe64(
+    _In_reads_(8) const UCHAR *Buffer)
+{
+    return ((ULONG64)AtaReqReadBe32(Buffer) << 32) |
+           AtaReqReadBe32(Buffer + 4);
+}
+
+static
+VOID
+AtaReqWriteLe64(
+    _Out_writes_(8) UCHAR *Buffer,
+    _In_ ULONG64 Value)
+{
+    ULONG i;
+
+    for (i = 0; i < 8; ++i)
+    {
+        Buffer[i] = (UCHAR)Value;
+        Value >>= 8;
+    }
+}
 
 static
 inline
@@ -816,15 +876,12 @@ AtaReqCompleteReadCapacity(
         CapacityData->LowestAlignedBlock_MSB = (UCHAR)(LowestAlignedBlock >> 8);
         CapacityData->LowestAlignedBlock_LSB = (UCHAR)LowestAlignedBlock;
 
-        if (AtaDevHasTrimFunction(&DevExt->IdentifyDeviceData))
+        if (AtaDevCanUseDsmTrim(DevExt))
         {
-            if (AtaDevHasDratFunction(&DevExt->IdentifyDeviceData))
-            {
-                CapacityData->LBPME = 1;
+            CapacityData->LBPME = 1;
 
-                if (AtaDevHasRzatFunction(&DevExt->IdentifyDeviceData))
-                    CapacityData->LBPRZ = 1;
-            }
+            if (AtaDevHasRzatFunction(&DevExt->IdentifyDeviceData))
+                CapacityData->LBPRZ = 1;
         }
 
         Length = CdbGetAllocationLength16((PCDB)Srb->Cdb);
@@ -1436,21 +1493,21 @@ AtaReqScsiInquiryBlockLimits(
     BlockLimitsPage->PageLength[0] = (UCHAR)(PageLength >> 8);
     BlockLimitsPage->PageLength[1] = (UCHAR)PageLength;
 
-    // TODO: Implement
-#if 0
-    if (AtaDevHasTrimFunction(&DevExt->IdentifyDeviceData))
+    if (AtaDevCanUseDsmTrim(DevExt))
     {
-        BlockLimitsPage->MaximumUnmapLBACount[0] = 0;
-        BlockLimitsPage->MaximumUnmapLBACount[1] = 0;
-        BlockLimitsPage->MaximumUnmapLBACount[2] = 0;
-        BlockLimitsPage->MaximumUnmapLBACount[4] = 0;
+        BlockLimitsPage->MaximumUnmapLBACount[0] =
+            (UCHAR)(ATA_DSM_MAX_UNMAP_LBA_COUNT >> 24);
+        BlockLimitsPage->MaximumUnmapLBACount[1] =
+            (UCHAR)(ATA_DSM_MAX_UNMAP_LBA_COUNT >> 16);
+        BlockLimitsPage->MaximumUnmapLBACount[2] =
+            (UCHAR)(ATA_DSM_MAX_UNMAP_LBA_COUNT >> 8);
+        BlockLimitsPage->MaximumUnmapLBACount[3] =
+            (UCHAR)ATA_DSM_MAX_UNMAP_LBA_COUNT;
 
-        BlockLimitsPage->MaximumUnmapBlockDescriptorCount[0] = 0;
-        BlockLimitsPage->MaximumUnmapBlockDescriptorCount[1] = 0;
-        BlockLimitsPage->MaximumUnmapBlockDescriptorCount[2] = 0;
-        BlockLimitsPage->MaximumUnmapBlockDescriptorCount[3] = 0;
+        /* One SCSI descriptor can expand to at most one 512-byte DSM block. */
+        BlockLimitsPage->MaximumUnmapBlockDescriptorCount[3] = 1;
+        BlockLimitsPage->OptimalUnmapGranularity[3] = 1;
     }
-#endif
 
     return sizeof(*BlockLimitsPage);
 }
@@ -1489,14 +1546,9 @@ AtaReqScsiInquiryLogicalBlockProvisioning(
         FIELD_OFFSET(VPD_LOGICAL_BLOCK_PROVISIONING_PAGE, ProvisioningGroupDescr) -
         RTL_SIZEOF_THROUGH_FIELD(VPD_LOGICAL_BLOCK_PROVISIONING_PAGE, PageLength);
 
-    if (AtaDevHasTrimFunction(&DevExt->IdentifyDeviceData))
+    if (AtaDevCanUseDsmTrim(DevExt))
     {
-        // TODO: Implement
-#if 0
         LogicalBlockProvisioningPage->LBPU = 1; // UNMAP
-        LogicalBlockProvisioningPage->LBPWS = 1; // WRITE SAME (16) + UNMAP
-        LogicalBlockProvisioningPage->LBPWS10 = 1; // WRITE SAME (10) + UNMAP
-#endif
 
         if (AtaDevHasDratFunction(&DevExt->IdentifyDeviceData))
             LogicalBlockProvisioningPage->ANC_SUP = 1;
@@ -1907,6 +1959,233 @@ AtaReqScsiAtaPassThrough(
 }
 
 static
+NTSTATUS
+AtaReqMapSrbDataBuffer(
+    _In_ PATA_DEVICE_REQUEST Request,
+    _Out_ PVOID *DataBuffer,
+    _Out_ PULONG DataLength)
+{
+    PMDL Mdl;
+    PVOID BaseAddress;
+    PVOID MdlAddress;
+    ULONG MdlLength;
+    ULONG_PTR BufferOffset;
+
+    *DataBuffer = NULL;
+    *DataLength = 0;
+
+    if (Request->Irp == NULL ||
+        Request->Srb == NULL ||
+        Request->Srb->DataBuffer == NULL)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    Mdl = Request->Irp->MdlAddress;
+    if (Mdl == NULL)
+        return STATUS_INVALID_PARAMETER;
+
+    MdlAddress = MmGetMdlVirtualAddress(Mdl);
+    if ((ULONG_PTR)Request->Srb->DataBuffer < (ULONG_PTR)MdlAddress)
+        return STATUS_INVALID_PARAMETER;
+
+    BufferOffset = (ULONG_PTR)Request->Srb->DataBuffer -
+                   (ULONG_PTR)MdlAddress;
+    MdlLength = MmGetMdlByteCount(Mdl);
+    if (BufferOffset > MdlLength)
+        return STATUS_INVALID_PARAMETER;
+
+    BaseAddress = MmGetSystemAddressForMdlSafe(Mdl, HighPagePriority);
+    if (BaseAddress == NULL)
+        return STATUS_INSUFFICIENT_RESOURCES;
+
+    *DataBuffer = (PUCHAR)BaseAddress + BufferOffset;
+    *DataLength = MdlLength - (ULONG)BufferOffset;
+    return STATUS_SUCCESS;
+}
+
+static
+ATA_COMPLETION_ACTION
+AtaReqCompleteUnmap(
+    _In_ PATA_DEVICE_REQUEST Request)
+{
+    if (SRB_STATUS(Request->SrbStatus) == SRB_STATUS_SUCCESS)
+    {
+        Request->DataTransferLength =
+            AtaReqReadBe16(((PCDB)Request->Srb->Cdb)->UNMAP.AllocationLength);
+    }
+    else
+    {
+        Request->DataTransferLength = 0;
+    }
+
+    return COMPLETE_IRP;
+}
+
+static
+UCHAR
+AtaReqScsiUnmap(
+    _In_ PATAPORT_DEVICE_EXTENSION DevExt,
+    _In_ PATA_DEVICE_REQUEST Request,
+    _In_ PSCSI_REQUEST_BLOCK Srb)
+{
+    PCDB Cdb = (PCDB)Srb->Cdb;
+    PUNMAP_LIST_HEADER Header;
+    PUNMAP_BLOCK_DESCRIPTOR Descriptor;
+    PATA_TASKFILE TaskFile = &Request->TaskFile;
+    PUCHAR SourceBuffer;
+    PUCHAR DsmBuffer;
+    ULONG DescriptorBytes;
+    ULONG DescriptorCount;
+    ULONG EntryCount = 0;
+    ULONG SourceBufferLength;
+    ULONG i;
+    USHORT ParameterLength;
+    USHORT DataLength;
+    NTSTATUS Status;
+
+    if (!AtaDevCanUseDsmTrim(DevExt))
+        return AtaReqTerminateInvalidOpCode(Srb);
+
+    if (Cdb->UNMAP.Anchor || Cdb->UNMAP.GroupNumber != 0)
+        return AtaReqTerminateInvalidField(Srb);
+
+    if (!(Srb->SrbFlags & SRB_FLAGS_DATA_OUT) ||
+        (Srb->SrbFlags & SRB_FLAGS_DATA_IN))
+    {
+        return AtaReqTerminateInvalidField(Srb);
+    }
+
+    ParameterLength = AtaReqReadBe16(Cdb->UNMAP.AllocationLength);
+    if (ParameterLength == 0)
+    {
+        Request->DataTransferLength = 0;
+        return SRB_STATUS_SUCCESS;
+    }
+
+    if (ParameterLength < sizeof(UNMAP_LIST_HEADER) ||
+        ParameterLength > Srb->DataTransferLength)
+    {
+        return AtaReqTerminateInvalidFieldParameter(Srb);
+    }
+
+    Status = AtaReqMapSrbDataBuffer(Request,
+                                    (PVOID *)&SourceBuffer,
+                                    &SourceBufferLength);
+    if (!NT_SUCCESS(Status))
+    {
+        if (Status == STATUS_INVALID_PARAMETER)
+            return AtaReqTerminateInvalidFieldParameter(Srb);
+
+        return SRB_STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    if (ParameterLength > SourceBufferLength)
+        return AtaReqTerminateInvalidFieldParameter(Srb);
+
+    Header = (PUNMAP_LIST_HEADER)SourceBuffer;
+    DataLength = AtaReqReadBe16(Header->DataLength);
+    DescriptorBytes = AtaReqReadBe16(Header->BlockDescrDataLength);
+
+    if (DataLength < 6 ||
+        DataLength + FIELD_OFFSET(UNMAP_LIST_HEADER, BlockDescrDataLength) != ParameterLength ||
+        DescriptorBytes != DataLength - 6 ||
+        (DescriptorBytes % sizeof(UNMAP_BLOCK_DESCRIPTOR)) != 0 ||
+        FIELD_OFFSET(UNMAP_LIST_HEADER, Descriptors) + DescriptorBytes > ParameterLength)
+    {
+        return AtaReqTerminateInvalidFieldParameter(Srb);
+    }
+
+    DescriptorCount = DescriptorBytes / sizeof(UNMAP_BLOCK_DESCRIPTOR);
+    Descriptor = &Header->Descriptors[0];
+
+    /* Validate the complete SCSI parameter list before allocating ATA state. */
+    for (i = 0; i < DescriptorCount; ++i)
+    {
+        ULONG64 Lba;
+        ULONG SectorCount;
+        ULONG RequiredEntries;
+
+        Lba = AtaReqReadBe64(Descriptor[i].StartingLba);
+        SectorCount = AtaReqReadBe32(Descriptor[i].LbaCount);
+
+        if (SectorCount == 0)
+            continue;
+
+        if (Lba >= ATA_MAX_LBA_48 ||
+            SectorCount > ATA_MAX_LBA_48 - Lba ||
+            Lba + SectorCount > DevExt->Device.TotalSectors)
+        {
+            return AtaReqTerminateInvalidFieldParameter(Srb);
+        }
+
+        RequiredEntries = ((SectorCount - 1) / ATA_DSM_MAX_RANGE_SECTORS) + 1;
+        if (RequiredEntries > ATA_DSM_RANGES_PER_BLOCK - EntryCount)
+            return AtaReqTerminateInvalidFieldParameter(Srb);
+
+        EntryCount += RequiredEntries;
+    }
+
+    if (EntryCount == 0)
+    {
+        Request->DataTransferLength = ParameterLength;
+        return SRB_STATUS_SUCCESS;
+    }
+
+    DsmBuffer = ExAllocatePoolZero(NonPagedPool, ATA_DSM_BLOCK_SIZE, ATAPORT_TAG);
+    if (DsmBuffer == NULL)
+        return SRB_STATUS_INSUFFICIENT_RESOURCES;
+
+    Request->DataBuffer = DsmBuffer;
+    Request->DataTransferLength = ATA_DSM_BLOCK_SIZE;
+    Request->Flags = REQUEST_FLAG_OWNS_DATA_BUFFER;
+
+    EntryCount = 0;
+    for (i = 0; i < DescriptorCount; ++i)
+    {
+        ULONG64 Lba;
+        ULONG SectorCount;
+
+        Lba = AtaReqReadBe64(Descriptor[i].StartingLba);
+        SectorCount = AtaReqReadBe32(Descriptor[i].LbaCount);
+
+        while (SectorCount != 0)
+        {
+            ULONG Chunk;
+            ULONG64 Entry;
+
+            Chunk = min(SectorCount, ATA_DSM_MAX_RANGE_SECTORS);
+            Entry = Lba | ((ULONG64)Chunk << 48);
+            AtaReqWriteLe64(&DsmBuffer[EntryCount * ATA_DSM_RANGE_SIZE], Entry);
+
+            ++EntryCount;
+            Lba += Chunk;
+            SectorCount -= Chunk;
+        }
+    }
+
+    if (!AtaReqAllocateMdl(Request))
+    {
+        Request->DataTransferLength = 0;
+        return SRB_STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    Request->Flags |= REQUEST_DMA_FLAGS |
+                      REQUEST_FLAG_DATA_OUT |
+                      REQUEST_FLAG_LBA48 |
+                      REQUEST_FLAG_SET_DEVICE_REGISTER;
+
+    RtlZeroMemory(TaskFile, sizeof(*TaskFile));
+    TaskFile->Command = IDE_COMMAND_DATA_SET_MANAGEMENT;
+    TaskFile->Feature = ATA_DSM_TRIM_FEATURE;
+    TaskFile->SectorCount = 1;
+    TaskFile->DriveSelect = DevExt->Device.DeviceSelect | IDE_LBA_MODE;
+
+    Request->Complete = AtaReqCompleteUnmap;
+    return SRB_STATUS_PENDING;
+}
+
+static
 UCHAR
 AtaReqExecuteScsiAta(
     _In_ PATAPORT_DEVICE_EXTENSION DevExt,
@@ -1977,6 +2256,9 @@ AtaReqExecuteScsiAta(
         case SCSIOP_VERIFY12:
         case SCSIOP_VERIFY16:
             return AtaReqScsiVerify(DevExt, Request, Srb);
+
+        case SCSIOP_UNMAP:
+            return AtaReqScsiUnmap(DevExt, Request, Srb);
 
         case SCSIOP_ATA_PASSTHROUGH12:
         case SCSIOP_ATA_PASSTHROUGH16:

--- a/drivers/storage/ide/atapi/satl.c
+++ b/drivers/storage/ide/atapi/satl.c
@@ -2024,44 +2024,24 @@ AtaReqCompleteUnmap(
 
 static
 UCHAR
-AtaReqScsiUnmap(
-    _In_ PATAPORT_DEVICE_EXTENSION DevExt,
+AtaReqGetUnmapDescriptors(
     _In_ PATA_DEVICE_REQUEST Request,
-    _In_ PSCSI_REQUEST_BLOCK Srb)
+    _In_ PSCSI_REQUEST_BLOCK Srb,
+    _In_ USHORT ParameterLength,
+    _Out_ PUNMAP_BLOCK_DESCRIPTOR *Descriptors,
+    _Out_ PULONG DescriptorCount)
 {
-    PCDB Cdb = (PCDB)Srb->Cdb;
     PUNMAP_LIST_HEADER Header;
-    PUNMAP_BLOCK_DESCRIPTOR Descriptor;
-    PATA_TASKFILE TaskFile = &Request->TaskFile;
     PUCHAR SourceBuffer;
-    PUCHAR DsmBuffer;
-    ULONG DescriptorBytes;
-    ULONG DescriptorCount;
-    ULONG EntryCount = 0;
     ULONG SourceBufferLength;
-    ULONG i;
-    USHORT ParameterLength;
+    ULONG DescriptorBytes;
+    ULONG DescriptorsEnd;
+    ULONG ExpectedParameterLength;
     USHORT DataLength;
     NTSTATUS Status;
 
-    if (!AtaDevCanUseDsmTrim(DevExt))
-        return AtaReqTerminateInvalidOpCode(Srb);
-
-    if (Cdb->UNMAP.Anchor || Cdb->UNMAP.GroupNumber != 0)
-        return AtaReqTerminateInvalidField(Srb);
-
-    if (!(Srb->SrbFlags & SRB_FLAGS_DATA_OUT) ||
-        (Srb->SrbFlags & SRB_FLAGS_DATA_IN))
-    {
-        return AtaReqTerminateInvalidField(Srb);
-    }
-
-    ParameterLength = AtaReqReadBe16(Cdb->UNMAP.AllocationLength);
-    if (ParameterLength == 0)
-    {
-        Request->DataTransferLength = 0;
-        return SRB_STATUS_SUCCESS;
-    }
+    *Descriptors = NULL;
+    *DescriptorCount = 0;
 
     if (ParameterLength < sizeof(UNMAP_LIST_HEADER) ||
         ParameterLength > Srb->DataTransferLength)
@@ -2087,46 +2067,159 @@ AtaReqScsiUnmap(
     DataLength = AtaReqReadBe16(Header->DataLength);
     DescriptorBytes = AtaReqReadBe16(Header->BlockDescrDataLength);
 
-    if (DataLength < 6 ||
-        DataLength + FIELD_OFFSET(UNMAP_LIST_HEADER, BlockDescrDataLength) != ParameterLength ||
-        DescriptorBytes != DataLength - 6 ||
-        (DescriptorBytes % sizeof(UNMAP_BLOCK_DESCRIPTOR)) != 0 ||
-        FIELD_OFFSET(UNMAP_LIST_HEADER, Descriptors) + DescriptorBytes > ParameterLength)
-    {
+    if (DataLength < 6)
         return AtaReqTerminateInvalidFieldParameter(Srb);
-    }
 
-    DescriptorCount = DescriptorBytes / sizeof(UNMAP_BLOCK_DESCRIPTOR);
-    Descriptor = &Header->Descriptors[0];
+    ExpectedParameterLength =
+        DataLength + FIELD_OFFSET(UNMAP_LIST_HEADER, BlockDescrDataLength);
+    if (ExpectedParameterLength != ParameterLength)
+        return AtaReqTerminateInvalidFieldParameter(Srb);
 
-    /* Validate the complete SCSI parameter list before allocating ATA state. */
-    for (i = 0; i < DescriptorCount; ++i)
+    if (DescriptorBytes != DataLength - 6)
+        return AtaReqTerminateInvalidFieldParameter(Srb);
+
+    if ((DescriptorBytes % sizeof(UNMAP_BLOCK_DESCRIPTOR)) != 0)
+        return AtaReqTerminateInvalidFieldParameter(Srb);
+
+    DescriptorsEnd =
+        FIELD_OFFSET(UNMAP_LIST_HEADER, Descriptors) + DescriptorBytes;
+    if (DescriptorsEnd > ParameterLength)
+        return AtaReqTerminateInvalidFieldParameter(Srb);
+
+    *Descriptors = &Header->Descriptors[0];
+    *DescriptorCount = DescriptorBytes / sizeof(UNMAP_BLOCK_DESCRIPTOR);
+    return SRB_STATUS_SUCCESS;
+}
+
+static
+BOOLEAN
+AtaReqValidateUnmapRanges(
+    _In_ PATAPORT_DEVICE_EXTENSION DevExt,
+    _In_reads_(DescriptorCount) PUNMAP_BLOCK_DESCRIPTOR Descriptors,
+    _In_ ULONG DescriptorCount,
+    _Out_ PULONG DsmEntryCount)
+{
+    ULONG DescriptorIndex;
+    ULONG EntryCount = 0;
+
+    for (DescriptorIndex = 0; DescriptorIndex < DescriptorCount; ++DescriptorIndex)
     {
         ULONG64 Lba;
         ULONG SectorCount;
         ULONG RequiredEntries;
 
-        Lba = AtaReqReadBe64(Descriptor[i].StartingLba);
-        SectorCount = AtaReqReadBe32(Descriptor[i].LbaCount);
+        Lba = AtaReqReadBe64(Descriptors[DescriptorIndex].StartingLba);
+        SectorCount = AtaReqReadBe32(Descriptors[DescriptorIndex].LbaCount);
 
         if (SectorCount == 0)
             continue;
 
-        if (Lba >= ATA_MAX_LBA_48 ||
-            SectorCount > ATA_MAX_LBA_48 - Lba ||
-            Lba + SectorCount > DevExt->Device.TotalSectors)
-        {
-            return AtaReqTerminateInvalidFieldParameter(Srb);
-        }
+        if (Lba >= ATA_MAX_LBA_48)
+            return FALSE;
+
+        if (SectorCount > ATA_MAX_LBA_48 - Lba)
+            return FALSE;
+
+        if (Lba + SectorCount > DevExt->Device.TotalSectors)
+            return FALSE;
 
         RequiredEntries = ((SectorCount - 1) / ATA_DSM_MAX_RANGE_SECTORS) + 1;
         if (RequiredEntries > ATA_DSM_RANGES_PER_BLOCK - EntryCount)
-            return AtaReqTerminateInvalidFieldParameter(Srb);
+            return FALSE;
 
         EntryCount += RequiredEntries;
     }
 
-    if (EntryCount == 0)
+    *DsmEntryCount = EntryCount;
+    return TRUE;
+}
+
+static
+VOID
+AtaReqBuildDsmTrimBlock(
+    _In_reads_(DescriptorCount) PUNMAP_BLOCK_DESCRIPTOR Descriptors,
+    _In_ ULONG DescriptorCount,
+    _Out_writes_bytes_(ATA_DSM_BLOCK_SIZE) PUCHAR DsmBuffer)
+{
+    ULONG DescriptorIndex;
+    ULONG EntryIndex = 0;
+
+    for (DescriptorIndex = 0; DescriptorIndex < DescriptorCount; ++DescriptorIndex)
+    {
+        ULONG64 Lba;
+        ULONG SectorCount;
+
+        Lba = AtaReqReadBe64(Descriptors[DescriptorIndex].StartingLba);
+        SectorCount = AtaReqReadBe32(Descriptors[DescriptorIndex].LbaCount);
+
+        while (SectorCount != 0)
+        {
+            ULONG Chunk;
+            ULONG64 Entry;
+
+            Chunk = min(SectorCount, ATA_DSM_MAX_RANGE_SECTORS);
+            Entry = Lba | ((ULONG64)Chunk << 48);
+            AtaReqWriteLe64(&DsmBuffer[EntryIndex * ATA_DSM_RANGE_SIZE], Entry);
+
+            ++EntryIndex;
+            Lba += Chunk;
+            SectorCount -= Chunk;
+        }
+    }
+}
+
+static
+UCHAR
+AtaReqScsiUnmap(
+    _In_ PATAPORT_DEVICE_EXTENSION DevExt,
+    _In_ PATA_DEVICE_REQUEST Request,
+    _In_ PSCSI_REQUEST_BLOCK Srb)
+{
+    PCDB Cdb = (PCDB)Srb->Cdb;
+    PUNMAP_BLOCK_DESCRIPTOR Descriptors;
+    PATA_TASKFILE TaskFile = &Request->TaskFile;
+    PUCHAR DsmBuffer;
+    ULONG DescriptorCount;
+    ULONG DsmEntryCount;
+    USHORT ParameterLength;
+    UCHAR SrbStatus;
+
+    if (!AtaDevCanUseDsmTrim(DevExt))
+        return AtaReqTerminateInvalidOpCode(Srb);
+
+    if (Cdb->UNMAP.Anchor || Cdb->UNMAP.GroupNumber != 0)
+        return AtaReqTerminateInvalidField(Srb);
+
+    if (!(Srb->SrbFlags & SRB_FLAGS_DATA_OUT) ||
+        (Srb->SrbFlags & SRB_FLAGS_DATA_IN))
+    {
+        return AtaReqTerminateInvalidField(Srb);
+    }
+
+    ParameterLength = AtaReqReadBe16(Cdb->UNMAP.AllocationLength);
+    if (ParameterLength == 0)
+    {
+        Request->DataTransferLength = 0;
+        return SRB_STATUS_SUCCESS;
+    }
+
+    SrbStatus = AtaReqGetUnmapDescriptors(Request,
+                                          Srb,
+                                          ParameterLength,
+                                          &Descriptors,
+                                          &DescriptorCount);
+    if (SrbStatus != SRB_STATUS_SUCCESS)
+        return SrbStatus;
+
+    if (!AtaReqValidateUnmapRanges(DevExt,
+                                   Descriptors,
+                                   DescriptorCount,
+                                   &DsmEntryCount))
+    {
+        return AtaReqTerminateInvalidFieldParameter(Srb);
+    }
+
+    if (DsmEntryCount == 0)
     {
         Request->DataTransferLength = ParameterLength;
         return SRB_STATUS_SUCCESS;
@@ -2140,29 +2233,7 @@ AtaReqScsiUnmap(
     Request->DataTransferLength = ATA_DSM_BLOCK_SIZE;
     Request->Flags = REQUEST_FLAG_OWNS_DATA_BUFFER;
 
-    EntryCount = 0;
-    for (i = 0; i < DescriptorCount; ++i)
-    {
-        ULONG64 Lba;
-        ULONG SectorCount;
-
-        Lba = AtaReqReadBe64(Descriptor[i].StartingLba);
-        SectorCount = AtaReqReadBe32(Descriptor[i].LbaCount);
-
-        while (SectorCount != 0)
-        {
-            ULONG Chunk;
-            ULONG64 Entry;
-
-            Chunk = min(SectorCount, ATA_DSM_MAX_RANGE_SECTORS);
-            Entry = Lba | ((ULONG64)Chunk << 48);
-            AtaReqWriteLe64(&DsmBuffer[EntryCount * ATA_DSM_RANGE_SIZE], Entry);
-
-            ++EntryCount;
-            Lba += Chunk;
-            SectorCount -= Chunk;
-        }
-    }
+    AtaReqBuildDsmTrimBlock(Descriptors, DescriptorCount, DsmBuffer);
 
     if (!AtaReqAllocateMdl(Request))
     {

--- a/drivers/storage/ide/atapi/scsi.c
+++ b/drivers/storage/ide/atapi/scsi.c
@@ -167,7 +167,8 @@ AtaReqRequeueRequest(
 
     ASSERT(!(Request->Flags & (REQUEST_FLAG_HAS_SG_LIST |
                                REQUEST_FLAG_HAS_MDL |
-                               REQUEST_FLAG_HAS_RESERVED_MAPPING)));
+                               REQUEST_FLAG_HAS_RESERVED_MAPPING |
+                               REQUEST_FLAG_OWNS_DATA_BUFFER)));
 
     /* Place the Srb back into the queue */
     if (AtaReqDeviceQueueAddSrb(Device, Request->Srb) != STATUS_PENDING)
@@ -243,6 +244,13 @@ AtaReqReleaseResources(
         IoFreeMdl(Request->Mdl);
     }
 
+    if (Request->Flags & REQUEST_FLAG_OWNS_DATA_BUFFER)
+    {
+        ASSERT(Request->DataBuffer);
+        ExFreePoolWithTag(Request->DataBuffer, ATAPORT_TAG);
+        Request->DataBuffer = NULL;
+    }
+
 #if DBG
     Request->Mdl = NULL;
     Request->SgList = NULL;
@@ -250,7 +258,8 @@ AtaReqReleaseResources(
 
     Request->Flags &= ~(REQUEST_FLAG_HAS_SG_LIST |
                         REQUEST_FLAG_HAS_MDL |
-                        REQUEST_FLAG_HAS_RESERVED_MAPPING);
+                        REQUEST_FLAG_HAS_RESERVED_MAPPING |
+                        REQUEST_FLAG_OWNS_DATA_BUFFER);
 }
 
 static
@@ -373,7 +382,8 @@ AtaReqCompleteRequest(
 
     ASSERT(!(Request->Flags & (REQUEST_FLAG_HAS_SG_LIST |
                                REQUEST_FLAG_HAS_MDL |
-                               REQUEST_FLAG_HAS_RESERVED_MAPPING)));
+                               REQUEST_FLAG_HAS_RESERVED_MAPPING |
+                               REQUEST_FLAG_OWNS_DATA_BUFFER)));
 
     SrbStatus = Request->SrbStatus;
 

--- a/sdk/include/reactos/drivers/ata/ata_shared.h
+++ b/sdk/include/reactos/drivers/ata/ata_shared.h
@@ -349,6 +349,9 @@ typedef struct _ATA_DEVICE_REQUEST
 
 #define REQUEST_FLAG_DEVICE_EXCLUSIVE_ACCESS  0x01000000
 
+/** The request owns DataBuffer and will release it */
+#define REQUEST_FLAG_OWNS_DATA_BUFFER         0x02000000
+
 /** Polled command */
 #define REQUEST_FLAG_POLL                     0x80000000
 


### PR DESCRIPTION
## Summary

Translate SCSI `UNMAP` requests in the ATAPI SATL into ATA DATA SET MANAGEMENT / TRIM commands.

This makes the existing classpnp TRIM path usable for ATA devices that advertise DSM/TRIM and have a usable LBA48 DMA path.

The change:

- advertises UNMAP only when ATA DSM/TRIM can actually be executed;
- reports matching READ CAPACITY(16), VPD Block Limits, VPD Logical Block Provisioning and `StorageDeviceTrimProperty` capabilities;
- converts SCSI UNMAP descriptors into ATA DSM range entries, including splitting ranges larger than 65535 sectors;
- emits one 512-byte DSM block per request with ATA command `0x06`, TRIM feature `0x01` and sector count `1`;
- owns and releases the internal DSM buffer/MDL explicitly across completion and requeue paths;
- validates the complete UNMAP parameter list, LBA48 bounds and the SRB data-buffer range before issuing the command;
- returns `STATUS_NOT_SUPPORTED` for the still-unimplemented direct DSM IOCTL path so classpnp correctly falls back to its standard SCSI UNMAP translation instead of caching false direct support.

WRITE SAME + UNMAP is not advertised or implemented by this change.

## Validation

Final source commit:

`b002f2436604b624cd28e85153a8206d27100293`

The commit is rebased on ReactOS `master` `851f1444a21db62e9852f85b6a96737d476a593f` and `git diff --check` is clean.

Build-farm run `32433582018` built target `atapi` successfully from that exact SHA. `source-sha.txt` matches the commit and `source-status.txt` is empty.

Final `atapi.sys`:

- size: 278,528 bytes
- SHA-256: `d4f85639dbc81d397fe17475351a076a85d098b59aab46fb76f13771b3afec48`

The final binary was injected byte-for-byte into an existing ReactOS test guest. Runtime validation used a separate disposable 64 MiB qcow2 IDE disk with QEMU `discard=unmap`; no physical host disk was used.

A temporary out-of-tree probe wrote 1 MiB of `0xA5` at offset 16 MiB and issued `IOCTL_STORAGE_MANAGE_DATA_SET_ATTRIBUTES / DeviceDsmAction_Trim` for exactly that raw-LBA range with `DEVICE_DSM_FLAG_TRIM_NOT_FS_ALLOCATED`. The probe is not part of this PR.

Guest results:

- `StorageDeviceTrimProperty`: `TrimEnabled=1`
- write of the 1 MiB test pattern succeeded
- TRIM IOCTL succeeded
- probe reached `TRIM_PROBE_DONE`
- QEMU exited with code 0
- no bugcheck or assertion was observed

The QEMU IDE trace captured the actual taskfile sent to the emulated drive:

```text
Features      = 0x01
Sector Count  = 0x01
Command       = 0x06
```

There is exactly one `cmd 0x06` in the final trace.

After shutdown, `qemu-img map --output=json` showed the trimmed 16-17 MiB range as `data=false, zero=true`; the written data was no longer present. `qemu-img check --output=json` reported `check-errors=0` and `image-end-offset=327680`, confirming the data clusters written for the test were no longer part of the live image allocation.
### Final readability cleanup

The final head `b002f2436604b624cd28e85153a8206d27100293` splits the UNMAP translation into explicit validation, range-checking and DSM-block construction helpers so the main request path reads linearly. No protocol semantics were intentionally changed.

Revalidation of that exact published SHA:

- mechanical readability gate and `git diff --check`: PASS;
- build-farm run `32433582018`: SUCCESS for `atapi`, clean source status;
- exact build-farm `atapi.sys`: 278,528 bytes, SHA-256 `d4f85639dbc81d397fe17475351a076a85d098b59aab46fb76f13771b3afec48`;
- fresh headless QEMU runtime: `TRIM_PROBE_TRIM_ENABLED=1`, write OK, TRIM OK, `TRIM_PROBE_DONE`, runtime end, QEMU exit 0;
- IDE trace contains exactly one DSM `cmd 0x06` with Features `0x01` and Sector Count `0x01`;
- the written 16-17 MiB range ends as `data=false, zero=true`; `qemu-img check` reports `check-errors=0`.