### PR TITLE
[NTOS:IO] Implement Win7+ I/O System case (in)sensitivity support

### DIFF
--- a/ntoskrnl/config/cmdata.c
+++ b/ntoskrnl/config/cmdata.c
@@ -565,6 +565,13 @@ DATA_SEG("INITDATA") CM_SYSTEM_CONTROL_VECTOR CmControlVector[] =
     },
     {
         L"Session Manager\\I/O System",
+        L"IoCaseInsensitive",
+        &IopCaseInsensitive,
+        NULL,
+        NULL
+    },
+    {
+        L"Session Manager\\I/O System",
         L"IoVerifierLevel",
         &DummyData,
         NULL,

--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -1437,6 +1437,7 @@ extern POBJECT_TYPE IoCompletionType;
 extern PDEVICE_NODE IopRootDeviceNode;
 extern KSPIN_LOCK IopDeviceTreeLock;
 extern ULONG IopTraceLevel;
+extern ULONG IopCaseInsensitive;
 extern GENERAL_LOOKASIDE IopMdlLookasideList;
 extern GENERIC_MAPPING IopCompletionMapping;
 extern GENERIC_MAPPING IopFileMapping;

--- a/ntoskrnl/io/iomgr/controller.c
+++ b/ntoskrnl/io/iomgr/controller.c
@@ -69,6 +69,9 @@ IoCreateController(IN ULONG Size)
                                NULL,
                                NULL);
 
+    /* Honor the internal I/O System case (in)sensitivity */
+    if (IopCaseInsensitive) ObjectAttributes.Attributes |= OBJ_CASE_INSENSITIVE;
+
     /* Create the Object */
     Status = ObCreateObject(KernelMode,
                             IoControllerObjectType,

--- a/ntoskrnl/io/iomgr/device.c
+++ b/ntoskrnl/io/iomgr/device.c
@@ -279,6 +279,10 @@ IopGetDeviceObjectPointer(IN PUNICODE_STRING ObjectName,
                                OBJ_KERNEL_HANDLE,
                                NULL,
                                NULL);
+
+    /* Honor the internal I/O System case (in)sensitivity */
+    if (IopCaseInsensitive) ObjectAttributes.Attributes |= OBJ_CASE_INSENSITIVE;
+
     Status = ZwOpenFile(&FileHandle,
                         DesiredAccess,
                         &ObjectAttributes,
@@ -1078,7 +1082,10 @@ IoCreateDevice(IN PDRIVER_OBJECT DriverObject,
                                NULL,
                                ReturnedSD);
 
-    /* Honor exclusive flag */
+    /* Honor the internal I/O System case (in)sensitivity */
+    if (IopCaseInsensitive) ObjectAttributes.Attributes |= OBJ_CASE_INSENSITIVE;
+
+    /* Honor the exclusive flag */
     if (Exclusive) ObjectAttributes.Attributes |= OBJ_EXCLUSIVE;
 
     /* Create a permanent object for named devices */

--- a/ntoskrnl/io/iomgr/driver.c
+++ b/ntoskrnl/io/iomgr/driver.c
@@ -521,18 +521,21 @@ IopInitializeDriverModule(
     }
 
     /* Create the driver object */
-    ULONG ObjectSize = sizeof(DRIVER_OBJECT) + sizeof(EXTENDED_DRIVER_EXTENSION);
-    OBJECT_ATTRIBUTES objAttrs;
-    PDRIVER_OBJECT driverObject;
-    InitializeObjectAttributes(&objAttrs,
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    InitializeObjectAttributes(&ObjectAttributes,
                                &DriverName,
-                               OBJ_PERMANENT | OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
+                               OBJ_PERMANENT | OBJ_KERNEL_HANDLE,
                                NULL,
                                NULL);
 
+    /* Honor the internal I/O System case (in)sensitivity */
+    if (IopCaseInsensitive) ObjectAttributes.Attributes |= OBJ_CASE_INSENSITIVE;
+
+    PDRIVER_OBJECT driverObject;
+    ULONG ObjectSize = sizeof(DRIVER_OBJECT) + sizeof(EXTENDED_DRIVER_EXTENSION);
     Status = ObCreateObject(KernelMode,
                             IoDriverObjectType,
-                            &objAttrs,
+                            &ObjectAttributes,
                             KernelMode,
                             NULL,
                             ObjectSize,

--- a/ntoskrnl/io/iomgr/iomgr.c
+++ b/ntoskrnl/io/iomgr/iomgr.c
@@ -13,9 +13,6 @@
 #define NDEBUG
 #include <debug.h>
 
-ULONG IopTraceLevel = 0;
-BOOLEAN PnpSystemInit = FALSE;
-
 VOID
 NTAPI
 IopTimerDispatch(
@@ -32,9 +29,18 @@ WmiInitialize(
 
 /* DATA ********************************************************************/
 
+ULONG IopTraceLevel = 0;
+BOOLEAN PnpSystemInit = FALSE;
+
 POBJECT_TYPE IoDeviceObjectType = NULL;
 POBJECT_TYPE IoFileObjectType = NULL;
 extern POBJECT_TYPE IoControllerObjectType;
+ULONG IopCaseInsensitive =
+#if (NTDDI_VERSION >= NTDDI_WIN7) || (DLL_EXPORT_VERSION >= _WIN32_WINNT_WIN7)
+    TRUE;
+#else
+    FALSE;
+#endif
 BOOLEAN IoCountOperations = TRUE;
 ULONG IoReadOperationCount = 0;
 LARGE_INTEGER IoReadTransferCount = {{0, 0}};


### PR DESCRIPTION
## Purpose & Proposed changes

This functionality is used to control the creation and opening of named device objects in a case-(in)sensitive way.
It is the counterpart to the equivalent functionality in the Object manager, see PR #7751.

It is controlled with a REG_DWORD value named `IoCaseInsensitive` inside the registry key
`HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\I/O System` .

When compiled for Win7+, case insensitivity is enabled, which is the expected default (like in the Object Manager).
When compiled for Vista and below, case insensitivity is disabled by default.
The registry setting allows changing this behaviour for backward/forward compatibility.

See the comparison tables at:
https://redplait.blogspot.com/2011/07/cmcontrolvector.html
https://redplait.blogspot.com/2012/06/cmcontrolvector-for-w8.html
https://redplait.blogspot.com/2016/03/cmcontrolvector-from-windows-10-build.html

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109904,109915
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109906,109916