### PR TITLE
[NTOS:MM] Don't block on the balancer while holding AddressCreationLock

### DIFF
--- a/ntoskrnl/mm/ARM3/pagfault.c
+++ b/ntoskrnl/mm/ARM3/pagfault.c
@@ -2657,6 +2657,15 @@ ExitUser:
 
     if (Status == STATUS_NO_MEMORY)
     {
+        /* Don't wait on the balancer while holding AddressCreationLock */
+        if (CurrentProcess->AddressCreationLock.Owner == KeGetCurrentThread())
+        {
+            static LARGE_INTEGER TinyTime = {{-1L, -1L}};
+            MmRebalanceMemoryConsumers();
+            KeDelayExecutionThread(KernelMode, FALSE, &TinyTime);
+            goto UserFault;
+        }
+
         MmRebalanceMemoryConsumersAndWait();
         goto UserFault;
     }

--- a/ntoskrnl/mm/ARM3/pagfault.c
+++ b/ntoskrnl/mm/ARM3/pagfault.c
@@ -2657,16 +2657,18 @@ ExitUser:
 
     if (Status == STATUS_NO_MEMORY)
     {
-        /* Don't wait on the balancer while holding AddressCreationLock */
+        /* Don't wait on the balancer while holding AddressCreationLock (CORE-20761) */
         if (CurrentProcess->AddressCreationLock.Owner == KeGetCurrentThread())
         {
             static LARGE_INTEGER TinyTime = {{-1L, -1L}};
             MmRebalanceMemoryConsumers();
             KeDelayExecutionThread(KernelMode, FALSE, &TinyTime);
-            goto UserFault;
+        }
+        else
+        {
+            MmRebalanceMemoryConsumersAndWait();
         }
 
-        MmRebalanceMemoryConsumersAndWait();
         goto UserFault;
     }
 


### PR DESCRIPTION
## Purpose
Fix an assert failure in `MmRebalanceMemoryConsumersAndWait()` that hits under low memory.

JIRA issue: [CORE-20761](https://jira.reactos.org/browse/CORE-20761)
## Proposed changes
- `MmNotPresentFaultSectionView` holds `AddressCreationLock` while calling `MmCreateVirtualMapping`, which can recursively fault in a page table page. Under low memory that recursive fault hit `MmRebalanceMemoryConsumersAndWait()`, which asserts the lock isn't held.
- Check if the current thread owns `AddressCreationLock` before waiting on `STATUS_NO_MEMORY`. If it does, kick the balancer without waiting and retry instead of asserting
## Testbot runs (Filled in by Devs)
- [ ] KVM x86:
- [ ] KVM x64: