### PR TITLE
[RTL] Implement Low Fragmentation Heap

### DIFF
--- a/sdk/lib/rtl/CMakeLists.txt
+++ b/sdk/lib/rtl/CMakeLists.txt
@@ -53,6 +53,7 @@ list(APPEND SOURCE
     generictable.c
     handle.c
     heap.c
+    heap_lfh.c
     heapdbg.c
     heappage.c
     heapuser.c

--- a/sdk/lib/rtl/heap.c
+++ b/sdk/lib/rtl/heap.c
@@ -3328,6 +3328,10 @@ RtlpValidateHeapEntry(
     if ((ULONG_PTR)HeapEntry & (HEAP_ENTRY_SIZE - 1)) goto invalid_entry;
     if (!(HeapEntry->Flags & HEAP_ENTRY_BUSY)) goto invalid_entry;
 
+    /* LFH owned blocks are not chained the normal way so validate them separately */
+    if ((Heap->FrontEndHeapType == 2) && (HeapEntry->UnusedBytes & HEAP_ENTRY_LFH_FLAG))
+        return RtlpValidateLFHEntry(Heap, HeapEntry);
+
     BigAllocation = HeapEntry->Flags & HEAP_ENTRY_VIRTUAL_ALLOC;
     Segment = Heap->Segments[HeapEntry->SegmentOffset];
 
@@ -3735,6 +3739,16 @@ RtlpValidateHeap(PHEAP Heap,
     {
         DPRINT1("HEAP: Total size of free blocks in arena (%Iu) does not equal to the one in heap header (%Iu)\n", TotalFreeSize, Heap->TotalFreeSize);
         return FALSE;
+    }
+
+    /* Validate the LFH frontend if this heap has one */
+    if (Heap->FrontEndHeapType == 2)
+    {
+        ULONG LFHFreeBlocksCount = 0;
+        SIZE_T LFHTotalFreeSize = 0;
+
+        if (!RtlpValidateLFH(Heap, &LFHFreeBlocksCount, &LFHTotalFreeSize))
+            return FALSE;
     }
 
     return TRUE;

--- a/sdk/lib/rtl/heap.c
+++ b/sdk/lib/rtl/heap.c
@@ -21,6 +21,7 @@
 
 #include <rtl.h>
 #include <heap.h>
+#include "heap_lfh.h"
 
 #define NDEBUG
 #include <debug.h>
@@ -1792,6 +1793,9 @@ RtlDestroyHeap(HANDLE HeapPtr) /* [in] Handle of heap */
         RtlpRemoveHeapFromProcessList(Heap);
     }
 
+    if (Heap->FrontEndHeapType == 2)
+        RtlpDestroyLFH(Heap);
+
     /* Delete the heap lock */
     if (!(Heap->Flags & HEAP_NO_SERIALIZE))
     {
@@ -2085,6 +2089,9 @@ RtlAllocateHeap(IN PVOID HeapPtr,
     if (RtlpHeapIsSpecial(Flags))
         return RtlDebugAllocateHeap(Heap, Flags, Size);
 
+    if ((Heap->FrontEndHeapType == 2) && RtlpLFHSizeFits(Size))
+        return RtlpLFHAllocate(Heap, Flags, Size);
+
     /* Check for the maximum size */
     if (Size >= 0x80000000)
     {
@@ -2310,6 +2317,13 @@ BOOLEAN NTAPI RtlFreeHeap(
 
     /* Get pointer to the heap entry */
     HeapEntry = (PHEAP_ENTRY)Ptr - 1;
+
+    if ((Heap->FrontEndHeapType == 2) &&
+        (HeapEntry->Flags & HEAP_ENTRY_BUSY) &&
+        (HeapEntry->UnusedBytes & HEAP_ENTRY_LFH_FLAG))
+    {
+        return RtlpLFHFree(Heap, Flags, Ptr);
+    }
 
     /* Protect with SEH in case the pointer is not valid */
     _SEH2_TRY
@@ -3230,6 +3244,12 @@ RtlSizeHeap(
         return (SIZE_T)-1;
     }
 
+    /* LFH blocks don't track exact padding. Ask the frontend */
+    if ((Heap->FrontEndHeapType == 2) && (HeapEntry->UnusedBytes & HEAP_ENTRY_LFH_FLAG))
+    {
+        return RtlpLFHSize(Heap, Ptr);
+    }
+
     /* Get size of this block depending if it's a usual or a big one */
     if (HeapEntry->Flags & HEAP_ENTRY_VIRTUAL_ALLOC)
     {
@@ -4085,8 +4105,7 @@ RtlSetHeapInformation(IN HANDLE HeapHandle OPTIONAL,
             return STATUS_UNSUCCESSFUL;
         }
 
-        DPRINT1("RtlSetHeapInformation() needs to enable LFH\n");
-        return STATUS_SUCCESS;
+        return RtlpInitializeLFH((PHEAP)HeapHandle);
     }
 
     return STATUS_SUCCESS;

--- a/sdk/lib/rtl/heap.c
+++ b/sdk/lib/rtl/heap.c
@@ -2777,6 +2777,16 @@ RtlReAllocateHeap(HANDLE HeapPtr,
         return Ptr;
     }
 
+    if ((Heap->FrontEndHeapType == 2) && (InUseEntry->UnusedBytes & HEAP_ENTRY_LFH_FLAG))
+    {
+        NewBaseAddress = RtlpLFHReAllocate(Heap, Flags, Ptr, Size);
+
+        if (HeapLocked)
+            RtlLeaveHeapLock(Heap->LockVariable);
+
+        return NewBaseAddress;
+    }
+
     if (InUseEntry->Flags & HEAP_ENTRY_VIRTUAL_ALLOC)
     {
         /* This is a virtually allocated block. Get its size */

--- a/sdk/lib/rtl/heap_lfh.c
+++ b/sdk/lib/rtl/heap_lfh.c
@@ -1,0 +1,334 @@
+/*
+ * PROJECT:     ReactOS Runtime Library
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Low-Fragmentation Heap (LFH) front-end allocator
+ * COPYRIGHT:   Copyright 2026 Alex Mendoza <05alex.mendozaa@gmail.com>
+ */
+
+/* Useful references:
+   http://illmatics.com/Understanding_the_LFH.pdf
+*/
+
+#include <rtl.h>
+#include "heap.h"
+#include "heap_lfh.h"
+
+#define NDEBUG
+#include <debug.h>
+
+/* PRIVATE FUNCTIONS *********************************************************/
+
+static
+VOID
+RtlpBuildLFHBucketTable(
+    _In_ PLFH_HEAP Lfh)
+{
+    ULONG Index;
+    SIZE_T UserSize, Granularity;
+
+    for (Index = 0; Index < LFH_BUCKET_COUNT; Index++)
+    {
+        if (Index < 32)
+        {
+            Granularity = 8;
+            UserSize = (Index + 1) * Granularity;
+        }
+        else if (Index < 64)
+        {
+            Granularity = 16;
+            UserSize = 256 + (Index - 31) * Granularity;
+        }
+        else if (Index < 96)
+        {
+            Granularity = 32;
+            UserSize = 768 + (Index - 63) * Granularity;
+        }
+        else
+        {
+            Granularity = 64;
+            UserSize = 1792 + (Index - 95) * Granularity;
+        }
+
+        Lfh->Buckets[Index].BlockSize = ALIGN_UP_BY(UserSize + sizeof(HEAP_ENTRY), HEAP_ENTRY_SIZE);
+        InitializeListHead(&Lfh->Buckets[Index].SubSegmentList);
+        Lfh->Buckets[Index].ActiveSubSegment = NULL;
+    }
+
+    /* Largest bucket must stay under the frontend's size maximum */
+    ASSERT(Lfh->Buckets[LFH_BUCKET_COUNT - 1].BlockSize < LFH_MAX_BLOCK_SIZE);
+}
+
+static
+PHEAP_BUCKET
+RtlpFindLFHBucket(
+    _In_ PLFH_HEAP Lfh,
+    _In_ SIZE_T AllocationSize)
+{
+    ULONG Index;
+
+    for (Index = 0; Index < LFH_BUCKET_COUNT; Index++)
+    {
+        if (Lfh->Buckets[Index].BlockSize >= AllocationSize)
+            return &Lfh->Buckets[Index];
+    }
+
+    return NULL;
+}
+
+static
+PHEAP_SUBSEGMENT
+RtlpAllocateLFHSubSegment(
+    _In_ PHEAP Heap,
+    _In_ PHEAP_BUCKET Bucket)
+{
+    PLFH_HEAP Lfh = (PLFH_HEAP)Heap->FrontEndHeap;
+    PLFH_BLOCK_ZONE Zone;
+    PHEAP_SUBSEGMENT SubSegment;
+    PLFH_FREE_ENTRY FreeEntry, NextFree;
+    SIZE_T ZoneSize, BlocksSize;
+    UCHAR SavedFrontEndHeapType;
+    ULONG Index;
+
+    BlocksSize = Bucket->BlockSize * LFH_MIN_BLOCKS_PER_SUBSEGMENT;
+    ZoneSize = ALIGN_UP_BY(sizeof(LFH_BLOCK_ZONE) + sizeof(HEAP_SUBSEGMENT) + BlocksSize, PAGE_SIZE);
+
+    SavedFrontEndHeapType = Heap->FrontEndHeapType;
+    Heap->FrontEndHeapType = 0;
+    Zone = RtlAllocateHeap(Heap, HEAP_NO_SERIALIZE, ZoneSize);
+    Heap->FrontEndHeapType = SavedFrontEndHeapType;
+
+    if (!Zone)
+        return NULL;
+
+    Zone->Base = Zone;
+    Zone->Size = ZoneSize;
+    InsertTailList(&Lfh->BlockZones, &Zone->ListEntry);
+
+    SubSegment = (PHEAP_SUBSEGMENT)(Zone + 1);
+    SubSegment->Bucket = Bucket;
+    SubSegment->BlockBase = (PUCHAR)(SubSegment + 1);
+    SubSegment->BlockSize = Bucket->BlockSize;
+    SubSegment->BlockCount = LFH_MIN_BLOCKS_PER_SUBSEGMENT;
+    SubSegment->FreeBlockCount = LFH_MIN_BLOCKS_PER_SUBSEGMENT;
+
+    FreeEntry = (PLFH_FREE_ENTRY)SubSegment->BlockBase;
+    SubSegment->FreeList = FreeEntry;
+    for (Index = 0; Index < SubSegment->BlockCount - 1; Index++)
+    {
+        NextFree = (PLFH_FREE_ENTRY)((PUCHAR)FreeEntry + SubSegment->BlockSize);
+        FreeEntry->Next = NextFree;
+        FreeEntry = NextFree;
+    }
+    FreeEntry->Next = NULL;
+
+    InsertTailList(&Bucket->SubSegmentList, &SubSegment->ListEntry);
+    return SubSegment;
+}
+
+/* PUBLIC FUNCTIONS ***********************************************************/
+
+NTSTATUS
+NTAPI
+RtlpInitializeLFH(
+    _In_ PHEAP Heap)
+{
+    PLFH_HEAP Lfh;
+
+    /* Already enabled, nothing to do */
+    if (Heap->FrontEndHeapType == 2)
+        return STATUS_SUCCESS;
+
+    Lfh = RtlAllocateHeap(Heap, HEAP_ZERO_MEMORY, sizeof(LFH_HEAP));
+    if (!Lfh)
+        return STATUS_NO_MEMORY;
+
+    Lfh->Heap = Heap;
+    InitializeListHead(&Lfh->BlockZones);
+    RtlpBuildLFHBucketTable(Lfh);
+
+    Heap->FrontEndHeap = Lfh;
+    Heap->FrontEndHeapType = 2;
+
+    return STATUS_SUCCESS;
+}
+
+VOID
+NTAPI
+RtlpDestroyLFH(
+    _In_ PHEAP Heap)
+{
+    PLFH_HEAP Lfh = (PLFH_HEAP)Heap->FrontEndHeap;
+    PLIST_ENTRY Entry;
+    PLFH_BLOCK_ZONE Zone;
+
+    if (!Lfh)
+        return;
+
+    while (!IsListEmpty(&Lfh->BlockZones))
+    {
+        Entry = RemoveHeadList(&Lfh->BlockZones);
+        Zone = CONTAINING_RECORD(Entry, LFH_BLOCK_ZONE, ListEntry);
+        RtlFreeHeap(Heap, HEAP_NO_SERIALIZE, Zone->Base);
+    }
+
+    Heap->FrontEndHeap = NULL;
+    Heap->FrontEndHeapType = 0;
+    RtlFreeHeap(Heap, 0, Lfh);
+}
+
+BOOLEAN
+NTAPI
+RtlpLFHSizeFits(
+    _In_ SIZE_T Size)
+{
+    return (Size + sizeof(HEAP_ENTRY)) < LFH_MAX_BLOCK_SIZE;
+}
+
+SIZE_T
+NTAPI
+RtlpLFHSize(
+    _In_ PHEAP Heap,
+    _In_ PVOID BaseAddress)
+{
+    PLFH_HEAP Lfh = (PLFH_HEAP)Heap->FrontEndHeap;
+    PHEAP_ENTRY HeapEntry = (PHEAP_ENTRY)BaseAddress - 1;
+    ULONG BucketIndex = HeapEntry->PreviousSize;
+
+    if (BucketIndex >= LFH_BUCKET_COUNT)
+        return (SIZE_T)-1;
+
+    return Lfh->Buckets[BucketIndex].BlockSize - sizeof(HEAP_ENTRY);
+}
+
+PVOID
+NTAPI
+RtlpLFHAllocate(
+    _In_ PHEAP Heap,
+    _In_ ULONG Flags,
+    _In_ SIZE_T Size)
+{
+    PLFH_HEAP Lfh = (PLFH_HEAP)Heap->FrontEndHeap;
+    PHEAP_BUCKET Bucket;
+    PHEAP_SUBSEGMENT SubSegment;
+    PLFH_FREE_ENTRY FreeEntry;
+    PHEAP_ENTRY HeapEntry;
+    SIZE_T AllocationSize;
+    ULONG BucketIndex;
+    BOOLEAN HeapLocked = FALSE;
+
+    AllocationSize = ALIGN_UP_BY((Size ? Size : 1) + sizeof(HEAP_ENTRY), HEAP_ENTRY_SIZE);
+
+    Bucket = RtlpFindLFHBucket(Lfh, AllocationSize);
+    if (!Bucket)
+        return NULL;
+    BucketIndex = (ULONG)(Bucket - Lfh->Buckets);
+
+    if (!(Flags & HEAP_NO_SERIALIZE))
+    {
+        RtlEnterHeapLock(Heap->LockVariable, TRUE);
+        HeapLocked = TRUE;
+    }
+
+    SubSegment = Bucket->ActiveSubSegment;
+    if (!SubSegment || !SubSegment->FreeBlockCount)
+    {
+        SubSegment = RtlpAllocateLFHSubSegment(Heap, Bucket);
+        if (!SubSegment)
+        {
+            if (HeapLocked) RtlLeaveHeapLock(Heap->LockVariable);
+            RtlSetLastWin32ErrorAndNtStatusFromNtStatus(STATUS_NO_MEMORY);
+            return NULL;
+        }
+        Bucket->ActiveSubSegment = SubSegment;
+    }
+
+    /* Pop a free block off the subsegment */
+    FreeEntry = SubSegment->FreeList;
+    SubSegment->FreeList = FreeEntry->Next;
+    SubSegment->FreeBlockCount--;
+
+    if (HeapLocked) RtlLeaveHeapLock(Heap->LockVariable);
+
+    HeapEntry = (PHEAP_ENTRY)FreeEntry;
+    HeapEntry->Size = (USHORT)(SubSegment->BlockSize >> HEAP_ENTRY_SHIFT);
+    HeapEntry->Flags = HEAP_ENTRY_BUSY;
+    HeapEntry->SmallTagIndex = (UCHAR)(LOBYTE(HeapEntry->Size) ^ HIBYTE(HeapEntry->Size) ^ HeapEntry->Flags);
+    HeapEntry->PreviousSize = (USHORT)BucketIndex;
+    HeapEntry->SegmentOffset = 0;
+    HeapEntry->UnusedBytes = HEAP_ENTRY_LFH_FLAG;
+
+    if (Flags & HEAP_ZERO_MEMORY)
+        RtlZeroMemory(HeapEntry + 1, Size);
+    else if (Heap->Flags & HEAP_FREE_CHECKING_ENABLED)
+        RtlFillMemoryUlong(HeapEntry + 1, Size & ~0x3, ARENA_INUSE_FILLER);
+
+    return HeapEntry + 1;
+}
+
+BOOLEAN
+NTAPI
+RtlpLFHFree(
+    _In_ PHEAP Heap,
+    _In_ ULONG Flags,
+    _In_ PVOID BaseAddress)
+{
+    PLFH_HEAP Lfh = (PLFH_HEAP)Heap->FrontEndHeap;
+    PHEAP_ENTRY HeapEntry = (PHEAP_ENTRY)BaseAddress - 1;
+    PHEAP_BUCKET Bucket;
+    PHEAP_SUBSEGMENT SubSegment;
+    PLFH_FREE_ENTRY FreeEntry;
+    ULONG BucketIndex = HeapEntry->PreviousSize;
+    BOOLEAN HeapLocked = FALSE;
+
+    if (BucketIndex >= LFH_BUCKET_COUNT)
+    {
+        DPRINT1("Corrupt LFH bucket index %lu for block %p\n", BucketIndex, BaseAddress);
+        return FALSE;
+    }
+    Bucket = &Lfh->Buckets[BucketIndex];
+
+    if (Heap->Flags & HEAP_FREE_CHECKING_ENABLED)
+        RtlFillMemory(BaseAddress, Bucket->BlockSize - sizeof(HEAP_ENTRY), ARENA_FREE_FILLER);
+
+    if (!(Flags & HEAP_NO_SERIALIZE))
+    {
+        RtlEnterHeapLock(Heap->LockVariable, TRUE);
+        HeapLocked = TRUE;
+    }
+
+    /* Walk the bucket's subsegments to find the one that owns this block */
+    SubSegment = NULL;
+    {
+        PLIST_ENTRY Entry;
+        for (Entry = Bucket->SubSegmentList.Flink;
+             Entry != &Bucket->SubSegmentList;
+             Entry = Entry->Flink)
+        {
+            PHEAP_SUBSEGMENT Candidate = CONTAINING_RECORD(Entry, HEAP_SUBSEGMENT, ListEntry);
+            PUCHAR Base = Candidate->BlockBase;
+            PUCHAR Limit = Base + Candidate->BlockCount * Candidate->BlockSize;
+
+            if ((PUCHAR)HeapEntry >= Base && (PUCHAR)HeapEntry < Limit)
+            {
+                SubSegment = Candidate;
+                break;
+            }
+        }
+    }
+
+    if (!SubSegment)
+    {
+        if (HeapLocked) RtlLeaveHeapLock(Heap->LockVariable);
+        DPRINT1("LFH block %p does not belong to any subsegment\n", BaseAddress);
+        return FALSE;
+    }
+
+    FreeEntry = (PLFH_FREE_ENTRY)HeapEntry;
+    FreeEntry->Next = SubSegment->FreeList;
+    SubSegment->FreeList = FreeEntry;
+    SubSegment->FreeBlockCount++;
+
+    if (HeapLocked) RtlLeaveHeapLock(Heap->LockVariable);
+
+    return TRUE;
+}

--- a/sdk/lib/rtl/heap_lfh.c
+++ b/sdk/lib/rtl/heap_lfh.c
@@ -202,6 +202,65 @@ RtlpLFHSize(
 
 PVOID
 NTAPI
+RtlpLFHReAllocate(
+    _In_ PHEAP Heap,
+    _In_ ULONG Flags,
+    _In_ PVOID Ptr,
+    _In_ SIZE_T Size)
+{
+    PLFH_HEAP Lfh = (PLFH_HEAP)Heap->FrontEndHeap;
+    PHEAP_ENTRY OldEntry = (PHEAP_ENTRY)Ptr - 1;
+    ULONG OldBucketIndex = OldEntry->PreviousSize;
+    SIZE_T OldUsableSize, NewAllocationSize, CopySize;
+    PHEAP_BUCKET NewBucket;
+    PVOID NewBaseAddress;
+
+    if (OldBucketIndex >= LFH_BUCKET_COUNT)
+    {
+        DPRINT1("Corrupt LFH bucket index %lu on realloc %p\n", OldBucketIndex, Ptr);
+        RtlSetLastWin32ErrorAndNtStatusFromNtStatus(STATUS_INVALID_PARAMETER);
+        return NULL;
+    }
+    OldUsableSize = Lfh->Buckets[OldBucketIndex].BlockSize - sizeof(HEAP_ENTRY);
+
+    NewAllocationSize = ALIGN_UP_BY((Size ? Size : 1) + sizeof(HEAP_ENTRY), HEAP_ENTRY_SIZE);
+    NewBucket = RtlpFindLFHBucket(Lfh, NewAllocationSize);
+
+    if (NewBucket && ((ULONG)(NewBucket - Lfh->Buckets) == OldBucketIndex))
+    {
+        if ((Flags & HEAP_ZERO_MEMORY) && (Size > OldUsableSize))
+            RtlZeroMemory((PUCHAR)Ptr + OldUsableSize, Size - OldUsableSize);
+
+        return Ptr;
+    }
+
+    if (Flags & HEAP_REALLOC_IN_PLACE_ONLY)
+    {
+        RtlSetLastWin32ErrorAndNtStatusFromNtStatus(STATUS_NO_MEMORY);
+        return NULL;
+    }
+
+    if (NewBucket)
+        NewBaseAddress = RtlpLFHAllocate(Heap, Flags, Size);
+    else
+        NewBaseAddress = RtlAllocateHeap(Heap, Flags, Size);
+
+    if (!NewBaseAddress)
+        return NULL;
+
+    CopySize = (OldUsableSize < Size) ? OldUsableSize : Size;
+    RtlCopyMemory(NewBaseAddress, Ptr, CopySize);
+
+    if ((Flags & HEAP_ZERO_MEMORY) && (Size > CopySize))
+        RtlZeroMemory((PUCHAR)NewBaseAddress + CopySize, Size - CopySize);
+
+    RtlpLFHFree(Heap, Flags, Ptr);
+
+    return NewBaseAddress;
+}
+
+PVOID
+NTAPI
 RtlpLFHAllocate(
     _In_ PHEAP Heap,
     _In_ ULONG Flags,

--- a/sdk/lib/rtl/heap_lfh.c
+++ b/sdk/lib/rtl/heap_lfh.c
@@ -125,6 +125,135 @@ RtlpAllocateLFHSubSegment(
     return SubSegment;
 }
 
+static
+BOOLEAN
+RtlpIsLFHBlockFree(
+    _In_ PHEAP_SUBSEGMENT SubSegment,
+    _In_ PVOID BlockAddress)
+{
+    PLFH_FREE_ENTRY FreeEntry;
+
+    for (FreeEntry = SubSegment->FreeList; FreeEntry; FreeEntry = FreeEntry->Next)
+    {
+        if ((PVOID)FreeEntry == BlockAddress)
+            return TRUE;
+    }
+
+    return FALSE;
+}
+
+static
+BOOLEAN
+RtlpValidateLFHSubSegment(
+    _In_ PHEAP Heap,
+    _In_ PHEAP_SUBSEGMENT SubSegment,
+    _In_ ULONG BucketIndex,
+    _Inout_ PULONG FreeBlocksCount,
+    _Inout_ PSIZE_T TotalFreeSize)
+{
+    PLFH_FREE_ENTRY FreeEntry;
+    PHEAP_ENTRY HeapEntry;
+    PUCHAR Block, Limit;
+    SIZE_T Offset;
+    ULONG WalkedFree, BusyValidated, Index;
+    UCHAR ExpectedTag;
+
+    Limit = SubSegment->BlockBase + SubSegment->BlockCount * SubSegment->BlockSize;
+
+    /* Walk the free list and check the bounds and the alignment of every free block */
+    WalkedFree = 0;
+    for (FreeEntry = SubSegment->FreeList; FreeEntry; FreeEntry = FreeEntry->Next)
+    {
+        if ((PUCHAR)FreeEntry < SubSegment->BlockBase || (PUCHAR)FreeEntry >= Limit)
+        {
+            DPRINT1("LFH free block %p is outside subsegment %p [%p .. %p)\n",
+                    FreeEntry, SubSegment, SubSegment->BlockBase, Limit);
+            return FALSE;
+        }
+
+        Offset = (PUCHAR)FreeEntry - SubSegment->BlockBase;
+        if (Offset % SubSegment->BlockSize != 0)
+        {
+            DPRINT1("LFH free block %p is not aligned to the block size %Iu\n",
+                    FreeEntry, SubSegment->BlockSize);
+            return FALSE;
+        }
+
+        WalkedFree++;
+        if (WalkedFree > SubSegment->BlockCount)
+        {
+            DPRINT1("LFH subsegment %p free list is corrupt (cycle?)\n", SubSegment);
+            return FALSE;
+        }
+    }
+
+    if (WalkedFree != SubSegment->FreeBlockCount)
+    {
+        DPRINT1("LFH subsegment %p FreeBlockCount %lu does not match walked count %lu\n",
+                SubSegment, SubSegment->FreeBlockCount, WalkedFree);
+        return FALSE;
+    }
+
+    /* Walk every block and validate the busy ones */
+    BusyValidated = 0;
+    for (Index = 0; Index < SubSegment->BlockCount; Index++)
+    {
+        Block = SubSegment->BlockBase + Index * SubSegment->BlockSize;
+
+        if (RtlpIsLFHBlockFree(SubSegment, Block))
+            continue;
+
+        HeapEntry = (PHEAP_ENTRY)Block;
+
+        if (!(HeapEntry->Flags & HEAP_ENTRY_BUSY))
+        {
+            DPRINT1("LFH block %p is neither on the free list nor marked busy\n", Block);
+            return FALSE;
+        }
+
+        if (!(HeapEntry->UnusedBytes & HEAP_ENTRY_LFH_FLAG))
+        {
+            DPRINT1("LFH block %p is missing its LFH ownership flag\n", Block);
+            return FALSE;
+        }
+
+        if (HeapEntry->PreviousSize != BucketIndex)
+        {
+            DPRINT1("LFH block %p bucket index %x does not match owning bucket %lx\n",
+                    Block, HeapEntry->PreviousSize, BucketIndex);
+            return FALSE;
+        }
+
+        if ((SIZE_T)(HeapEntry->Size << HEAP_ENTRY_SHIFT) != SubSegment->BlockSize)
+        {
+            DPRINT1("LFH block %p has size %x, expected %Iu\n",
+                    Block, HeapEntry->Size << HEAP_ENTRY_SHIFT, SubSegment->BlockSize);
+            return FALSE;
+        }
+
+        ExpectedTag = (UCHAR)(LOBYTE(HeapEntry->Size) ^ HIBYTE(HeapEntry->Size) ^ HeapEntry->Flags);
+        if (HeapEntry->SmallTagIndex != ExpectedTag)
+        {
+            DPRINT1("LFH block %p has a corrupt checksum\n", Block);
+            return FALSE;
+        }
+
+        BusyValidated++;
+    }
+
+    if (BusyValidated != SubSegment->BlockCount - SubSegment->FreeBlockCount)
+    {
+        DPRINT1("LFH subsegment %p has %lu busy blocks, expected %lu\n",
+                SubSegment, BusyValidated, SubSegment->BlockCount - SubSegment->FreeBlockCount);
+        return FALSE;
+    }
+
+    *FreeBlocksCount += WalkedFree;
+    *TotalFreeSize += WalkedFree * SubSegment->BlockSize;
+
+    return TRUE;
+}
+
 /* PUBLIC FUNCTIONS ***********************************************************/
 
 NTSTATUS
@@ -388,6 +517,113 @@ RtlpLFHFree(
     SubSegment->FreeBlockCount++;
 
     if (HeapLocked) RtlLeaveHeapLock(Heap->LockVariable);
+
+    return TRUE;
+}
+
+BOOLEAN
+NTAPI
+RtlpValidateLFHEntry(
+    _In_ PHEAP Heap,
+    _In_ PHEAP_ENTRY HeapEntry)
+{
+    PLFH_HEAP Lfh = (PLFH_HEAP)Heap->FrontEndHeap;
+    PHEAP_BUCKET Bucket;
+    PHEAP_SUBSEGMENT SubSegment;
+    PLIST_ENTRY Entry;
+    PUCHAR Block = (PUCHAR)HeapEntry;
+    ULONG BucketIndex;
+    UCHAR ExpectedTag;
+    BOOLEAN Found = FALSE;
+
+    if (!Lfh)
+        goto invalid;
+
+    if ((ULONG_PTR)HeapEntry & (HEAP_ENTRY_SIZE - 1))
+        goto invalid;
+
+    if (!(HeapEntry->Flags & HEAP_ENTRY_BUSY))
+        goto invalid;
+
+    if (!(HeapEntry->UnusedBytes & HEAP_ENTRY_LFH_FLAG))
+        goto invalid;
+
+    BucketIndex = HeapEntry->PreviousSize;
+    if (BucketIndex >= LFH_BUCKET_COUNT)
+        goto invalid;
+
+    Bucket = &Lfh->Buckets[BucketIndex];
+    if ((SIZE_T)(HeapEntry->Size << HEAP_ENTRY_SHIFT) != Bucket->BlockSize)
+        goto invalid;
+
+    ExpectedTag = (UCHAR)(LOBYTE(HeapEntry->Size) ^ HIBYTE(HeapEntry->Size) ^ HeapEntry->Flags);
+    if (HeapEntry->SmallTagIndex != ExpectedTag) goto invalid;
+
+    /* Find the owning subsegment and check block alignment inside it */
+    for (Entry = Bucket->SubSegmentList.Flink;
+         Entry != &Bucket->SubSegmentList;
+         Entry = Entry->Flink)
+    {
+        PUCHAR Limit;
+
+        SubSegment = CONTAINING_RECORD(Entry, HEAP_SUBSEGMENT, ListEntry);
+        Limit = SubSegment->BlockBase + SubSegment->BlockCount * SubSegment->BlockSize;
+
+        if (Block >= SubSegment->BlockBase && Block < Limit)
+        {
+            if (((SIZE_T)(Block - SubSegment->BlockBase)) % SubSegment->BlockSize != 0)
+                goto invalid;
+
+            Found = TRUE;
+            break;
+        }
+    }
+
+    if (!Found) goto invalid;
+
+    return TRUE;
+
+invalid:
+    DPRINT1("Invalid LFH heap entry %p in heap %p\n", HeapEntry, Heap);
+    return FALSE;
+}
+
+BOOLEAN
+NTAPI
+RtlpValidateLFH(
+    _In_ PHEAP Heap,
+    _Inout_ PULONG FreeBlocksCount,
+    _Inout_ PSIZE_T TotalFreeSize)
+{
+    PLFH_HEAP Lfh = (PLFH_HEAP)Heap->FrontEndHeap;
+    PLIST_ENTRY Entry;
+    PHEAP_SUBSEGMENT SubSegment;
+    ULONG BucketIndex;
+
+    if (!Lfh)
+        return TRUE;
+
+    for (BucketIndex = 0; BucketIndex < LFH_BUCKET_COUNT; BucketIndex++)
+    {
+        PHEAP_BUCKET Bucket = &Lfh->Buckets[BucketIndex];
+
+        for (Entry = Bucket->SubSegmentList.Flink;
+             Entry != &Bucket->SubSegmentList;
+             Entry = Entry->Flink)
+        {
+            SubSegment = CONTAINING_RECORD(Entry, HEAP_SUBSEGMENT, ListEntry);
+
+            if (SubSegment->Bucket != Bucket)
+            {
+                DPRINT1("LFH subsegment %p claims bucket %p, found under bucket %p\n",
+                        SubSegment, SubSegment->Bucket, Bucket);
+                return FALSE;
+            }
+
+            if (!RtlpValidateLFHSubSegment(Heap, SubSegment, BucketIndex, FreeBlocksCount, TotalFreeSize))
+                return FALSE;
+        }
+    }
 
     return TRUE;
 }

--- a/sdk/lib/rtl/heap_lfh.c
+++ b/sdk/lib/rtl/heap_lfh.c
@@ -85,26 +85,41 @@ RtlpAllocateLFHSubSegment(
     PLFH_BLOCK_ZONE Zone;
     PHEAP_SUBSEGMENT SubSegment;
     PLFH_FREE_ENTRY FreeEntry, NextFree;
-    SIZE_T ZoneSize, BlocksSize;
+    SIZE_T BlocksSize, SubSegmentSpanSize, ZoneSize, ZonePayload;
     UCHAR SavedFrontEndHeapType;
     ULONG Index;
 
     BlocksSize = Bucket->BlockSize * LFH_MIN_BLOCKS_PER_SUBSEGMENT;
-    ZoneSize = ALIGN_UP_BY(sizeof(LFH_BLOCK_ZONE) + sizeof(HEAP_SUBSEGMENT) + BlocksSize, PAGE_SIZE);
+    SubSegmentSpanSize = ALIGN_UP_BY(sizeof(HEAP_SUBSEGMENT) + BlocksSize, MEMORY_ALLOCATION_ALIGNMENT);
 
-    SavedFrontEndHeapType = Heap->FrontEndHeapType;
-    Heap->FrontEndHeapType = 0;
-    Zone = RtlAllocateHeap(Heap, HEAP_NO_SERIALIZE, ZoneSize);
-    Heap->FrontEndHeapType = SavedFrontEndHeapType;
+    Zone = Lfh->CurrentZone;
+    if (!Zone || (SIZE_T)(Zone->Limit - Zone->FreePointer) < SubSegmentSpanSize)
+    {
+        /* current zone (if any) is out of room, grow the backend for a fresh one */
+        ZonePayload = (SubSegmentSpanSize > LFH_ZONE_SIZE) ? SubSegmentSpanSize : LFH_ZONE_SIZE;
+        ZoneSize = ALIGN_UP_BY(sizeof(LFH_BLOCK_ZONE) + ZonePayload, PAGE_SIZE);
 
-    if (!Zone)
-        return NULL;
+        SavedFrontEndHeapType = Heap->FrontEndHeapType;
+        Heap->FrontEndHeapType = 0;
+        Zone = RtlAllocateHeap(Heap, HEAP_NO_SERIALIZE, ZoneSize);
+        Heap->FrontEndHeapType = SavedFrontEndHeapType;
 
-    Zone->Base = Zone;
-    Zone->Size = ZoneSize;
-    InsertTailList(&Lfh->BlockZones, &Zone->ListEntry);
+        if (!Zone)
+            return NULL;
 
-    SubSegment = (PHEAP_SUBSEGMENT)(Zone + 1);
+        Zone->Base = Zone;
+        Zone->Size = ZoneSize;
+        Zone->FreePointer = (PUCHAR)(Zone + 1);
+        Zone->Limit = (PUCHAR)Zone + ZoneSize;
+        Zone->LiveSubSegmentCount = 0;
+        InsertTailList(&Lfh->BlockZones, &Zone->ListEntry);
+        Lfh->CurrentZone = Zone;
+    }
+
+    SubSegment = (PHEAP_SUBSEGMENT)Zone->FreePointer;
+    Zone->FreePointer += SubSegmentSpanSize;
+    Zone->LiveSubSegmentCount++;
+
     SubSegment->Bucket = Bucket;
     SubSegment->Zone = Zone;
     SubSegment->BlockBase = (PUCHAR)(SubSegment + 1);
@@ -133,6 +148,7 @@ RtlpRetireLFHSubSegment(
     _In_ PHEAP_BUCKET Bucket,
     _In_ PHEAP_SUBSEGMENT SubSegment)
 {
+    PLFH_HEAP Lfh = (PLFH_HEAP)Heap->FrontEndHeap;
     PLFH_BLOCK_ZONE Zone = SubSegment->Zone;
 
     RemoveEntryList(&SubSegment->ListEntry);
@@ -140,7 +156,14 @@ RtlpRetireLFHSubSegment(
     if (Bucket->ActiveSubSegment == SubSegment)
         Bucket->ActiveSubSegment = NULL;
 
+    Zone->LiveSubSegmentCount--;
+    if (Zone->LiveSubSegmentCount != 0)
+        return;
+
     RemoveEntryList(&Zone->ListEntry);
+
+    if (Lfh->CurrentZone == Zone)
+        Lfh->CurrentZone = NULL;
 
     /* zone header, subsegment header and blocks are all a singular backend allocation */
     RtlFreeHeap(Heap, HEAP_NO_SERIALIZE, Zone->Base);

--- a/sdk/lib/rtl/heap_lfh.c
+++ b/sdk/lib/rtl/heap_lfh.c
@@ -181,7 +181,7 @@ NTAPI
 RtlpLFHSizeFits(
     _In_ SIZE_T Size)
 {
-    return (Size + sizeof(HEAP_ENTRY)) < LFH_MAX_BLOCK_SIZE;
+    return Size <= 3840;
 }
 
 SIZE_T

--- a/sdk/lib/rtl/heap_lfh.c
+++ b/sdk/lib/rtl/heap_lfh.c
@@ -106,6 +106,7 @@ RtlpAllocateLFHSubSegment(
 
     SubSegment = (PHEAP_SUBSEGMENT)(Zone + 1);
     SubSegment->Bucket = Bucket;
+    SubSegment->Zone = Zone;
     SubSegment->BlockBase = (PUCHAR)(SubSegment + 1);
     SubSegment->BlockSize = Bucket->BlockSize;
     SubSegment->BlockCount = LFH_MIN_BLOCKS_PER_SUBSEGMENT;
@@ -123,6 +124,26 @@ RtlpAllocateLFHSubSegment(
 
     InsertTailList(&Bucket->SubSegmentList, &SubSegment->ListEntry);
     return SubSegment;
+}
+
+static
+VOID
+RtlpRetireLFHSubSegment(
+    _In_ PHEAP Heap,
+    _In_ PHEAP_BUCKET Bucket,
+    _In_ PHEAP_SUBSEGMENT SubSegment)
+{
+    PLFH_BLOCK_ZONE Zone = SubSegment->Zone;
+
+    RemoveEntryList(&SubSegment->ListEntry);
+
+    if (Bucket->ActiveSubSegment == SubSegment)
+        Bucket->ActiveSubSegment = NULL;
+
+    RemoveEntryList(&Zone->ListEntry);
+
+    /* zone header, subsegment header and blocks are all a singular backend allocation */
+    RtlFreeHeap(Heap, HEAP_NO_SERIALIZE, Zone->Base);
 }
 
 static
@@ -515,6 +536,10 @@ RtlpLFHFree(
     FreeEntry->Next = SubSegment->FreeList;
     SubSegment->FreeList = FreeEntry;
     SubSegment->FreeBlockCount++;
+
+    /* subsegment just went fully idle, retire it and give the zone back */
+    if (SubSegment->FreeBlockCount == SubSegment->BlockCount)
+        RtlpRetireLFHSubSegment(Heap, Bucket, SubSegment);
 
     if (HeapLocked) RtlLeaveHeapLock(Heap->LockVariable);
 

--- a/sdk/lib/rtl/heap_lfh.h
+++ b/sdk/lib/rtl/heap_lfh.h
@@ -11,6 +11,7 @@
 #define LFH_BUCKET_COUNT 128
 #define LFH_MAX_BLOCK_SIZE 0x1000
 #define LFH_MIN_BLOCKS_PER_SUBSEGMENT 16
+#define LFH_ZONE_SIZE 0x10000 // bump allocated among multiple subsegments
 #define HEAP_ENTRY_LFH_FLAG 0x80
 
 typedef struct _LFH_FREE_ENTRY
@@ -44,12 +45,16 @@ typedef struct _LFH_BLOCK_ZONE
     LIST_ENTRY ListEntry;
     PVOID Base;
     SIZE_T Size;
+    PUCHAR FreePointer; // next byte available for carving a subsegment
+    PUCHAR Limit;
+    ULONG LiveSubSegmentCount; // subsegments carved from this zone that aren't retired
 } LFH_BLOCK_ZONE, *PLFH_BLOCK_ZONE;
 
 typedef struct _LFH_HEAP
 {
     PHEAP Heap; // owning backend heap
     LIST_ENTRY BlockZones;
+    PLFH_BLOCK_ZONE CurrentZone; // zone we're bump allocating subsegments from
     HEAP_BUCKET Buckets[LFH_BUCKET_COUNT];
 } LFH_HEAP, *PLFH_HEAP;
 

--- a/sdk/lib/rtl/heap_lfh.h
+++ b/sdk/lib/rtl/heap_lfh.h
@@ -1,0 +1,90 @@
+/*
+ * PROJECT:     ReactOS Runtime Library
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Low-Fragmentation Heap (LFH) front-end allocator
+ * COPYRIGHT:   Copyright 2026 Alex Mendoza <05alex.mendozaa@gmail.com>
+ */
+
+#ifndef RTL_HEAP_LFH_H
+#define RTL_HEAP_LFH_H
+
+#define LFH_BUCKET_COUNT 128
+#define LFH_MAX_BLOCK_SIZE 0x1000
+#define LFH_MIN_BLOCKS_PER_SUBSEGMENT 16
+#define HEAP_ENTRY_LFH_FLAG 0x80
+
+typedef struct _LFH_FREE_ENTRY
+{
+    struct _LFH_FREE_ENTRY *Next;
+} LFH_FREE_ENTRY, *PLFH_FREE_ENTRY;
+
+struct _HEAP_BUCKET;
+
+typedef struct _HEAP_SUBSEGMENT
+{
+    LIST_ENTRY ListEntry;
+    struct _HEAP_BUCKET *Bucket; // owning bucket
+    PUCHAR BlockBase;
+    SIZE_T BlockSize;
+    ULONG BlockCount;
+    ULONG FreeBlockCount;
+    PLFH_FREE_ENTRY FreeList;
+} HEAP_SUBSEGMENT, *PHEAP_SUBSEGMENT;
+
+typedef struct _HEAP_BUCKET
+{
+    SIZE_T BlockSize; // rounded allocation size for this bucket
+    LIST_ENTRY SubSegmentList;
+    PHEAP_SUBSEGMENT ActiveSubSegment;
+} HEAP_BUCKET, *PHEAP_BUCKET;
+
+typedef struct _LFH_BLOCK_ZONE
+{
+    LIST_ENTRY ListEntry;
+    PVOID Base;
+    SIZE_T Size;
+} LFH_BLOCK_ZONE, *PLFH_BLOCK_ZONE;
+
+typedef struct _LFH_HEAP
+{
+    PHEAP Heap; // owning backend heap
+    LIST_ENTRY BlockZones;
+    HEAP_BUCKET Buckets[LFH_BUCKET_COUNT];
+} LFH_HEAP, *PLFH_HEAP;
+
+NTSTATUS
+NTAPI
+RtlpInitializeLFH(
+    _In_ PHEAP Heap);
+
+VOID
+NTAPI
+RtlpDestroyLFH(
+    _In_ PHEAP Heap);
+
+BOOLEAN
+NTAPI
+RtlpLFHSizeFits(
+    _In_ SIZE_T Size);
+
+PVOID
+NTAPI
+RtlpLFHAllocate(
+    _In_ PHEAP Heap,
+    _In_ ULONG Flags,
+    _In_ SIZE_T Size);
+
+SIZE_T
+NTAPI
+RtlpLFHSize(
+    _In_ PHEAP Heap,
+    _In_ PVOID BaseAddress);
+
+BOOLEAN
+NTAPI
+RtlpLFHFree(
+    _In_ PHEAP Heap,
+    _In_ ULONG Flags,
+    _In_ PVOID BaseAddress);
+
+#endif /* RTL_HEAP_LFH_H */

--- a/sdk/lib/rtl/heap_lfh.h
+++ b/sdk/lib/rtl/heap_lfh.h
@@ -24,6 +24,7 @@ typedef struct _HEAP_SUBSEGMENT
 {
     LIST_ENTRY ListEntry;
     struct _HEAP_BUCKET *Bucket; // owning bucket
+    struct _LFH_BLOCK_ZONE *Zone; // owning zone (for retirement)
     PUCHAR BlockBase;
     SIZE_T BlockSize;
     ULONG BlockCount;

--- a/sdk/lib/rtl/heap_lfh.h
+++ b/sdk/lib/rtl/heap_lfh.h
@@ -95,4 +95,17 @@ RtlpLFHFree(
     _In_ ULONG Flags,
     _In_ PVOID BaseAddress);
 
+BOOLEAN
+NTAPI
+RtlpValidateLFHEntry(
+    _In_ PHEAP Heap,
+    _In_ PHEAP_ENTRY HeapEntry);
+
+BOOLEAN
+NTAPI
+RtlpValidateLFH(
+    _In_ PHEAP Heap,
+    _Inout_ PULONG FreeBlocksCount,
+    _Inout_ PSIZE_T TotalFreeSize);
+
 #endif /* RTL_HEAP_LFH_H */

--- a/sdk/lib/rtl/heap_lfh.h
+++ b/sdk/lib/rtl/heap_lfh.h
@@ -80,6 +80,14 @@ RtlpLFHSize(
     _In_ PHEAP Heap,
     _In_ PVOID BaseAddress);
 
+PVOID
+NTAPI
+RtlpLFHReAllocate(
+    _In_ PHEAP Heap,
+    _In_ ULONG Flags,
+    _In_ PVOID Ptr,
+    _In_ SIZE_T Size);
+
 BOOLEAN
 NTAPI
 RtlpLFHFree(


### PR DESCRIPTION
## Purpose
Implements the Low Fragmentation Heap (LFH) frontend allocator for the Rtl heap manager. 

JIRA issue: None

## Proposed changes
- Create `heap_lfh.h` / `heap_lfh.c`: bucket/subsegment/block zone frontend allocator,
- Hook `RtlAllocateHeap`/`RtlFreeHeap`/`RtlSizeHeap` to route to the frontend when `FrontEndHeapType == 2` and the request fits a bucket.
- Make `RtlSetHeapInformation(HeapCompatibilityInformation, 2)` call `RtlpInitializeLFH()`
- Tear down the frontend in `RtlDestroyHeap()`
- Include the file in the CMakeLists.

## TODO
- [x] ~~`RtlReAllocateHeap()` is not LFH aware. It will fall through to the generic backend path for LFH owned blocks and mishandle them.~~
- [x] ~~`RtlValidateHeap()` doesn't inspect LFH subsegments yet. It skips over LFH owned memory rather than validating it.~~
- [x] ~~Subsegments never shrink or return their block zone to the backend once fully freed (needs retirement logic)~~
- [x] ~~Rework `LFH_BLOCK_ZONE` to host multiple subsegments instead of 1:1, and thus, update retirement to return a subsegment's span to its zone (instead of freeing the zone outright)~~
- [ ] Try to get at least some of whatever quirks Windows has (if any)
- [ ] No usermode/KMTest tests

## Testbot runs (Filled in by Devs)
- [ ] KVM x86:
- [ ] KVM x64: