### PR TITLE
[W32TIME] Support DllServer re-registration and unregistration

### DIFF
--- a/base/services/w32time/register.c
+++ b/base/services/w32time/register.c
@@ -294,8 +294,9 @@ UnregisterService(VOID)
     hServiceManager = OpenSCManagerW(NULL, NULL, SC_MANAGER_CREATE_SERVICE);
     if (!hServiceManager)
     {
-        DPRINT1("OpenSCManager() failed!\n");
-        return GetLastError();
+        error = GetLastError();
+        DPRINT1("OpenSCManager() failed, error %lu\n", error);
+        return error;
     }
 
     hService = OpenServiceW(hServiceManager, g_pszServiceName, DELETE);
@@ -305,7 +306,7 @@ UnregisterService(VOID)
     {
         if (error == ERROR_SERVICE_DOES_NOT_EXIST)
             return ERROR_SUCCESS;
-        DPRINT1("OpenService() failed!\n");
+        DPRINT1("OpenService() failed, error %lu\n", error);
     }
     else
     {
@@ -313,7 +314,7 @@ UnregisterService(VOID)
         if (error == ERROR_SERVICE_MARKED_FOR_DELETE)
             error = ERROR_SUCCESS;
         if (error)
-            DPRINT1("DeleteService() failed!\n");
+            DPRINT1("DeleteService() failed, error %lu\n", error);
 
         CloseServiceHandle(hService);
     }

--- a/base/services/w32time/register.c
+++ b/base/services/w32time/register.c
@@ -11,6 +11,8 @@
 
 #include "resource.h"
 
+PCWSTR g_pszServiceName = L"W32Time";
+
 static
 PWSTR
 ReadString(
@@ -78,7 +80,7 @@ RegisterService(VOID)
     }
 
     hService = CreateServiceW(hServiceManager,
-                              L"W32Time",
+                              g_pszServiceName,
                               pszDisplayName,
                               GENERIC_WRITE,
                               SERVICE_WIN32_SHARE_PROCESS,
@@ -86,6 +88,11 @@ RegisterService(VOID)
                               SERVICE_ERROR_NORMAL,
                               L"%SystemRoot%\\system32\\svchost.exe -k netsvcs",
                               L"Time", NULL, NULL, L"LocalSystem", NULL);
+
+    if (!hService && GetLastError() == ERROR_SERVICE_EXISTS)
+    {
+        hService = OpenServiceW(hServiceManager, g_pszServiceName, SERVICE_CHANGE_CONFIG);
+    }
     if (hService == NULL)
     {
         DPRINT1("CreateService() failed!\n");
@@ -277,10 +284,47 @@ DllRegisterServer(VOID)
 }
 
 
+static
+UINT
+UnregisterService(VOID)
+{
+    UINT error;
+    SC_HANDLE hServiceManager, hService;
+
+    hServiceManager = OpenSCManagerW(NULL, NULL, SC_MANAGER_CREATE_SERVICE);
+    if (!hServiceManager)
+    {
+        DPRINT1("OpenSCManager() failed!\n");
+        return GetLastError();
+    }
+
+    hService = OpenServiceW(hServiceManager, g_pszServiceName, DELETE);
+    error = GetLastError();
+    CloseServiceHandle(hServiceManager);
+    if (!hService)
+    {
+        if (error == ERROR_SERVICE_DOES_NOT_EXIST)
+            return ERROR_SUCCESS;
+        DPRINT1("OpenService() failed!\n");
+    }
+    else
+    {
+        error = DeleteService(hService) ? ERROR_SUCCESS : GetLastError();
+        if (error == ERROR_SERVICE_MARKED_FOR_DELETE)
+            error = ERROR_SUCCESS;
+        if (error)
+            DPRINT1("DeleteService() failed!\n");
+
+        CloseServiceHandle(hService);
+    }
+    return error;
+}
+
+
 HRESULT
 WINAPI
 DllUnregisterServer(VOID)
 {
-    DPRINT1("DllUnregisterServer()\n");
-    return S_OK;
+    UINT error = UnregisterService();
+    return HRESULT_FROM_WIN32(error);
 }


### PR DESCRIPTION
## Purpose

(Un)registration should ignore already installed/deleted soft errors.

JIRA issue: [CORE-20747](https://jira.reactos.org/browse/CORE-20747)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109691,109694
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109692,109695