### PR TITLE
[MSHTML] Fix random test failure of htmldoc

### DIFF
--- a/dll/win32/mshtml/mshtml_private.h
+++ b/dll/win32/mshtml/mshtml_private.h
@@ -891,6 +891,7 @@ void nsAString_InitDepend(nsAString*,const PRUnichar*) DECLSPEC_HIDDEN;
 UINT32 nsAString_GetData(const nsAString*,const PRUnichar**) DECLSPEC_HIDDEN;
 void nsAString_Finish(nsAString*) DECLSPEC_HIDDEN;
 
+HRESULT map_nsresult(nsresult);
 HRESULT return_nsstr(nsresult,nsAString*,BSTR*) DECLSPEC_HIDDEN;
 
 static inline HRESULT return_nsstr_variant(nsresult nsres, nsAString *nsstr, VARIANT *p)

--- a/dll/win32/mshtml/navigate.c
+++ b/dll/win32/mshtml/navigate.c
@@ -1041,8 +1041,12 @@ static HRESULT read_stream_data(nsChannelBSC *This, IStream *stream)
                 (nsIRequest*)&This->nschannel->nsIHttpChannel_iface, This->nscontext,
                 &This->nsstream->nsIInputStream_iface, This->bsc.readed-This->nsstream->buf_size,
                 This->nsstream->buf_size);
-        if(NS_FAILED(nsres))
-            ERR("OnDataAvailable failed: %08x\n", nsres);
+#ifdef __REACTOS__
+        if(NS_FAILED(nsres)) {
+            WARN("OnDataAvailable failed: %08lx\n", nsres);
+            return map_nsresult(nsres);
+        }
+#endif
 
         if(This->nsstream->buf_size == sizeof(This->nsstream->buf)) {
             ERR("buffer is full\n");

--- a/dll/win32/mshtml/navigate.c
+++ b/dll/win32/mshtml/navigate.c
@@ -1046,6 +1046,9 @@ static HRESULT read_stream_data(nsChannelBSC *This, IStream *stream)
             WARN("OnDataAvailable failed: %08lx\n", nsres);
             return map_nsresult(nsres);
         }
+#else
+        if(NS_FAILED(nsres))
+            ERR("OnDataAvailable failed: %08x\n", nsres);
 #endif
 
         if(This->nsstream->buf_size == sizeof(This->nsstream->buf)) {

--- a/dll/win32/mshtml/nsembed.c
+++ b/dll/win32/mshtml/nsembed.c
@@ -838,6 +838,36 @@ void nsAString_Finish(nsAString *str)
     NS_StringContainerFinish(str);
 }
 
+HRESULT map_nsresult(nsresult nsres)
+{
+    switch(nsres) {
+    case NS_OK:
+        return S_OK;
+    case NS_ERROR_OUT_OF_MEMORY:
+        return E_OUTOFMEMORY;
+    case NS_ERROR_NOT_IMPLEMENTED:
+        return E_NOTIMPL;
+    case NS_NOINTERFACE:
+        return E_NOINTERFACE;
+    case NS_ERROR_INVALID_POINTER:
+        return E_POINTER;
+    case NS_ERROR_INVALID_ARG:
+        return E_INVALIDARG;
+    case NS_ERROR_UNEXPECTED:
+        return E_UNEXPECTED;
+#ifndef __REACTOS__
+    /* FIXME: These are not yet defined for ReactOS */
+    case NS_ERROR_DOM_NO_MODIFICATION_ALLOWED_ERR:
+        return 0x80700007; /* according to tests */
+    case NS_ERROR_DOM_SYNTAX_ERR:
+        return E_INVALIDARG; /* FIXME: Throw SyntaxError for IE9+ modes */
+#endif
+    case NS_BINDING_ABORTED:
+        return E_ABORT;
+    }
+    return E_FAIL;
+}
+
 HRESULT return_nsstr(nsresult nsres, nsAString *nsstr, BSTR *p)
 {
     const PRUnichar *str;


### PR DESCRIPTION
CORE-14606

## Purpose

_Fix mshtml winetests for htmldoc test._

JIRA issue: [CORE-14606](https://jira.reactos.org/browse/CORE-14606)

## Proposed changes

_Import some wine code from read_stream_data function in navigate.c._
_Import function map_nsresult into nsembed.c._
_Define function map_nsreslts in mshtml_private.h._

Import part of https://gitlab.winehq.org/wine/wine/-/commit/78a05ca6dd746325de4a17b4fbe892b9ff50a373
authored Mar 26, 2019 by Jacek Caban
Description: mshtml: Introduce map_nsresult and use it in return_nsstr.

Import part of https://gitlab.winehq.org/wine/wine/-/commit/9944c4bd688b40c3c856d37517c2587996157cd9
authored Mar 26, 2019 by Jacek Caban 
Description: mshtml: Propagate nsIDOMCSSStyleDeclaration errors.

Import https://gitlab.winehq.org/wine/wine/-/commit/c2d55cd24eee7acec8f704d8295790858bb040d9
wine commit from Nov 7, 2022 by Gabriel Ivancescu from Wine 7.21 Released 11-Nov-2022:
Description: mshtml: Return E_ABORT if wine-gecko's OnDataAvailable aborts the binding.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=109928,109968 LGTM (I chose a crash to compare against)
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=109966,109969 (Only runs 2 tests. Bad for a while)