### PR TITLE
[FREELDR] Minor hwpci.c reformatting; SAL2-annotate *FindPciBios()

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/hwpci.c
+++ b/boot/freeldr/freeldr/arch/i386/hwpci.c
@@ -74,10 +74,11 @@ GetPciIrqRoutingTable(VOID)
 }
 
 BOOLEAN
-PcFindPciBios(PPCI_REGISTRY_INFO BusData)
+PcFindPciBios(
+    _Out_ PPCI_REGISTRY_INFO BusData)
 {
-    REGS  RegsIn;
-    REGS  RegsOut;
+    REGS RegsIn;
+    REGS RegsOut;
 
     RegsIn.b.ah = 0xB1; /* Subfunction B1h */
     RegsIn.b.al = 0x01; /* PCI BIOS present */
@@ -110,7 +111,8 @@ PcFindPciBios(PPCI_REGISTRY_INFO BusData)
 
 static
 VOID
-DetectPciIrqRoutingTable(PCONFIGURATION_COMPONENT_DATA BusKey)
+DetectPciIrqRoutingTable(
+    _In_ PCONFIGURATION_COMPONENT_DATA BusKey)
 {
     PCM_PARTIAL_RESOURCE_LIST PartialResourceList;
     PCM_PARTIAL_RESOURCE_DESCRIPTOR PartialDescriptor;
@@ -119,50 +121,50 @@ DetectPciIrqRoutingTable(PCONFIGURATION_COMPONENT_DATA BusKey)
     ULONG Size;
 
     Table = GetPciIrqRoutingTable();
-    if (Table != NULL)
+    if (!Table)
+        return;
+
+    TRACE("Table size: %u\n", Table->TableSize);
+
+    /* Set 'Configuration Data' value */
+    Size = FIELD_OFFSET(CM_PARTIAL_RESOURCE_LIST, PartialDescriptors[2]) + Table->TableSize;
+    PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
+    if (PartialResourceList == NULL)
     {
-        TRACE("Table size: %u\n", Table->TableSize);
-
-        /* Set 'Configuration Data' value */
-        Size = FIELD_OFFSET(CM_PARTIAL_RESOURCE_LIST, PartialDescriptors[2]) + Table->TableSize;
-        PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
-        if (PartialResourceList == NULL)
-        {
-            ERR("Failed to allocate resource descriptor\n");
-            return;
-        }
-
-        /* Initialize resource descriptor */
-        RtlZeroMemory(PartialResourceList, Size);
-        PartialResourceList->Version = 1;
-        PartialResourceList->Revision = 1;
-        PartialResourceList->Count = 2;
-
-        PartialDescriptor = &PartialResourceList->PartialDescriptors[0];
-        PartialDescriptor->Type = CmResourceTypeBusNumber;
-        PartialDescriptor->ShareDisposition = CmResourceShareDeviceExclusive;
-        PartialDescriptor->u.BusNumber.Start = 0;
-        PartialDescriptor->u.BusNumber.Length = 1;
-
-        PartialDescriptor = &PartialResourceList->PartialDescriptors[1];
-        PartialDescriptor->Type = CmResourceTypeDeviceSpecific;
-        PartialDescriptor->ShareDisposition = CmResourceShareUndetermined;
-        PartialDescriptor->u.DeviceSpecificData.DataSize = Table->TableSize;
-
-        RtlCopyMemory(&PartialResourceList->PartialDescriptors[2],
-                      Table, Table->TableSize);
-
-        FldrCreateComponentKey(BusKey,
-                               PeripheralClass,
-                               RealModeIrqRoutingTable,
-                               0,
-                               0,
-                               0xFFFFFFFF,
-                               "PCI Real-mode IRQ Routing Table",
-                               PartialResourceList,
-                               Size,
-                               &TableKey);
+        ERR("Failed to allocate resource descriptor\n");
+        return;
     }
+
+    /* Initialize resource descriptor */
+    RtlZeroMemory(PartialResourceList, Size);
+    PartialResourceList->Version = 1;
+    PartialResourceList->Revision = 1;
+    PartialResourceList->Count = 2;
+
+    PartialDescriptor = &PartialResourceList->PartialDescriptors[0];
+    PartialDescriptor->Type = CmResourceTypeBusNumber;
+    PartialDescriptor->ShareDisposition = CmResourceShareDeviceExclusive;
+    PartialDescriptor->u.BusNumber.Start = 0;
+    PartialDescriptor->u.BusNumber.Length = 1;
+
+    PartialDescriptor = &PartialResourceList->PartialDescriptors[1];
+    PartialDescriptor->Type = CmResourceTypeDeviceSpecific;
+    PartialDescriptor->ShareDisposition = CmResourceShareUndetermined;
+    PartialDescriptor->u.DeviceSpecificData.DataSize = Table->TableSize;
+
+    RtlCopyMemory(&PartialResourceList->PartialDescriptors[2],
+                  Table, Table->TableSize);
+
+    FldrCreateComponentKey(BusKey,
+                           PeripheralClass,
+                           RealModeIrqRoutingTable,
+                           0,
+                           0,
+                           0xFFFFFFFF,
+                           "PCI Real-mode IRQ Routing Table",
+                           PartialResourceList,
+                           Size,
+                           &TableKey);
 }
 
 VOID

--- a/boot/freeldr/freeldr/arch/i386/xbox/machxbox.c
+++ b/boot/freeldr/freeldr/arch/i386/xbox/machxbox.c
@@ -32,7 +32,8 @@ extern ULONG FrameBufferSize;
 extern PCM_FRAMEBUF_DEVICE_DATA FrameBufferData;
 
 static BOOLEAN
-XboxFindPciBios(PPCI_REGISTRY_INFO BusData)
+XboxFindPciBios(
+    _Out_ PPCI_REGISTRY_INFO BusData)
 {
     /* We emulate PCI BIOS here, there are 2 known working PCI buses on an original Xbox */
     BusData->NoBuses = 2;

--- a/boot/freeldr/freeldr/include/arch/i386/machpc98.h
+++ b/boot/freeldr/freeldr/include/arch/i386/machpc98.h
@@ -94,7 +94,9 @@ extern ULONG PcBiosMapCount;
 PFREELDR_MEMORY_DESCRIPTOR Pc98MemGetMemoryMap(ULONG *MemoryMapSize);
 
 /* hwpci.c */
-BOOLEAN PcFindPciBios(PPCI_REGISTRY_INFO BusData);
+BOOLEAN
+PcFindPciBios(
+    _Out_ PPCI_REGISTRY_INFO BusData);
 
 /*
  * Disk Variables and Functions

--- a/boot/freeldr/freeldr/include/arch/pc/machpc.h
+++ b/boot/freeldr/freeldr/include/arch/pc/machpc.h
@@ -48,7 +48,10 @@ VOID PcVideoPrepareForReactOS(VOID);
 VOID PcPrepareForReactOS(VOID);
 
 PFREELDR_MEMORY_DESCRIPTOR PcMemGetMemoryMap(ULONG *MemoryMapSize);
-BOOLEAN PcFindPciBios(PPCI_REGISTRY_INFO BusData);
+
+BOOLEAN
+PcFindPciBios(
+    _Out_ PPCI_REGISTRY_INFO BusData);
 
 /*
  * Disk Variables and Functions


### PR DESCRIPTION
## Purpose

Preparation for streamlining PCI bus support on Freeloader, for any architecture where it could make sense (and not just on x86/x64).
Since future commits will touch this file, I take the opportunity to do the reformatting separately first.

Extracted from PR #7416.
