### PR TITLE
[MMC] Mmc .msc file launcher

### DIFF
--- a/base/applications/mmc/CMakeLists.txt
+++ b/base/applications/mmc/CMakeLists.txt
@@ -8,8 +8,8 @@ list(APPEND SOURCE
 
 add_rc_deps(mmc.rc ${CMAKE_CURRENT_SOURCE_DIR}/resources/mmc.ico)
 add_executable(mmc ${SOURCE} mmc.rc)
-target_link_libraries(mmc uuid)
 set_module_type(mmc win32gui UNICODE)
+target_link_libraries(mmc uuid)
 add_importlibs(mmc user32 gdi32 comdlg32 advapi32 shell32 comctl32 ole32 oleaut32 shlwapi msvcrt kernel32 ntdll)
 add_pch(mmc precomp.h SOURCE)
 add_cd_file(TARGET mmc DESTINATION reactos/system32 FOR all)

--- a/base/applications/mmc/CMakeLists.txt
+++ b/base/applications/mmc/CMakeLists.txt
@@ -3,11 +3,13 @@ list(APPEND SOURCE
     console.c
     misc.c
     mmc.c
+    mscfile.c
     precomp.h)
 
 add_rc_deps(mmc.rc ${CMAKE_CURRENT_SOURCE_DIR}/resources/mmc.ico)
 add_executable(mmc ${SOURCE} mmc.rc)
+target_link_libraries(mmc uuid)
 set_module_type(mmc win32gui UNICODE)
-add_importlibs(mmc user32 gdi32 comdlg32 advapi32 shell32 comctl32 msvcrt kernel32 ntdll)
+add_importlibs(mmc user32 gdi32 comdlg32 advapi32 shell32 comctl32 ole32 oleaut32 shlwapi msvcrt kernel32 ntdll)
 add_pch(mmc precomp.h SOURCE)
 add_cd_file(TARGET mmc DESTINATION reactos/system32 FOR all)

--- a/base/applications/mmc/mmc.c
+++ b/base/applications/mmc/mmc.c
@@ -39,8 +39,8 @@ _tWinMain(HINSTANCE hInstance,
 
     InitCommonControls();
 
-    // We have extended the MMC_ConsoleFile format with a custom RosLaunch node that can launch external files.
-    // This support can be removed after we have converted all our Snap-ins from .exe to real MMC COM DLLs.
+    /* We have extended the MMC_ConsoleFile format with a custom RosLaunch node that can launch external files.
+     * This support can be removed after we have converted all our Snap-ins from .exe to real MMC COM DLLs. */
     if (HandleRosMscLaunch(lpCmdLine))
         return 0;
 

--- a/base/applications/mmc/mmc.c
+++ b/base/applications/mmc/mmc.c
@@ -39,6 +39,11 @@ _tWinMain(HINSTANCE hInstance,
 
     InitCommonControls();
 
+    // We have extended the MMC_ConsoleFile format with a custom RosLaunch node that can launch external files.
+    // This support can be removed after we have converted all our Snap-ins from .exe to real MMC COM DLLs.
+    if (HandleRosMscLaunch(lpCmdLine))
+        return 0;
+
     if (!RegisterMMCWndClasses())
     {
         /* FIXME - Display error */

--- a/base/applications/mmc/mscfile.c
+++ b/base/applications/mmc/mscfile.c
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     ReactOS MMC
- * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     .msc file parser
- * COPYRIGHT:   Copyright 2024 Whindmar Saksit <whindsaks@proton.me>
+ * COPYRIGHT:   Copyright 2026 Whindmar Saksit <whindsaks@proton.me>
  */
 
 #define COBJMACROS
@@ -88,8 +88,8 @@ static HRESULT LoadXmlFromVariant(VARIANT *pVarUrl, IXMLDOMElement **ppDocElm)
 static HRESULT GetMscRootNode(PCWSTR pszFilePath, IXMLDOMNode **ppRoot)
 {
     HRESULT hr;
-    SIZE_T len = lstrlenW(pszFilePath);
-    SIZE_T cch = sizeof("file:///") + (len * 2); // *2 is overkill but we don't know how many escaped characters there are
+    DWORD len = lstrlenW(pszFilePath);
+    DWORD cch = sizeof("file:///") + (len * 2); // *2 is overkill but we don't know how many escaped characters there are
     PWSTR pszUrl = LocalAlloc(LPTR, cch * sizeof(*pszUrl));
     if (!pszUrl)
         return E_OUTOFMEMORY;

--- a/base/applications/mmc/mscfile.c
+++ b/base/applications/mmc/mscfile.c
@@ -10,7 +10,7 @@
 #include <oleauto.h>
 #include <oaidl.h>
 #include <shlwapi.h>
-#include <initguid.h> // For CLSID_DOMDocument30
+#include <initguid.h> /* For CLSID_DOMDocument30 */
 #include <msxml2.h>
 
 static HRESULT xmldomnode_getattributevalue(IXMLDOMNode *pnode, LPCWSTR name, BSTR *pout)
@@ -89,7 +89,7 @@ static HRESULT GetMscRootNode(PCWSTR pszFilePath, IXMLDOMNode **ppRoot)
 {
     HRESULT hr;
     DWORD len = lstrlenW(pszFilePath);
-    DWORD cch = sizeof("file:///") + (len * 2); // *2 is overkill but we don't know how many escaped characters there are
+    DWORD cch = sizeof("file:///") + (len * 2); /* Doubling the length is overkill but we don't know how many escaped characters there are */
     PWSTR pszUrl = LocalAlloc(LPTR, cch * sizeof(*pszUrl));
     if (!pszUrl)
         return E_OUTOFMEMORY;

--- a/base/applications/mmc/mscfile.c
+++ b/base/applications/mmc/mscfile.c
@@ -1,0 +1,159 @@
+/*
+ * PROJECT:     ReactOS MMC
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     .msc file parser
+ * COPYRIGHT:   Copyright 2024 Whindmar Saksit <whindsaks@proton.me>
+ */
+
+#define COBJMACROS
+#include "precomp.h"
+#include <oleauto.h>
+#include <oaidl.h>
+#include <shlwapi.h>
+#include <initguid.h> // For CLSID_DOMDocument30
+#include <msxml2.h>
+
+static HRESULT xmldomnode_getattributevalue(IXMLDOMNode *pnode, LPCWSTR name, BSTR *pout)
+{
+    IXMLDOMNamedNodeMap *pmap;
+    HRESULT hr = E_OUTOFMEMORY;
+    BSTR bsname = SysAllocString(name);
+    *pout = NULL;
+    if (bsname && SUCCEEDED(hr = IXMLDOMNode_get_attributes(pnode, &pmap)))
+    {
+        if (SUCCEEDED(hr = IXMLDOMNamedNodeMap_getNamedItem(pmap, bsname, &pnode)))
+        {
+            hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+            if (pnode)
+            {
+                hr = IXMLDOMNode_get_text(pnode, pout);
+                if (SUCCEEDED(hr) && !*pout)
+                    hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+                IXMLDOMNode_Release(pnode);
+            }
+        }
+        IXMLDOMNamedNodeMap_Release(pmap);
+    }
+    SysFreeString(bsname);
+    return hr;
+}
+
+static HRESULT xmldomelem_getelembytag(IXMLDOMElement *pelem, LPCWSTR name, long index, IXMLDOMNode**ppout)
+{
+    HRESULT hr = E_OUTOFMEMORY;
+    IXMLDOMNodeList *pnl;
+    BSTR bsname = SysAllocString(name);
+    *ppout = NULL;
+    if (bsname && SUCCEEDED(hr = IXMLDOMElement_getElementsByTagName(pelem, bsname, &pnl)))
+    {
+        hr = IXMLDOMNodeList_get_item(pnl, index, ppout);
+        if (SUCCEEDED(hr) && !*ppout)
+            hr = HRESULT_FROM_WIN32(ERROR_NO_MORE_ITEMS);
+        IUnknown_Release(pnl);
+    }
+    SysFreeString(bsname);
+    return hr;
+}
+
+static HRESULT xmldomunk_getelembytag(IUnknown *punk, LPCWSTR name, long index, IXMLDOMNode**ppout)
+{
+    IXMLDOMElement *pelem;
+    HRESULT hr = IUnknown_QueryInterface(punk, &IID_IXMLDOMElement, (void**)&pelem);
+    if (FAILED(hr))
+    {
+        *ppout = NULL;
+        return hr;
+    }
+    hr = xmldomelem_getelembytag(pelem, name, index, ppout);
+    IUnknown_Release(pelem);
+    return hr;
+}
+
+static HRESULT LoadXmlFromVariant(VARIANT *pVarUrl, IXMLDOMElement **ppDocElm)
+{
+    VARIANT_BOOL succ = VARIANT_FALSE;
+    IXMLDOMDocument *pDoc;
+    HRESULT hr = CoCreateInstance(&CLSID_DOMDocument30, NULL, CLSCTX_INPROC_SERVER,
+                                  &IID_IXMLDOMDocument, (void**)&pDoc);
+    if (FAILED(hr))
+        return hr;
+    else if (SUCCEEDED(hr = IXMLDOMDocument_load(pDoc, *pVarUrl, &succ)) && succ)
+        hr = IXMLDOMDocument_get_documentElement(pDoc, ppDocElm);
+    else if (SUCCEEDED(hr))
+        hr = E_FAIL;
+    IUnknown_Release(pDoc);
+    return hr;
+}
+
+static HRESULT GetMscRootNode(PCWSTR pszFilePath, IXMLDOMNode **ppRoot)
+{
+    HRESULT hr;
+    SIZE_T len = lstrlenW(pszFilePath);
+    SIZE_T cch = sizeof("file:///") + (len * 2); // *2 is overkill but we don't know how many escaped characters there are
+    PWSTR pszUrl = LocalAlloc(LPTR, cch * sizeof(*pszUrl));
+    if (!pszUrl)
+        return E_OUTOFMEMORY;
+    hr = UrlCreateFromPathW(pszFilePath, pszUrl, &cch, 0);
+    if (SUCCEEDED(hr))
+    {
+        IXMLDOMElement *pDocElm;
+        BSTR bsurl = SysAllocString(pszUrl);
+        VARIANT v;
+        V_VT(&v) = VT_BSTR;
+        V_BSTR(&v) = bsurl;
+        hr = bsurl ? LoadXmlFromVariant(&v, &pDocElm) : E_OUTOFMEMORY;
+        VariantClear(&v);
+        LocalFree(pszUrl);
+        if (SUCCEEDED(hr))
+        {
+            BSTR bs = 0;
+            hr = IXMLDOMElement_get_nodeName(pDocElm, &bs);
+            if (SUCCEEDED(hr))
+            {
+                hr = lstrcmpiW(bs, L"MMC_ConsoleFile") ? HRESULT_FROM_WIN32(ERROR_BAD_FORMAT) : S_OK;
+                SysFreeString(bs);
+                if (SUCCEEDED(hr))
+                    hr = IUnknown_QueryInterface(pDocElm, &IID_IXMLDOMNode, (void**)ppRoot);
+            }
+            IUnknown_Release(pDocElm);
+        }
+    }
+    return hr;
+}
+
+EXTERN_C BOOL HandleRosMscLaunch(PCWSTR pszCmdLine)
+{
+    BOOL result = FALSE;
+    IXMLDOMNode *pRoot;
+    HRESULT hrCom = CoInitialize(NULL);
+
+    int argc;
+    LPWSTR *argv = CommandLineToArgvW(pszCmdLine, &argc);
+    if (argv && argc > 0)
+    {
+        if (SUCCEEDED(GetMscRootNode(argv[0], &pRoot)))
+        {
+            IXMLDOMNode *pNode;
+            HRESULT hr = xmldomunk_getelembytag((IUnknown*)pRoot, L"RosLaunch", 0, &pNode);
+            IUnknown_Release(pRoot);
+            if (SUCCEEDED(hr))
+            {
+                UINT flags = SEE_MASK_DOENVSUBST | SEE_MASK_FLAG_DDEWAIT | SEE_MASK_FLAG_NO_UI;
+                SHELLEXECUTEINFOW sei = { sizeof(sei), flags, NULL, NULL, NULL, NULL, NULL, SW_SHOW };
+                if (SUCCEEDED(xmldomnode_getattributevalue(pNode, L"File", (BSTR*)&sei.lpFile)))
+                {
+                    xmldomnode_getattributevalue(pNode, L"Parameters", (BSTR*)&sei.lpParameters);
+                    result = sei.lpFile && *sei.lpFile && ShellExecuteExW(&sei);
+                    SysFreeString((BSTR)sei.lpFile);
+                    SysFreeString((BSTR)sei.lpParameters);
+                }
+                IUnknown_Release(pNode);
+            }
+        }
+        LocalFree(argv);
+    }
+
+    if (SUCCEEDED(hrCom))
+        CoUninitialize();
+    return result;
+}

--- a/base/applications/mmc/precomp.h
+++ b/base/applications/mmc/precomp.h
@@ -50,7 +50,7 @@ extern HANDLE hAppHeap;
 extern HWND hwndMainConsole;
 extern HWND hwndMDIClient;
 
-/* mscfile.cpp */
+/* mscfile.c */
 
 EXTERN_C BOOL HandleRosMscLaunch(PCWSTR pszCmdLine);
 

--- a/base/applications/mmc/precomp.h
+++ b/base/applications/mmc/precomp.h
@@ -50,4 +50,8 @@ extern HANDLE hAppHeap;
 extern HWND hwndMainConsole;
 extern HWND hwndMDIClient;
 
+/* mscfile.cpp */
+
+EXTERN_C BOOL HandleRosMscLaunch(PCWSTR pszCmdLine);
+
 #endif /* _MMC_PCH_ */

--- a/base/applications/mscutils/CMakeLists.txt
+++ b/base/applications/mscutils/CMakeLists.txt
@@ -5,8 +5,8 @@ add_subdirectory(eventvwr)
 add_subdirectory(servman)
 
 list(APPEND MSC_FILES
-    certmgr.msc
     certlm.msc
+    certmgr.msc
     compmgmt.msc
     devmgmt.msc
     diskmgmt.msc

--- a/base/applications/mscutils/CMakeLists.txt
+++ b/base/applications/mscutils/CMakeLists.txt
@@ -3,3 +3,17 @@ add_subdirectory(certmgr)
 add_subdirectory(devmgmt)
 add_subdirectory(eventvwr)
 add_subdirectory(servman)
+
+list(APPEND MSC_FILES
+    certmgr.msc
+    certlm.msc
+    compmgmt.msc
+    devmgmt.msc
+    diskmgmt.msc
+    eventvwr.msc
+    lusrmgr.msc
+    services.msc)
+
+foreach(item ${MSC_FILES})
+    add_cd_file(FILE "${CMAKE_CURRENT_SOURCE_DIR}/${item}" DESTINATION reactos/system32 FOR all)
+endforeach(item)

--- a/base/applications/mscutils/certlm.msc
+++ b/base/applications/mscutils/certlm.msc
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<MMC_ConsoleFile ConsoleVersion="2.0">
+  <VisualAttributes>
+    <Icon File="%windir%\system32\certmgr.exe" />
+  </VisualAttributes>
+  <RosLaunch File="%windir%\system32\certmgr.exe" />
+</MMC_ConsoleFile>

--- a/base/applications/mscutils/certmgr.msc
+++ b/base/applications/mscutils/certmgr.msc
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<MMC_ConsoleFile ConsoleVersion="2.0">
+  <VisualAttributes>
+    <Icon File="%windir%\system32\certmgr.exe" />
+  </VisualAttributes>
+  <RosLaunch File="%windir%\system32\certmgr.exe" />
+</MMC_ConsoleFile>

--- a/base/applications/mscutils/compmgmt.msc
+++ b/base/applications/mscutils/compmgmt.msc
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<MMC_ConsoleFile ConsoleVersion="2.0">
+  <VisualAttributes>
+    <Icon File="%windir%\system32\mmc.exe" />
+  </VisualAttributes>
+  <RosLaunch File="%windir%\explorer.exe" Parameters="/E,shell:Common Administrative Tools" />
+</MMC_ConsoleFile>

--- a/base/applications/mscutils/devmgmt.msc
+++ b/base/applications/mscutils/devmgmt.msc
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<MMC_ConsoleFile ConsoleVersion="2.0">
+  <VisualAttributes>
+    <Icon File="%windir%\system32\devmgmt.exe" />
+  </VisualAttributes>
+  <RosLaunch File="%windir%\system32\devmgmt.exe" />
+</MMC_ConsoleFile>

--- a/base/applications/mscutils/diskmgmt.msc
+++ b/base/applications/mscutils/diskmgmt.msc
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<MMC_ConsoleFile ConsoleVersion="2.0">
+  <VisualAttributes>
+    <Icon File="%windir%\system32\mmc.exe" />
+  </VisualAttributes>
+  <RosLaunch File="%windir%\explorer.exe" Parameters="/E,shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}" />
+</MMC_ConsoleFile>

--- a/base/applications/mscutils/eventvwr.msc
+++ b/base/applications/mscutils/eventvwr.msc
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<MMC_ConsoleFile ConsoleVersion="2.0">
+  <VisualAttributes>
+    <Icon File="%windir%\system32\eventvwr.exe" />
+  </VisualAttributes>
+  <RosLaunch File="%windir%\system32\eventvwr.exe" />
+</MMC_ConsoleFile>

--- a/base/applications/mscutils/lusrmgr.msc
+++ b/base/applications/mscutils/lusrmgr.msc
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<MMC_ConsoleFile ConsoleVersion="2.0">
+  <VisualAttributes>
+    <Icon File="%windir%\system32\mmc.exe" />
+  </VisualAttributes>
+  <RosLaunch File="%windir%\system32\usrmgr.cpl" />
+</MMC_ConsoleFile>

--- a/base/applications/mscutils/services.msc
+++ b/base/applications/mscutils/services.msc
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<MMC_ConsoleFile ConsoleVersion="2.0">
+  <VisualAttributes>
+    <Icon File="%windir%\system32\servman.exe" />
+  </VisualAttributes>
+  <RosLaunch File="%windir%\system32\servman.exe" />
+</MMC_ConsoleFile>

--- a/boot/bootdata/hivecls.inf
+++ b/boot/bootdata/hivecls.inf
@@ -436,6 +436,11 @@ HKCR,"xslfile","FriendlyTypeName",0x00020000,"@%SystemRoot%\system32\msxml3r.dll
 HKCR,"xslfile\DefaultIcon","",0x00020000,"%SystemRoot%\system32\msxml3.dll,1"
 HKCR,"xslfile\shell\open\command","",0x00020000,"%SystemRoot%\system32\notepad.exe ""%1"""
 
+; MSC files
+HKCR,".msc","",0x00000000,"MSCFile"
+HKCR,"mscfile","",,"%MSCFILE%"
+HKCR,"mscfile\shell\open\command",,0x00020000,"%SystemRoot%\system32\mmc.exe "%1" %*"
+
 ; MSI files
 HKCR,".msi","",0x00000000,"Msi.Package"
 HKCR,"Msi.Package","",0x00000000,"ReactOS Installer Package"
@@ -823,6 +828,7 @@ AVIFILE="Video Clip"
 
 ;; Misc file types without friendly (localized in .dll resources) name
 CSSFILE="Cascading Style Sheet"
+MSCFILE="Management Console Document"
 SCFFILE="ReactOS Explorer Command"
 WMZFILE="Compressed Enhanced Metafile"
 WSFFILE="Windows Script File"

--- a/boot/bootdata/hivecls.inf
+++ b/boot/bootdata/hivecls.inf
@@ -439,7 +439,8 @@ HKCR,"xslfile\shell\open\command","",0x00020000,"%SystemRoot%\system32\notepad.e
 ; MSC files
 HKCR,".msc","",0x00000000,"MSCFile"
 HKCR,"mscfile","",,"%MSCFILE%"
-HKCR,"mscfile\shell\open\command",,0x00020000,"%SystemRoot%\system32\mmc.exe "%1" %*"
+HKCR,"mscfile\DefaultIcon","",0x00020000,"%SystemRoot%\system32\mmc.exe"
+HKCR,"mscfile\shell\open\command","",0x00020000,"%SystemRoot%\system32\mmc.exe ""%1"" %*"
 
 ; MSI files
 HKCR,".msi","",0x00000000,"Msi.Package"


### PR DESCRIPTION
Extends the .msc XML format with custom execute support so we can launch utilities the user expects until we can implement full MMC COM Snap-In support (a very large task).

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: