### PR TITLE
[PCIIDEX] Enable AHCI/SATA flags without cleaning up existing ones

### DIFF
--- a/drivers/storage/ide/pciidex/chipset/ahci_generic.c
+++ b/drivers/storage/ide/pciidex/chipset/ahci_generic.c
@@ -644,7 +644,7 @@ AhciGetControllerProperties(
     if (!Controller->IoBase)
         return STATUS_NO_MATCH; // Try IDE/RAID
 
-    Controller->Flags = CTRL_FLAG_IS_AHCI | CTRL_FLAG_SATA_HBA_ACPI;
+    Controller->Flags |= CTRL_FLAG_IS_AHCI | CTRL_FLAG_SATA_HBA_ACPI;
     Controller->Start = AtaAhciHbaStart;
     Controller->Stop = AtaAhciHbaStop;
     Controller->FreeResources = AtaAhciHbaFreeResouces;


### PR DESCRIPTION
I don't believe this should be erasing the existing flags on this function call
Could be wrong, but this was causing an issue for me.

## Testbot runs (Filled in by Devs)

N/A