### PR TITLE
[NETKVM] Fix the ConnectRate parameter bounds

### DIFF
--- a/drivers/network/dd/netkvm/Common/ParaNdis-Common.c
+++ b/drivers/network/dd/netkvm/Common/ParaNdis-Common.c
@@ -134,7 +134,7 @@ static const tConfigurationEntries defaultConfiguration =
 {
     { "Promiscuous",    0,  0,  1 },
     { "Priority",       0,  0,  1 },
-    { "ConnectRate",    10000,100,10 },
+    { "ConnectRate",    10000,10,10000 },
     { "DoLog",          1,  0,  1 },
     { "DebugLevel",     2,  0,  8 },
     { "ConnectTimer",   0,  0,  300000 },


### PR DESCRIPTION
The default configuration table is `{ Name, ulValue, ulMinimal, ulMaximal }`, and the ConnectRate entry reads

```c
{ "ConnectRate",    10000,100,10 },
```

i.e. a minimum of 100 and a maximum of 10. `GetConfigurationEntry` accepts a registry value only when

```c
if (ulValue >= pEntry->ulMinimal && ulValue <= pEntry->ulMaximal)
```

which no value satisfies, so every configured ConnectRate is logged as out of range and discarded, and the adapter always reports the default.

This is a regression from `3000d45250` ("[NETKVM] Reduce log level and default to 10 Gbit/s connection", #8448), which raised the default from 100 to 10000 but transposed the minimum and maximum in the same edit. Upstream virtio-win had `{ 100, 10, 10000 }`.

This restores the `10..10000` range while keeping the intended 10000 default. The range covers every value the INF offers (10, 100, 1001, 10000 Mbit/s).

`ConnectRate` feeds `ulFormalLinkSpeed` and is reported through `OID_GEN_LINK_SPEED`, so the visible effect is that the adapter's reported link speed becomes configurable again.

### Why ReactOS and not virtio-win

netkvm is listed in `media/doc/3rd Party Files.txt`, but that entry pins a *commit-tree* URL rather than a branch, which is this tree's convention for code with no live upstream — virtio-win deleted its NDIS5 driver. This particular bug is also ReactOS-only, since it was introduced here.

### Scope

Deliberately C-only. The INF's `"1001"` entry for 1 Gbit looks like a typo for 1000, but upstream virtio-win used 1001 consistently and even as the INF *Default*, and nothing special-cases it — so changing it is a separate cosmetic question, not part of this fix. With the range corrected, 1001 is accepted.

### Testing

Built for i386 from `c00b0a4035` with this change applied — RosBE (the pinned `ghcr.io/reactos/rosbe-unix-release-engineering` image), `BUILD_TYPE=Debug`, `KDBG=1` — clean, zero failures.

**Not runtime tested.** Confirming the visible effect needs a virtio-net adapter bound in a booted guest with ConnectRate set in the adapter properties, which I have not done.
