### PR TITLE
[NETKVM] End the va_list in DebugPrint

### DIFF
--- a/drivers/network/dd/netkvm/Common/ParaNdis-Debug.c
+++ b/drivers/network/dd/netkvm/Common/ParaNdis-Debug.c
@@ -110,6 +110,7 @@ static void __cdecl DebugPrint(const char *fmt, ...)
     va_list list;
     va_start(list, fmt);
     PrintProcedure(DPFLTR_DEFAULT_ID, 9 | DPFLTR_MASK, fmt, list);
+    va_end(list);
 #if defined(VIRTIO_DBG_USE_IOPORT)
     {
         NTSTATUS status;
@@ -120,7 +121,10 @@ static void __cdecl DebugPrint(const char *fmt, ...)
             char buf[256];
             size_t len, i;
             buf[0] = 0;
+            // The list was consumed above; start a fresh one for the second pass
+            va_start(list, fmt);
             status = RtlStringCbVPrintfA(buf, sizeof(buf), fmt, list);
+            va_end(list);
             if (status == STATUS_SUCCESS) len = strlen(buf);
             else if (status == STATUS_BUFFER_OVERFLOW) len = sizeof(buf);
             else { memcpy(buf, "Can't print", 11); len = 11; }


### PR DESCRIPTION
`DebugPrint` starts a `va_list` with `va_start` and formats from it, but never calls `va_end` on any path. There is no early return between the `va_start` and the closing brace, so this is simply missing.

On the targets ReactOS builds for this happens to be harmless, but it is undefined behaviour and breaks on any ABI where `va_end` has real work to do.

### Why ReactOS and not virtio-win

netkvm is listed in `media/doc/3rd Party Files.txt`, but that entry pins a *commit-tree* URL rather than a branch, which is this tree's convention for code with no live upstream — virtio-win deleted its NDIS5 driver, so there is nowhere upstream to send this. ReactOS has also already patched these files locally (e.g. `dc6dfbf668`). No `__REACTOS__` guard for the same reason; there are none anywhere in this directory.

### A related issue, deliberately not folded in

`list` is passed to `PrintProcedure` and then reused by `RtlStringCbVPrintfA` with no `va_copy`, which is also indeterminate per C11 7.16.1p3. That second use only compiles when `VIRTIO_DBG_USE_IOPORT` is defined, and it is commented out in `ndis56common.h`, so it is dead by default. Mentioning it rather than expanding a one-line fix to touch code that never builds.

### Testing

Built for i386 from `c00b0a4035` with this change applied — RosBE (the pinned `ghcr.io/reactos/rosbe-unix-release-engineering` image), `BUILD_TYPE=Debug`, `KDBG=1` — clean, zero failures.

**Not runtime tested.** Exercising netkvm needs a virtio-net adapter bound in a booted guest, which I have not done for this change.
