### PR TITLE
[NETKVM] Do not inspect the packet filter value when the copy failed

### DIFF
--- a/drivers/network/dd/netkvm/Common/ParaNdis-Oid.c
+++ b/drivers/network/dd/netkvm/Common/ParaNdis-Oid.c
@@ -123,14 +123,18 @@ NDIS_STATUS ParaNdis_OnSetPacketFilter(PARANDIS_ADAPTER *pContext, tOidDesc *pOi
         &newValue,
         sizeof(newValue));
 
-    if (newValue & ~PARANDIS_PACKET_FILTERS)
-        status = NDIS_STATUS_INVALID_DATA;
-
     if (status == NDIS_STATUS_SUCCESS)
     {
-        pContext->PacketFilter = newValue;
-        DPrintf(1, ("[%s] PACKET FILTER SET TO %x", __FUNCTION__, pContext->PacketFilter));
-        ParaNdis_UpdateDeviceFilters(pContext);
+        if (newValue & ~PARANDIS_PACKET_FILTERS)
+        {
+            status = NDIS_STATUS_INVALID_DATA;
+        }
+        else
+        {
+            pContext->PacketFilter = newValue;
+            DPrintf(1, ("[%s] PACKET FILTER SET TO %x", __FUNCTION__, pContext->PacketFilter));
+            ParaNdis_UpdateDeviceFilters(pContext);
+        }
     }
     return status;
 }

--- a/drivers/network/dd/netkvm/Common/ParaNdis-Oid.c
+++ b/drivers/network/dd/netkvm/Common/ParaNdis-Oid.c
@@ -655,9 +655,12 @@ NDIS_STATUS ParaNdis_OnSetVlanId(PARANDIS_ADAPTER *pContext, tOidDesc *pOid)
     if (IsVlanSupported(pContext))
     {
         status = ParaNdis_OidSetCopy(pOid, &pContext->VlanId, sizeof(pContext->VlanId));
-        pContext->VlanId &= 0xfff;
-        DPrintf(0, ("[%s] new value %d on MAC %X", __FUNCTION__, pContext->VlanId, pContext->CurrentMacAddress[5]));
-        ParaNdis_DeviceFiltersUpdateVlanId(pContext);
+        if (status == NDIS_STATUS_SUCCESS)
+        {
+            pContext->VlanId &= 0xfff;
+            DPrintf(0, ("[%s] new value %d on MAC %X", __FUNCTION__, pContext->VlanId, pContext->CurrentMacAddress[5]));
+            ParaNdis_DeviceFiltersUpdateVlanId(pContext);
+        }
     }
     return status;
 }


### PR DESCRIPTION
`ParaNdis_OnSetPacketFilter` reads the requested filter with `ParaNdis_OidSetCopy` and then immediately tests `newValue`, without first checking that the copy succeeded:

```c
ULONG newValue;
NDIS_STATUS status = ParaNdis_OidSetCopy(pOid, &newValue, sizeof(newValue));

if (newValue & ~PARANDIS_PACKET_FILTERS)
    status = NDIS_STATUS_INVALID_DATA;
```

`ParaNdis_OidSetCopy` returns without writing `pDest` on two paths that are reachable here — `NDIS_STATUS_BUFFER_TOO_SHORT` when the information buffer is shorter than 4 bytes, and `NDIS_STATUS_BUFFER_OVERFLOW` when it is longer — because the packet-filter OID is registered with plain `ohfQuerySet`, i.e. without `ohfSetLessOK` or `ohfSetMoreOK`.

So with a 3-byte or 5-byte information buffer, `newValue` is an uninitialised local, and an arbitrary stack value decides whether the specific failure reported by `ParaNdis_OidSetCopy` is replaced with `NDIS_STATUS_INVALID_DATA`.

Testing the value only once it is known to have been read also preserves the correct `*pBytesNeeded` that those two paths set, which the old overwrite misrepresented. The success-path semantics are unchanged: a copied value with bad bits still yields `NDIS_STATUS_INVALID_DATA`.

This matches the status-gating idiom already used by the other `ParaNdis_OidSetCopy` callers in the driver.

### Why ReactOS and not virtio-win

netkvm is listed in `media/doc/3rd Party Files.txt`, but that entry pins a *commit-tree* URL rather than a branch, which is this tree's convention for code with no live upstream — virtio-win deleted its NDIS5 driver, so there is nowhere upstream to send this. No `__REACTOS__` guard for the same reason; there are none anywhere in this directory.

### Testing

Built for i386 from `c00b0a4035` with this change applied — RosBE (the pinned `ghcr.io/reactos/rosbe-unix-release-engineering` image), `BUILD_TYPE=Debug`, `KDBG=1` — clean, zero failures.

**Not runtime tested.** Reaching this path needs an NDIS client issuing `OID_GEN_CURRENT_PACKET_FILTER` with a mis-sized buffer against a bound virtio-net adapter, which I have not set up.
