### PR TITLE
[SETUPAPI] Fix SetupDiDeleteDeviceInfo

### DIFF
--- a/dll/win32/setupapi/devinst.c
+++ b/dll/win32/setupapi/devinst.c
@@ -4999,11 +4999,10 @@ IsDeviceInfoInDeviceInfoSet(
  */
 BOOL WINAPI
 SetupDiDeleteDeviceInfo(
-        IN HDEVINFO DeviceInfoSet,
-        IN PSP_DEVINFO_DATA DeviceInfoData)
+    _In_ HDEVINFO DeviceInfoSet,
+    _In_ PSP_DEVINFO_DATA DeviceInfoData)
 {
     struct DeviceInfoSet *deviceInfoSet;
-    struct DeviceInfo *deviceInfo = (struct DeviceInfo *)DeviceInfoData;
     BOOL ret = FALSE;
 
     TRACE("%s(%p %p)\n", __FUNCTION__, DeviceInfoSet, DeviceInfoData);
@@ -5012,12 +5011,13 @@ SetupDiDeleteDeviceInfo(
         SetLastError(ERROR_INVALID_HANDLE);
     else if ((deviceInfoSet = (struct DeviceInfoSet *)DeviceInfoSet)->magic != SETUP_DEVICE_INFO_SET_MAGIC)
         SetLastError(ERROR_INVALID_HANDLE);
-    else if (DeviceInfoData && DeviceInfoData->cbSize != sizeof(SP_DEVINFO_DATA))
+    else if (!DeviceInfoData || DeviceInfoData->cbSize != sizeof(*DeviceInfoData) || !DeviceInfoData->Reserved)
         SetLastError(ERROR_INVALID_USER_BUFFER);
-    else if (!IsDeviceInfoInDeviceInfoSet(deviceInfoSet, deviceInfo))
+    else if (!IsDeviceInfoInDeviceInfoSet(deviceInfoSet, (struct DeviceInfo *)DeviceInfoData->Reserved))
         SetLastError(ERROR_INVALID_PARAMETER);
     else
     {
+        struct DeviceInfo *deviceInfo = (struct DeviceInfo *)DeviceInfoData->Reserved;
         RemoveEntryList(&deviceInfo->ListEntry);
         DestroyDeviceInfo(deviceInfo);
         ret = TRUE;

--- a/dll/win32/setupapi/setupapi.spec
+++ b/dll/win32/setupapi/setupapi.spec
@@ -311,7 +311,7 @@
 @ stdcall SetupDiCreateDeviceInterfaceRegKeyW(ptr ptr long long ptr ptr)
 @ stdcall SetupDiCreateDeviceInterfaceW(ptr ptr ptr wstr long ptr)
 @ stdcall SetupDiDeleteDevRegKey(ptr ptr long long long)
-@ stdcall SetupDiDeleteDeviceInfo(long ptr)
+@ stdcall SetupDiDeleteDeviceInfo(ptr ptr)
 @ stdcall SetupDiDeleteDeviceInterfaceData(ptr ptr)
 @ stdcall SetupDiDeleteDeviceInterfaceRegKey(ptr ptr long)
 @ stdcall SetupDiDestroyClassImageList(ptr)


### PR DESCRIPTION
## Purpose

SetupDiDeleteDeviceInfo always returned FALSE as it used the SP_DEVINFO_DATA structure internally rather than accessing the DeviceInfo structure. This caused the list items never to be found. As a result, the NVIDIA 368.81 installer does not instantly fail, and attempts to detect devices.

JIRA issue: [CORE-20472](https://jira.reactos.org/browse/CORE-20472)
<img width="1598" height="1312" alt="image" src="https://github.com/user-attachments/assets/a31ff80f-1544-485f-b167-d1dab7d4d696" />

## Proposed changes

- use DeviceInfoData->Reserved to access the DeviceInfo struct


## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: