### PR TITLE
[NETKVM] Negotiate the control-queue RX and VLAN features before using them

### DIFF
--- a/drivers/network/dd/netkvm/Common/ParaNdis-Common.c
+++ b/drivers/network/dd/netkvm/Common/ParaNdis-Common.c
@@ -2751,6 +2751,18 @@ NDIS_STATUS ParaNdis_PowerOn(PARANDIS_ADAPTER *pContext)
         VirtIODeviceEnableGuestFeature(pContext, VIRTIO_F_VERSION_1);
     if (VirtIODeviceGetHostFeature(pContext, VIRTIO_F_ANY_LAYOUT))
         VirtIODeviceEnableGuestFeature(pContext, VIRTIO_F_ANY_LAYOUT);
+    if (pContext->bHasControlQueue) {
+        VirtIODeviceEnableGuestFeature(pContext, VIRTIO_NET_F_CTRL_VQ);
+        if (VirtIODeviceGetHostFeature(pContext, VIRTIO_NET_F_CTRL_RX)) {
+            VirtIODeviceEnableGuestFeature(pContext, VIRTIO_NET_F_CTRL_RX);
+        }
+        if (VirtIODeviceGetHostFeature(pContext, VIRTIO_NET_F_CTRL_RX_EXTRA)) {
+            VirtIODeviceEnableGuestFeature(pContext, VIRTIO_NET_F_CTRL_RX_EXTRA);
+        }
+        if (VirtIODeviceGetHostFeature(pContext, VIRTIO_NET_F_CTRL_VLAN)) {
+            VirtIODeviceEnableGuestFeature(pContext, VIRTIO_NET_F_CTRL_VLAN);
+        }
+    }
 
     status = FinalizeFeatures(pContext);
     if (status == NDIS_STATUS_SUCCESS) {

--- a/drivers/network/dd/netkvm/Common/ParaNdis-Common.c
+++ b/drivers/network/dd/netkvm/Common/ParaNdis-Common.c
@@ -818,6 +818,15 @@ NDIS_STATUS ParaNdis_InitializeContext(
             pContext->bHasControlQueue = TRUE;
             VirtIODeviceEnableGuestFeature(pContext, VIRTIO_NET_F_CTRL_VQ);
         }
+        if (VirtIODeviceGetHostFeature(pContext, VIRTIO_NET_F_CTRL_RX)) {
+            VirtIODeviceEnableGuestFeature(pContext, VIRTIO_NET_F_CTRL_RX);
+        }
+        if (VirtIODeviceGetHostFeature(pContext, VIRTIO_NET_F_CTRL_RX_EXTRA)) {
+            VirtIODeviceEnableGuestFeature(pContext, VIRTIO_NET_F_CTRL_RX_EXTRA);
+        }
+        if (VirtIODeviceGetHostFeature(pContext, VIRTIO_NET_F_CTRL_VLAN)) {
+            VirtIODeviceEnableGuestFeature(pContext, VIRTIO_NET_F_CTRL_VLAN);
+        }
     }
     else
     {
@@ -881,7 +890,9 @@ NDIS_STATUS ParaNdis_InitializeContext(
         DPrintf(0, ("[%s] %sable indirect Tx(!%s)", __FUNCTION__, pContext->bUseIndirect ? "En" : "Dis", reason) );
     }
 
-    if (VirtIODeviceGetHostFeature(pContext, VIRTIO_NET_F_CTRL_RX_EXTRA) &&
+    if (pContext->bHasControlQueue &&
+        VirtIODeviceGetHostFeature(pContext, VIRTIO_NET_F_CTRL_RX) &&
+        VirtIODeviceGetHostFeature(pContext, VIRTIO_NET_F_CTRL_RX_EXTRA) &&
         pContext->bDoHwPacketFiltering)
     {
         DPrintf(0, ("[%s] Using hardware packet filtering", __FUNCTION__));
@@ -2683,7 +2694,8 @@ static VOID SetAllVlanFilters(PARANDIS_ADAPTER *pContext, BOOLEAN bOn)
 */
 VOID ParaNdis_DeviceFiltersUpdateVlanId(PARANDIS_ADAPTER *pContext)
 {
-    if (pContext->bHasHardwareFilters)
+    if (pContext->bHasHardwareFilters &&
+        VirtIODeviceGetHostFeature(pContext, VIRTIO_NET_F_CTRL_VLAN))
     {
         ULONG newFilterSet;
         if (IsVlanSupported(pContext))


### PR DESCRIPTION
`ParaNdis_InitializeContext` enabled only `VIRTIO_NET_F_CTRL_VQ` as a guest feature, but the driver goes on to issue commands the virtio spec gates behind three further features:

- `VIRTIO_NET_F_CTRL_RX` for `VIRTIO_NET_CTRL_RX` (promiscuous, all-multi, all-uni, no-bcast, no-multi) and for `VIRTIO_NET_CTRL_MAC_TABLE_SET`
- `VIRTIO_NET_F_CTRL_RX_EXTRA` for the extra RX-mode commands
- `VIRTIO_NET_F_CTRL_VLAN` for `VIRTIO_NET_CTRL_VLAN` add/del

Using a command class the guest never acknowledged is out of spec — the device is entitled to fail it — and the hardware-filter path was being selected on nothing more than the host *offering* `CTRL_RX_EXTRA`.

**Commit 1** acknowledges the three features when the device offers them, then:

- requires `bHasControlQueue` and `CTRL_RX` in addition to `CTRL_RX_EXTRA` before claiming hardware packet filtering, since that path needs a control queue and issues plain `CTRL_RX` and MAC-table commands as well as the extra ones;
- requires `CTRL_VLAN` before touching the VLAN filter set, rather than inferring it from `bHasHardwareFilters`, which is a different feature.

Hardware filtering is an optimisation — `ShallPassPacket` runs on every received packet regardless — so a host that offers `CTRL_RX_EXTRA` without `CTRL_RX` loses nothing but the out-of-spec commands.

**Commit 2** covers the resume path, which is the part that makes commit 1 complete. `ParaNdis_PowerOn` resets the device (clearing `ullGuestFeatures`) and re-enables a fixed list — MRG_RXBUF, EVENT_IDX, GUEST_CSUM, VERSION_1, ANY_LAYOUT — that does not include the control queue at all. `bHasControlQueue` survives the reset, so `FindNetQueues` still looks for three queues and `ParaNdis_UpdateDeviceFilters` goes on to issue control commands, none of whose features have been acknowledged since the reset. On a device that enforces its feature bits the control queue may not be usable after resume. Note the missing `CTRL_VQ` there is a pre-existing bug, not one this series introduces.

### Why ReactOS and not virtio-win

netkvm is listed in `media/doc/3rd Party Files.txt`, but that entry pins a *commit-tree* URL rather than a branch, which is this tree's convention for code with no live upstream — virtio-win deleted its NDIS5 driver. Modern upstream NetKVM already negotiates all three features correctly; only this NDIS5 fork does not. No `__REACTOS__` guard, for the same reason; there are none in this directory.

### Testing

Built for i386 from `c00b0a4035` with both commits applied — RosBE (the pinned `ghcr.io/reactos/rosbe-unix-release-engineering` image), `BUILD_TYPE=Debug`, `KDBG=1` — clean, zero failures.

**Not runtime tested**, and this is the largest of the netkvm changes, so I would rather say so plainly. Confirming it needs a virtio-net adapter bound in a booted guest, checking that the hardware-filter path is selected only when the host offers all three features, and an S3/S4 cycle for the second commit. Happy to split the two commits if reviewers prefer them separate.
