### PR TITLE
[KERNEL32] Fix signature of BaseGetNamedObjectDirectory

### DIFF
--- a/dll/win32/kernel32/client/file/filemap.c
+++ b/dll/win32/kernel32/client/file/filemap.c
@@ -316,7 +316,7 @@ OpenFileMappingW(IN DWORD dwDesiredAccess,
     InitializeObjectAttributes(&ObjectAttributes,
                                &UnicodeName,
                                (bInheritHandle ? OBJ_INHERIT : 0),
-                               BaseGetNamedObjectDirectory(),
+                               BasepGetNamedObjectDirectory(),
                                NULL);
 
     /* Convert COPY to READ */

--- a/dll/win32/kernel32/client/utils.c
+++ b/dll/win32/kernel32/client/utils.c
@@ -59,15 +59,20 @@ BasepAnsiStringToUnicodeSize(IN PANSI_STRING String)
     return RtlAnsiStringToUnicodeSize(String);
 }
 
-HANDLE
+NTSTATUS
 WINAPI
-BaseGetNamedObjectDirectory(VOID)
+BaseGetNamedObjectDirectory(PHANDLE DirectoryHandle)
 {
     OBJECT_ATTRIBUTES ObjectAttributes;
     NTSTATUS Status;
     HANDLE DirHandle, BnoHandle, Token, NewToken;
 
-    if (BaseNamedObjectDirectory) return BaseNamedObjectDirectory;
+    *DirectoryHandle = BaseNamedObjectDirectory;
+
+    if (BaseNamedObjectDirectory)
+    {
+        return STATUS_SUCCESS;
+    }
 
     if (NtCurrentTeb()->IsImpersonating)
     {
@@ -75,7 +80,10 @@ BaseGetNamedObjectDirectory(VOID)
                                    TOKEN_IMPERSONATE,
                                    TRUE,
                                    &Token);
-        if (!NT_SUCCESS(Status)) return BaseNamedObjectDirectory;
+        if (!NT_SUCCESS(Status))
+        {
+            return Status;
+        }
 
         NewToken = NULL;
         Status = NtSetInformationThread(NtCurrentThread(),
@@ -85,7 +93,7 @@ BaseGetNamedObjectDirectory(VOID)
         if (!NT_SUCCESS (Status))
         {
             NtClose(Token);
-            return BaseNamedObjectDirectory;
+            return Status;
         }
     }
     else
@@ -149,7 +157,24 @@ Quickie:
         NtClose(Token);
     }
 
-    return BaseNamedObjectDirectory;
+    *DirectoryHandle = BaseNamedObjectDirectory;
+    return STATUS_SUCCESS;
+}
+
+HANDLE
+WINAPI
+BasepGetNamedObjectDirectory(VOID)
+{
+    NTSTATUS Status;
+    HANDLE DirectoryHandle;
+
+    Status = BaseGetNamedObjectDirectory(&DirectoryHandle);
+    if (!NT_SUCCESS(Status))
+    {
+        return NULL;
+    }
+
+    return DirectoryHandle;
 }
 
 VOID
@@ -328,7 +353,7 @@ BaseFormatObjectAttributes(OUT POBJECT_ATTRIBUTES ObjectAttributes,
     if (ObjectName)
     {
         Attributes |= OBJ_OPENIF;
-        RootDirectory = BaseGetNamedObjectDirectory();
+        RootDirectory = BasepGetNamedObjectDirectory();
     }
     else
     {

--- a/dll/win32/kernel32/include/base_x.h
+++ b/dll/win32/kernel32/include/base_x.h
@@ -151,7 +151,7 @@
     InitializeObjectAttributes(ObjectAttributes,                                \
                                &ObjectName,                                     \
                                inh ? OBJ_INHERIT : 0,                           \
-                               BaseGetNamedObjectDirectory(),                   \
+                               BasepGetNamedObjectDirectory(),                  \
                                NULL);                                           \
     Status = NtOpen##ntobj(&Handle, acc, ObjectAttributes);                     \
     if (!NT_SUCCESS(Status))                                                    \

--- a/dll/win32/kernel32/include/kernel32.h
+++ b/dll/win32/kernel32/include/kernel32.h
@@ -299,7 +299,7 @@ extern HANDLE BaseNamedObjectDirectory;
 
 HANDLE
 WINAPI
-BaseGetNamedObjectDirectory(VOID);
+BasepGetNamedObjectDirectory(VOID);
 
 NTSTATUS
 WINAPI


### PR DESCRIPTION
## Purpose

Fix signature of BaseGetNamedObjectDirectory

On Win 7+ the function is exported from kernelbase.dll and the signature is documented here: https://undoc.airesoft.co.uk/kernel32.dll/BaseGetNamedObjectDirectory.php It is also defined like this in Wine.
For convenience and to keep the diff small, a wrapper function BasepGetNamedObjectDirectory is added.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
