### PR TITLE
[NTUSER] Open the startup desktop with MAXIMUM_ALLOWED

### DIFF
--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -948,7 +948,7 @@ IntResolveDesktop(
                                 ExWindowStationObjectType,
                                 UserMode,
                                 NULL,
-                                WINSTA_ACCESS_ALL,
+                                MAXIMUM_ALLOWED,
                                 NULL,
                                 (PHANDLE)&hTempWinSta);
     if (!NT_SUCCESS(Status))
@@ -1192,11 +1192,15 @@ IntResolveDesktop(
         if (bInherit)
             ObjectAttributes->Attributes |= OBJ_INHERIT;
 
+        /* 
+         * A sandboxed process can be denied a piece of DESKTOP_ALL_ACCESS 
+         * on its startup desktop and must still be able to connect to it.
+         */
         Status = ObOpenObjectByName(ObjectAttributes,
                                     ExDesktopObjectType,
                                     UserMode,
                                     NULL,
-                                    DESKTOP_ALL_ACCESS,
+                                    MAXIMUM_ALLOWED,
                                     NULL,
                                     (PHANDLE)&hDesktop);
         if (!NT_SUCCESS(Status))


### PR DESCRIPTION
Fixes the chrome sandbox process insta-crash so it actually gets to the job work and fails under the ui restriction

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109691,109697,109699
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109692,109698,109700