### PR TITLE
[RAMDISK] Validate read and write bounds

### DIFF
--- a/drivers/storage/class/ramdisk/ramdisk.c
+++ b/drivers/storage/class/ramdisk/ramdisk.c
@@ -1048,8 +1048,8 @@ RamdiskReadWrite(IN PDEVICE_OBJECT DeviceObject,
                  IN PIRP Irp)
 {
     PRAMDISK_DRIVE_EXTENSION DeviceExtension;
-    // ULONG Length;
-    // LARGE_INTEGER ByteOffset;
+    ULONG Length;
+    LARGE_INTEGER ByteOffset;
     PIO_STACK_LOCATION IoStackLocation;
     NTSTATUS Status, ReturnStatus;
 
@@ -1064,12 +1064,26 @@ RamdiskReadWrite(IN PDEVICE_OBJECT DeviceObject,
 
     /* Capture parameters */
     IoStackLocation = IoGetCurrentIrpStackLocation(Irp);
-    // Length = IoStackLocation->Parameters.Read.Length;
-    // ByteOffset = IoStackLocation->Parameters.Read.ByteOffset;
+    Length = IoStackLocation->Parameters.Read.Length;
+    ByteOffset = IoStackLocation->Parameters.Read.ByteOffset;
 
-    /* FIXME: Validate offset */
+    /* Validate that the transfer stays within the RAM disk. */
+    if ((ByteOffset.QuadPart < 0) ||
+        (ByteOffset.QuadPart > DeviceExtension->DiskLength.QuadPart) ||
+        (Length > DeviceExtension->DiskLength.QuadPart - ByteOffset.QuadPart))
+    {
+        Status = STATUS_INVALID_PARAMETER;
+        goto Complete;
+    }
 
-    /* FIXME: Validate sector */
+    /* RAM disk transfers must start and end on sector boundaries. */
+    if ((DeviceExtension->BytesPerSector == 0) ||
+        ((ByteOffset.QuadPart % DeviceExtension->BytesPerSector) != 0) ||
+        ((Length % DeviceExtension->BytesPerSector) != 0))
+    {
+        Status = STATUS_INVALID_PARAMETER;
+        goto Complete;
+    }
 
     /* Validate write */
     if ((IoStackLocation->MajorFunction == IRP_MJ_WRITE) &&


### PR DESCRIPTION
## Purpose

Validate RAM disk read/write requests before the driver maps the backing physical memory.

`RamdiskReadWrite()` already had explicit placeholders for validating the request offset and sector alignment, but requests were forwarded to `RamdiskReadWriteReal()` without either check. The real I/O path derives a physical address from the caller-provided byte offset and maps it with `MmMapIoSpace()`.

## Proposed changes

- Reject negative byte offsets.
- Reject offsets beyond the RAM disk's reported `DiskLength`.
- Reject transfers that extend past `DiskLength`, using subtraction (`DiskLength - ByteOffset`) so the bounds check does not depend on an overflow-prone `ByteOffset + Length` expression.
- Require both the byte offset and transfer length to be aligned to the RAM disk's reported sector size.
- Reject an invalid zero `BytesPerSector` value rather than attempting modulo/division with it.

The checks happen before the synchronous/asynchronous I/O split, so invalid requests cannot reach the backing-memory mapping path.

## Scope

The production change is intentionally limited to:

- `drivers/storage/class/ramdisk/ramdisk.c`

No RAM disk creation, deletion, PnP, bootloader, filesystem, or unrelated storage behavior is changed by this PR.

## Validation

Candidate SHA:

`7274702603569b5f2229c80e83f3e78bb0a336a8`

Targeted remote builds of that exact SHA:

- GCC / i386 / Debug: SUCCESS — GitHub Actions run `32439577210`.
- Clang / i386 / Debug: SUCCESS — GitHub Actions run `32440533717`.
- GCC / amd64 / Debug: SUCCESS — GitHub Actions run `32440553112`.

For all three runs, `source-sha.txt` records the exact candidate SHA and `source-status.txt` is empty.

The Clang build exposes an existing `RamdiskCreateDiskDevice()` warning about potentially uninitialized `SymbolicLinkName`; that code is outside this diff and is being kept separate from this focused I/O-validation change.

Mechanical readability preflight: PASS. The final diff was also reviewed as a cold reader and contains no unrelated formatting/refactor churn.

### Runtime A/B

A temporary test-only fixture boots the ReactOS Live Image as `ramdisk(0)` and never forms part of the production branch. The SYSTEM hive remains unchanged from upstream (`SYSTEM\Setup\CmdLine = setup -mini`); a temporary `syssetup` hook launches the probe from `InstallLiveCD()` before `userinit.exe`.

An initial successful user-mode A/B showed that ordinary `NtReadFile` requests on the named boot RAMDISK are normalized by the mounted filesystem/top attached device before reaching the RAMDISK dispatch. Those results were therefore not used as evidence for this change.

The final fixture loads a temporary kernel test driver that resolves the boot RAMDISK, obtains the attachment base with `IoGetDeviceAttachmentBaseRef()`, verifies the direct target as `\Driver\RamDisk`, queries its actual length and sector size, and sends five `IRP_MJ_READ` requests directly to that device:

- the last valid sector;
- one sector starting exactly at EOF;
- a two-sector transfer crossing EOF;
- an in-range but misaligned offset;
- an in-range but misaligned length.

The kernel fixture passed a targeted GCC/i386 Debug build in GitHub Actions run `32464433523`.

Final test-only fixture SHAs:

- baseline: `461af155d3298d2f4eb59cde8d761fc3ccfd4676`;
- fixed: `0969fbabec9d9077352a1219f5fde3af76dad9b2`.

Immediately before the runtime runs, `git diff baseline..fixed` contained only the production `drivers/storage/class/ramdisk/ramdisk.c` change (20 insertions, 6 deletions); all test instrumentation was identical.

Final headless-QEMU runs:

- baseline: `32464523133`;
- fixed: `32464541318`.

Both runs reached the direct `\Driver\RamDisk` target, reported the same `DiskLength=331677696` and `BytesPerSector=2048`, completed all five requests, emitted `RAMDISK_PROBE_DONE`, and recorded `marker_found=1`, `qemu_exited_before_marker=0`, `qemu_exit_code=0`, with an empty `source-status.txt`.

Observed direct-driver results:

| Case | Baseline | Fixed |
| --- | --- | --- |
| last valid sector | `STATUS_SUCCESS`, 2048 bytes | `STATUS_SUCCESS`, 2048 bytes |
| exactly at EOF | `STATUS_SUCCESS`, 2048 bytes | `STATUS_INVALID_PARAMETER`, 0 bytes |
| crosses EOF | `STATUS_SUCCESS`, 4096 bytes | `STATUS_INVALID_PARAMETER`, 0 bytes |
| misaligned offset | `STATUS_SUCCESS`, 2048 bytes | `STATUS_INVALID_PARAMETER`, 0 bytes |
| misaligned length | `STATUS_SUCCESS`, 2049 bytes | `STATUS_INVALID_PARAMETER`, 0 bytes |

The A/B therefore demonstrates that the candidate preserves a valid final-sector read while rejecting the four invalid requests at the RAMDISK driver boundary.

## Testbot runs

- [ ] KVM x86:
- [ ] KVM x64:
