### PR TITLE
[GITHUB] Use annotation feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,13 +64,16 @@ jobs:
         echo "CCACHE_DIR=${{github.workspace}}/ccache" >> $GITHUB_ENV
         echo "CCACHE_MAXSIZE=1G" >> $GITHUB_ENV
         echo "CCACHE_SLOPPINESS=time_macros" >> $GITHUB_ENV
+    - name: Configure problem matchers
+      run: echo ::add-matcher::src/.github/workflows/problem-matcher.json
     - name: Ease ccache compiler check (GCC)
       if: ${{ matrix.compiler == 'gcc' }}
       run: echo "CCACHE_COMPILERCHECK=string:${{steps.get_rosbe_spec.outputs.git-sha}}-${{hashfiles('./build_rosbe_ci.sh')}}" >> $GITHUB_ENV
     - name: Configure
       run: echo 'cmake -S ${{github.workspace}}/src -B ${{github.workspace}}/build -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-${{matrix.compiler}}.cmake -DARCH:STRING=${{matrix.arch}} -DCMAKE_BUILD_TYPE=${{matrix.config}} -DDLL_EXPORT_VERSION=${{matrix.dllver}} -DENABLE_CCACHE=1 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{env.D_CLANG_VERSION}}' | ${{github.workspace}}/RosBE-CI/RosBE.sh . 0 ${{matrix.arch}}
+    # GCC and Clang use relative file paths for error messages, use sed to convert these to absolute paths so that github could parse them
     - name: Build
-      run: echo 'cmake --build ${{github.workspace}}/build -- -k0' | ${{github.workspace}}/RosBE-CI/RosBE.sh . 0 ${{matrix.arch}}
+      run: set -o pipefail && echo 'cmake --build ${{github.workspace}}/build --' | ${{github.workspace}}/RosBE-CI/RosBE.sh . 0 ${{matrix.arch}} 2>&1 | sed 's|^\.\./src/|${{github.workspace}}/src/|'
     - name: Generate ISOs
       run: echo 'cmake --build ${{github.workspace}}/build --target bootcd' | ${{github.workspace}}/RosBE-CI/RosBE.sh . 0 ${{matrix.arch}}
     - name: Print ccache statistics
@@ -123,6 +126,8 @@ jobs:
       uses: actions/checkout@v6
       with:
         path: src
+    - name: Configure problem matchers
+      run: echo ::add-matcher::src/.github/workflows/problem-matcher.json
     - name: Configure
       run: cmake -S src -B build -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=${{matrix.arch}} -DCMAKE_BUILD_TYPE=${{matrix.config}} -DDLL_EXPORT_VERSION=${{matrix.dllver}} -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1
     - name: Build
@@ -185,6 +190,8 @@ jobs:
       uses: actions/checkout@v6
       with:
         path: src
+    - name: Configure problem matchers
+      run: echo ::add-matcher::src/.github/workflows/problem-matcher.json
     - name: Configure
       run: cmake -S src -B build -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=${{matrix.arch}} -DCMAKE_BUILD_TYPE=${{matrix.config}} -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1
     - name: Build base module
@@ -290,6 +297,8 @@ jobs:
       uses: actions/checkout@v6
       with:
         path: src
+    - name: Configure problem matchers
+      run: echo ::add-matcher::src/.github/workflows/problem-matcher.json
     - name: Configure
       run: cmake -S src -B build -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=${{matrix.arch}} -DCMAKE_BUILD_TYPE=${{matrix.config}} -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 -DUSE_CLANG_CL:BOOL=TRUE
     - name: Build
@@ -327,6 +336,8 @@ jobs:
     - uses: actions/checkout@v6
       with:
         path: src
+    - name: Configure problem matchers
+      run: echo ::add-matcher::src/.github/workflows/problem-matcher.json
     - name: Configure
       run: |
         mkdir build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       run: echo "CCACHE_COMPILERCHECK=string:${{steps.get_rosbe_spec.outputs.git-sha}}-${{hashfiles('./build_rosbe_ci.sh')}}" >> $GITHUB_ENV
     - name: Configure
       run: echo 'cmake -S ${{github.workspace}}/src -B ${{github.workspace}}/build -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-${{matrix.compiler}}.cmake -DARCH:STRING=${{matrix.arch}} -DCMAKE_BUILD_TYPE=${{matrix.config}} -DDLL_EXPORT_VERSION=${{matrix.dllver}} -DENABLE_CCACHE=1 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{env.D_CLANG_VERSION}}' | ${{github.workspace}}/RosBE-CI/RosBE.sh . 0 ${{matrix.arch}}
-    # GCC and Clang use relative file paths for error messages, use sed to convert these to absolute paths so that github could parse them
+    # GCC and Clang use relative file paths for error messages, use sed to convert these to absolute paths so that GitHub could parse them
     - name: Build
       run: set -o pipefail && echo 'cmake --build ${{github.workspace}}/build --' | ${{github.workspace}}/RosBE-CI/RosBE.sh . 0 ${{matrix.arch}} 2>&1 | sed 's|^\.\./src/|${{github.workspace}}/src/|'
     - name: Generate ISOs

--- a/.github/workflows/problem-matcher.json
+++ b/.github/workflows/problem-matcher.json
@@ -1,0 +1,69 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "gcc",
+            "severity": "error",
+            "pattern": [
+                {
+                    "regexp": "^(.+):(\\d+):(\\d+):\\s+(fatal error|error|warning|note):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        },
+        {
+            "owner": "msvc",
+            "pattern": [
+                {
+                    "regexp": "^(?:\\s+\\d+\\>)?([^\\s].*)\\((\\d+),?(\\d+)?(?:,\\d+,\\d+)?\\)\\s*:\\s+(error|warning|info)\\s+(\\w{1,2}\\d+)\\s*:\\s*(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "code": 5,
+                    "message": 6
+                }
+            ]
+        },
+        {
+            "owner": "clang",
+            "pattern": [
+                {
+                    "regexp": "^(.*?)\\((\\d+),(\\d+)\\):\\s+(warning|error|note):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        },
+        {
+            "owner": "msvc-linker",
+            "pattern": [
+                {
+                    "regexp": "^(.*?)\\s*:\\s*(fatal error|error|warning)\\s+([A-Z0-9]+)\\s*:\\s*(.*)$",
+                    "file": 1,
+                    "severity": 2,
+                    "code": 3,
+                    "message": 4
+                }
+            ]
+        },
+        {
+            "owner": "gcc-linker",
+            "severity": "error",
+            "pattern": [
+                {
+                    "regexp": "^(.*?(?:ld|collect2)(?:\\.exe)?):\\s*(?:(warning|error|fatal error):?\\s+)?(.*)$",
+                    "file": 1,
+                    "severity": 2,
+                    "message": 3
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Purpose

Enable the Github actions annotation feature for gcc, clang and msvc. This allows you to spot very easily what causes a build to fail. Sed is used to change relative file paths to absolute file paths as it will not work by default. Currently only linker errors and C/C++ compiler errors are annotated.

JIRA issue: None

Some examples:
<img width="1218" height="530" alt="image" src="https://github.com/user-attachments/assets/2c5b6cbc-89cf-410a-b937-eba8ae85f23d" />
<img width="2115" height="1493" alt="image" src="https://github.com/user-attachments/assets/ea017709-8caa-4fbd-90c6-52aaa8373393" />
<img width="2455" height="158" alt="image" src="https://github.com/user-attachments/assets/6f5614d8-9cb9-4d41-a1da-0c0915df3857" />



## Testbot runs (Filled in by Devs)

N/A