### PR TITLE
[SMSS] Implement foreign API functions

### DIFF
--- a/base/system/smss/smloop.c
+++ b/base/system/smss/smloop.c
@@ -37,32 +37,58 @@ HANDLE SmUniqueProcessId;
 
 NTSTATUS
 NTAPI
-SmpCreateForeignSession(IN PSM_API_MSG SmApiMsg,
-                        IN PSMP_CLIENT_CONTEXT ClientContext,
-                        IN HANDLE SmApiPort)
+SmpCreateForeignSession(_In_ PSM_API_MSG SmApiMsg,
+                        _In_ PSMP_CLIENT_CONTEXT ClientContext,
+                        _In_ HANDLE SmApiPort)
 {
-    DPRINT1("%s is not yet implemented\n", __FUNCTION__);
-    return STATUS_NOT_IMPLEMENTED;
+    ULONG MuSessionId;
+
+    /* Get the Terminal Server session ID of the calling subsystem */
+    SmpGetProcessMuSessionId(ClientContext->ProcessHandle, &MuSessionId);
+
+    /* Make sure a subsystem is actually registered for this session */
+    if (!SmpCheckDuplicateMuSessionId(MuSessionId))
+    {
+        DPRINT1("CreateForeignSession: no subsystem for MuSessionId %lu\n",
+                MuSessionId);
+        return STATUS_OBJECT_NAME_NOT_FOUND;
+    }
+
+    /* Register a new foreign session tied to the calling subsystem */
+    SmApiMsg->u.CreateForeignSession.SessionId =
+        SmpAllocateSessionId(ClientContext->Subsystem, NULL);
+    return STATUS_SUCCESS;
 }
 
 NTSTATUS
 NTAPI
-SmpSessionComplete(IN PSM_API_MSG SmApiMsg,
-                   IN PSMP_CLIENT_CONTEXT ClientContext,
-                   IN HANDLE SmApiPort)
+SmpSessionComplete(_In_ PSM_API_MSG SmApiMsg,
+                   _In_ PSMP_CLIENT_CONTEXT ClientContext,
+                   _In_ HANDLE SmApiPort)
 {
-    DPRINT1("%s is not yet implemented\n", __FUNCTION__);
-    return STATUS_NOT_IMPLEMENTED;
+    PSM_SESSION_COMPLETE_MSG SessionComplete = &SmApiMsg->u.SessionComplete;
+
+    DPRINT("SessionComplete: SessionId %lu complete. Status=0x%08lx\n", SessionComplete->SessionId,
+            SessionComplete->SessionStatus);
+
+    /* If the foreign session failed to come up, tear it back down */
+    if (!NT_SUCCESS(SessionComplete->SessionStatus))
+    {
+        SmpDeleteSession(SessionComplete->SessionId);
+    }
+
+    return STATUS_SUCCESS;
 }
 
 NTSTATUS
 NTAPI
-SmpTerminateForeignSession(IN PSM_API_MSG SmApiMsg,
-                           IN PSMP_CLIENT_CONTEXT ClientContext,
-                           IN HANDLE SmApiPort)
+SmpTerminateForeignSession(_In_ PSM_API_MSG SmApiMsg,
+                           _In_ PSMP_CLIENT_CONTEXT ClientContext,
+                           _In_ HANDLE SmApiPort)
 {
-    DPRINT1("%s is not yet implemented\n", __FUNCTION__);
-    return STATUS_NOT_IMPLEMENTED;
+    /* Tear down every foreign session owned by the calling subsystem */
+    SmpDeleteSessionsBySubsystem(ClientContext->Subsystem);
+    return STATUS_SUCCESS;
 }
 
 NTSTATUS

--- a/base/system/smss/smsessn.c
+++ b/base/system/smss/smsessn.c
@@ -118,6 +118,36 @@ SmpDeleteSession(IN ULONG SessionId)
     }
 }
 
+VOID
+NTAPI
+SmpDeleteSessionsBySubsystem(_In_ PSMP_SUBSYSTEM Subsystem)
+{
+    PSMP_SESSION Session;
+    PLIST_ENTRY NextEntry, OldEntry;
+
+    /* Lock the session list */
+    RtlEnterCriticalSection(&SmpSessionListLock);
+
+    /* Scan every session and remove the ones owned by this subsystem */
+    NextEntry = SmpSessionListHead.Flink;
+    while (NextEntry != &SmpSessionListHead)
+    {
+        Session = CONTAINING_RECORD(NextEntry, SMP_SESSION, Entry);
+        OldEntry = NextEntry;
+        NextEntry = NextEntry->Flink;
+
+        if (Session->Subsystem == Subsystem)
+        {
+            /* Unlink it and free its memory */
+            RemoveEntryList(OldEntry);
+            RtlFreeHeap(SmpHeap, 0, Session);
+        }
+    }
+
+    /* Release the lock */
+    RtlLeaveCriticalSection(&SmpSessionListLock);
+}
+
 ULONG
 NTAPI
 SmpAllocateSessionId(IN PSMP_SUBSYSTEM Subsystem,

--- a/base/system/smss/smss.h
+++ b/base/system/smss/smss.h
@@ -186,6 +186,12 @@ SmpDeleteSession(
     IN ULONG SessionId
 );
 
+VOID
+NTAPI
+SmpDeleteSessionsBySubsystem(
+    _In_ PSMP_SUBSYSTEM Subsystem
+);
+
 ULONG
 NTAPI
 SmpAllocateSessionId(

--- a/sdk/include/reactos/subsys/sm/smmsg.h
+++ b/sdk/include/reactos/subsys/sm/smmsg.h
@@ -42,7 +42,7 @@ typedef enum _SMSRV_API_NUMBER
 //
 typedef struct _SM_CREATE_FOREIGN_SESSION_MSG
 {
-    ULONG NotImplemented;
+    ULONG SessionId;
 } SM_CREATE_FOREIGN_SESSION_MSG, *PSM_CREATE_FOREIGN_SESSION_MSG;
 
 typedef struct _SM_SESSION_COMPLETE_MSG


### PR DESCRIPTION
## Purpose
Implement the foreign session APIs in SMSS, along with a helper for them and some header struct renaming.

JIRA issue: None

## Proposed changes
- Implement `SmpCreateForeignSession`, `SmpSessionComplete`, `SmpTerminateForeignSession`
- Add `SmpDeleteSessionsBySubsystem` in `smsessn.c` (and add it to the header so the Foreign functions can call it)
- Change `SM_CREATE_FOREIGN_SESSION_MSG`
- Change their annotations to SAL2.

## Testbot runs (Filled in by Devs)
- [ ] KVM x86:
- [ ] KVM x64: