### PR TITLE
[PARTMGR] Return the updated partition numbers from IOCTL_DISK_SET_DRIVE_LAYOUT_EX

### DIFF
--- a/drivers/storage/partmgr/partmgr.c
+++ b/drivers/storage/partmgr/partmgr.c
@@ -829,7 +829,7 @@ FdoIoctlDiskSetDriveLayoutEx(
             // set updated partition numbers
             for (UINT32 i = 0; i < layoutEx->PartitionCount; i++)
             {
-                PPARTITION_INFORMATION_EX part = &layoutEx->PartitionEntry[i];
+                PPARTITION_INFORMATION_EX part = &layoutUser->PartitionEntry[i];
 
                 part->PartitionNumber = layoutEx->PartitionEntry[i].PartitionNumber;
             }


### PR DESCRIPTION
Both drive-layout IOCTLs are `METHOD_BUFFERED` and report the layout back to the caller in place, with the partition numbers assigned during the write filled in. `FdoIoctlDiskSetDriveLayout` does that correctly. `FdoIoctlDiskSetDriveLayoutEx` takes the address of its own private copy instead:

```c
for (UINT32 i = 0; i < layoutEx->PartitionCount; i++)
{
    PPARTITION_INFORMATION_EX part = &layoutEx->PartitionEntry[i];

    part->PartitionNumber = layoutEx->PartitionEntry[i].PartitionNumber;
}
```

That is a self-assignment. `layoutEx` is the driver's own allocation; the caller's buffer is `layoutUser`. `PartMgrUpdatePartitionDevices` does assign the numbers into `layoutEx`, but they are never propagated back, so every entry the caller sees comes back with whatever it sent — zero, for a freshly created layout.

The non-extended sibling gets this right, copying into `layoutInfo` (the system buffer). This points the extended one at the same place.

The write stays in bounds: the loop count is the `PartitionCount` that `layoutSize` was computed from and validated against the input length, and the system buffer is allocated as `max(input, output)`.

### Testing

Built for i386 from `c00b0a4035` with this change applied — RosBE (the pinned `ghcr.io/reactos/rosbe-unix-release-engineering` image), `BUILD_TYPE=Debug`, `KDBG=1` — clean, zero failures. The resulting ISO boots text-mode Setup and the live desktop under QEMU 11.1, enumerates three attached disks including two with no partition table at all, and completes a partition/format/copy install to disk with no bugchecks, asserts or KDB entries on COM1.

The specific return path is **not** covered by that: exercising it needs a user-mode caller issuing `IOCTL_DISK_SET_DRIVE_LAYOUT_EX` on an installed system, which I have not done. The argument for the change is the self-assignment itself and the sibling handler's behaviour.
