### PR TITLE
[PARTMGR] Validate the output buffer of IOCTL_DISK_SET_DRIVE_LAYOUT[_EX]

### DIFF
--- a/drivers/storage/partmgr/partmgr.c
+++ b/drivers/storage/partmgr/partmgr.c
@@ -684,6 +684,14 @@ FdoIoctlDiskSetDriveLayout(
         return STATUS_INFO_LENGTH_MISMATCH;
     }
 
+    // The updated layout is written back into the same buffer, and this
+    // call reports layoutSize bytes to the I/O manager, so the output
+    // buffer has to be able to hold it too.
+    if (!VerifyIrpOutBufferSize(Irp, layoutSize))
+    {
+        return STATUS_BUFFER_TOO_SMALL;
+    }
+
     PDRIVE_LAYOUT_INFORMATION_EX layoutEx = PartMgrConvertLayoutToExtended(layoutInfo);
 
     if (layoutEx == NULL)
@@ -777,6 +785,14 @@ FdoIoctlDiskSetDriveLayoutEx(
     if (!VerifyIrpInBufferSize(Irp, layoutSize))
     {
         return STATUS_INFO_LENGTH_MISMATCH;
+    }
+
+    // The updated layout is written back into the same buffer, and this
+    // call reports layoutSize bytes to the I/O manager, so the output
+    // buffer has to be able to hold it too.
+    if (!VerifyIrpOutBufferSize(Irp, layoutSize))
+    {
+        return STATUS_BUFFER_TOO_SMALL;
     }
 
     // we need to copy the structure from the IRP input buffer


### PR DESCRIPTION
Both handlers set `Irp->IoStatus.Information` to `layoutSize`, which is derived purely from the **input** buffer length — `PartitionCount` is read from the input buffer and `layoutSize` is validated only against `InputBufferLength`.

The two lengths are independent, and `IopCompleteRequest` copies `Information` bytes back with no clamp against `OutputBufferLength`:

```c
RtlCopyMemory(Irp->UserBuffer,
              Irp->AssociatedIrp.SystemBuffer,
              Irp->IoStatus.Information);
```

So a caller passing a large input layout together with a short — but non-NULL — output buffer overruns its own output buffer.

A NULL or zero-length output buffer is **not** affected: `IopDeviceFsIoControl` only sets `IRP_INPUT_OPERATION` when an output buffer is present, and the copy back is skipped without it.

`VerifyIrpOutBufferSize` is what the rest of this driver uses for exactly this, including `FdoIoctlDiskGetDriveLayoutEx`, and it reports the required size the same way.

### A deliberate behaviour change worth discussing

This makes the call fail **before** the partition table is written, where previously it wrote the table and then overran the caller. Every in-tree caller passes the same buffer for input and output (`base/setup/lib/utils/partlist.c`, `base/system/diskpart/partlist.c`) and is unaffected.

Out-of-tree callers may differ: `DeviceIoControl(..., &layout, size, NULL, 0, ...)` is a common pattern, and that case stays working. But if matching Windows on a short non-NULL output buffer matters more than failing loudly, the alternative is to perform the write and skip the write-back with `Information = 0`. Happy to switch to that if reviewers prefer it.

### Testing

Built for i386 from `c00b0a4035` — RosBE (pinned `ghcr.io/reactos/rosbe-unix-release-engineering` image), `BUILD_TYPE=Debug`, `KDBG=1` — clean, zero failures. The ISO boots text-mode Setup and the live desktop under QEMU 11.1 and completes an install to disk with no bugchecks.

The overrun path itself is **not** exercised by that; the claim rests on reading `IopCompleteRequest` and `IopDeviceFsIoControl`.
