### PR TITLE
[SETUPAPI] Implement SetupDiGetActualModelsSectionA/W

### DIFF
--- a/dll/win32/setupapi/devinst.c
+++ b/dll/win32/setupapi/devinst.c
@@ -523,6 +523,249 @@ done:
     return ret;
 }
 
+/**
+ * @brief
+ * Returns the appropriate decorated INF Models section for a device.
+ *
+ * @param[in] Context
+ * INFCONTEXT pointing to a manufacturer ID line.
+ *
+ * @param[in] AlternatePlatformInfo
+ * Alternate platform information, or NULL for using the current platform.
+ *
+ * @param[out] InfSectionWithExt
+ * Optional buffer that receives the decorated Models section name.
+ *
+ * @param[in] InfSectionWithExtSize
+ * Size of InfSectionWithExt in characters.
+ *
+ * @param[out] RequiredSize
+ * Receives the required buffer size in characters (including NUL).
+ *
+ * @param[in] Reserved
+ * Must be NULL.
+ *
+ * @return
+ * TRUE on success, FALSE on failure.
+ **/
+BOOL WINAPI
+SetupDiGetActualModelsSectionW(
+    _In_ PINFCONTEXT Context,
+    _In_opt_ PSP_ALTPLATFORM_INFO AlternatePlatformInfo,
+    _Out_writes_opt_(InfSectionWithExtSize) PWSTR InfSectionWithExt,
+    _In_ DWORD InfSectionWithExtSize,
+    _Out_opt_ PDWORD RequiredSize,
+    _Reserved_ PVOID Reserved)
+{
+    static SP_ALTPLATFORM_INFO CurrentPlatform = { 0 };
+    static BYTE CurrentProductType = 0;
+    static WORD CurrentSuiteMask = 0;
+
+    PSP_ALTPLATFORM_INFO pPlatformInfo;
+    BYTE ProductType;
+    WORD SuiteMask;
+    WCHAR ModelsSection[LINE_LEN + 1];
+    WCHAR BestSection[LINE_LEN + 1];
+    DWORD BestScore1 = ULONG_MAX, BestScore2 = ULONG_MAX;
+    DWORD BestScore3 = ULONG_MAX, BestScore4 = ULONG_MAX, BestScore5 = ULONG_MAX;
+    DWORD FieldCount, i, dwFullLength;
+
+    TRACE("%s(%p %p %p %lu %p %p)\n", __FUNCTION__, Context,
+          AlternatePlatformInfo, InfSectionWithExt, InfSectionWithExtSize,
+          RequiredSize, Reserved);
+
+    if (!Context)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    if (AlternatePlatformInfo &&
+        AlternatePlatformInfo->cbSize != sizeof(SP_ALTPLATFORM_INFO))
+    {
+        SetLastError(ERROR_INVALID_USER_BUFFER);
+        return FALSE;
+    }
+
+    /* Resolve platform */
+    if (AlternatePlatformInfo)
+    {
+        pPlatformInfo = AlternatePlatformInfo;
+        ProductType = 0;
+        SuiteMask = 0;
+    }
+    else
+    {
+        if (CurrentPlatform.cbSize != sizeof(CurrentPlatform))
+        {
+            SYSTEM_INFO SystemInfo;
+            GetSystemInfo(&SystemInfo);
+            CurrentPlatform.cbSize = sizeof(CurrentPlatform);
+            CurrentPlatform.Platform = OsVersionInfo.dwPlatformId;
+            CurrentPlatform.MajorVersion = OsVersionInfo.dwMajorVersion;
+            CurrentPlatform.MinorVersion = OsVersionInfo.dwMinorVersion;
+            CurrentPlatform.ProcessorArchitecture = SystemInfo.wProcessorArchitecture;
+            CurrentPlatform.Reserved = 0;
+            CurrentProductType = OsVersionInfo.wProductType;
+            CurrentSuiteMask = OsVersionInfo.wSuiteMask;
+        }
+        pPlatformInfo = &CurrentPlatform;
+        ProductType = CurrentProductType;
+        SuiteMask = CurrentSuiteMask;
+    }
+
+    /* Field 1: models-section-name */
+    if (!SetupGetStringFieldW(Context, 1, ModelsSection, ARRAYSIZE(ModelsSection), NULL) &&
+        !SetupGetStringFieldW(Context, 0, ModelsSection, ARRAYSIZE(ModelsSection), NULL))
+    {
+        SetLastError(ERROR_INVALID_DATA);
+        return FALSE;
+    }
+
+    strcpyW(BestSection, ModelsSection);
+    FieldCount = SetupGetFieldCount(Context);
+
+    /* Fields 2..N are the TargetOSVersion decorations */
+    for (i = 2; i <= FieldCount; i++)
+    {
+        WCHAR Candidate[LINE_LEN + 2]; /* +1 for possible leading '.' and +1 for NUL */
+        DWORD Score1, Score2, Score3, Score4, Score5;
+        DWORD DecLen;
+
+        if (!SetupGetStringFieldW(Context, i, Candidate, ARRAYSIZE(Candidate) - 1, NULL))
+            continue;
+
+        if (!Candidate[0])
+            continue;
+
+        /* CheckSectionValid expects a leading dot */
+        if (Candidate[0] != '.')
+        {
+            memmove(Candidate + 1, Candidate, (lstrlenW(Candidate) + 1) * sizeof(WCHAR));
+            Candidate[0] = '.';
+        }
+
+        if (!CheckSectionValid(Candidate, pPlatformInfo, ProductType, SuiteMask,
+                               &Score1, &Score2, &Score3, &Score4, &Score5))
+        {
+            continue;
+        }
+
+        /* Lower scores are better */
+        if (Score1 > BestScore1) continue;
+        if (Score1 < BestScore1) goto better;
+        if (Score2 > BestScore2) continue;
+        if (Score2 < BestScore2) goto better;
+        if (Score3 > BestScore3) continue;
+        if (Score3 < BestScore3) goto better;
+        if (Score4 > BestScore4) continue;
+        if (Score4 < BestScore4) goto better;
+        if (Score5 > BestScore5) continue;
+        if (Score5 < BestScore5) goto better;
+        continue;
+
+better:
+        DecLen = lstrlenW(Candidate);
+        if (lstrlenW(ModelsSection) + DecLen >= ARRAYSIZE(BestSection))
+            continue;
+
+        strcpyW(BestSection, ModelsSection);
+        strcatW(BestSection, Candidate);
+        BestScore1 = Score1;
+        BestScore2 = Score2;
+        BestScore3 = Score3;
+        BestScore4 = Score4;
+        BestScore5 = Score5;
+    }
+
+    dwFullLength = lstrlenW(BestSection);
+    if (RequiredSize)
+        *RequiredSize = dwFullLength + 1;
+
+    if (InfSectionWithExtSize > 0)
+    {
+        if (InfSectionWithExtSize < dwFullLength + 1)
+        {
+            SetLastError(ERROR_INSUFFICIENT_BUFFER);
+            return FALSE;
+        }
+        strcpyW(InfSectionWithExt, BestSection);
+    }
+
+    TRACE("Returning section %s\n", debugstr_w(BestSection));
+    return TRUE;
+}
+
+/**
+ * @brief
+ * ANSI version of SetupDiGetActualModelsSectionW.
+ *
+ * @param[in] Context
+ * INFCONTEXT pointing to a manufacturer ID line.
+ *
+ * @param[in] AlternatePlatformInfo
+ * Alternate platform information, or NULL for using the current platform.
+ *
+ * @param[out] InfSectionWithExt
+ * Optional buffer that receives the decorated Models section name.
+ *
+ * @param[in] InfSectionWithExtSize
+ * Size of InfSectionWithExt in characters.
+ *
+ * @param[out] RequiredSize
+ * Receives the required buffer size in characters (including NUL).
+ *
+ * @param[in] Reserved
+ * Must be NULL.
+ *
+ * @return
+ * TRUE on success, FALSE on failure.
+ **/
+BOOL WINAPI
+SetupDiGetActualModelsSectionA(
+    _In_ PINFCONTEXT Context,
+    _In_opt_ PSP_ALTPLATFORM_INFO AlternatePlatformInfo,
+    _Out_writes_opt_(InfSectionWithExtSize) PSTR InfSectionWithExt,
+    _In_ DWORD InfSectionWithExtSize,
+    _Out_opt_ PDWORD RequiredSize,
+    _Reserved_ PVOID Reserved)
+{
+    PWSTR Buffer = NULL;
+    DWORD Required = 0;
+    BOOL ret;
+
+    if (InfSectionWithExtSize > 0)
+    {
+        Buffer = HeapAlloc(GetProcessHeap(), 0, InfSectionWithExtSize * sizeof(WCHAR));
+        if (!Buffer)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            return FALSE;
+        }
+    }
+
+    ret = SetupDiGetActualModelsSectionW(Context, AlternatePlatformInfo,
+                                         Buffer, InfSectionWithExtSize,
+                                         &Required, Reserved);
+
+    if (!ret && GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+        Required = 0;
+
+    if (RequiredSize)
+        *RequiredSize = Required;
+
+    if (ret && Buffer && InfSectionWithExt)
+    {
+        WideCharToMultiByte(CP_ACP, 0, Buffer, -1,
+                            InfSectionWithExt, InfSectionWithExtSize,
+                            NULL, NULL);
+    }
+
+    if (Buffer)
+        HeapFree(GetProcessHeap(), 0, Buffer);
+
+    return ret;
+}
 
 BOOL
 CreateDeviceInfo(

--- a/dll/win32/setupapi/setupapi.spec
+++ b/dll/win32/setupapi/setupapi.spec
@@ -322,8 +322,8 @@
 @ stdcall SetupDiEnumDeviceInterfaces(long ptr ptr long ptr)
 @ stdcall SetupDiEnumDriverInfoA(long ptr long long ptr)
 @ stdcall SetupDiEnumDriverInfoW(long ptr long long ptr)
-@ stub -version=0x502+ SetupDiGetActualModelsSectionA
-@ stub -version=0x502+ SetupDiGetActualModelsSectionW
+@ stdcall -version=0x502+ SetupDiGetActualModelsSectionA(ptr ptr ptr long ptr ptr)
+@ stdcall -version=0x502+ SetupDiGetActualModelsSectionW(ptr ptr ptr long ptr ptr)
 @ stdcall SetupDiGetActualSectionToInstallA(long str str long ptr ptr)
 @ stdcall SetupDiGetActualSectionToInstallExA(long str ptr str long ptr ptr ptr)
 @ stdcall SetupDiGetActualSectionToInstallExW(long wstr ptr wstr long ptr ptr ptr)

--- a/modules/rostests/apitests/setupapi/CMakeLists.txt
+++ b/modules/rostests/apitests/setupapi/CMakeLists.txt
@@ -2,6 +2,7 @@
 list(APPEND SOURCE
     devclass.c
     SetupDiInstallClassExA.c
+    SetupDiGetActualModelsSection.c
     SetupInstallServicesFromInfSectionEx.c
     testlist.c)
 

--- a/modules/rostests/apitests/setupapi/SetupDiGetActualModelsSection.c
+++ b/modules/rostests/apitests/setupapi/SetupDiGetActualModelsSection.c
@@ -1,0 +1,166 @@
+/*
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for SetupDiGetActualModelsSectionA/W
+ * COPYRIGHT:   Copyright 2026 Alex Mendoza <05alex.mendozaa@gmail.com>
+ */
+
+#include <apitest.h>
+
+#define WIN32_NO_STATUS
+#include <stdio.h>
+#include <windef.h>
+#include <winbase.h>
+#include <winreg.h>
+#include <winuser.h>
+#include <setupapi.h>
+
+static const char TestInfData[] =
+    "[Version]\n"
+    "Signature=\"$Windows NT$\"\n"
+    "Class=TestClass\n"
+    "ClassGuid={12345678-1234-1234-1234-123456789ABC}\n"
+    "\n"
+    "[Manufacturer]\n"
+    "%TestMfg%=TestModels,NTx86,NTamd64,NT\n"
+    "\n"
+    "[TestModels.NTx86]\n"
+    "%DeviceDesc%=InstallSection,TEST\\VID_1234&PID_5678\n"
+    "\n"
+    "[TestModels.NTamd64]\n"
+    "%DeviceDesc%=InstallSection,TEST\\VID_1234&PID_5678\n"
+    "\n"
+    "[TestModels.NT]\n"
+    "%DeviceDesc%=InstallSection,TEST\\VID_1234&PID_5678\n"
+    "\n"
+    "[TestModels]\n"
+    "%DeviceDesc%=InstallSection,TEST\\VID_1234&PID_5678\n"
+    "\n"
+    "[InstallSection]\n"
+    "\n"
+    "[Strings]\n"
+    "TestMfg=\"Test Manufacturer\"\n"
+    "DeviceDesc=\"Test Device\"\n";
+
+static void create_test_inf(LPCSTR filename)
+{
+    HANDLE hFile;
+    DWORD written;
+
+    hFile = CreateFileA(filename, GENERIC_WRITE, 0, NULL,
+                        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    ok(hFile != INVALID_HANDLE_VALUE, "CreateFile failed\n");
+    if (hFile == INVALID_HANDLE_VALUE)
+        return;
+
+    WriteFile(hFile, TestInfData, sizeof(TestInfData) - 1, &written, NULL);
+    CloseHandle(hFile);
+}
+
+static void test_SetupDiGetActualModelsSectionW(void)
+{
+    HINF hInf;
+    INFCONTEXT ctx;
+    WCHAR Buffer[LINE_LEN];
+    DWORD Required = 0;
+    BOOL ret;
+    char path[MAX_PATH];
+
+    GetTempPathA(sizeof(path), path);
+    lstrcatA(path, "test_models.inf");
+    create_test_inf(path);
+
+    hInf = SetupOpenInfFileA(path, NULL, INF_STYLE_WIN4, NULL);
+    ok(hInf != INVALID_HANDLE_VALUE, "SetupOpenInfFileA failed: %lu\n", GetLastError());
+    if (hInf == INVALID_HANDLE_VALUE)
+    {
+        DeleteFileA(path);
+        return;
+    }
+
+    /* Find the manufacturer line */
+    ret = SetupFindFirstLineW(hInf, L"Manufacturer", NULL, &ctx);
+    ok(ret, "SetupFindFirstLineW failed: %lu\n", GetLastError());
+
+    /* NULL context must fail */
+    SetLastError(0xdeadbeef);
+    ret = SetupDiGetActualModelsSectionW(NULL, NULL, Buffer, ARRAYSIZE(Buffer), &Required, NULL);
+    ok(!ret, "Expected failure with NULL Context\n");
+    ok(GetLastError() == ERROR_INVALID_PARAMETER,
+       "Expected ERROR_INVALID_PARAMETER, got %lu\n", GetLastError());
+
+    /* Query required size only */
+    Required = 0;
+    ret = SetupDiGetActualModelsSectionW(&ctx, NULL, NULL, 0, &Required, NULL);
+    ok(ret, "SetupDiGetActualModelsSectionW (size query) failed: %lu\n", GetLastError());
+    ok(Required > 1, "Expected Required > 1, got %lu\n", Required);
+
+    /* Actual call */
+    ZeroMemory(Buffer, sizeof(Buffer));
+    Required = 0;
+    ret = SetupDiGetActualModelsSectionW(&ctx, NULL, Buffer, ARRAYSIZE(Buffer), &Required, NULL);
+    ok(ret, "SetupDiGetActualModelsSectionW failed: %lu\n", GetLastError());
+    ok(Buffer[0] != 0, "Expected non-empty section name\n");
+    ok(Required == lstrlenW(Buffer) + 1,
+       "Required size mismatch: %lu vs %u\n", Required, lstrlenW(Buffer) + 1);
+
+    trace("Got Models section: %s\n", wine_dbgstr_w(Buffer));
+
+    /* Too small buffer */
+    SetLastError(0xdeadbeef);
+    ret = SetupDiGetActualModelsSectionW(&ctx, NULL, Buffer, 1, &Required, NULL);
+    ok(!ret, "Expected failure with tiny buffer\n");
+    ok(GetLastError() == ERROR_INSUFFICIENT_BUFFER,
+       "Expected ERROR_INSUFFICIENT_BUFFER, got %lu\n", GetLastError());
+
+    SetupCloseInfFile(hInf);
+    DeleteFileA(path);
+}
+
+static void test_SetupDiGetActualModelsSectionA(void)
+{
+    HINF hInf;
+    INFCONTEXT ctx;
+    char Buffer[LINE_LEN];
+    DWORD Required = 0;
+    BOOL ret;
+    char path[MAX_PATH];
+
+    GetTempPathA(sizeof(path), path);
+    lstrcatA(path, "test_models.inf");
+    create_test_inf(path);
+
+    hInf = SetupOpenInfFileA(path, NULL, INF_STYLE_WIN4, NULL);
+    ok(hInf != INVALID_HANDLE_VALUE, "SetupOpenInfFileA failed\n");
+    if (hInf == INVALID_HANDLE_VALUE)
+    {
+        DeleteFileA(path);
+        return;
+    }
+
+    ret = SetupFindFirstLineA(hInf, "Manufacturer", NULL, &ctx);
+    ok(ret, "SetupFindFirstLineA failed\n");
+
+    /* Size query */
+    Required = 0;
+    ret = SetupDiGetActualModelsSectionA(&ctx, NULL, NULL, 0, &Required, NULL);
+    ok(ret, "SetupDiGetActualModelsSectionA (size query) failed: %lu\n", GetLastError());
+    ok(Required > 1, "Expected Required > 1\n");
+
+    /* Actual call */
+    ZeroMemory(Buffer, sizeof(Buffer));
+    ret = SetupDiGetActualModelsSectionA(&ctx, NULL, Buffer, sizeof(Buffer), &Required, NULL);
+    ok(ret, "SetupDiGetActualModelsSectionA failed: %lu\n", GetLastError());
+    ok(Buffer[0] != 0, "Expected non-empty section name\n");
+
+    trace("Got Models section (A): %s\n", Buffer);
+
+    SetupCloseInfFile(hInf);
+    DeleteFileA(path);
+}
+
+START_TEST(SetupDiGetActualModelsSection)
+{
+    test_SetupDiGetActualModelsSectionW();
+    test_SetupDiGetActualModelsSectionA();
+}

--- a/modules/rostests/apitests/setupapi/SetupDiInstallClassExA.c
+++ b/modules/rostests/apitests/setupapi/SetupDiInstallClassExA.c
@@ -1,7 +1,7 @@
 /*
  * SetupAPI device class-related functions tests
  *
- * Copyright 2015 Víctor Martínez (victor.martinez@reactos.org)
+ * Copyright 2015 VÃ­ctor MartÃ­nez (victor.martinez@reactos.org)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public Licence as

--- a/modules/rostests/apitests/setupapi/SetupInstallServicesFromInfSectionEx.c
+++ b/modules/rostests/apitests/setupapi/SetupInstallServicesFromInfSectionEx.c
@@ -1,7 +1,7 @@
 /*
  * SetupAPI device class-related functions tests
  *
- * Copyright 2015 Víctor Martínez (victor.martinez@reactos.org)
+ * Copyright 2015 VÃ­ctor MartÃ­nez (victor.martinez@reactos.org)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public Licence as

--- a/modules/rostests/apitests/setupapi/testlist.c
+++ b/modules/rostests/apitests/setupapi/testlist.c
@@ -3,13 +3,15 @@
 #include <apitest.h>
 
 extern void func_devclass(void);
-extern void func_SetupInstallServicesFromInfSectionEx(void);
+extern void func_SetupDiGetActualModelsSection(void);
 extern void func_SetupDiInstallClassExA(void);
+extern void func_SetupInstallServicesFromInfSectionEx(void);
 
 const struct test winetest_testlist[] =
 {
     { "devclass", func_devclass },
-    { "SetupInstallServicesFromInfSectionEx", func_SetupInstallServicesFromInfSectionEx},
-    { "SetupDiInstallClassExA", func_SetupDiInstallClassExA},
+    { "SetupDiGetActualModelsSection", func_SetupDiGetActualModelsSection },
+    { "SetupDiInstallClassExA", func_SetupDiInstallClassExA },
+    { "SetupInstallServicesFromInfSectionEx", func_SetupInstallServicesFromInfSectionEx },
     { 0, 0 }
 };

--- a/sdk/include/psdk/setupapi.h
+++ b/sdk/include/psdk/setupapi.h
@@ -1469,6 +1469,34 @@ SetupDiGetActualSectionToInstallExW(
   _Out_opt_ PWSTR *Extension,
   _Reserved_ PVOID Reserved);
 
+WINSETUPAPI
+BOOL
+WINAPI
+SetupDiGetActualModelsSectionA(
+    _In_ PINFCONTEXT Context,
+    _In_opt_ PSP_ALTPLATFORM_INFO AlternatePlatformInfo,
+    _Out_writes_opt_(InfSectionWithExtSize) PSTR InfSectionWithExt,
+    _In_ DWORD InfSectionWithExtSize,
+    _Out_opt_ PDWORD RequiredSize,
+    _Reserved_ PVOID Reserved);
+
+WINSETUPAPI
+BOOL
+WINAPI
+SetupDiGetActualModelsSectionW(
+    _In_ PINFCONTEXT Context,
+    _In_opt_ PSP_ALTPLATFORM_INFO AlternatePlatformInfo,
+    _Out_writes_opt_(InfSectionWithExtSize) PWSTR InfSectionWithExt,
+    _In_ DWORD InfSectionWithExtSize,
+    _Out_opt_ PDWORD RequiredSize,
+    _Reserved_ PVOID Reserved);
+
+#ifdef UNICODE
+#define SetupDiGetActualModelsSection SetupDiGetActualModelsSectionW
+#else
+#define SetupDiGetActualModelsSection SetupDiGetActualModelsSectionA
+#endif
+
 WINSETUPAPI BOOL WINAPI SetupDiGetClassBitmapIndex(_In_opt_ CONST GUID*, _Out_ PINT);
 
 WINSETUPAPI


### PR DESCRIPTION
## Purpose

Implement SetupDiGetActualModelsSectionA/W so GPU driver installers don't auto-fail when they find out it's a stub.

JIRA issue: [CORE-20472](https://jira.reactos.org/browse/CORE-20472)

## Proposed changes
- Implement `SetupDiGetActualModelsSectionW` (and the ANSI thunk)
- Export the two functions from the `.spec`

## TODO
- [x] Add an apitest.

Results:
<img width="641" height="139" alt="image" src="https://github.com/user-attachments/assets/7d101e3c-8250-461f-8f57-6a9053d11588" />

## Testbot runs (Filled in by Devs)

- [x] ✅ KVM x86: https://reactos.org/testman/compare.php?ids=109661,109665
  `SetupDiGetActualModelsSection: 21 tests executed (0 marked as todo, 0 failures), 0 skipped.`

  ✅ _**UPDATE:**_ https://reactos.org/testman/compare.php?ids=109679,109682
  `SetupDiGetActualModelsSection: 19 tests executed (0 marked as todo, 0 failures), 0 skipped.`

- [x] ✅ KVM x64: https://reactos.org/testman/compare.php?ids=109662,109666
  `SetupDiGetActualModelsSection: 21 tests executed (0 marked as todo, 0 failures), 0 skipped.`

  ✅ _**UPDATE:**_ https://reactos.org/testman/compare.php?ids=109681,109683
  `SetupDiGetActualModelsSection: 19 tests executed (0 marked as todo, 0 failures), 0 skipped.`

- [x] ⚠️ Win2003_x64: https://reactos.org/testman/compare.php?ids=109660,109663
  ```
  SetupDiGetActualModelsSection.c:95: Test failed: Expected failure with non-NULL Reserved
  SetupDiGetActualModelsSection.c:96: Test failed: Expected ERROR_INVALID_PARAMETER, got 0
  SetupDiGetActualModelsSection.c:114: Got Models section: L"TestModels.NTamd64"
  SetupDiGetActualModelsSection.c:163: Got Models section (A): TestModels.NTamd64

  SetupDiGetActualModelsSection: 21 tests executed (0 marked as todo, 2 failures), 0 skipped.
  ```
  https://reactos.org/testman/detail.php?id=91469814&prev=0

  ✅ _**UPDATE:**_ https://reactos.org/testman/compare.php?ids=109677,109680
  `SetupDiGetActualModelsSection: 19 tests executed (0 marked as todo, 0 failures), 0 skipped.`

- [x] ⚠️ Test WHS (Windows Server 2003 - Build 3790 SP2 - i386): https://reactos.org/testman/compare.php?ids=109627,109664
  ```
  SetupDiGetActualModelsSection.c:95: Test failed: Expected failure with non-NULL Reserved
  SetupDiGetActualModelsSection.c:96: Test failed: Expected ERROR_INVALID_PARAMETER, got 0
  SetupDiGetActualModelsSection.c:114: Got Models section: L"TestModels.NTx86"
  SetupDiGetActualModelsSection.c:163: Got Models section (A): TestModels.NTx86

  SetupDiGetActualModelsSection: 21 tests executed (0 marked as todo, 2 failures), 0 skipped.
  ```
  https://reactos.org/testman/detail.php?id=91469682&prev=0

  ✅ _**UPDATE:**_ https://reactos.org/testman/compare.php?ids=109671,109678
  `SetupDiGetActualModelsSection: 19 tests executed (0 marked as todo, 0 failures), 0 skipped.`

- [x] ⚠️ Windows 7 (local test by @HBelusca):
  ```
  Microsoft Windows [version 6.1.7601]
  Copyright (c) 2009 Microsoft Corporation. Tous droits réservés.

  X:\temp\TEST_x64>setupapi_apitest.exe SetupDiGetActualModelsSection
  SetupDiGetActualModelsSection.c:95: Test failed: Expected failure with non-NULL Reserved
  SetupDiGetActualModelsSection.c:96: Test failed: Expected ERROR_INVALID_PARAMETER, got 0
  SetupDiGetActualModelsSection.c:114: Got Models section: L"TestModels.NTamd64"
  SetupDiGetActualModelsSection.c:163: Got Models section (A): TestModels.NTamd64

  SetupDiGetActualModelsSection: 21 tests executed (0 marked as todo, 2 failures), 0 skipped.

  X:\temp\TEST_x64>cd ..\TEST_x86

  X:\temp\TEST_x86>setupapi_apitest.exe SetupDiGetActualModelsSection
  SetupDiGetActualModelsSection.c:95: Test failed: Expected failure with non-NULL Reserved
  SetupDiGetActualModelsSection.c:96: Test failed: Expected ERROR_INVALID_PARAMETER, got 0
  SetupDiGetActualModelsSection.c:114: Got Models section: L"TestModels.NTx86"
  SetupDiGetActualModelsSection.c:163: Got Models section (A): TestModels.NTx86

  SetupDiGetActualModelsSection: 21 tests executed (0 marked as todo, 2 failures), 0 skipped.

  X:\temp\TEST_x86>
  ```
