### PR TITLE
[PARTMGR] Stop leaking the partition symbolic-link string on every device start

### DIFF
--- a/drivers/storage/partmgr/partition.c
+++ b/drivers/storage/partmgr/partition.c
@@ -118,10 +118,7 @@ PartitionHandleStartDevice(
     _swprintf(nameBuf, PartitionSymLinkFormat,
         fdoExtension->DiskData.DeviceNumber, PartExt->DetectedNumber);
 
-    if (!RtlCreateUnicodeString(&partitionSymlink, nameBuf))
-    {
-        return STATUS_INSUFFICIENT_RESOURCES;
-    }
+    RtlInitUnicodeString(&partitionSymlink, nameBuf);
 
     NTSTATUS status = IoCreateSymbolicLink(&partitionSymlink, &PartExt->DeviceName);
 


### PR DESCRIPTION
`PartitionHandleStartDevice` builds the `\Device\HarddiskN\PartitionM` link name into a stack buffer, then copies it into a freshly allocated `UNICODE_STRING`:

```c
if (!RtlCreateUnicodeString(&partitionSymlink, nameBuf))
{
    return STATUS_INSUFFICIENT_RESOURCES;
}
```

That allocation is never freed on any path — not on success, not on the `IoCreateSymbolicLink` failure return, not on any of the interface-registration failure returns. So every partition device start leaks its name from paged pool.

`IoCreateSymbolicLink` copies both strings (the link name is captured by the object manager, the target is copied in `NtCreateSymbolicLinkObject`), so nothing needs to own the name past the call. `RtlInitUnicodeString` on the stack buffer is enough — which is exactly what `PartitionHandleRemove` already does when building the same name to delete the link.

`nameBuf` is function-scoped and stays live across both remaining uses (`IoCreateSymbolicLink` and the `INFO` trace), and `_swprintf` into `WCHAR[64]` is safe for the longest name the format can produce (16 + 10 + 10 + 10 + NUL = 47).

This also removes the function's only `STATUS_INSUFFICIENT_RESOURCES` path. Under pool exhaustion the failure now surfaces from `IoCreateSymbolicLink` instead, with the same `NT_SUCCESS` outcome. Note `PartitionCreateDevice` already ignores `RtlCreateUnicodeString` failure entirely, so this function was the outlier.

### Testing

Built for i386 from `c00b0a4035` — RosBE (pinned `ghcr.io/reactos/rosbe-unix-release-engineering` image), `BUILD_TYPE=Debug`, `KDBG=1` — clean, zero failures. The ISO boots text-mode Setup and the live desktop under QEMU 11.1, enumerates disks and completes an install to disk with no bugchecks, so the symlink path runs.

The leak itself is **not** measured — distinguishing leaked from not-leaked needs a kernel debugger, which I have not attached. The argument is the code path plus the precedent in `PartitionHandleRemove`.
