### PR TITLE
[NTOS:SE] Notify every interested filesystem of an upcoming logon session termination

### DIFF
--- a/ntoskrnl/include/internal/tag.h
+++ b/ntoskrnl/include/internal/tag.h
@@ -167,6 +167,7 @@
 #define TAG_SID_AND_ATTRIBUTES  'aSeS'
 #define TAG_SID_VALIDATE        'vSeS'
 #define TAG_DACL                'lcaD'
+#define TAG_LOGON_TERMINATED    'eToL'
 
 /* LPC Tags */
 #define TAG_LPC_MESSAGE         'McpL'

--- a/ntoskrnl/se/srm.c
+++ b/ntoskrnl/se/srm.c
@@ -22,6 +22,12 @@ typedef struct _SEP_LOGON_SESSION_TERMINATED_NOTIFICATION
     PSE_LOGON_SESSION_TERMINATED_ROUTINE CallbackRoutine;
 } SEP_LOGON_SESSION_TERMINATED_NOTIFICATION, *PSEP_LOGON_SESSION_TERMINATED_NOTIFICATION;
 
+typedef struct _SEP_LOGON_SESSION_TERMINATED_NOTIFY_CONTEXT
+{
+    LUID LogonId;
+    WORK_QUEUE_ITEM NotifyWorkItem;
+} SEP_LOGON_SESSION_TERMINATED_NOTIFY_CONTEXT, *PSEP_LOGON_SESSION_TERMINATED_NOTIFY_CONTEXT;
+
 VOID
 NTAPI
 SepRmCommandServerThread(
@@ -75,6 +81,87 @@ static PSEP_LOGON_SESSION_REFERENCES _SepLogonSessions[MAX_LOGON_SESSION_LISTS_I
 PSEP_LOGON_SESSION_REFERENCES* const SepLogonSessions = _SepLogonSessions;
 
 /* PRIVATE FUNCTIONS **********************************************************/
+
+/**
+ * @brief
+ * Main SRM worker that deploys notification to every registered
+ * filesystem that is interested for logon session termination notify.
+ *
+ * @param[in] Parameter
+ * A pointer to the session notify dispatch buffer containing the logon
+ * session ID of interest, provided by the method who inquired us to
+ * notify every registered filesystem.
+ */
+_Function_class_(WORKER_THREAD_ROUTINE)
+static VOID
+NTAPI
+SepRmNotifyFsCallbacksWorker(
+    _In_ PVOID Parameter)
+{
+    PSEP_LOGON_SESSION_TERMINATED_NOTIFICATION Notification;
+    PSEP_LOGON_SESSION_TERMINATED_NOTIFY_CONTEXT SessionNotify = (PSEP_LOGON_SESSION_TERMINATED_NOTIFY_CONTEXT)Parameter;
+    PAGED_CODE();
+
+    KeAcquireGuardedMutex(&SepRmDbLock);
+
+    for (Notification = SepLogonNotifications;
+         Notification != NULL;
+         Notification = Notification->Next)
+    {
+        Notification->CallbackRoutine(&SessionNotify->LogonId);
+    }
+
+    KeReleaseGuardedMutex(&SepRmDbLock);
+    ExFreePoolWithTag(SessionNotify, TAG_LOGON_TERMINATED);
+}
+
+/**
+ * @brief
+ * Alerts every registered filesystem of an impeding logon termination
+ * that is about to occur soon.
+ *
+ * @param[in] Session
+ * A pointer to the logon session that is about to be terminated, of
+ * which the interested filesystems get acknowledged of this fact with
+ * a notification.
+ *
+ * @remarks
+ * Logon session termination can occur when a thread may die as the
+ * process gets cleaned up. So service this operation with a Executive
+ * worker thread.
+ */
+static
+VOID
+SepRmNotifyTerminatedLogonSession(
+    _In_ PSEP_LOGON_SESSION_REFERENCES Session)
+{
+    PSEP_LOGON_SESSION_TERMINATED_NOTIFY_CONTEXT SessionNotify;
+
+    /* No filesystem has taken interest for this logon session */
+    if (!(Session->Flags & SEP_LOGON_SESSION_TERMINATION_NOTIFY))
+    {
+        DPRINT("No filesystem cares to be notified for this [%08x-%08x] logon ID, bail out!\n",
+               Session->LogonId.HighPart, Session->LogonId.LowPart);
+        return;
+    }
+
+    SessionNotify = ExAllocatePoolZero(NonPagedPool,
+                                       sizeof(*SessionNotify),
+                                       TAG_LOGON_TERMINATED);
+    if (SessionNotify == NULL)
+    {
+        DPRINT1("Failed to allocate memory pool to hold the logon session termination notify work item!\n");
+        return;
+    }
+
+    /* Setup the worker thread and deploy it immediately as soon as possible */
+    ExInitializeWorkItem(&SessionNotify->NotifyWorkItem,
+                         SepRmNotifyFsCallbacksWorker,
+                         SessionNotify);
+
+    SessionNotify->LogonId = Session->LogonId;
+    ExQueueWorkItem(&SessionNotify->NotifyWorkItem, CriticalWorkQueue);
+}
 
 /**
  * @brief
@@ -1020,7 +1107,8 @@ AllocateLinksAgain:
  * De-references a logon session. If the session has a reference
  * count of 0 by the time the function has de-referenced the logon,
  * that means the session is no longer used and can be safely deleted
- * from the logon sessions database.
+ * from the logon sessions database. Whoever registered for logon termination
+ * notification (typically filesystems) gets alerted of this fact.
  *
  * @param[in] LogonLuid
  * A logon session ID to de-reference.
@@ -1071,7 +1159,8 @@ SepRmDereferenceLogonSession(
                     ObfDereferenceDeviceMap(DeviceMap);
                 }
 
-                /* FIXME: Alert LSA and filesystems that a logon is about to be deleted */
+                /* Alert filesystems that a logon session is about to be deleted */
+                SepRmNotifyTerminatedLogonSession(CurrentSession);
             }
 
             return STATUS_SUCCESS;
@@ -1520,9 +1609,9 @@ SeGetLogonIdDeviceMap(
 
 /**
  * @brief
- * Marks a logon session for future termination, given its logon ID. This triggers
- * a callout (the registered callback) when the logon is no longer used by anyone,
- * that is, no token is still referencing the speciffied logon session.
+ * Marks a logon session for termination notification, given its logon ID. This triggers
+ * a callout (that is registered by a filesystem) when the logon is no longer used by
+ * anyone that is, no token is still referencing the speciffied logon session.
  *
  * @param[in] LogonId
  * The ID of the logon session.
@@ -1569,9 +1658,10 @@ SeMarkLogonSessionForTerminationNotification(
         return STATUS_NOT_FOUND;
     }
 
-    /* Mark the logon session for termination */
+    /* Mark the logon session for termination notification */
     SessionToMark->Flags |= SEP_LOGON_SESSION_TERMINATION_NOTIFY;
-    DPRINT("SeMarkLogonSessionForTerminationNotification(): Logon session marked for termination with success!\n");
+    DPRINT("SeMarkLogonSessionForTerminationNotification(): Logon session [%08x-%08x] marked for termination notification with success!\n",
+           LogonId->HighPart, LogonId->LowPart);
 
     /* Release the database lock */
     KeReleaseGuardedMutex(&SepRmDbLock);
@@ -1581,7 +1671,9 @@ SeMarkLogonSessionForTerminationNotification(
 /**
  * @brief
  * Registers a callback that will be called once a logon session
- * terminates.
+ * terminates. This is typically registered by a filesystem, of
+ * which it receives a notification from the kernel once the
+ * logon session of interest is terminated through this callback.
  *
  * @param[in] CallbackRoutine
  * Callback routine address.


### PR DESCRIPTION
ROS has `SeRegisterLogonSessionTerminatedRoutine` and `SeMarkLogonSessionForTerminationNotification` that filesystems can use to get notified of a logon session of interest that is about to be terminated as its last refcount is dereferenced. 

Though they're both useless because ROS lacks the necessary implementation for this kind of stuff, consequently whoever (and by that I mean FSDs) registered their callback to await for the logon session termination notification, they never get notified like at all.

This patch implements the final bits of this mechanism. Also clarify some comments in the documentation.
## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109637,109644
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109638,109645