### PR TITLE
[USER32] Implement raw input APIs

### DIFF
--- a/win32ss/user/user32/misc/stubs.c
+++ b/win32ss/user/user32/misc/stubs.c
@@ -298,18 +298,31 @@ DefRawInputProc(
 }
 
 /*
- * @unimplemented
+ * @implemented
  */
 UINT
 WINAPI
 DECLSPEC_HOTPATCH
 GetRawInputBuffer(
-    PRAWINPUT pData,
-    PUINT pcbSize,
-    UINT cbSizeHeader)
+    _In_opt_ PRAWINPUT pData,
+    _Inout_ PUINT pcbSize,
+    _In_ UINT cbSizeHeader)
 {
-  UNIMPLEMENTED;
-  return 0;
+    PCLIENTTHREADINFO pcti = GetWin32ClientInfo()->pClientThreadInfo;
+
+    if (!pcbSize || cbSizeHeader != sizeof(RAWINPUTHEADER))
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return (UINT)-1;
+    }
+
+    if (!pcti || !(pcti->fsWakeBits & QS_RAWINPUT))
+    {
+        *pcbSize = 0;
+        return 0;
+    }
+
+    return NtUserGetRawInputBuffer(pData, pcbSize, cbSizeHeader);
 }
 
 /*

--- a/win32ss/user/user32/misc/stubs.c
+++ b/win32ss/user/user32/misc/stubs.c
@@ -235,18 +235,40 @@ CsrBroadcastSystemMessageExW(
 }
 
 /*
- * @unimplemented
+ * @implemented
  */
 UINT
 WINAPI
 GetRawInputDeviceInfoA(
-    HANDLE hDevice,
-    UINT uiCommand,
-    LPVOID pData,
-    PUINT pcbSize)
+    _In_opt_ HANDLE hDevice,
+    _In_ UINT uiCommand,
+    _Inout_opt_ LPVOID pData,
+    _Inout_ PUINT pcbSize)
 {
-  UNIMPLEMENTED;
-  return 0;
+    UINT Ret;
+    LPVOID pDataW = pData;
+    UINT cbSize = *pcbSize;
+
+    if (uiCommand == RIDI_DEVICENAME && pData)
+    {
+        pDataW = HeapAlloc(GetProcessHeap(), 0, cbSize * sizeof(WCHAR));
+        if (!pDataW)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            return (UINT)-1;
+        }
+    }
+
+    Ret = NtUserGetRawInputDeviceInfo(hDevice, uiCommand, pDataW, &cbSize);
+    if (Ret >= 0 && uiCommand == RIDI_DEVICENAME && pDataW)
+    {
+        if (WideCharToMultiByte(CP_THREAD_ACP, 0, pDataW, cbSize, pData, *pcbSize, NULL, NULL) == 0)
+            Ret = (UINT)-1;
+    }
+    if (pData != pDataW)
+        HeapFree(GetProcessHeap(), 0, pDataW);
+    *pcbSize = cbSize;
+    return Ret;
 }
 
 /*

--- a/win32ss/user/user32/misc/stubs.c
+++ b/win32ss/user/user32/misc/stubs.c
@@ -220,21 +220,6 @@ GetAccCursorInfo ( PCURSORINFO pci )
 /*
  * @unimplemented
  */
-UINT
-WINAPI
-GetRawInputDeviceInfoW(
-    HANDLE hDevice,
-    UINT uiCommand,
-    LPVOID pData,
-    PUINT pcbSize)
-{
-  UNIMPLEMENTED;
-  return 0;
-}
-
-/*
- * @unimplemented
- */
 LONG
 WINAPI
 CsrBroadcastSystemMessageExW(
@@ -303,71 +288,6 @@ GetRawInputBuffer(
 {
   UNIMPLEMENTED;
   return 0;
-}
-
-/*
- * @unimplemented
- */
-UINT
-WINAPI
-GetRawInputData(
-    HRAWINPUT hRawInput,
-    UINT uiCommand,
-    LPVOID pData,
-    PUINT pcbSize,
-    UINT cbSizeHeader)
-{
-  UNIMPLEMENTED;
-  return 0;
-}
-
-/*
- * @unimplemented
- */
-UINT
-WINAPI
-GetRawInputDeviceList(
-    PRAWINPUTDEVICELIST pRawInputDeviceList,
-    PUINT puiNumDevices,
-    UINT cbSize)
-{
-    if(pRawInputDeviceList)
-        memset(pRawInputDeviceList, 0, sizeof *pRawInputDeviceList);
-    if(puiNumDevices)
-       *puiNumDevices = 0;
-
-    UNIMPLEMENTED;
-    return 0;
-}
-
-/*
- * @unimplemented
- */
-UINT
-WINAPI
-DECLSPEC_HOTPATCH
-GetRegisteredRawInputDevices(
-    PRAWINPUTDEVICE pRawInputDevices,
-    PUINT puiNumDevices,
-    UINT cbSize)
-{
-  UNIMPLEMENTED;
-  return 0;
-}
-
-/*
- * @unimplemented
- */
-BOOL
-WINAPI
-DECLSPEC_HOTPATCH
-RegisterRawInputDevices(
-    PCRAWINPUTDEVICE pRawInputDevices,
-    UINT uiNumDevices,
-    UINT cbSize)
-{
-  UNIMPLEMENTED;
-  return FALSE;
 }
 
 /*

--- a/win32ss/user/user32/user32.spec
+++ b/win32ss/user/user32/user32.spec
@@ -361,12 +361,12 @@
 @ stdcall GetPropW(long wstr)
 @ stdcall GetQueueStatus(long)
 @ stdcall GetRawInputBuffer(ptr ptr long)
-@ stdcall GetRawInputData(ptr long ptr ptr long)
+@ stdcall GetRawInputData(ptr long ptr ptr long) NtUserGetRawInputData
 @ stdcall GetRawInputDeviceInfoA(ptr long ptr ptr)
-@ stdcall GetRawInputDeviceInfoW(ptr long ptr ptr)
-@ stdcall GetRawInputDeviceList(ptr ptr long)
+@ stdcall GetRawInputDeviceInfoW(ptr long ptr ptr) NtUserGetRawInputDeviceInfo
+@ stdcall GetRawInputDeviceList(ptr ptr long) NtUserGetRawInputDeviceList
 @ stdcall GetReasonTitleFromReasonCode(long long long)
-@ stdcall GetRegisteredRawInputDevices(ptr ptr long)
+@ stdcall GetRegisteredRawInputDevices(ptr ptr long) NtUserGetRegisteredRawInputDevices
 # GetRipFlags
 @ stdcall GetScrollBarInfo(long long ptr) ; NtUserGetScrollBarInfo
 @ stdcall GetScrollInfo(long long ptr)
@@ -590,7 +590,7 @@
 @ stdcall RegisterMessagePumpHook(ptr)
 @ stdcall -version=0x602+ RegisterPointerDeviceNotifications(long long)
 @ stdcall -version=0x600+ RegisterPowerSettingNotification(long ptr long)
-@ stdcall RegisterRawInputDevices(ptr long long)
+@ stdcall -import RegisterRawInputDevices(ptr long long) NtUserRegisterRawInputDevices
 @ stdcall RegisterServicesProcess(long)
 @ stdcall RegisterShellHookWindow(long)
 @ stdcall RegisterSystemThread(long long)


### PR DESCRIPTION
## Purpose

Implement user32 part of raw input APIs:
- GetRawInputBuffer
- GetRawInputData
- GetRawInputDeviceInfoA
- GetRawInputDeviceInfoW
- GetRawInputDeviceList
- GetRegisteredRawInputDevices
- RegisterRawInputDevices

See [here](https://learn.microsoft.com/en-us/windows/win32/inputdev/raw-input) for a general overview.

win32k `NtUser*` counterpart APIs are still unimplemented, so this doesn't change the results of `user32_winetest.exe` input tests.

JIRA Issue: [CORE-9818](https://jira.reactos.org/browse/CORE-9818)