### PR TITLE
[STORPORT] Free mapped device bases

### DIFF
--- a/drivers/storage/port/storport/storport.c
+++ b/drivers/storage/port/storport/storport.c
@@ -628,8 +628,37 @@ StorPortFreeDeviceBase(
     _In_ PVOID HwDeviceExtension,
     _In_ PVOID MappedAddress)
 {
+    PMINIPORT_DEVICE_EXTENSION MiniportExtension;
+    PFDO_DEVICE_EXTENSION DeviceExtension;
+    PMAPPED_ADDRESS Mapping, PreviousMapping = NULL;
+
     DPRINT1("StorPortFreeDeviceBase(%p %p)\n",
             HwDeviceExtension, MappedAddress);
+
+    MiniportExtension = CONTAINING_RECORD(HwDeviceExtension,
+                                          MINIPORT_DEVICE_EXTENSION,
+                                          HwDeviceExtension);
+    DeviceExtension = MiniportExtension->Miniport->DeviceExtension;
+
+    for (Mapping = DeviceExtension->MappedAddressList;
+         Mapping != NULL;
+         Mapping = Mapping->NextMappedAddress)
+    {
+        if (Mapping->MappedAddress == MappedAddress)
+        {
+            MmUnmapIoSpace(Mapping->MappedAddress, Mapping->NumberOfBytes);
+
+            if (PreviousMapping != NULL)
+                PreviousMapping->NextMappedAddress = Mapping->NextMappedAddress;
+            else
+                DeviceExtension->MappedAddressList = Mapping->NextMappedAddress;
+
+            ExFreePoolWithTag(Mapping, TAG_ADDRESS_MAPPING);
+            return;
+        }
+
+        PreviousMapping = Mapping;
+    }
 }
 
 
@@ -747,6 +776,8 @@ StorPortGetDeviceBase(
                                  NumberOfBytes,
                                  FALSE);
     DPRINT1("Mapped Address: %p\n", MappedAddress);
+    if (MappedAddress == NULL)
+        return NULL;
 
     Status = AllocateAddressMapping(&MiniportExtension->Miniport->DeviceExtension->MappedAddressList,
                                     IoAddress,
@@ -755,7 +786,8 @@ StorPortGetDeviceBase(
                                     SystemIoBusNumber);
     if (!NT_SUCCESS(Status))
     {
-        DPRINT1("Checkpoint!\n");
+        DPRINT1("Failed to track mapped address (Status 0x%08lx)\n", Status);
+        MmUnmapIoSpace(MappedAddress, NumberOfBytes);
         MappedAddress = NULL;
     }
 


### PR DESCRIPTION
## Purpose

`StorPortGetDeviceBase()` already records memory-space mappings so the port driver can release them later, but `StorPortFreeDeviceBase()` is still an empty stub. The allocation path can also leave a live mapping behind if the bookkeeping allocation fails.

## Changes

Implement the free path using the existing `MappedAddressList`. `StorPortGetDeviceBase()` now stops when `MmMapIoSpace()` fails and unmaps a successful range if it cannot be recorded.

I/O-space addresses keep their current behavior: they are returned directly and are never added to the mapping list.

## Testing

- `git diff --check`
- GCC/i386: `32539743815`
- Clang/i386: `32539752349`
- GCC/amd64: `32539758828`
- Clang/amd64: `32539766317`
- BootCD A/B fixture, kept out of this PR: fixed `32549153532` reported `pass`; baseline `32549172825` reported `fail`; both reached `STORPORT_DEVICE_BASE_PROBE_OBSERVED` without an early QEMU exit.
