### PR TITLE
[APIC] Add header files for x2APIC

### DIFF
--- a/hal/halx86/apic/apicp.h
+++ b/hal/halx86/apic/apicp.h
@@ -193,7 +193,8 @@ typedef union _APIC_BASE_ADDRESS_REGISTER
     {
         UINT64 Reserved1:8;
         UINT64 BootStrapCPUCore:1;
-        UINT64 Reserved2:2;
+        UINT64 Reserved2:1;
+        UINT64 EnableX2Apic:1;
         UINT64 Enable:1;
         UINT64 BaseAddress:40;
         UINT64 ReservedMBZ:12;

--- a/hal/halx86/apic/x2apic.h
+++ b/hal/halx86/apic/x2apic.h
@@ -1,0 +1,51 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Header file for x2APIC
+ * COPYRIGHT:   Copyright 2026 Alex Mendoza <05alex.mendozaa@gmail.com>
+ */
+
+#pragma once
+
+#include "apicp.h"
+
+#define X2APIC_MSR_BASE 0x00000800
+#define CPUID_X2APIC_FEATURE_BIT 21
+#define X2APIC_MSR_ICR 0x00000830
+#define X2APIC_MSR_SELF_IPI 0x0000083F
+
+FORCEINLINE
+APIC_REGISTER
+X2ApicMsrFromRegister(APIC_REGISTER Register)
+{
+    return (APIC_REGISTER)(X2APIC_MSR_BASE + (Register / 0x10));
+}
+
+FORCEINLINE
+ULONG
+X2ApicRead(_In_ APIC_REGISTER Register)
+{
+    return (ULONG)__readmsr(X2ApicMsrFromRegister(Register));
+}
+
+FORCEINLINE
+VOID
+X2ApicWrite(_In_ APIC_REGISTER Register, _In_ ULONG Value)
+{
+    __writemsr(X2ApicMsrFromRegister(Register), Value);
+}
+
+FORCEINLINE
+VOID
+X2ApicWriteIcr(_In_ APIC_INTERRUPT_COMMAND_REGISTER IcrValue)
+{
+    __writemsr(X2APIC_MSR_ICR, IcrValue.LongLong);
+}
+
+BOOLEAN
+NTAPI
+X2ApicIsSupported(VOID);
+
+VOID
+NTAPI
+X2ApicEnable(VOID);


### PR DESCRIPTION
## Purpose

Add a new header for x2APIC stuff, and modify the _APIC_BASE_ADDRESS_REGISTER so it has the x2APIC field. This is so I don't do a giant PR doing HAL and Ke and everything x2APIC needs.

JIRA issue: None

## Proposed changes
- Modify `_APIC_BASE_ADDRESS_REGISTER` to include the `EnableX2Apic` field,
- Add a new header file (`x2apic.h`) declaring some helpers and declarations for functions (will be implemented in another PR)

The EnableX2Apic field is taken from Intel SDM Vol. 3A §10.12.1.