### PR TITLE
[SMSS][CSRSRV] Improve various debug diagnostics

### DIFF
--- a/base/system/smss/smloop.c
+++ b/base/system/smss/smloop.c
@@ -255,7 +255,7 @@ SmpStopCsr(IN PSM_API_MSG SmApiMsg,
     return STATUS_NOT_IMPLEMENTED;
 }
 
-PSM_API_HANDLER SmpApiDispatch[SmpMaxApiNumber - SmpCreateForeignSessionApi] =
+const PSM_API_HANDLER SmpApiDispatch[SmpMaxApiNumber - SmpCreateForeignSessionApi] =
 {
     SmpCreateForeignSession,
     SmpSessionComplete,
@@ -265,6 +265,20 @@ PSM_API_HANDLER SmpApiDispatch[SmpMaxApiNumber - SmpCreateForeignSessionApi] =
     SmpStartCsr,
     SmpStopCsr
 };
+
+#if DBG
+const PCSTR SmpApiName[SmpMaxApiNumber - SmpCreateForeignSessionApi + 1] =
+{
+    "SmCreateForeignSession",
+    "SmSessionComplete",
+    "SmTerminateForeignSession",
+    "SmExecPgm",
+    "SmLoadDeferedSubsystem",
+    "SmStartCsr",
+    "SmStopCsr",
+    "Unknown Sm Api Number"
+};
+#endif
 
 /* FUNCTIONS ******************************************************************/
 
@@ -489,20 +503,27 @@ SmpApiLoop(
                     break;
                 }
 
+#if DBG
+                DPRINT("SMSS: %s Api Request received from %lx.%lx\n",
+                       SmpApiName[min(RequestMsg.ApiNumber, SmpMaxApiNumber)],
+                       RequestMsg.h.ClientId.UniqueProcess,
+                       RequestMsg.h.ClientId.UniqueThread);
+#endif
+
                 RequestMsg.ReturnValue = STATUS_PENDING;
 
                 /* Check if the API is valid */
                 if (RequestMsg.ApiNumber >= SmpMaxApiNumber)
                 {
                     /* It isn't, fail */
-                    DPRINT1("Invalid API: %lx\n", RequestMsg.ApiNumber);
+                    DPRINT1("SMSS: Invalid Sm Api Number %lx\n", RequestMsg.ApiNumber);
                     Status = STATUS_NOT_IMPLEMENTED;
                 }
                 else if ((RequestMsg.ApiNumber <= SmpTerminateForeignSessionApi) &&
                          !(ClientContext->Subsystem))
                 {
                     /* It's valid, but doesn't have a subsystem with it */
-                    DPRINT1("Invalid session API\n");
+                    DPRINT1("SMSS: Invalid session API\n");
                     Status = STATUS_INVALID_PARAMETER;
                 }
                 else

--- a/base/system/smss/smloop.c
+++ b/base/system/smss/smloop.c
@@ -482,6 +482,7 @@ SmpApiLoop(
 
             /* An actual API message */
             default:
+            {
                 if (!ClientContext)
                 {
                     ReplyMsg = NULL;
@@ -507,15 +508,25 @@ SmpApiLoop(
                 else
                 {
                     /* It's totally okay, so call the dispatcher for it */
-                    Status = SmpApiDispatch[RequestMsg.ApiNumber](&RequestMsg,
-                                                                  ClientContext,
-                                                                  SmApiPort);
+                    _SEH2_TRY
+                    {
+                        Status = SmpApiDispatch[RequestMsg.ApiNumber](&RequestMsg,
+                                                                      ClientContext,
+                                                                      SmApiPort);
+                    }
+                    _SEH2_EXCEPT(SmpUnhandledExceptionFilter(_SEH2_GetExceptionInformation()))
+                    {
+                        ReplyMsg = NULL;
+                        _SEH2_YIELD(break);
+                    }
+                    _SEH2_END;
                 }
 
                 /* Write the result value and return the message back */
                 RequestMsg.ReturnValue = Status;
                 ReplyMsg = &RequestMsg;
                 break;
+            }
         }
     }
 

--- a/base/system/smss/smss.c
+++ b/base/system/smss/smss.c
@@ -10,8 +10,6 @@
 
 #include "smss.h"
 
-#include <pseh/pseh2.h>
-
 #define NDEBUG
 #include <debug.h>
 
@@ -405,7 +403,9 @@ SmpTerminate(
 }
 
 LONG
-SmpUnhandledExceptionFilter(IN PEXCEPTION_POINTERS ExceptionInfo)
+NTAPI
+SmpUnhandledExceptionFilter(
+    _In_ PEXCEPTION_POINTERS ExceptionInfo)
 {
     PEXCEPTION_RECORD ExceptionRecord = ExceptionInfo->ExceptionRecord;
     ULONG_PTR Parameters[4];

--- a/base/system/smss/smss.c
+++ b/base/system/smss/smss.c
@@ -371,19 +371,20 @@ SmpExecuteInitialCommand(IN ULONG MuSessionId,
 
 NTSTATUS
 NTAPI
-SmpTerminate(IN PULONG_PTR Parameters,
-             IN ULONG ParameterMask,
-             IN ULONG ParameterCount)
+SmpTerminate(
+    _In_reads_(ParameterCount) PULONG_PTR Parameters,
+    _In_ ULONG ParameterMask,
+    _In_ ULONG ParameterCount)
 {
     NTSTATUS Status;
-    BOOLEAN Old;
     ULONG Response;
+    BOOLEAN Old;
 
     /* Give the shutdown privilege to the thread */
-    if (RtlAdjustPrivilege(SE_SHUTDOWN_PRIVILEGE, TRUE, TRUE, &Old) ==
-        STATUS_NO_TOKEN)
+    Status = RtlAdjustPrivilege(SE_SHUTDOWN_PRIVILEGE, TRUE, TRUE, &Old);
+    if (Status == STATUS_NO_TOKEN)
     {
-        /* Thread doesn't have a token, give it to the entire process */
+        /* The thread doesn't have a token, give it to the entire process */
         RtlAdjustPrivilege(SE_SHUTDOWN_PRIVILEGE, TRUE, FALSE, &Old);
     }
 
@@ -395,7 +396,11 @@ SmpTerminate(IN PULONG_PTR Parameters,
                               OptionShutdownSystem,
                               &Response);
 
-    /* Terminate the process if the hard error didn't already */
+    /* Terminate the process if the hard error didn't already.
+     * In case the Parameters array has at least 2 elements,
+     * use Parameters[1] that contains the actual failure code,
+     * instead of what NtRaiseHardError() returned. */
+    if (ParameterCount >= 2) Status = Parameters[1];
     return NtTerminateProcess(NtCurrentProcess(), Status);
 }
 

--- a/base/system/smss/smss.h
+++ b/base/system/smss/smss.h
@@ -238,10 +238,9 @@ SmpExecuteInitialCommand(IN ULONG MuSessionId,
 NTSTATUS
 NTAPI
 SmpTerminate(
-    IN PULONG_PTR Parameters,
-    IN ULONG ParameterMask,
-    IN ULONG ParameterCount
-);
+    _In_reads_(ParameterCount) PULONG_PTR Parameters,
+    _In_ ULONG ParameterMask,
+    _In_ ULONG ParameterCount);
 
 /* smsubsys.c */
 

--- a/base/system/smss/smss.h
+++ b/base/system/smss/smss.h
@@ -36,6 +36,9 @@
 
 #include <ntstrsafe.h>
 
+/* PSEH for SEH Support */
+#include <pseh/pseh2.h>
+
 /* SM Protocol Header */
 #include <sm/smmsg.h>
 
@@ -241,6 +244,11 @@ SmpTerminate(
     _In_reads_(ParameterCount) PULONG_PTR Parameters,
     _In_ ULONG ParameterMask,
     _In_ ULONG ParameterCount);
+
+LONG
+NTAPI
+SmpUnhandledExceptionFilter(
+    _In_ PEXCEPTION_POINTERS ExceptionInfo);
 
 /* smsubsys.c */
 

--- a/subsystems/csr/csrsrv/api.c
+++ b/subsystems/csr/csrsrv/api.c
@@ -79,16 +79,15 @@ CsrCallServerFromServer(IN PCSR_API_MESSAGE ReceiveMsg,
 
         /* Make sure that the ID is within limits, and the entry exists */
         if ((ApiId >= ServerDll->HighestApiSupported) ||
-            ((ServerDll->ValidTable) && !(ServerDll->ValidTable[ApiId])))
+            (ServerDll->ValidTable && !ServerDll->ValidTable[ApiId]))
         {
             /* We are beyond the Maximum API ID, or it doesn't exist */
 #ifdef CSR_DBG
-            DPRINT1("API: %d\n", ApiId);
             DPRINT1("CSRSS: %lx (%s) is invalid ApiTableIndex for %Z or is an "
                     "invalid API to call from the server.\n",
-                    ApiId,
-                    ((ServerDll->NameTable) && (ServerDll->NameTable[ApiId])) ?
-                    ServerDll->NameTable[ApiId] : "*** UNKNOWN ***",
+                    CSR_API_NUMBER_TO_API_ID(ReceiveMsg->ApiNumber),
+                    (ServerDll->NameTable && ServerDll->NameTable[ApiId])
+                        ? ServerDll->NameTable[ApiId] : "*** UNKNOWN ***",
                     &ServerDll->Name);
             if (NtCurrentPeb()->BeingDebugged) DbgBreakPoint();
 #endif

--- a/subsystems/csr/csrsrv/session.c
+++ b/subsystems/csr/csrsrv/session.c
@@ -18,7 +18,7 @@
 RTL_CRITICAL_SECTION CsrNtSessionLock;
 LIST_ENTRY CsrNtSessionList;
 
-PSB_API_ROUTINE CsrServerSbApiDispatch[SbpMaxApiNumber - SbpCreateSession] =
+const PSB_API_ROUTINE CsrServerSbApiDispatch[SbpMaxApiNumber - SbpCreateSession] =
 {
     CsrSbCreateSession,
     CsrSbTerminateSession,
@@ -26,13 +26,16 @@ PSB_API_ROUTINE CsrServerSbApiDispatch[SbpMaxApiNumber - SbpCreateSession] =
     CsrSbCreateProcess
 };
 
-PCHAR CsrServerSbApiName[SbpMaxApiNumber - SbpCreateSession] =
+#if DBG
+const PCSTR CsrServerSbApiName[SbpMaxApiNumber - SbpCreateSession + 1] =
 {
     "SbCreateSession",
     "SbTerminateSession",
     "SbForeignSessionComplete",
-    "SbCreateProcess"
+    "SbCreateProcess",
+    "Unknown CSR Sb Api Number"
 };
+#endif
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
@@ -538,35 +541,37 @@ CsrSbApiRequestThread(
             continue;
         }
 
-        /*
-         * It's an API Message, check if it's within limits. If it's not,
-         * the NT Behaviour is to set this to the Maximum API.
-         */
-        if (ReceiveMsg.ApiNumber > SbpMaxApiNumber)
-        {
-            ReceiveMsg.ApiNumber = SbpMaxApiNumber;
-            DPRINT1("CSRSS: %lx is invalid Sb ApiNumber\n", ReceiveMsg.ApiNumber);
-        }
+        /* This is an actual API message */
+#if DBG
+        DPRINT("CSRSS: %s Session Api Request received from %lx.%lx\n",
+               CsrServerSbApiName[min(ReceiveMsg.ApiNumber, SbpMaxApiNumber)],
+               ReceiveMsg.h.ClientId.UniqueProcess,
+               ReceiveMsg.h.ClientId.UniqueThread);
+#endif
 
         /* Reuse the message */
         ReplyMsg = &ReceiveMsg;
 
-        /* Make sure that the message is supported */
+        /* Make sure that the API is supported */
         if (ReceiveMsg.ApiNumber < SbpMaxApiNumber)
         {
             /* Call the API */
             if (!CsrServerSbApiDispatch[ReceiveMsg.ApiNumber](&ReceiveMsg))
             {
+#if DBG
                 DPRINT1("CSRSS: %s Session Api called and failed\n",
                         CsrServerSbApiName[ReceiveMsg.ApiNumber]);
-
+#endif
                 /* It failed, so return nothing */
                 ReplyMsg = NULL;
             }
         }
         else
         {
-            /* We don't support this API Number */
+            /* This API number is not supported */
+            DPRINT1("CSRSS: Invalid Sb Api Number %lx\n", ReceiveMsg.ApiNumber);
+            /* The NT behaviour is to reset it to the Maximum API ID */
+            ReceiveMsg.ApiNumber = SbpMaxApiNumber;
             ReplyMsg->ReturnValue = STATUS_NOT_IMPLEMENTED;
         }
     }


### PR DESCRIPTION
## Purpose

Improve debug diagnostics in SMSS and CSRSRV.

## Proposed changes

- ### `[SMSS] Improve the SmpTerminate() routine a bit`

  - Use SAL2 annotations.
  - When terminating the process if the hard error did not already, prefer using `Parameters[1]` that contains the actual failure code, instead of what `NtRaiseHardError()` returned.

- ### `[SMSS] SmpApiLoop(): SEH-wrap the SmpApiDispatch[] routine calls`

  If any one of them crashes, this will emit a diagnostic message before taking down SMSS.
  SAL2-annotate `SmpUnhandledExceptionFilter()`.

- ### `[SMSS][CSRSRV] Improve debug tracing on subsystem session-related callbacks`

  Note: The debug-logged API names corresponding to the callbacks come from the SMSS and CSRSRV Windows checked builds, and cross-checked with the System Informer phnt headers[^1][^2].

  [^1]: https://ntdoc.m417z.com/smapinumber
  [^2]: https://github.com/winsiderss/systeminformer/blob/master/phnt/include/ntsmss.h
