### PR TITLE
[HALX86][MINIHAL] Further code cleanup

### DIFF
--- a/hal/halx86/acpi/busemul.c
+++ b/hal/halx86/acpi/busemul.c
@@ -16,6 +16,7 @@
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
+#ifndef _MINIHAL_
 CODE_SEG("INIT")
 VOID
 NTAPI
@@ -26,7 +27,6 @@ HalpRegisterKdSupportFunctions(VOID)
     KdReleasePciDeviceforDebugging = HalpReleasePciDeviceForDebugging;
 
     /* Register memory functions */
-#ifndef _MINIHAL_
 #if (NTDDI_VERSION >= NTDDI_VISTA)
     KdMapPhysicalMemory64 = HalpMapPhysicalMemory64Vista;
     KdUnmapVirtualAddress = HalpUnmapVirtualAddressVista;
@@ -34,11 +34,11 @@ HalpRegisterKdSupportFunctions(VOID)
     KdMapPhysicalMemory64 = HalpMapPhysicalMemory64;
     KdUnmapVirtualAddress = HalpUnmapVirtualAddress;
 #endif
-#endif
 
     /* Register ACPI stub */
     KdCheckPowerButton = HalpCheckPowerButton;
 }
+#endif // !_MINIHAL_
 
 NTSTATUS
 NTAPI
@@ -109,6 +109,7 @@ HalpFindBusAddressTranslation(IN PHYSICAL_ADDRESS BusAddress,
 
 /* PUBLIC FUNCTIONS **********************************************************/
 
+#ifndef _MINIHAL_
 /*
  * @implemented
  */
@@ -119,6 +120,7 @@ HalAdjustResourceList(IN OUT PIO_RESOURCE_REQUIREMENTS_LIST* pRequirementsList)
     /* Deprecated, return success */
     return STATUS_SUCCESS;
 }
+#endif // !_MINIHAL_
 
 /*
  * @implemented
@@ -227,6 +229,7 @@ HalGetBusDataByOffset(IN BUS_DATA_TYPE BusDataType,
     return 0;
 }
 
+#ifndef _MINIHAL_
 /*
  * @implemented
  */
@@ -245,6 +248,7 @@ HalGetInterruptVector(IN INTERFACE_TYPE InterfaceType,
                                       Irql,
                                       Affinity);
 }
+#endif // !_MINIHAL_
 
 /*
  * @implemented

--- a/hal/halx86/generic/spinlock.c
+++ b/hal/halx86/generic/spinlock.c
@@ -39,7 +39,7 @@ KefAcquireSpinLockAtDpcLevel(
     *SpinLock = (KSPIN_LOCK)KeGetCurrentThread() | 1;
 #endif
 }
-#endif /* defined(_MINIHAL_) */
+#endif // _MINIHAL_
 
 /*
  * @implemented
@@ -86,6 +86,7 @@ KfReleaseSpinLock(PKSPIN_LOCK SpinLock,
     KeLowerIrql(OldIrql);
 }
 
+#ifndef _MINIHAL_
 /*
  * @implemented
  */
@@ -185,7 +186,6 @@ KeReleaseInStackQueuedSpinLock(IN PKLOCK_QUEUE_HANDLE LockHandle)
     KeLowerIrql(LockHandle->OldIrql);
 }
 
-#ifndef _MINIHAL_
 /*
  * @implemented
  */
@@ -217,9 +217,9 @@ KeTryToAcquireQueuedSpinLock(IN KSPIN_LOCK_QUEUE_NUMBER LockNumber,
     /* HACK */
     return KeTryToAcquireSpinLockAtDpcLevel(Lock);
 }
-#endif /* !defined(_MINIHAL_) */
+#endif // !_MINIHAL_
 
-#endif /* defined(_M_IX86) */
+#endif // _M_IX86
 
 VOID
 NTAPI
@@ -253,4 +253,3 @@ HalpReleaseCmosSpinLock(VOID)
     /* Restore the flags */
     __writeeflags(Flags);
 }
-

--- a/hal/halx86/legacy/bussupp.c
+++ b/hal/halx86/legacy/bussupp.c
@@ -12,99 +12,16 @@
 #define NDEBUG
 #include <debug.h>
 
-CODE_SEG("INIT")
-PBUS_HANDLER
-NTAPI
-HalpAllocateAndInitPciBusHandler(
-    IN ULONG PciType,
-    IN ULONG BusNo,
-    IN BOOLEAN TestAllocation
-);
-
-CODE_SEG("INIT")
-VOID
-NTAPI
-HalpFixupPciSupportedRanges(
-    IN ULONG BusCount
-);
-
-CODE_SEG("INIT")
-NTSTATUS
-NTAPI
-HalpGetChipHacks(
-    IN USHORT VendorId,
-    IN USHORT DeviceId,
-    IN UCHAR RevisionId,
-    IN PULONG HackFlags
-);
-
-CODE_SEG("INIT")
-BOOLEAN
-NTAPI
-HalpGetPciBridgeConfig(
-    IN ULONG PciType,
-    IN PUCHAR BusCount
-);
-
-CODE_SEG("INIT")
-BOOLEAN
-NTAPI
-HalpIsBridgeDevice(
-    IN PPCI_COMMON_CONFIG PciData
-);
-
-CODE_SEG("INIT")
-BOOLEAN
-NTAPI
-HalpIsIdeDevice(
-    IN PPCI_COMMON_CONFIG PciData
-);
-
-CODE_SEG("INIT")
-BOOLEAN
-NTAPI
-HalpIsRecognizedCard(
-    IN PPCI_REGISTRY_INFO_INTERNAL PciRegistryInfo,
-    IN PPCI_COMMON_CONFIG PciData,
-    IN ULONG Flags
-);
-
-CODE_SEG("INIT")
-BOOLEAN
-NTAPI
-HalpIsValidPCIDevice(
-    IN PBUS_HANDLER BusHandler,
-    IN PCI_SLOT_NUMBER Slot
-);
-
-CODE_SEG("INIT")
-NTSTATUS
-NTAPI
-HalpMarkChipsetDecode(
-    IN BOOLEAN OverrideEnable
-);
-
-CODE_SEG("INIT")
-VOID
-NTAPI
-HalpRegisterInternalBusHandlers(
-    VOID
-);
-
-CODE_SEG("INIT")
-VOID
-NTAPI
-ShowSize(
-    IN ULONG Size
-);
-
 /* GLOBALS ********************************************************************/
 
+#ifndef _MINIHAL_
 extern KSPIN_LOCK HalpPCIConfigLock;
 ULONG HalpPciIrqMask;
+#endif
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
+#ifndef _MINIHAL_
 PBUS_HANDLER
 NTAPI
 HalpAllocateBusHandler(IN INTERFACE_TYPE InterfaceType,
@@ -152,9 +69,8 @@ HalpAllocateBusHandler(IN INTERFACE_TYPE InterfaceType,
     return Bus;
 }
 
-#ifndef _MINIHAL_
 CODE_SEG("INIT")
-VOID
+static VOID
 NTAPI
 HalpRegisterInternalBusHandlers(VOID)
 {
@@ -226,13 +142,11 @@ HalpRegisterInternalBusHandlers(VOID)
     /* No support for EISA or MCA */
     ASSERT(HalpBusType == MACHINE_TYPE_ISA);
 }
-#endif // _MINIHAL_
 
-#ifndef _MINIHAL_
 CODE_SEG("INIT")
-NTSTATUS
+static NTSTATUS
 NTAPI
-HalpMarkChipsetDecode(BOOLEAN OverrideEnable)
+HalpMarkChipsetDecode(IN BOOLEAN OverrideEnable)
 {
     NTSTATUS Status;
     UNICODE_STRING KeyString;
@@ -278,7 +192,7 @@ HalpMarkChipsetDecode(BOOLEAN OverrideEnable)
 }
 
 CODE_SEG("INIT")
-PBUS_HANDLER
+static PBUS_HANDLER
 NTAPI
 HalpAllocateAndInitPciBusHandler(IN ULONG PciType,
                                  IN ULONG BusNo,
@@ -363,7 +277,7 @@ HalpAllocateAndInitPciBusHandler(IN ULONG PciType,
 }
 
 CODE_SEG("INIT")
-BOOLEAN
+static BOOLEAN
 NTAPI
 HalpIsValidPCIDevice(IN PBUS_HANDLER BusHandler,
                      IN PCI_SLOT_NUMBER Slot)
@@ -422,10 +336,8 @@ HalpIsValidPCIDevice(IN PBUS_HANDLER BusHandler,
     return TRUE;
 }
 
-static BOOLEAN WarningsGiven[5];
-
 CODE_SEG("INIT")
-NTSTATUS
+static NTSTATUS
 NTAPI
 HalpGetChipHacks(IN USHORT VendorId,
                  IN USHORT DeviceId,
@@ -489,7 +401,7 @@ HalpGetChipHacks(IN USHORT VendorId,
 }
 
 CODE_SEG("INIT")
-BOOLEAN
+static BOOLEAN
 NTAPI
 HalpIsRecognizedCard(IN PPCI_REGISTRY_INFO_INTERNAL PciRegistryInfo,
                      IN PPCI_COMMON_CONFIG PciData,
@@ -570,7 +482,7 @@ HalpIsRecognizedCard(IN PPCI_REGISTRY_INFO_INTERNAL PciRegistryInfo,
 }
 
 CODE_SEG("INIT")
-BOOLEAN
+static BOOLEAN
 NTAPI
 HalpIsIdeDevice(IN PPCI_COMMON_CONFIG PciData)
 {
@@ -623,7 +535,7 @@ HalpIsIdeDevice(IN PPCI_COMMON_CONFIG PciData)
 }
 
 CODE_SEG("INIT")
-BOOLEAN
+static BOOLEAN
 NTAPI
 HalpIsBridgeDevice(IN PPCI_COMMON_CONFIG PciData)
 {
@@ -636,8 +548,10 @@ HalpIsBridgeDevice(IN PPCI_COMMON_CONFIG PciData)
              (PciData->SubClass == PCI_SUBCLASS_BR_CARDBUS)));
 }
 
+static BOOLEAN WarningsGiven[5];
+
 CODE_SEG("INIT")
-BOOLEAN
+static BOOLEAN
 NTAPI
 HalpGetPciBridgeConfig(IN ULONG PciType,
                        IN PUCHAR BusCount)
@@ -691,7 +605,7 @@ HalpGetPciBridgeConfig(IN ULONG PciType,
 }
 
 CODE_SEG("INIT")
-VOID
+static VOID
 NTAPI
 HalpFixupPciSupportedRanges(IN ULONG BusCount)
 {
@@ -756,9 +670,8 @@ HalpFixupPciSupportedRanges(IN ULONG BusCount)
 }
 
 CODE_SEG("INIT")
-VOID
-NTAPI
-ShowSize(ULONG x)
+static VOID
+ShowSize(IN ULONG x)
 {
     if (!x) return;
     DbgPrint(" [size=");
@@ -1015,7 +928,7 @@ HalpDebugPciDumpBus(IN PBUS_HANDLER BusHandler,
         }
     }
 }
-#endif
+#endif // !_MINIHAL_
 
 CODE_SEG("INIT")
 VOID
@@ -1253,7 +1166,7 @@ HalpInitializePciBus(VOID)
     /* Tell PnP if this hard supports correct decoding */
     HalpMarkChipsetDecode(ExtendedAddressDecoding);
     DbgPrint("====== PCI BUS DETECTION COMPLETE =======\n\n");
-#endif
+#endif // !_MINIHAL_
 }
 
 #ifndef _MINIHAL_
@@ -1276,7 +1189,6 @@ HalpRegisterKdSupportFunctions(VOID)
     KdReleasePciDeviceforDebugging = HalpReleasePciDeviceForDebugging;
 
     /* Register memory functions */
-#ifndef _MINIHAL_
 #if (NTDDI_VERSION >= NTDDI_VISTA)
     KdMapPhysicalMemory64 = HalpMapPhysicalMemory64Vista;
     KdUnmapVirtualAddress = HalpUnmapVirtualAddressVista;
@@ -1284,12 +1196,11 @@ HalpRegisterKdSupportFunctions(VOID)
     KdMapPhysicalMemory64 = HalpMapPhysicalMemory64;
     KdUnmapVirtualAddress = HalpUnmapVirtualAddress;
 #endif
-#endif
 
     /* Register ACPI stub */
     KdCheckPowerButton = HalpCheckPowerButton;
 }
-#endif // _MINIHAL_
+#endif // !_MINIHAL_
 
 NTSTATUS
 NTAPI
@@ -1467,7 +1378,7 @@ HalAdjustResourceList(IN PIO_RESOURCE_REQUIREMENTS_LIST *ResourceList)
     HalDereferenceBusHandler(Handler);
     return Status;
 }
-#endif // _MINIHAL_
+#endif // !_MINIHAL_
 
 /*
  * @implemented
@@ -1532,7 +1443,7 @@ HalGetBusData(IN BUS_DATA_TYPE BusDataType,
                                  0,
                                  Length);
 }
-#endif // _MINIHAL_
+#endif // !_MINIHAL_
 
 /*
  * @implemented
@@ -1664,7 +1575,7 @@ HalSetBusDataByOffset(IN BUS_DATA_TYPE BusDataType,
     HalDereferenceBusHandler(Handler);
     return Status;
 }
-#endif // _MINIHAL_
+#endif // !_MINIHAL_
 
 /*
  * @implemented

--- a/hal/halx86/minihal/halinit.c
+++ b/hal/halx86/minihal/halinit.c
@@ -5,61 +5,10 @@
  * COPYRIGHT:   Copyright 1998 David Welch <welch@cwcom.net>
  */
 
-/* INCLUDES *****************************************************************/
+/* INCLUDES ******************************************************************/
 
 #include <hal.h>
-#define NDEBUG
-#include <debug.h>
 
-/* FUNCTIONS ***************************************************************/
-
-VOID
-NTAPI
-HalpInitProcessor(
-    IN ULONG ProcessorNumber,
-    IN PLOADER_PARAMETER_BLOCK LoaderBlock)
-{
-}
-
-VOID
-HalpInitPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
-{
-}
-
-VOID
-HalpInitPhase1(VOID)
-{
-}
-
-CODE_SEG("INIT")
-NTSTATUS
-NTAPI
-HalpSetupAcpiPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
-{
-    return STATUS_SUCCESS;
-}
-
-VOID
-NTAPI
-HalpInitializePICs(IN BOOLEAN EnableInterrupts)
-{
-}
-
-PDMA_ADAPTER
-NTAPI
-HalpGetDmaAdapter(
-    IN PVOID Context,
-    IN PDEVICE_DESCRIPTION DeviceDescription,
-    OUT PULONG NumberOfMapRegisters)
-{
-    return NULL;
-}
-
-BOOLEAN
-NTAPI
-HalpBiosDisplayReset(VOID)
-{
-    return FALSE;
-}
+/* FUNCTIONS *****************************************************************/
 
 /* EOF */


### PR DESCRIPTION
## Purpose

Preparation for minimal bus support reworking in the mini_hal library, so as to be able to have Freeloader supporting PCI bus with this library, on any architecture where it could make sense (and not just on x86).

Addendum to commit 9ba1849a97 (PR #5359).

Extracted from PR #7416.

## Proposed changes

- Remove unnecessary functions pre-declarations.
- Further exclude from compilation routines that are not actually used in (nor necessary for) the mini-hal library.
