### PR TITLE
[NETSH] Compare the stack entry against the tail, not the head twice

### DIFF
--- a/base/applications/network/netsh/context.c
+++ b/base/applications/network/netsh/context.c
@@ -263,7 +263,7 @@ RemoveContextFromStack(
     {
         if (pStackEntry->pContext == pContextEntry)
         {
-            if (pStackEntry == pContextStackHead && pStackEntry == pContextStackHead)
+            if (pStackEntry == pContextStackHead && pStackEntry == pContextStackTail)
             {
                 pContextStackHead = NULL;
                 pContextStackTail = NULL;


### PR DESCRIPTION
## Purpose

`RemoveContextFromStack` tests `pStackEntry == pContextStackHead` twice in the same condition, so the first branch takes every entry that happens to be the head, not only the one that is head and tail at once. The branch below it, the one that relinks `pStackEntry->pNext->pPrev` and moves the head forward, is then unreachable. Removing the head of a stack that has more than one entry sets both head and tail to NULL and frees only that entry, so the remaining entries are lost and leaked.

The body of the first branch is what says which test was meant: it clears both ends, and that is only correct for the single element case.

## Proposed changes

- Compare the second test against `pContextStackTail`

I found this by reading, not by hitting it in a running netsh session, so I have not confirmed the leak on a live context stack.
