### PR TITLE
[WINSPOOL][SPOOLSS][SPOOLSV][LOCALSPL] Implement printer creation and deletion

### DIFF
--- a/modules/rostests/apitests/winspool/AddPrinter.c
+++ b/modules/rostests/apitests/winspool/AddPrinter.c
@@ -1,0 +1,257 @@
+/*
+ * PROJECT:     ReactOS Print Spooler DLL API Tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for AddPrinter, SetPrinter and DeletePrinter
+ * COPYRIGHT:   Copyright 2026 Ahmed Arif <arif.ing@outlook.com>
+ */
+
+#include <apitest.h>
+
+#define WIN32_NO_STATUS
+#include <windef.h>
+#include <winbase.h>
+#include <wingdi.h>
+#include <winspool.h>
+#include <stdio.h>
+#include <strsafe.h>
+
+#define TEST_PRINTER_NAME   "ReactOS AddPrinter Test"
+#define TEST_PRINTER_NAMEW  L"ReactOS AddPrinter Test"
+
+/**
+ * The ANSI entries convert the strings of the caller's structure for the
+ * Unicode call underneath. That conversion must never happen in place: the
+ * caller keeps owning the structure and reads its strings again afterwards.
+ * Getting this wrong leaves freed Unicode pointers in the caller's ANSI
+ * structure, which is what made Visual Basic 6 applications crash in
+ * MultiByteToWideChar while adding a printer (CORE-19134).
+ */
+static void
+Test_AddPrinterA_DoesNotModifyCallersStructure(void)
+{
+    CHAR szComment[] = "Test comment";
+    CHAR szDatatype[] = "RAW";
+    CHAR szDriverName[] = "ReactOS Test Driver";
+    CHAR szLocation[] = "Test location";
+    CHAR szParameters[] = "Test parameters";
+    CHAR szPortName[] = "FILE:";
+    CHAR szPrinterName[] = TEST_PRINTER_NAME;
+    CHAR szPrintProcessor[] = "WinPrint";
+    CHAR szSepFile[] = "Test sepfile";
+    CHAR szShareName[] = "Test share";
+    HANDLE hPrinter;
+    PRINTER_INFO_2A pi2;
+    PRINTER_INFO_2A pi2Saved;
+
+    ZeroMemory(&pi2, sizeof(pi2));
+    pi2.pPrinterName = szPrinterName;
+    pi2.pShareName = szShareName;
+    pi2.pPortName = szPortName;
+    pi2.pDriverName = szDriverName;
+    pi2.pComment = szComment;
+    pi2.pLocation = szLocation;
+    pi2.pSepFile = szSepFile;
+    pi2.pPrintProcessor = szPrintProcessor;
+    pi2.pDatatype = szDatatype;
+    pi2.pParameters = szParameters;
+
+    CopyMemory(&pi2Saved, &pi2, sizeof(pi2));
+
+    // This is expected to fail, because "ReactOS Test Driver" is not installed.
+    // What it must not do is touch our structure.
+    SetLastError(0xDEADBEEF);
+    hPrinter = AddPrinterA(NULL, 2, (PBYTE)&pi2);
+
+    if (hPrinter)
+    {
+        DeletePrinter(hPrinter);
+        ClosePrinter(hPrinter);
+    }
+
+    ok(pi2.pServerName == pi2Saved.pServerName, "pServerName was changed to %p!\n", pi2.pServerName);
+    ok(pi2.pPrinterName == pi2Saved.pPrinterName, "pPrinterName was changed to %p!\n", pi2.pPrinterName);
+    ok(pi2.pShareName == pi2Saved.pShareName, "pShareName was changed to %p!\n", pi2.pShareName);
+    ok(pi2.pPortName == pi2Saved.pPortName, "pPortName was changed to %p!\n", pi2.pPortName);
+    ok(pi2.pDriverName == pi2Saved.pDriverName, "pDriverName was changed to %p!\n", pi2.pDriverName);
+    ok(pi2.pComment == pi2Saved.pComment, "pComment was changed to %p!\n", pi2.pComment);
+    ok(pi2.pLocation == pi2Saved.pLocation, "pLocation was changed to %p!\n", pi2.pLocation);
+    ok(pi2.pDevMode == pi2Saved.pDevMode, "pDevMode was changed to %p!\n", pi2.pDevMode);
+    ok(pi2.pSepFile == pi2Saved.pSepFile, "pSepFile was changed to %p!\n", pi2.pSepFile);
+    ok(pi2.pPrintProcessor == pi2Saved.pPrintProcessor, "pPrintProcessor was changed to %p!\n", pi2.pPrintProcessor);
+    ok(pi2.pDatatype == pi2Saved.pDatatype, "pDatatype was changed to %p!\n", pi2.pDatatype);
+    ok(pi2.pParameters == pi2Saved.pParameters, "pParameters was changed to %p!\n", pi2.pParameters);
+
+    // The strings themselves have to be intact as well.
+    ok(!strcmp(szPrinterName, TEST_PRINTER_NAME), "szPrinterName is \"%s\"!\n", szPrinterName);
+    ok(!strcmp(szPortName, "FILE:"), "szPortName is \"%s\"!\n", szPortName);
+    ok(!strcmp(szDriverName, "ReactOS Test Driver"), "szDriverName is \"%s\"!\n", szDriverName);
+    ok(!strcmp(szPrintProcessor, "WinPrint"), "szPrintProcessor is \"%s\"!\n", szPrintProcessor);
+}
+
+static void
+Test_AddPrinter_InvalidParameters(void)
+{
+    PRINTER_INFO_2W pi2;
+
+    ZeroMemory(&pi2, sizeof(pi2));
+
+    SetLastError(0xDEADBEEF);
+    ok(!AddPrinterW(NULL, 1, (PBYTE)&pi2), "AddPrinterW succeeded for level 1!\n");
+    ok(GetLastError() == ERROR_INVALID_LEVEL, "AddPrinterW returns error %lu!\n", GetLastError());
+
+    SetLastError(0xDEADBEEF);
+    ok(!AddPrinterW(NULL, 2, NULL), "AddPrinterW succeeded for a NULL structure!\n");
+
+    SetLastError(0xDEADBEEF);
+    ok(!DeletePrinter(NULL), "DeletePrinter succeeded for a NULL handle!\n");
+    ok(GetLastError() == ERROR_INVALID_HANDLE, "DeletePrinter returns error %lu!\n", GetLastError());
+}
+
+#define TEST_DRIVER_NAMEW   L"ReactOS AddPrinter Test Driver"
+
+/**
+ * Installs a throwaway printer driver, then runs the sequence a printer setup
+ * performs: AddPrinterDriverEx, AddPrinter, EnumPrinters, SetPrinter and
+ * DeletePrinter (CORE-19134, CORE-20750).
+ */
+static void
+Test_AddPrinter_Cycle(void)
+{
+    BOOL bFound;
+    DRIVER_INFO_3W di3;
+    DWORD cbNeeded;
+    DWORD dwReturned;
+    DWORD i;
+    HANDLE hPrinter = NULL;
+    PPRINTER_INFO_2W pPrinterInfo = NULL;
+    PRINTER_INFO_2W pi2;
+    WCHAR wszConfigFile[MAX_PATH];
+    WCHAR wszDataFile[MAX_PATH];
+    WCHAR wszDriverPath[MAX_PATH];
+    WCHAR wszSystemDir[MAX_PATH];
+
+    if (!GetSystemDirectoryW(wszSystemDir, _countof(wszSystemDir)))
+    {
+        skip("GetSystemDirectoryW failed with error %lu!\n", GetLastError());
+        return;
+    }
+
+    // Any existing DLL will do; the driver is never actually used for printing here.
+    StringCchPrintfW(wszDriverPath, _countof(wszDriverPath), L"%s\\localspl.dll", wszSystemDir);
+    StringCchPrintfW(wszDataFile, _countof(wszDataFile), L"%s\\localspl.dll", wszSystemDir);
+    StringCchPrintfW(wszConfigFile, _countof(wszConfigFile), L"%s\\printui.dll", wszSystemDir);
+
+    ZeroMemory(&di3, sizeof(di3));
+    di3.cVersion = 3;
+    di3.pName = TEST_DRIVER_NAMEW;
+    di3.pEnvironment = NULL;
+    di3.pDriverPath = wszDriverPath;
+    di3.pDataFile = wszDataFile;
+    di3.pConfigFile = wszConfigFile;
+    di3.pDefaultDataType = L"RAW";
+
+    SetLastError(0xDEADBEEF);
+    if (!AddPrinterDriverExW(NULL, 3, (PBYTE)&di3, APD_COPY_ALL_FILES))
+    {
+        skip("AddPrinterDriverExW failed with error %lu!\n", GetLastError());
+        return;
+    }
+
+    ZeroMemory(&pi2, sizeof(pi2));
+    pi2.pPrinterName = TEST_PRINTER_NAMEW;
+    pi2.pPortName = L"FILE:";
+    pi2.pDriverName = TEST_DRIVER_NAMEW;
+    pi2.pPrintProcessor = L"WinPrint";
+    pi2.pDatatype = L"RAW";
+    pi2.pComment = L"Added by winspool_apitest";
+    pi2.pLocation = L"";
+    pi2.pShareName = L"";
+    pi2.pSepFile = L"";
+    pi2.pParameters = L"";
+
+    SetLastError(0xDEADBEEF);
+    hPrinter = AddPrinterW(NULL, 2, (PBYTE)&pi2);
+    ok(hPrinter != NULL, "AddPrinterW failed with error %lu!\n", GetLastError());
+
+    if (!hPrinter)
+        return;
+
+    // The new printer has to show up in the enumeration.
+    bFound = FALSE;
+    cbNeeded = 0;
+    dwReturned = 0;
+    EnumPrintersW(PRINTER_ENUM_LOCAL, NULL, 2, NULL, 0, &cbNeeded, &dwReturned);
+
+    if (cbNeeded)
+    {
+        pPrinterInfo = HeapAlloc(GetProcessHeap(), 0, cbNeeded);
+
+        if (pPrinterInfo && EnumPrintersW(PRINTER_ENUM_LOCAL, NULL, 2, (PBYTE)pPrinterInfo, cbNeeded, &cbNeeded, &dwReturned))
+        {
+            for (i = 0; i < dwReturned; i++)
+            {
+                if (!wcscmp(pPrinterInfo[i].pPrinterName, TEST_PRINTER_NAMEW))
+                {
+                    bFound = TRUE;
+                    break;
+                }
+            }
+        }
+
+        if (pPrinterInfo)
+            HeapFree(GetProcessHeap(), 0, pPrinterInfo);
+    }
+
+    ok(bFound, "The added printer was not returned by EnumPrintersW!\n");
+
+    // Changing the printer has to work as well.
+    pi2.pComment = L"Changed by winspool_apitest";
+    SetLastError(0xDEADBEEF);
+    ok(SetPrinterW(hPrinter, 2, (PBYTE)&pi2, 0), "SetPrinterW failed with error %lu!\n", GetLastError());
+
+    SetLastError(0xDEADBEEF);
+    ok(SetPrinterW(hPrinter, 0, NULL, PRINTER_CONTROL_PAUSE), "SetPrinterW(PAUSE) failed with error %lu!\n", GetLastError());
+
+    SetLastError(0xDEADBEEF);
+    ok(SetPrinterW(hPrinter, 0, NULL, PRINTER_CONTROL_RESUME), "SetPrinterW(RESUME) failed with error %lu!\n", GetLastError());
+
+    // Now delete it again.
+    SetLastError(0xDEADBEEF);
+    ok(DeletePrinter(hPrinter), "DeletePrinter failed with error %lu!\n", GetLastError());
+    ClosePrinter(hPrinter);
+
+    // ...and it must be gone.
+    bFound = FALSE;
+    cbNeeded = 0;
+    dwReturned = 0;
+    EnumPrintersW(PRINTER_ENUM_LOCAL, NULL, 2, NULL, 0, &cbNeeded, &dwReturned);
+
+    if (cbNeeded)
+    {
+        pPrinterInfo = HeapAlloc(GetProcessHeap(), 0, cbNeeded);
+
+        if (pPrinterInfo && EnumPrintersW(PRINTER_ENUM_LOCAL, NULL, 2, (PBYTE)pPrinterInfo, cbNeeded, &cbNeeded, &dwReturned))
+        {
+            for (i = 0; i < dwReturned; i++)
+            {
+                if (!wcscmp(pPrinterInfo[i].pPrinterName, TEST_PRINTER_NAMEW))
+                {
+                    bFound = TRUE;
+                    break;
+                }
+            }
+        }
+
+        if (pPrinterInfo)
+            HeapFree(GetProcessHeap(), 0, pPrinterInfo);
+    }
+
+    ok(!bFound, "The deleted printer is still returned by EnumPrintersW!\n");
+}
+
+START_TEST(AddPrinter)
+{
+    Test_AddPrinter_InvalidParameters();
+    Test_AddPrinterA_DoesNotModifyCallersStructure();
+    Test_AddPrinter_Cycle();
+}

--- a/modules/rostests/apitests/winspool/AddPrinter.c
+++ b/modules/rostests/apitests/winspool/AddPrinter.c
@@ -11,6 +11,7 @@
 #include <windef.h>
 #include <winbase.h>
 #include <wingdi.h>
+#include <winuser.h>
 #include <winspool.h>
 #include <stdio.h>
 #include <strsafe.h>
@@ -107,6 +108,45 @@ Test_AddPrinter_InvalidParameters(void)
     ok(GetLastError() == ERROR_INVALID_HANDLE, "DeletePrinter returns error %lu!\n", GetLastError());
 }
 
+/* Changing the printers has to reach this session, or application lists go stale. */
+static UINT g_uLastBroadcast;
+static WCHAR g_wszLastDevice[MAX_PATH];
+
+static LRESULT CALLBACK
+BroadcastWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+    if (message == WM_DEVMODECHANGE || message == WM_WININICHANGE)
+    {
+        g_uLastBroadcast = message;
+
+        if (lParam)
+            StringCchCopyW(g_wszLastDevice, _countof(g_wszLastDevice), (PCWSTR)lParam);
+        else
+            g_wszLastDevice[0] = 0;
+    }
+
+    return DefWindowProcW(hWnd, message, wParam, lParam);
+}
+
+static HWND
+CreateBroadcastListener(VOID)
+{
+    WNDCLASSEXW wc;
+
+    ZeroMemory(&wc, sizeof(wc));
+    wc.cbSize = sizeof(wc);
+    wc.lpfnWndProc = BroadcastWndProc;
+    wc.hInstance = GetModuleHandleW(NULL);
+    wc.lpszClassName = L"AddPrinterBroadcastListener";
+
+    if (!RegisterClassExW(&wc))
+        return NULL;
+
+    /* HWND_BROADCAST only reaches top-level windows. */
+    return CreateWindowExW(0, wc.lpszClassName, L"", WS_OVERLAPPED,
+                           0, 0, 0, 0, NULL, NULL, wc.hInstance, NULL);
+}
+
 #define TEST_DRIVER_NAMEW   L"ReactOS AddPrinter Test Driver"
 
 /**
@@ -123,6 +163,7 @@ Test_AddPrinter_Cycle(void)
     DWORD dwReturned;
     DWORD i;
     HANDLE hPrinter = NULL;
+    HWND hwndListener;
     PPRINTER_INFO_2W pPrinterInfo = NULL;
     PRINTER_INFO_2W pi2;
     WCHAR wszConfigFile[MAX_PATH];
@@ -170,6 +211,9 @@ Test_AddPrinter_Cycle(void)
     pi2.pParameters = L"";
 
     SetLastError(0xDEADBEEF);
+    hwndListener = CreateBroadcastListener();
+
+    g_uLastBroadcast = 0;
     hPrinter = AddPrinterW(NULL, 2, (PBYTE)&pi2);
     ok(hPrinter != NULL, "AddPrinterW failed with error %lu!\n", GetLastError());
 
@@ -204,10 +248,23 @@ Test_AddPrinter_Cycle(void)
 
     ok(bFound, "The added printer was not returned by EnumPrintersW!\n");
 
+    if (hwndListener)
+    {
+        ok(g_uLastBroadcast != 0, "AddPrinterW broadcast nothing!\n");
+    }
+
     // Changing the printer has to work as well.
     pi2.pComment = L"Changed by winspool_apitest";
     SetLastError(0xDEADBEEF);
+    g_uLastBroadcast = 0;
     ok(SetPrinterW(hPrinter, 2, (PBYTE)&pi2, 0), "SetPrinterW failed with error %lu!\n", GetLastError());
+
+    if (hwndListener)
+    {
+        ok(g_uLastBroadcast != 0, "SetPrinterW broadcast nothing!\n");
+        ok(!wcscmp(g_wszLastDevice, TEST_PRINTER_NAMEW) || g_uLastBroadcast == WM_WININICHANGE,
+           "SetPrinterW broadcast for \"%S\"!\n", g_wszLastDevice);
+    }
 
     SetLastError(0xDEADBEEF);
     ok(SetPrinterW(hPrinter, 0, NULL, PRINTER_CONTROL_PAUSE), "SetPrinterW(PAUSE) failed with error %lu!\n", GetLastError());
@@ -217,8 +274,15 @@ Test_AddPrinter_Cycle(void)
 
     // Now delete it again.
     SetLastError(0xDEADBEEF);
+    g_uLastBroadcast = 0;
     ok(DeletePrinter(hPrinter), "DeletePrinter failed with error %lu!\n", GetLastError());
     ClosePrinter(hPrinter);
+
+    if (hwndListener)
+    {
+        ok(g_uLastBroadcast != 0, "DeletePrinter broadcast nothing!\n");
+        DestroyWindow(hwndListener);
+    }
 
     // ...and it must be gone.
     bFound = FALSE;

--- a/modules/rostests/apitests/winspool/CMakeLists.txt
+++ b/modules/rostests/apitests/winspool/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 list(APPEND SOURCE
+    AddPrinter.c
     ClosePrinter.c
     EnumPrinters.c
     EnumPrintProcessorDatatypes.c

--- a/modules/rostests/apitests/winspool/CMakeLists.txt
+++ b/modules/rostests/apitests/winspool/CMakeLists.txt
@@ -16,5 +16,5 @@ list(APPEND SOURCE
 add_executable(winspool_apitest ${SOURCE})
 target_link_libraries(winspool_apitest wine ${PSEH_LIB})
 set_module_type(winspool_apitest win32cui)
-add_importlibs(winspool_apitest winspool msvcrt kernel32 ntdll)
+add_importlibs(winspool_apitest winspool user32 msvcrt kernel32 ntdll)
 add_rostests_file(TARGET winspool_apitest)

--- a/modules/rostests/apitests/winspool/testlist.c
+++ b/modules/rostests/apitests/winspool/testlist.c
@@ -8,6 +8,7 @@
 #define STANDALONE
 #include <apitest.h>
 
+extern void func_AddPrinter(void);
 extern void func_ClosePrinter(void);
 extern void func_EnumPrinters(void);
 extern void func_EnumPrintProcessorDatatypes(void);
@@ -24,6 +25,7 @@ extern void func_StartDocPrinter(void);
 
 const struct test winetest_testlist[] =
 {
+    { "AddPrinter", func_AddPrinter },
     { "ClosePrinter", func_ClosePrinter },
     { "EnumPrinters", func_EnumPrinters },
     { "EnumPrintProcessorDatatypes", func_EnumPrintProcessorDatatypes },

--- a/win32ss/printing/base/spoolss/printers.c
+++ b/win32ss/printing/base/spoolss/printers.c
@@ -31,10 +31,11 @@ AddPrinterExW( PWSTR pName, DWORD Level, PBYTE pPrinter, PBYTE pClientInfo, DWOR
     BOOL bReturnValue;
     DWORD dwErrorCode = ERROR_INVALID_PRINTER_NAME;
     HANDLE hPrinter = NULL;
+    HANDLE hReturn = NULL;
     PWSTR pPrinterName = NULL;
     PLIST_ENTRY pEntry;
     PSPOOLSS_PRINTER_HANDLE pHandle;
-    PSPOOLSS_PRINT_PROVIDER pPrintProvider;
+    PSPOOLSS_PRINT_PROVIDER pPrintProvider = NULL;
 
     if ( Level != 2 )
     {
@@ -53,14 +54,21 @@ AddPrinterExW( PWSTR pName, DWORD Level, PBYTE pPrinter, PBYTE pClientInfo, DWOR
     {
         pPrintProvider = CONTAINING_RECORD(pEntry, SPOOLSS_PRINT_PROVIDER, Entry);
 
-        hPrinter = pPrintProvider->PrintProvider.fpAddPrinterEx(pName, Level, pPrinter, pClientInfo, ClientInfoLevel);
+        hPrinter = NULL;
+        bReturnValue = ERROR_NOT_SUPPORTED;
 
-        bReturnValue = GetLastError();
+        if (pPrintProvider->PrintProvider.fpAddPrinterEx)
+        {
+            hPrinter = pPrintProvider->PrintProvider.fpAddPrinterEx(pName, Level, pPrinter, pClientInfo, ClientInfoLevel);
+            bReturnValue = GetLastError();
+        }
 
-        // Fallback.... ?
-
+        // Fall back to the plain entry when this Print Provider has no Ex variant.
         if ( hPrinter == NULL && bReturnValue == ERROR_NOT_SUPPORTED )
         {
+            if (!pPrintProvider->PrintProvider.fpAddPrinter)
+                continue;
+
             hPrinter = pPrintProvider->PrintProvider.fpAddPrinter(pName, Level, pPrinter);
         }
 
@@ -81,6 +89,10 @@ AddPrinterExW( PWSTR pName, DWORD Level, PBYTE pPrinter, PBYTE pClientInfo, DWOR
             pHandle->pPrintProvider = pPrintProvider;
             pHandle->hPrinter = hPrinter;
 
+            // Every other spoolss entry expects a SPOOLSS_PRINTER_HANDLE, so hand
+            // out the wrapper rather than the Print Provider's own handle.
+            hReturn = (HANDLE)pHandle;
+
             dwErrorCode = ERROR_SUCCESS;
             goto Cleanup;
         }
@@ -90,6 +102,12 @@ AddPrinterExW( PWSTR pName, DWORD Level, PBYTE pPrinter, PBYTE pClientInfo, DWOR
             dwErrorCode = GetLastError();
             goto Cleanup;
         }
+        else if (bReturnValue != ROUTER_UNKNOWN && bReturnValue != ERROR_INVALID_NAME)
+        {
+            // Remember why this Print Provider refused, so that the caller gets the
+            // real reason instead of a generic ERROR_INVALID_PRINTER_NAME.
+            dwErrorCode = bReturnValue;
+        }
     }
 
 Cleanup:
@@ -97,8 +115,12 @@ Cleanup:
     if (dwErrorCode == ERROR_INVALID_NAME)
         dwErrorCode = ERROR_INVALID_PRINTER_NAME;
 
+    // The Printer was created but we could not wrap it, so don't leak it.
+    if (!hReturn && hPrinter && pPrintProvider && pPrintProvider->PrintProvider.fpClosePrinter)
+        pPrintProvider->PrintProvider.fpClosePrinter(hPrinter);
+
     SetLastError(dwErrorCode);
-    return hPrinter;
+    return hReturn;
 }
 
 HANDLE WINAPI
@@ -107,10 +129,11 @@ AddPrinterW(PWSTR pName, DWORD Level, PBYTE pPrinter)
     BOOL bReturnValue;
     DWORD dwErrorCode = ERROR_INVALID_PRINTER_NAME;
     HANDLE hPrinter = NULL;
+    HANDLE hReturn = NULL;
     PWSTR pPrinterName = NULL;
     PLIST_ENTRY pEntry;
     PSPOOLSS_PRINTER_HANDLE pHandle;
-    PSPOOLSS_PRINT_PROVIDER pPrintProvider;
+    PSPOOLSS_PRINT_PROVIDER pPrintProvider = NULL;
 
     FIXME("AddPrinterW(%S, %lu, %p)\n", pName, Level, pPrinter);
 
@@ -133,6 +156,9 @@ AddPrinterW(PWSTR pName, DWORD Level, PBYTE pPrinter)
     {
         pPrintProvider = CONTAINING_RECORD(pEntry, SPOOLSS_PRINT_PROVIDER, Entry);
 
+        if (!pPrintProvider->PrintProvider.fpAddPrinter)
+            continue;
+
         hPrinter = pPrintProvider->PrintProvider.fpAddPrinter(pName, Level, pPrinter);
 
         bReturnValue = GetLastError();
@@ -152,6 +178,10 @@ AddPrinterW(PWSTR pName, DWORD Level, PBYTE pPrinter)
             pHandle->pPrintProvider = pPrintProvider;
             pHandle->hPrinter = hPrinter;
 
+            // Every other spoolss entry expects a SPOOLSS_PRINTER_HANDLE, so hand
+            // out the wrapper rather than the Print Provider's own handle.
+            hReturn = (HANDLE)pHandle;
+
             dwErrorCode = ERROR_SUCCESS;
             goto Cleanup;
         }
@@ -161,6 +191,12 @@ AddPrinterW(PWSTR pName, DWORD Level, PBYTE pPrinter)
             dwErrorCode = GetLastError();
             goto Cleanup;
         }
+        else if (bReturnValue != ROUTER_UNKNOWN && bReturnValue != ERROR_INVALID_NAME)
+        {
+            // Remember why this Print Provider refused, so that the caller gets the
+            // real reason instead of a generic ERROR_INVALID_PRINTER_NAME.
+            dwErrorCode = bReturnValue;
+        }
     }
 
 Cleanup:
@@ -168,8 +204,12 @@ Cleanup:
     if (dwErrorCode == ERROR_INVALID_NAME)
         dwErrorCode = ERROR_INVALID_PRINTER_NAME;
 
+    // The Printer was created but we could not wrap it, so don't leak it.
+    if (!hReturn && hPrinter && pPrintProvider && pPrintProvider->PrintProvider.fpClosePrinter)
+        pPrintProvider->PrintProvider.fpClosePrinter(hPrinter);
+
     SetLastError(dwErrorCode);
-    return hPrinter;
+    return hReturn;
 }
 
 BOOL WINAPI
@@ -207,6 +247,12 @@ DeletePrinter(HANDLE hPrinter)
     if (!pHandle)
     {
         SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    if (!pHandle->pPrintProvider->PrintProvider.fpDeletePrinter)
+    {
+        SetLastError(ERROR_INVALID_FUNCTION);
         return FALSE;
     }
 
@@ -432,6 +478,12 @@ SetPrinterW(HANDLE hPrinter, DWORD Level, PBYTE pPrinter, DWORD Command)
     if (!pHandle)
     {
         SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    if (!pHandle->pPrintProvider->PrintProvider.fpSetPrinter)
+    {
+        SetLastError(ERROR_INVALID_FUNCTION);
         return FALSE;
     }
 

--- a/win32ss/printing/base/spoolsv/printers.c
+++ b/win32ss/printing/base/spoolsv/printers.c
@@ -27,11 +27,79 @@ _RpcAbortPrinter(WINSPOOL_PRINTER_HANDLE hPrinter)
     return dwErrorCode;
 }
 
+/**
+ * @name _FixupPrinterContainer
+ *
+ * pDevMode and pSecurityDescriptor are declared as ULONG_PTR in the IDL, so
+ * their contents are not carried inside the printer structure but in their own
+ * containers. Point the structure at the data that actually arrived.
+ */
+static VOID
+_FixupPrinterContainer(WINSPOOL_PRINTER_CONTAINER* pPrinterContainer, WINSPOOL_DEVMODE_CONTAINER* pDevModeContainer, WINSPOOL_SECURITY_CONTAINER* pSecurityContainer)
+{
+    PBYTE pPrinterInfo = (PBYTE)pPrinterContainer->PrinterInfo.pPrinterInfo1;
+    PBYTE pDevMode = NULL;
+    PBYTE pSecurityDescriptor = NULL;
+
+    if (!pPrinterInfo)
+        return;
+
+    if (pDevModeContainer && pDevModeContainer->cbBuf)
+        pDevMode = pDevModeContainer->pDevMode;
+
+    if (pSecurityContainer && pSecurityContainer->cbBuf)
+        pSecurityDescriptor = pSecurityContainer->pSecurity;
+
+    switch (pPrinterContainer->Level)
+    {
+        case 2:
+            ((PPRINTER_INFO_2W)pPrinterInfo)->pDevMode = (PDEVMODEW)pDevMode;
+            ((PPRINTER_INFO_2W)pPrinterInfo)->pSecurityDescriptor = pSecurityDescriptor;
+            break;
+
+        case 3:
+            ((PPRINTER_INFO_3)pPrinterInfo)->pSecurityDescriptor = pSecurityDescriptor;
+            break;
+
+        case 8:
+        case 9:
+            ((PPRINTER_INFO_9W)pPrinterInfo)->pDevMode = (PDEVMODEW)pDevMode;
+            break;
+
+        default:
+            break;
+    }
+}
+
 DWORD
 _RpcAddPrinter(WINSPOOL_HANDLE pName, WINSPOOL_PRINTER_CONTAINER* pPrinterContainer, WINSPOOL_DEVMODE_CONTAINER* pDevModeContainer, WINSPOOL_SECURITY_CONTAINER* pSecurityContainer, WINSPOOL_PRINTER_HANDLE* pHandle)
 {
-    UNIMPLEMENTED;
-    return ERROR_INVALID_FUNCTION;
+    DWORD dwErrorCode;
+
+    dwErrorCode = RpcImpersonateClient(NULL);
+    if (dwErrorCode != ERROR_SUCCESS)
+    {
+        ERR("RpcImpersonateClient failed with error %lu!\n", dwErrorCode);
+        return dwErrorCode;
+    }
+
+    *pHandle = NULL;
+
+    if (!pPrinterContainer || !pPrinterContainer->PrinterInfo.pPrinterInfo1)
+    {
+        dwErrorCode = ERROR_INVALID_PARAMETER;
+        goto Cleanup;
+    }
+
+    _FixupPrinterContainer(pPrinterContainer, pDevModeContainer, pSecurityContainer);
+
+    *pHandle = AddPrinterW(pName, pPrinterContainer->Level, (PBYTE)pPrinterContainer->PrinterInfo.pPrinterInfo1);
+    if (!*pHandle)
+        dwErrorCode = GetLastError();
+
+Cleanup:
+    RpcRevertToSelf();
+    return dwErrorCode;
 }
 
 DWORD
@@ -311,8 +379,29 @@ _RpcSeekPrinter( WINSPOOL_PRINTER_HANDLE hPrinter, LARGE_INTEGER liDistanceToMov
 DWORD
 _RpcSetPrinter(WINSPOOL_PRINTER_HANDLE hPrinter, WINSPOOL_PRINTER_CONTAINER* pPrinterContainer, WINSPOOL_DEVMODE_CONTAINER* pDevModeContainer, WINSPOOL_SECURITY_CONTAINER* pSecurityContainer, DWORD Command)
 {
-    UNIMPLEMENTED;
-    return ERROR_INVALID_FUNCTION;
+    DWORD dwErrorCode;
+
+    dwErrorCode = RpcImpersonateClient(NULL);
+    if (dwErrorCode != ERROR_SUCCESS)
+    {
+        ERR("RpcImpersonateClient failed with error %lu!\n", dwErrorCode);
+        return dwErrorCode;
+    }
+
+    if (!pPrinterContainer)
+    {
+        dwErrorCode = ERROR_INVALID_PARAMETER;
+        goto Cleanup;
+    }
+
+    _FixupPrinterContainer(pPrinterContainer, pDevModeContainer, pSecurityContainer);
+
+    if (!SetPrinterW(hPrinter, pPrinterContainer->Level, (PBYTE)pPrinterContainer->PrinterInfo.pPrinterInfo1, Command))
+        dwErrorCode = GetLastError();
+
+Cleanup:
+    RpcRevertToSelf();
+    return dwErrorCode;
 }
 
 DWORD

--- a/win32ss/printing/base/winspool/printers.c
+++ b/win32ss/printing/base/winspool/printers.c
@@ -60,6 +60,10 @@ typedef struct _COMPUI_USERDATA
     Ok, I admit that this has historical reasons. It's still not straightforward in any way though! */
 static const WCHAR wszWindowsKey[] = L"Software\\Microsoft\\Windows NT\\CurrentVersion\\Windows";
 static const WCHAR wszDeviceValue[] = L"Device";
+static const WCHAR wszDevicesKey[] = L"Software\\Microsoft\\Windows NT\\CurrentVersion\\Devices";
+static const WCHAR wszPrinterPortsKey[] = L"Software\\Microsoft\\Windows NT\\CurrentVersion\\PrinterPorts";
+static const WCHAR wszWinspoolPrefix[] = L"winspool,";
+static const WCHAR wszPortTimeouts[] = L",15,45";
 
 static DWORD
 _StartDocPrinterSpooled(PSPOOLER_HANDLE pHandle, PDOC_INFO_1W pDocInfo1, PADDJOB_INFO_1W pAddJobInfo1)
@@ -196,116 +200,205 @@ Cleanup:
     return (dwErrorCode == ERROR_SUCCESS);
 }
 
+/**
+ * @name _UpdatePerUserPrinterEntries
+ *
+ * Maintains the per-user "Devices" and "PrinterPorts" registry values for a
+ * Printer, in the same format the Windows NT spooler uses:
+ *
+ *   Devices\<Printer>      = "winspool,<Port>"
+ *   PrinterPorts\<Printer> = "winspool,<Port>,15,45"
+ *
+ * These are what the legacy win.ini [devices] and [PrinterPorts] sections map
+ * onto, and SetDefaultPrinter refuses a Printer that is not listed there.
+ * They are per-user data, so they have to be written here in winspool.drv,
+ * which runs in the caller's context, and not in the spooler service.
+ */
+static VOID
+_UpdatePerUserPrinterEntries(PCWSTR pwszPrinterName, PCWSTR pwszPortName, BOOL bAdd)
+{
+    HKEY hKey;
+    PWSTR pwszData;
+    SIZE_T cchData;
+
+    if (!pwszPrinterName || !*pwszPrinterName)
+        return;
+
+    if (bAdd)
+    {
+        if (!pwszPortName)
+            pwszPortName = L"";
+
+        // "winspool," + port + ",15,45" + terminator
+        cchData = wcslen(wszWinspoolPrefix) + wcslen(pwszPortName) + _countof(wszPortTimeouts);
+
+        pwszData = HeapAlloc(hProcessHeap, 0, cchData * sizeof(WCHAR));
+        if (!pwszData)
+            return;
+
+        if (RegCreateKeyExW(HKEY_CURRENT_USER, wszDevicesKey, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_SET_VALUE, NULL, &hKey, NULL) == ERROR_SUCCESS)
+        {
+            StringCchPrintfW(pwszData, cchData, L"%s%s", wszWinspoolPrefix, pwszPortName);
+            RegSetValueExW(hKey, pwszPrinterName, 0, REG_SZ, (const BYTE*)pwszData, (wcslen(pwszData) + 1) * sizeof(WCHAR));
+            RegCloseKey(hKey);
+        }
+
+        if (RegCreateKeyExW(HKEY_CURRENT_USER, wszPrinterPortsKey, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_SET_VALUE, NULL, &hKey, NULL) == ERROR_SUCCESS)
+        {
+            StringCchPrintfW(pwszData, cchData, L"%s%s%s", wszWinspoolPrefix, pwszPortName, wszPortTimeouts);
+            RegSetValueExW(hKey, pwszPrinterName, 0, REG_SZ, (const BYTE*)pwszData, (wcslen(pwszData) + 1) * sizeof(WCHAR));
+            RegCloseKey(hKey);
+        }
+
+        HeapFree(hProcessHeap, 0, pwszData);
+    }
+    else
+    {
+        if (RegOpenKeyExW(HKEY_CURRENT_USER, wszDevicesKey, 0, KEY_SET_VALUE, &hKey) == ERROR_SUCCESS)
+        {
+            RegDeleteValueW(hKey, pwszPrinterName);
+            RegCloseKey(hKey);
+        }
+
+        if (RegOpenKeyExW(HKEY_CURRENT_USER, wszPrinterPortsKey, 0, KEY_SET_VALUE, &hKey) == ERROR_SUCCESS)
+        {
+            RegDeleteValueW(hKey, pwszPrinterName);
+            RegCloseKey(hKey);
+        }
+
+        // Drop the default printer as well if it was this one.
+        if (RegOpenKeyExW(HKEY_CURRENT_USER, wszWindowsKey, 0, KEY_QUERY_VALUE | KEY_SET_VALUE, &hKey) == ERROR_SUCCESS)
+        {
+            DWORD cbData = 0;
+
+            if (RegQueryValueExW(hKey, wszDeviceValue, NULL, NULL, NULL, &cbData) == ERROR_SUCCESS)
+            {
+                pwszData = HeapAlloc(hProcessHeap, 0, cbData + sizeof(WCHAR));
+
+                if (pwszData)
+                {
+                    if (RegQueryValueExW(hKey, wszDeviceValue, NULL, NULL, (PBYTE)pwszData, &cbData) == ERROR_SUCCESS)
+                    {
+                        SIZE_T cchPrinterName = wcslen(pwszPrinterName);
+
+                        pwszData[cbData / sizeof(WCHAR)] = 0;
+
+                        if (_wcsnicmp(pwszData, pwszPrinterName, cchPrinterName) == 0 && pwszData[cchPrinterName] == L',')
+                            RegDeleteValueW(hKey, wszDeviceValue);
+                    }
+
+                    HeapFree(hProcessHeap, 0, pwszData);
+                }
+            }
+
+            RegCloseKey(hKey);
+        }
+    }
+}
+
+/**
+ * The string members of PRINTER_INFO_2A and PRINTER_INFO_2W sit at identical
+ * offsets, so one table can drive the ANSI -> Unicode conversion of all of them.
+ */
+static const DWORD dwPrinterInfo2StringOffsets[] = {
+    FIELD_OFFSET(PRINTER_INFO_2W, pServerName),
+    FIELD_OFFSET(PRINTER_INFO_2W, pPrinterName),
+    FIELD_OFFSET(PRINTER_INFO_2W, pShareName),
+    FIELD_OFFSET(PRINTER_INFO_2W, pPortName),
+    FIELD_OFFSET(PRINTER_INFO_2W, pDriverName),
+    FIELD_OFFSET(PRINTER_INFO_2W, pComment),
+    FIELD_OFFSET(PRINTER_INFO_2W, pLocation),
+    FIELD_OFFSET(PRINTER_INFO_2W, pSepFile),
+    FIELD_OFFSET(PRINTER_INFO_2W, pPrintProcessor),
+    FIELD_OFFSET(PRINTER_INFO_2W, pDatatype),
+    FIELD_OFFSET(PRINTER_INFO_2W, pParameters)
+};
+
 HANDLE WINAPI
 AddPrinterA(PSTR pName, DWORD Level, PBYTE pPrinter)
 {
-    UNICODE_STRING pNameW, usBuffer;
-    PWSTR pwstrNameW;
-    PRINTER_INFO_2W *ppi2w = (PRINTER_INFO_2W*)pPrinter;
-    PRINTER_INFO_2A *ppi2a = (PRINTER_INFO_2A*)pPrinter;
+    DWORD i;
     HANDLE ret = NULL;
-    PWSTR pwszPrinterName = NULL;
-    PWSTR pwszServerName = NULL;
-    PWSTR pwszShareName = NULL;
-    PWSTR pwszPortName = NULL;
-    PWSTR pwszDriverName = NULL;
-    PWSTR pwszComment = NULL;
-    PWSTR pwszLocation = NULL;
-    PWSTR pwszSepFile = NULL;
-    PWSTR pwszPrintProcessor = NULL;
-    PWSTR pwszDatatype = NULL;
-    PWSTR pwszParameters = NULL;
-    PDEVMODEW pdmw = NULL;
+    PRINTER_INFO_2A* ppi2a = (PRINTER_INFO_2A*)pPrinter;
+    PRINTER_INFO_2W pi2w;
+    UNICODE_STRING usName;
 
-    TRACE("AddPrinterA(%s, %d, %p)\n", debugstr_a(pName), Level, pPrinter);
+    TRACE("AddPrinterA(%s, %lu, %p)\n", debugstr_a(pName), Level, pPrinter);
 
-    if(Level != 2)
+    if (Level != 2)
     {
-        ERR("Level = %d, unsupported!\n", Level);
+        ERR("Level = %lu, unsupported!\n", Level);
         SetLastError(ERROR_INVALID_LEVEL);
         return NULL;
     }
 
-    pwstrNameW = AsciiToUnicode(&pNameW,pName);
-
-    if (ppi2a->pShareName)
+    if (!ppi2a)
     {
-        pwszShareName = AsciiToUnicode(&usBuffer, ppi2a->pShareName);
-        if (!(ppi2w->pShareName = pwszShareName)) goto Cleanup;
-    }
-    if (ppi2a->pPortName)
-    {
-        pwszPortName = AsciiToUnicode(&usBuffer, ppi2a->pPortName);
-        if (!(ppi2w->pPortName = pwszPortName)) goto Cleanup;
-    }
-    if (ppi2a->pDriverName)
-    {
-        pwszDriverName = AsciiToUnicode(&usBuffer, ppi2a->pDriverName);
-        if (!(ppi2w->pDriverName = pwszDriverName)) goto Cleanup;
-    }
-    if (ppi2a->pComment)
-    {
-        pwszComment = AsciiToUnicode(&usBuffer, ppi2a->pComment);
-        if (!(ppi2w->pComment = pwszComment)) goto Cleanup;
-    }
-    if (ppi2a->pLocation)
-    {
-        pwszLocation = AsciiToUnicode(&usBuffer, ppi2a->pLocation);
-        if (!(ppi2w->pLocation = pwszLocation)) goto Cleanup;
-    }
-    if (ppi2a->pSepFile)
-    {
-        pwszSepFile = AsciiToUnicode(&usBuffer, ppi2a->pSepFile);
-        if (!(ppi2w->pSepFile = pwszSepFile)) goto Cleanup;
-    }
-    if (ppi2a->pServerName)
-    {
-        pwszPrintProcessor = AsciiToUnicode(&usBuffer, ppi2a->pPrintProcessor);
-        if (!(ppi2w->pPrintProcessor = pwszPrintProcessor)) goto Cleanup;
-    }
-    if (ppi2a->pDatatype)
-    {
-        pwszDatatype = AsciiToUnicode(&usBuffer, ppi2a->pDatatype);
-        if (!(ppi2w->pDatatype = pwszDatatype)) goto Cleanup;
-    }
-    if (ppi2a->pParameters)
-    {
-        pwszParameters = AsciiToUnicode(&usBuffer, ppi2a->pParameters);
-        if (!(ppi2w->pParameters = pwszParameters)) goto Cleanup;
-    }
-    if ( ppi2a->pDevMode )
-    {
-        RosConvertAnsiDevModeToUnicodeDevmode( ppi2a->pDevMode, &pdmw );
-        ppi2w->pDevMode = pdmw;
-    }
-    if (ppi2a->pServerName)
-    {
-        pwszServerName = AsciiToUnicode(&usBuffer, ppi2a->pServerName);
-        if (!(ppi2w->pPrinterName = pwszServerName)) goto Cleanup;
-    }
-    if (ppi2a->pPrinterName)
-    {
-        pwszPrinterName = AsciiToUnicode(&usBuffer, ppi2a->pPrinterName);
-        if (!(ppi2w->pPrinterName = pwszPrinterName)) goto Cleanup;
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return NULL;
     }
 
-    ret = AddPrinterW(pwstrNameW, Level, (LPBYTE)ppi2w);
+    usName.Buffer = NULL;
+
+    // The caller still owns its ANSI structure and may read the strings it
+    // points to after we return (Visual Basic 6 does exactly that when it walks
+    // its Printers collection), so we must never convert it in place.
+    // Everything goes into a private PRINTER_INFO_2W instead.
+    ZeroMemory(&pi2w, sizeof(pi2w));
+
+    pi2w.pSecurityDescriptor = ppi2a->pSecurityDescriptor;
+    pi2w.Attributes = ppi2a->Attributes;
+    pi2w.Priority = ppi2a->Priority;
+    pi2w.DefaultPriority = ppi2a->DefaultPriority;
+    pi2w.StartTime = ppi2a->StartTime;
+    pi2w.UntilTime = ppi2a->UntilTime;
+    pi2w.Status = ppi2a->Status;
+    pi2w.cJobs = ppi2a->cJobs;
+    pi2w.AveragePPM = ppi2a->AveragePPM;
+
+    for (i = 0; i < _countof(dwPrinterInfo2StringOffsets); i++)
+    {
+        UNICODE_STRING usField;
+        LPCSTR pszSource = *(LPCSTR*)((PBYTE)ppi2a + dwPrinterInfo2StringOffsets[i]);
+        PWSTR* ppwszTarget = (PWSTR*)((PBYTE)&pi2w + dwPrinterInfo2StringOffsets[i]);
+
+        if (!pszSource)
+            continue;
+
+        usField.Buffer = NULL;
+        *ppwszTarget = AsciiToUnicode(&usField, pszSource);
+        if (!*ppwszTarget)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            goto Cleanup;
+        }
+    }
+
+    if (ppi2a->pDevMode)
+    {
+        RosConvertAnsiDevModeToUnicodeDevmode(ppi2a->pDevMode, &pi2w.pDevMode);
+        if (!pi2w.pDevMode)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            goto Cleanup;
+        }
+    }
+
+    ret = AddPrinterW(AsciiToUnicode(&usName, pName), Level, (PBYTE)&pi2w);
 
 Cleanup:
-    if (pdmw) HeapFree(hProcessHeap, 0, pdmw);
-    if (pwszPrinterName) HeapFree(hProcessHeap, 0, pwszPrinterName);
-    if (pwszServerName) HeapFree(hProcessHeap, 0, pwszServerName);
-    if (pwszShareName) HeapFree(hProcessHeap, 0, pwszShareName);
-    if (pwszPortName) HeapFree(hProcessHeap, 0, pwszPortName);
-    if (pwszDriverName) HeapFree(hProcessHeap, 0, pwszDriverName);
-    if (pwszComment) HeapFree(hProcessHeap, 0, pwszComment);
-    if (pwszLocation) HeapFree(hProcessHeap, 0, pwszLocation);
-    if (pwszSepFile) HeapFree(hProcessHeap, 0, pwszSepFile);
-    if (pwszPrintProcessor) HeapFree(hProcessHeap, 0, pwszPrintProcessor);
-    if (pwszDatatype) HeapFree(hProcessHeap, 0, pwszDatatype);
-    if (pwszParameters) HeapFree(hProcessHeap, 0, pwszParameters);
+    for (i = 0; i < _countof(dwPrinterInfo2StringOffsets); i++)
+    {
+        PWSTR pwszField = *(PWSTR*)((PBYTE)&pi2w + dwPrinterInfo2StringOffsets[i]);
 
-    RtlFreeUnicodeString(&pNameW);
+        if (pwszField)
+            HeapFree(hProcessHeap, 0, pwszField);
+    }
+
+    if (pi2w.pDevMode)
+        HeapFree(hProcessHeap, 0, pi2w.pDevMode);
+
+    RtlFreeUnicodeString(&usName);
     return ret;
 }
 
@@ -389,7 +482,7 @@ AddPrinterW(PWSTR pName, DWORD Level, PBYTE pPrinter)
             dwErrorCode = ERROR_NOT_ENOUGH_MEMORY;
             ERR("HeapAlloc failed!\n");
             _RpcDeletePrinter(hPrinter);
-            _RpcClosePrinter(hPrinter);
+            _RpcClosePrinter(&hPrinter);
             goto Cleanup;
         }
 
@@ -398,6 +491,11 @@ AddPrinterW(PWSTR pName, DWORD Level, PBYTE pPrinter)
         pHandle->hSPLFile = INVALID_HANDLE_VALUE;
         pHandle->hSpoolFileHandle = INVALID_HANDLE_VALUE;
         hHandle = (HANDLE)pHandle;
+
+        // Make the new Printer known to this user, so that it can be enumerated
+        // through the legacy win.ini sections and picked as the default one.
+        _UpdatePerUserPrinterEntries(((PPRINTER_INFO_2W)pPrinter)->pPrinterName,
+                                     ((PPRINTER_INFO_2W)pPrinter)->pPortName, TRUE);
     }
 
 Cleanup:
@@ -451,7 +549,9 @@ Cleanup:
 BOOL WINAPI
 DeletePrinter(HANDLE hPrinter)
 {
+    DWORD cbNeeded = 0;
     DWORD dwErrorCode;
+    PPRINTER_INFO_2W pPrinterInfo = NULL;
     PSPOOLER_HANDLE pHandle = (PSPOOLER_HANDLE)hPrinter;
 
     TRACE("DeletePrinter(%p)\n", hPrinter);
@@ -463,10 +563,23 @@ DeletePrinter(HANDLE hPrinter)
         goto Cleanup;
     }
 
+    // Remember which Printer this is while we still can, for the per-user cleanup below.
+    GetPrinterW(hPrinter, 2, NULL, 0, &cbNeeded);
+    if (cbNeeded)
+    {
+        pPrinterInfo = HeapAlloc(hProcessHeap, 0, cbNeeded);
+
+        if (pPrinterInfo && !GetPrinterW(hPrinter, 2, (PBYTE)pPrinterInfo, cbNeeded, &cbNeeded))
+        {
+            HeapFree(hProcessHeap, 0, pPrinterInfo);
+            pPrinterInfo = NULL;
+        }
+    }
+
     // Do the RPC call.
     RpcTryExcept
     {
-        dwErrorCode = _RpcDeletePrinter(&pHandle->hPrinter);
+        dwErrorCode = _RpcDeletePrinter(pHandle->hPrinter);
     }
     RpcExcept(EXCEPTION_EXECUTE_HANDLER)
     {
@@ -475,7 +588,13 @@ DeletePrinter(HANDLE hPrinter)
     }
     RpcEndExcept;
 
+    if (dwErrorCode == ERROR_SUCCESS && pPrinterInfo)
+        _UpdatePerUserPrinterEntries(pPrinterInfo->pPrinterName, NULL, FALSE);
+
 Cleanup:
+    if (pPrinterInfo)
+        HeapFree(hProcessHeap, 0, pPrinterInfo);
+
     SetLastError(dwErrorCode);
     return (dwErrorCode == ERROR_SUCCESS);
 }
@@ -3038,8 +3157,6 @@ Cleanup:
 BOOL WINAPI
 SetDefaultPrinterW(LPCWSTR pszPrinter)
 {
-    const WCHAR wszDevicesKey[] = L"Software\\Microsoft\\Windows NT\\CurrentVersion\\Devices";
-
     DWORD cbDeviceValueData;
     DWORD cbPrinterValueData = 0;
     DWORD cchPrinter;
@@ -3147,177 +3264,261 @@ Cleanup:
     return (dwErrorCode == ERROR_SUCCESS);
 }
 
+/**
+ * Converts one ANSI string member into a freshly allocated Unicode string and
+ * records it so that the caller can release it again.
+ * Returns FALSE only when the allocation actually failed.
+ */
+static BOOL
+_ConvertPrinterInfoStringToUnicode(LPCSTR pszSource, PWSTR* ppwszTarget, PWSTR* ppwszCleanup, PDWORD pcCleanup)
+{
+    UNICODE_STRING usField;
+
+    if (!pszSource)
+        return TRUE;
+
+    usField.Buffer = NULL;
+    *ppwszTarget = AsciiToUnicode(&usField, pszSource);
+    if (!*ppwszTarget)
+    {
+        SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+        return FALSE;
+    }
+
+    ppwszCleanup[(*pcCleanup)++] = *ppwszTarget;
+    return TRUE;
+}
+
 BOOL WINAPI
 SetPrinterA(HANDLE hPrinter, DWORD Level, PBYTE pPrinter, DWORD Command)
 {
     BOOL Ret = FALSE;
-    UNICODE_STRING usBuffer;
-    PPRINTER_INFO_STRESS ppisa = (PPRINTER_INFO_STRESS)pPrinter;
-    PPRINTER_INFO_STRESS ppisw = (PPRINTER_INFO_STRESS)pPrinter;
-    PPRINTER_INFO_2A ppi2a = (PPRINTER_INFO_2A)pPrinter;
-    PPRINTER_INFO_2W ppi2w = (PPRINTER_INFO_2W)pPrinter;
-    PPRINTER_INFO_7A ppi7a = (PPRINTER_INFO_7A)pPrinter;
-    PPRINTER_INFO_7W ppi7w = (PPRINTER_INFO_7W)pPrinter;
-    PPRINTER_INFO_9A ppi9a = (PPRINTER_INFO_9A)pPrinter;
-    PPRINTER_INFO_9W ppi9w = (PPRINTER_INFO_9W)pPrinter;
-    PWSTR pwszPrinterName = NULL;
-    PWSTR pwszServerName = NULL;
-    PWSTR pwszShareName = NULL;
-    PWSTR pwszPortName = NULL;
-    PWSTR pwszDriverName = NULL;
-    PWSTR pwszComment = NULL;
-    PWSTR pwszLocation = NULL;
-    PWSTR pwszSepFile = NULL;
-    PWSTR pwszPrintProcessor = NULL;
-    PWSTR pwszDatatype = NULL;
-    PWSTR pwszParameters = NULL;
+    DWORD cCleanup = 0;
+    DWORD i;
+    PBYTE pPrinterW = pPrinter;
     PDEVMODEW pdmw = NULL;
+    PWSTR apwszCleanup[_countof(dwPrinterInfo2StringOffsets)];
+
+    // As in AddPrinterA, the caller keeps ownership of its ANSI structure and
+    // may still use the strings it points to once we return, so the conversion
+    // is done into a private structure rather than in place.
+    union
+    {
+        PRINTER_INFO_STRESS pis;
+        PRINTER_INFO_2W pi2;
+        PRINTER_INFO_4W pi4;
+        PRINTER_INFO_5W pi5;
+        PRINTER_INFO_6 pi6;
+        PRINTER_INFO_7W pi7;
+        PRINTER_INFO_9W pi9;
+    }
+    InfoW;
 
     FIXME("SetPrinterA(%p, %lu, %p, %lu)\n", hPrinter, Level, pPrinter, Command);
+
+    ZeroMemory(&InfoW, sizeof(InfoW));
 
     switch ( Level )
     {
         case 0:
-            if ( Command == 0 )
-            {
-                if (ppisa->pPrinterName)
-                {
-                    pwszPrinterName = AsciiToUnicode(&usBuffer, (LPCSTR)ppisa->pPrinterName);
-                    if (!(ppisw->pPrinterName = pwszPrinterName)) goto Cleanup;
-                }
-                if (ppisa->pServerName)
-                {
-                    pwszServerName = AsciiToUnicode(&usBuffer, (LPCSTR)ppisa->pServerName);
-                    if (!(ppisw->pPrinterName = pwszServerName)) goto Cleanup;
-                }
-            }
+        {
+            PPRINTER_INFO_STRESS ppisa = (PPRINTER_INFO_STRESS)pPrinter;
+
             if ( Command == PRINTER_CONTROL_SET_STATUS )
             {
-                // Set the pPrinter parameter to a pointer to a DWORD value that specifies the new printer status.
-                PRINTER_INFO_6 pi6;
-                pi6.dwStatus = (DWORD_PTR)pPrinter;
-                pPrinter = (LPBYTE)&pi6;
+                // pPrinter is not a structure here, but carries the new printer status itself.
+                InfoW.pi6.dwStatus = PtrToUlong(pPrinter);
+                pPrinterW = (PBYTE)&InfoW;
                 Level = 6;
                 Command = 0;
+                break;
             }
-            break;
-        case 2:
+
+            if ( Command != 0 )
+                break;
+
+            if (!ppisa)
             {
-                if (ppi2a->pShareName)
+                SetLastError(ERROR_INVALID_PARAMETER);
+                goto Cleanup;
+            }
+
+            InfoW.pis = *ppisa;
+            InfoW.pis.pPrinterName = NULL;
+            InfoW.pis.pServerName = NULL;
+            pPrinterW = (PBYTE)&InfoW;
+
+            if (!_ConvertPrinterInfoStringToUnicode((LPCSTR)ppisa->pPrinterName, &InfoW.pis.pPrinterName, apwszCleanup, &cCleanup))
+                goto Cleanup;
+
+            if (!_ConvertPrinterInfoStringToUnicode((LPCSTR)ppisa->pServerName, &InfoW.pis.pServerName, apwszCleanup, &cCleanup))
+                goto Cleanup;
+
+            break;
+        }
+
+        case 2:
+        {
+            PPRINTER_INFO_2A ppi2a = (PPRINTER_INFO_2A)pPrinter;
+
+            if (!ppi2a)
+            {
+                SetLastError(ERROR_INVALID_PARAMETER);
+                goto Cleanup;
+            }
+
+            pPrinterW = (PBYTE)&InfoW;
+
+            InfoW.pi2.pSecurityDescriptor = ppi2a->pSecurityDescriptor;
+            InfoW.pi2.Attributes = ppi2a->Attributes;
+            InfoW.pi2.Priority = ppi2a->Priority;
+            InfoW.pi2.DefaultPriority = ppi2a->DefaultPriority;
+            InfoW.pi2.StartTime = ppi2a->StartTime;
+            InfoW.pi2.UntilTime = ppi2a->UntilTime;
+            InfoW.pi2.Status = ppi2a->Status;
+            InfoW.pi2.cJobs = ppi2a->cJobs;
+            InfoW.pi2.AveragePPM = ppi2a->AveragePPM;
+
+            for (i = 0; i < _countof(dwPrinterInfo2StringOffsets); i++)
+            {
+                LPCSTR pszSource = *(LPCSTR*)((PBYTE)ppi2a + dwPrinterInfo2StringOffsets[i]);
+                PWSTR* ppwszTarget = (PWSTR*)((PBYTE)&InfoW.pi2 + dwPrinterInfo2StringOffsets[i]);
+
+                if (!_ConvertPrinterInfoStringToUnicode(pszSource, ppwszTarget, apwszCleanup, &cCleanup))
+                    goto Cleanup;
+            }
+
+            if ( ppi2a->pDevMode )
+            {
+                RosConvertAnsiDevModeToUnicodeDevmode( ppi2a->pDevMode, &pdmw );
+                if (!pdmw)
                 {
-                    pwszShareName = AsciiToUnicode(&usBuffer, ppi2a->pShareName);
-                    if (!(ppi2w->pShareName = pwszShareName)) goto Cleanup;
-                }
-                if (ppi2a->pPortName)
-                {
-                    pwszPortName = AsciiToUnicode(&usBuffer, ppi2a->pPortName);
-                    if (!(ppi2w->pPortName = pwszPortName)) goto Cleanup;
-                }
-                if (ppi2a->pDriverName)
-                {
-                    pwszDriverName = AsciiToUnicode(&usBuffer, ppi2a->pDriverName);
-                    if (!(ppi2w->pDriverName = pwszDriverName)) goto Cleanup;
-                }
-                if (ppi2a->pComment)
-                {
-                    pwszComment = AsciiToUnicode(&usBuffer, ppi2a->pComment);
-                    if (!(ppi2w->pComment = pwszComment)) goto Cleanup;
-                }
-                if (ppi2a->pLocation)
-                {
-                    pwszLocation = AsciiToUnicode(&usBuffer, ppi2a->pLocation);
-                    if (!(ppi2w->pLocation = pwszLocation)) goto Cleanup;
-                }
-                if (ppi2a->pSepFile)
-                {
-                    pwszSepFile = AsciiToUnicode(&usBuffer, ppi2a->pSepFile);
-                    if (!(ppi2w->pSepFile = pwszSepFile)) goto Cleanup;
-                }
-                if (ppi2a->pServerName)
-                {
-                    pwszPrintProcessor = AsciiToUnicode(&usBuffer, ppi2a->pPrintProcessor);
-                    if (!(ppi2w->pPrintProcessor = pwszPrintProcessor)) goto Cleanup;
-                }
-                if (ppi2a->pDatatype)
-                {
-                    pwszDatatype = AsciiToUnicode(&usBuffer, ppi2a->pDatatype);
-                    if (!(ppi2w->pDatatype = pwszDatatype)) goto Cleanup;
-                }
-                if (ppi2a->pParameters)
-                {
-                    pwszParameters = AsciiToUnicode(&usBuffer, ppi2a->pParameters);
-                    if (!(ppi2w->pParameters = pwszParameters)) goto Cleanup;
+                    SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+                    goto Cleanup;
                 }
 
-                if ( ppi2a->pDevMode )
-                {
-                    RosConvertAnsiDevModeToUnicodeDevmode( ppi2a->pDevMode, &pdmw );
-                    ppi2w->pDevMode = pdmw;
-                }
+                InfoW.pi2.pDevMode = pdmw;
             }
-        //
-        //  These two strings are relitive and common to these three Levels.
-        //  Fall through...
-        //
-        case 4:
-        case 5:
-            {
-                if (ppi2a->pServerName) // 4 & 5 : pPrinterName.
-                {
-                    pwszServerName = AsciiToUnicode(&usBuffer, ppi2a->pServerName);
-                    if (!(ppi2w->pPrinterName = pwszServerName)) goto Cleanup;
-                }
-                if (ppi2a->pPrinterName) // 4 : pServerName, 5 : pPortName.
-                {
-                    pwszPrinterName = AsciiToUnicode(&usBuffer, ppi2a->pPrinterName);
-                    if (!(ppi2w->pPrinterName = pwszPrinterName)) goto Cleanup;
-                }
-            }
+
             break;
+        }
+
+        case 4:
+        {
+            PPRINTER_INFO_4A ppi4a = (PPRINTER_INFO_4A)pPrinter;
+
+            if (!ppi4a)
+            {
+                SetLastError(ERROR_INVALID_PARAMETER);
+                goto Cleanup;
+            }
+
+            pPrinterW = (PBYTE)&InfoW;
+            InfoW.pi4.Attributes = ppi4a->Attributes;
+
+            if (!_ConvertPrinterInfoStringToUnicode(ppi4a->pPrinterName, &InfoW.pi4.pPrinterName, apwszCleanup, &cCleanup))
+                goto Cleanup;
+
+            if (!_ConvertPrinterInfoStringToUnicode(ppi4a->pServerName, &InfoW.pi4.pServerName, apwszCleanup, &cCleanup))
+                goto Cleanup;
+
+            break;
+        }
+
+        case 5:
+        {
+            PPRINTER_INFO_5A ppi5a = (PPRINTER_INFO_5A)pPrinter;
+
+            if (!ppi5a)
+            {
+                SetLastError(ERROR_INVALID_PARAMETER);
+                goto Cleanup;
+            }
+
+            pPrinterW = (PBYTE)&InfoW;
+            InfoW.pi5.Attributes = ppi5a->Attributes;
+            InfoW.pi5.DeviceNotSelectedTimeout = ppi5a->DeviceNotSelectedTimeout;
+            InfoW.pi5.TransmissionRetryTimeout = ppi5a->TransmissionRetryTimeout;
+
+            if (!_ConvertPrinterInfoStringToUnicode(ppi5a->pPrinterName, &InfoW.pi5.pPrinterName, apwszCleanup, &cCleanup))
+                goto Cleanup;
+
+            if (!_ConvertPrinterInfoStringToUnicode(ppi5a->pPortName, &InfoW.pi5.pPortName, apwszCleanup, &cCleanup))
+                goto Cleanup;
+
+            break;
+        }
+
         case 3:
         case 6:
+            // These levels carry no strings, so they are passed through unchanged.
             break;
+
         case 7:
+        {
+            PPRINTER_INFO_7A ppi7a = (PPRINTER_INFO_7A)pPrinter;
+
+            if (!ppi7a)
             {
-                if (ppi7a->pszObjectGUID)
-                {
-                    pwszPrinterName = AsciiToUnicode(&usBuffer, ppi7a->pszObjectGUID);
-                    if (!(ppi7w->pszObjectGUID = pwszPrinterName)) goto Cleanup;
-                }
+                SetLastError(ERROR_INVALID_PARAMETER);
+                goto Cleanup;
             }
+
+            pPrinterW = (PBYTE)&InfoW;
+            InfoW.pi7.dwAction = ppi7a->dwAction;
+
+            if (!_ConvertPrinterInfoStringToUnicode(ppi7a->pszObjectGUID, &InfoW.pi7.pszObjectGUID, apwszCleanup, &cCleanup))
+                goto Cleanup;
+
             break;
+        }
 
         case 8:
         /* 8 is the global default printer info and 9 already sets it instead of the per-user one */
         /* still, PRINTER_INFO_8W is the same as PRINTER_INFO_9W */
         /* fall through */
         case 9:
+        {
+            PPRINTER_INFO_9A ppi9a = (PPRINTER_INFO_9A)pPrinter;
+
+            if (!ppi9a)
+            {
+                SetLastError(ERROR_INVALID_PARAMETER);
+                goto Cleanup;
+            }
+
+            pPrinterW = (PBYTE)&InfoW;
+
+            if ( ppi9a->pDevMode )
             {
                 RosConvertAnsiDevModeToUnicodeDevmode( ppi9a->pDevMode, &pdmw );
-                ppi9w->pDevMode = pdmw;
+                if (!pdmw)
+                {
+                    SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+                    goto Cleanup;
+                }
+
+                InfoW.pi9.pDevMode = pdmw;
             }
+
             break;
+        }
 
         default:
-            FIXME( "Unsupported level %d\n", Level);
+            FIXME( "Unsupported level %lu\n", Level);
             SetLastError( ERROR_INVALID_LEVEL );
+            return FALSE;
     }
 
-    Ret = SetPrinterW( hPrinter, Level, pPrinter, Command );
+    Ret = SetPrinterW( hPrinter, Level, pPrinterW, Command );
 
 Cleanup:
-    if (pdmw) HeapFree(hProcessHeap, 0, pdmw);
-    if (pwszPrinterName) HeapFree(hProcessHeap, 0, pwszPrinterName);
-    if (pwszServerName) HeapFree(hProcessHeap, 0, pwszServerName);
-    if (pwszShareName) HeapFree(hProcessHeap, 0, pwszShareName);
-    if (pwszPortName) HeapFree(hProcessHeap, 0, pwszPortName);
-    if (pwszDriverName) HeapFree(hProcessHeap, 0, pwszDriverName);
-    if (pwszComment) HeapFree(hProcessHeap, 0, pwszComment);
-    if (pwszLocation) HeapFree(hProcessHeap, 0, pwszLocation);
-    if (pwszSepFile) HeapFree(hProcessHeap, 0, pwszSepFile);
-    if (pwszPrintProcessor) HeapFree(hProcessHeap, 0, pwszPrintProcessor);
-    if (pwszDatatype) HeapFree(hProcessHeap, 0, pwszDatatype);
-    if (pwszParameters) HeapFree(hProcessHeap, 0, pwszParameters);
+    if (pdmw)
+        HeapFree(hProcessHeap, 0, pdmw);
+
+    for (i = 0; i < cCleanup; i++)
+        HeapFree(hProcessHeap, 0, apwszCleanup[i]);
+
     return Ret;
 }
 
@@ -3330,6 +3531,7 @@ SetPrinterW(HANDLE hPrinter, DWORD Level, PBYTE pPrinter, DWORD Command)
     WINSPOOL_SECURITY_CONTAINER SecurityContainer;
     SECURITY_DESCRIPTOR *sd = NULL;
     DWORD size;
+    PRINTER_INFO_6 pi6;
     PSPOOLER_HANDLE pHandle = (PSPOOLER_HANDLE)hPrinter;
 
     FIXME("SetPrinterW(%p, %lu, %p, %lu)\n", hPrinter, Level, pPrinter, Command);
@@ -3350,8 +3552,7 @@ SetPrinterW(HANDLE hPrinter, DWORD Level, PBYTE pPrinter, DWORD Command)
             if ( Command == PRINTER_CONTROL_SET_STATUS )
             {
                 // Set the pPrinter parameter to a pointer to a DWORD value that specifies the new printer status.
-                PRINTER_INFO_6 pi6;
-                pi6.dwStatus = (DWORD_PTR)pPrinter;
+                pi6.dwStatus = PtrToUlong(pPrinter);
                 pPrinter = (LPBYTE)&pi6;
                 Level = 6;
                 Command = 0;

--- a/win32ss/printing/base/winspool/printers.c
+++ b/win32ss/printing/base/winspool/printers.c
@@ -64,6 +64,7 @@ static const WCHAR wszDevicesKey[] = L"Software\\Microsoft\\Windows NT\\CurrentV
 static const WCHAR wszPrinterPortsKey[] = L"Software\\Microsoft\\Windows NT\\CurrentVersion\\PrinterPorts";
 static const WCHAR wszWinspoolPrefix[] = L"winspool,";
 static const WCHAR wszPortTimeouts[] = L",15,45";
+static const WCHAR wszDevicesSection[] = L"Devices";
 
 static DWORD
 _StartDocPrinterSpooled(PSPOOLER_HANDLE pHandle, PDOC_INFO_1W pDocInfo1, PADDJOB_INFO_1W pAddJobInfo1)
@@ -297,6 +298,28 @@ _UpdatePerUserPrinterEntries(PCWSTR pwszPrinterName, PCWSTR pwszPortName, BOOL b
 }
 
 /**
+ * @name _BroadcastPrinterChange
+ *
+ * Lets the applications of this session refresh their printer list. The
+ * spooler is a service and cannot reach those windows from its own session.
+ * Both messages carry a string, so they are sent and not posted.
+ */
+static VOID
+_BroadcastPrinterChange(PCWSTR pwszPrinterName)
+{
+    DWORD_PTR dwResult;
+
+    if (pwszPrinterName)
+    {
+        SendMessageTimeoutW(HWND_BROADCAST, WM_DEVMODECHANGE, 0, (LPARAM)pwszPrinterName,
+                            SMTO_ABORTIFHUNG, 1000, &dwResult);
+    }
+
+    SendMessageTimeoutW(HWND_BROADCAST, WM_WININICHANGE, 0, (LPARAM)wszDevicesSection,
+                        SMTO_ABORTIFHUNG, 1000, &dwResult);
+}
+
+/**
  * The string members of PRINTER_INFO_2A and PRINTER_INFO_2W sit at identical
  * offsets, so one table can drive the ANSI -> Unicode conversion of all of them.
  */
@@ -496,6 +519,8 @@ AddPrinterW(PWSTR pName, DWORD Level, PBYTE pPrinter)
         // through the legacy win.ini sections and picked as the default one.
         _UpdatePerUserPrinterEntries(((PPRINTER_INFO_2W)pPrinter)->pPrinterName,
                                      ((PPRINTER_INFO_2W)pPrinter)->pPortName, TRUE);
+
+        _BroadcastPrinterChange(((PPRINTER_INFO_2W)pPrinter)->pPrinterName);
     }
 
 Cleanup:
@@ -589,7 +614,10 @@ DeletePrinter(HANDLE hPrinter)
     RpcEndExcept;
 
     if (dwErrorCode == ERROR_SUCCESS && pPrinterInfo)
+    {
         _UpdatePerUserPrinterEntries(pPrinterInfo->pPrinterName, NULL, FALSE);
+        _BroadcastPrinterChange(pPrinterInfo->pPrinterName);
+    }
 
 Cleanup:
     if (pPrinterInfo)
@@ -3665,6 +3693,11 @@ SetPrinterW(HANDLE hPrinter, DWORD Level, PBYTE pPrinter, DWORD Command)
     RpcEndExcept;
 
     if ( sd ) HeapFree( GetProcessHeap(), 0, sd );
+
+    // A pure Command call only pauses or resumes the queue. Level 2 is the
+    // only level here that carries the name along.
+    if (dwErrorCode == ERROR_SUCCESS && Level != 0)
+        _BroadcastPrinterChange(Level == 2 ? ((PPRINTER_INFO_2W)pPrinter)->pPrinterName : NULL);
 
     SetLastError(dwErrorCode);
     return (dwErrorCode == ERROR_SUCCESS);

--- a/win32ss/printing/providers/localspl/main.c
+++ b/win32ss/printing/providers/localspl/main.c
@@ -36,9 +36,9 @@ static const PRINTPROVIDOR _PrintProviderFunctions = {
     LocalSetJob,                                // fpSetJob
     LocalGetJob,                                // fpGetJob
     LocalEnumJobs,                              // fpEnumJobs
-    NULL,                                       // fpAddPrinter
-    NULL,                                       // fpDeletePrinter
-    NULL,                                       // fpSetPrinter
+    LocalAddPrinter,                            // fpAddPrinter
+    LocalDeletePrinter,                         // fpDeletePrinter
+    LocalSetPrinter,                            // fpSetPrinter
     LocalGetPrinter,                            // fpGetPrinter
     LocalEnumPrinters,                          // fpEnumPrinters
     LocalAddPrinterDriver,                      // fpAddPrinterDriver

--- a/win32ss/printing/providers/localspl/ports.c
+++ b/win32ss/printing/providers/localspl/ports.c
@@ -160,6 +160,87 @@ Cleanup:
     return (dwErrorCode == ERROR_SUCCESS);
 }
 
+/**
+ * @name RefreshPortList
+ *
+ * Re-enumerates the ports of every Print Monitor and adds the ones we don't
+ * know about yet to the Port List.
+ *
+ * The Port List is built once while the spooler starts up, but ports can appear
+ * at any time afterwards: a Print Monitor may add one on its own, and installers
+ * routinely add one through XcvData("AddPort") before creating their printer.
+ * Without this refresh such a port stays invisible to the local Print Provider
+ * until the spooler is restarted, and AddPrinter fails with ERROR_UNKNOWN_PORT.
+ */
+VOID
+RefreshPortList(void)
+{
+    BOOL bReturnValue;
+    DWORD cbNeeded;
+    DWORD dwReturned;
+    DWORD i;
+    PLIST_ENTRY pEntry;
+    PLOCAL_PRINT_MONITOR pPrintMonitor;
+    PPORT_INFO_1W p;
+    PPORT_INFO_1W pPortInfo1 = NULL;
+
+    TRACE("RefreshPortList()\n");
+
+    for (pEntry = PrintMonitorList.Flink; pEntry != &PrintMonitorList; pEntry = pEntry->Flink)
+    {
+        // Cleanup from the previous run.
+        if (pPortInfo1)
+        {
+            DllFreeSplMem(pPortInfo1);
+            pPortInfo1 = NULL;
+        }
+
+        pPrintMonitor = CONTAINING_RECORD(pEntry, LOCAL_PRINT_MONITOR, Entry);
+
+        // Determine the required buffer size for EnumPorts.
+        if (pPrintMonitor->bIsLevel2)
+            bReturnValue = ((PMONITOR2)pPrintMonitor->pMonitor)->pfnEnumPorts(pPrintMonitor->hMonitor, NULL, 1, NULL, 0, &cbNeeded, &dwReturned);
+        else
+            bReturnValue = ((LPMONITOREX)pPrintMonitor->pMonitor)->Monitor.pfnEnumPorts(NULL, 1, NULL, 0, &cbNeeded, &dwReturned);
+
+        if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+            continue;
+
+        pPortInfo1 = DllAllocSplMem(cbNeeded);
+        if (!pPortInfo1)
+        {
+            ERR("DllAllocSplMem failed!\n");
+            break;
+        }
+
+        // Get the ports handled by this monitor.
+        if (pPrintMonitor->bIsLevel2)
+            bReturnValue = ((PMONITOR2)pPrintMonitor->pMonitor)->pfnEnumPorts(pPrintMonitor->hMonitor, NULL, 1, (PBYTE)pPortInfo1, cbNeeded, &cbNeeded, &dwReturned);
+        else
+            bReturnValue = ((LPMONITOREX)pPrintMonitor->pMonitor)->Monitor.pfnEnumPorts(NULL, 1, (PBYTE)pPortInfo1, cbNeeded, &cbNeeded, &dwReturned);
+
+        if (!bReturnValue)
+        {
+            ERR("Print Monitor \"%S\" failed with error %lu on EnumPorts!\n", pPrintMonitor->pwszName, GetLastError());
+            continue;
+        }
+
+        // Add the ports we don't know yet.
+        p = pPortInfo1;
+
+        for (i = 0; i < dwReturned; i++)
+        {
+            if (!FindPort(p->pName))
+                CreatePortEntry(p->pName, pPrintMonitor);
+
+            p++;
+        }
+    }
+
+    if (pPortInfo1)
+        DllFreeSplMem(pPortInfo1);
+}
+
 BOOL WINAPI
 LocalEnumPorts(PWSTR pName, DWORD Level, PBYTE pPorts, DWORD cbBuf, PDWORD pcbNeeded, PDWORD pcReturned)
 {

--- a/win32ss/printing/providers/localspl/precomp.h
+++ b/win32ss/printing/providers/localspl/precomp.h
@@ -128,6 +128,8 @@ struct _LOCAL_PRINTER
     PLOCAL_PRINT_PROCESSOR pPrintProcessor;
     PLOCAL_PORT pPort;
     SKIPLIST JobList;
+    DWORD cRefs;                                /** Number of handles currently referring to this Printer. */
+    BOOL bPendingDeletion;                      /** LocalDeletePrinter has been called; the structure is released with the last handle. */
 };
 
 /**
@@ -293,6 +295,7 @@ BOOL WINAPI LocalDeleteMonitor(PWSTR pName, PWSTR pEnvironment, PWSTR pMonitorNa
 // ports.c
 PLOCAL_PORT FindPort(PCWSTR pwszName);
 BOOL InitializePortList(void);
+VOID RefreshPortList(void);
 BOOL WINAPI LocalEnumPorts(PWSTR pName, DWORD Level, PBYTE pPorts, DWORD cbBuf, PDWORD pcbNeeded, PDWORD pcReturned);
 BOOL WINAPI LocalAddPortEx(PWSTR pName, DWORD Level, PBYTE lpBuffer, PWSTR lpMonitorName);
 BOOL WINAPI LocalAddPort(LPWSTR pName, HWND hWnd, LPWSTR pMonitorName);
@@ -309,6 +312,7 @@ DWORD WINAPI LocalSetPrinterDataEx(HANDLE hPrinter, LPCWSTR pKeyName, LPCWSTR pV
 
 // printerdrivers.c
 BOOL InitializePrinterDrivers(VOID);
+HKEY open_driver_reg(LPCWSTR pEnvironment);
 BOOL WINAPI LocalAddPrinterDriver(LPWSTR pName, DWORD level, LPBYTE pDriverInfo);
 BOOL WINAPI LocalAddPrinterDriverEx(LPWSTR pName, DWORD level, LPBYTE pDriverInfo, DWORD dwFileCopyFlags);
 BOOL WINAPI LocalGetPrinterDriver(HANDLE hPrinter, LPWSTR pEnvironment, DWORD Level, LPBYTE pDriverInfo, DWORD cbBuf, LPDWORD pcbNeeded);
@@ -332,6 +336,10 @@ PPRINTENV_T validate_envW(LPCWSTR env);
 extern SKIPLIST PrinterList;
 BOOL InitializePrinterList(void);
 BOOL WINAPI LocalEnumPrinters(DWORD Flags, LPWSTR Name, DWORD Level, LPBYTE pPrinterEnum, DWORD cbBuf, LPDWORD pcbNeeded, LPDWORD pcReturned);
+HANDLE WINAPI LocalAddPrinter(PWSTR pName, DWORD Level, PBYTE pPrinterInfo);
+BOOL WINAPI LocalDeletePrinter(HANDLE hPrinter);
+BOOL WINAPI LocalSetPrinter(HANDLE hPrinter, DWORD Level, PBYTE pPrinterInfo, DWORD Command);
+VOID ReleaseLocalPrinter(PLOCAL_PRINTER pPrinter);
 BOOL WINAPI LocalGetPrinter(HANDLE hPrinter, DWORD Level, LPBYTE pPrinter, DWORD cbBuf, LPDWORD pcbNeeded);
 BOOL WINAPI LocalOpenPrinter(PWSTR lpPrinterName, HANDLE* phPrinter, PPRINTER_DEFAULTSW pDefault);
 DWORD WINAPI LocalPrinterMessageBox(HANDLE hPrinter, DWORD Error, HWND hWnd, LPWSTR pText, LPWSTR pCaption, DWORD dwType);

--- a/win32ss/printing/providers/localspl/printerdrivers.c
+++ b/win32ss/printing/providers/localspl/printerdrivers.c
@@ -870,6 +870,13 @@ static BOOL apd_copyfile( WCHAR *pathname, WCHAR *file_part, apd_data_t *apd )
     return apd->lazy || res;
 }
 
+static inline WCHAR *get_file_part( WCHAR *name )
+{
+    WCHAR *ptr = wcsrchr( name, '\\' );
+    if (ptr) return ptr + 1;
+    return name;
+}
+
 /******************************************************************
  * driver_load [internal]
  *
@@ -899,19 +906,16 @@ static HMODULE driver_load(const PRINTENV_T * env, LPWSTR dllname)
 
     lstrcatW(fullname, env->versionsubdir);
     lstrcatW(fullname, backslashW);
-    lstrcatW(fullname, dllname);
+
+    // The caller usually hands us the path the driver files were installed from,
+    // but they have been copied into the version subdirectory under their bare
+    // name, so only that part may be appended here.
+    lstrcatW(fullname, get_file_part(dllname));
 
     hui = LoadLibraryW(fullname);
     FIXME("%p: LoadLibrary(%s) %d\n", hui, debugstr_w(fullname), GetLastError());
 
     return hui;
-}
-
-static inline WCHAR *get_file_part( WCHAR *name )
-{
-    WCHAR *ptr = wcsrchr( name, '\\' );
-    if (ptr) return ptr + 1;
-    return name;
 }
 
 /******************************************************************************

--- a/win32ss/printing/providers/localspl/printers.c
+++ b/win32ss/printing/providers/localspl/printers.c
@@ -351,16 +351,18 @@ BroadcastChange(PLOCAL_HANDLE pHandle)
 {
     PLOCAL_PRINTER pPrinter;
     PSKIPLIST_NODE pNode;
-    DWORD cchMachineName = 0;
+    DWORD_PTR dwResult;
     WCHAR wszMachineName[MAX_PATH] = {0}; // if not local, use Machine Name then Printer Name... pPrinter->pJob->pwszMachineName?
 
     for (pNode = PrinterList.Head.Next[0]; pNode; pNode = pNode->Next[0])
     {
         pPrinter = (PLOCAL_PRINTER)pNode->Element;
 
-        StringCchCopyW( &wszMachineName[cchMachineName], sizeof(wszMachineName), pPrinter->pwszPrinterName );
+        StringCchCopyW( wszMachineName, _countof(wszMachineName), pPrinter->pwszPrinterName );
 
-        PostMessageW( HWND_BROADCAST, WM_DEVMODECHANGE, 0, (LPARAM)&wszMachineName );
+        // The lParam is a string, so this has to be sent rather than posted.
+        SendMessageTimeoutW( HWND_BROADCAST, WM_DEVMODECHANGE, 0, (LPARAM)wszMachineName,
+                             SMTO_ABORTIFHUNG, 1000, &dwResult );
     }
 }
 

--- a/win32ss/printing/providers/localspl/printers.c
+++ b/win32ss/printing/providers/localspl/printers.c
@@ -1232,6 +1232,9 @@ _LocalOpenPrinterHandle(PWSTR pwszPrinterName, PWSTR pwszJobParameter, PHANDLE p
     pHandle->HandleType = HandleType_Printer;
     pHandle->pSpecificHandle = pPrinterHandle;
 
+    // Keep the Printer alive for as long as this handle exists.
+    pPrinter->cRefs++;
+
     // Return it.
     *phPrinter = (HANDLE)pHandle;
     return ERROR_SUCCESS;
@@ -1277,8 +1280,9 @@ _LocalOpenPrintServerHandle(PHANDLE phPrinter)
 }
 
 static DWORD
-_LocalOpenXcvHandle(PWSTR pwszParameter, PHANDLE phPrinter)
+_LocalOpenXcvHandle(PWSTR pwszParameter, PHANDLE phPrinter, PPRINTER_DEFAULTSW pDefault)
 {
+    ACCESS_MASK GrantedAccess;
     BOOL bReturnValue;
     DWORD dwErrorCode;
     HANDLE hXcv;
@@ -1330,11 +1334,35 @@ _LocalOpenXcvHandle(PWSTR pwszParameter, PHANDLE phPrinter)
         goto Failure;
     }
 
+    // Determine the access to grant on the port.
+    // Print Monitors gate their administrative Xcv operations (AddPort, DeletePort,
+    // ConfigurePort, ...) on SERVER_ACCESS_ADMINISTER, so passing a fixed
+    // SERVER_EXECUTE here made every one of them fail with ERROR_ACCESS_DENIED.
+    GrantedAccess = SERVER_EXECUTE;
+
+    if (pDefault && pDefault->DesiredAccess)
+    {
+        GrantedAccess = pDefault->DesiredAccess;
+
+        // Map the generic rights the same way the print server object does.
+        if (GrantedAccess & GENERIC_READ)
+            GrantedAccess = (GrantedAccess & ~GENERIC_READ) | SERVER_READ;
+
+        if (GrantedAccess & GENERIC_WRITE)
+            GrantedAccess = (GrantedAccess & ~GENERIC_WRITE) | SERVER_WRITE;
+
+        if (GrantedAccess & GENERIC_EXECUTE)
+            GrantedAccess = (GrantedAccess & ~GENERIC_EXECUTE) | SERVER_EXECUTE;
+
+        if (GrantedAccess & GENERIC_ALL)
+            GrantedAccess = (GrantedAccess & ~GENERIC_ALL) | SERVER_ALL_ACCESS;
+    }
+
     // Call the monitor's XcvOpenPort function.
     if (pPrintMonitor->bIsLevel2)
-        bReturnValue = ((PMONITOR2)pPrintMonitor->pMonitor)->pfnXcvOpenPort(pPrintMonitor->hMonitor, pwszParameter, SERVER_EXECUTE, &hXcv);
+        bReturnValue = ((PMONITOR2)pPrintMonitor->pMonitor)->pfnXcvOpenPort(pPrintMonitor->hMonitor, pwszParameter, GrantedAccess, &hXcv);
     else
-        bReturnValue = ((LPMONITOREX)pPrintMonitor->pMonitor)->Monitor.pfnXcvOpenPort(pwszParameter, SERVER_EXECUTE, &hXcv);
+        bReturnValue = ((LPMONITOREX)pPrintMonitor->pMonitor)->Monitor.pfnXcvOpenPort(pwszParameter, GrantedAccess, &hXcv);
 
     if (!bReturnValue)
     {
@@ -1510,7 +1538,7 @@ LocalOpenPrinter(PWSTR lpPrinterName, HANDLE* phPrinter, PPRINTER_DEFAULTSW pDef
         //    ", XcvPort LPT1:"
         //    "\\COMPUTERNAME\, XcvPort LPT1:"
         FIXME("OpenXcvHandle : %S\n",pwszSecondParameter);
-        dwErrorCode = _LocalOpenXcvHandle(pwszSecondParameter, phPrinter);
+        dwErrorCode = _LocalOpenXcvHandle(pwszSecondParameter, phPrinter, pDefault);
     }
     else
     {
@@ -1933,6 +1961,689 @@ _LocalClosePortHandle(PLOCAL_PORT_HANDLE pPortHandle)
         ((LPMONITOREX)pPortHandle->pPort->pPrintMonitor->pMonitor)->Monitor.pfnClosePort(pPortHandle->hPort);
 }
 
+/**
+ * @name _FreeLocalPrinter
+ *
+ * Releases all resources held by a LOCAL_PRINTER structure.
+ */
+static void
+_FreeLocalPrinter(PLOCAL_PRINTER pPrinter)
+{
+    if (pPrinter->pDefaultDevMode)
+        DllFreeSplMem(pPrinter->pDefaultDevMode);
+
+    if (pPrinter->pwszDefaultDatatype)
+        DllFreeSplStr(pPrinter->pwszDefaultDatatype);
+
+    if (pPrinter->pwszDescription)
+        DllFreeSplStr(pPrinter->pwszDescription);
+
+    if (pPrinter->pwszLocation)
+        DllFreeSplStr(pPrinter->pwszLocation);
+
+    if (pPrinter->pwszPrinterDriver)
+        DllFreeSplStr(pPrinter->pwszPrinterDriver);
+
+    if (pPrinter->pwszPrinterName)
+        DllFreeSplStr(pPrinter->pwszPrinterName);
+
+    DllFreeSplMem(pPrinter);
+}
+
+/**
+ * @name ReleaseLocalPrinter
+ *
+ * Drops one handle reference on a Printer and frees it when the last handle to
+ * a Printer that LocalDeletePrinter marked for deletion goes away.
+ */
+VOID
+ReleaseLocalPrinter(PLOCAL_PRINTER pPrinter)
+{
+    if (!pPrinter)
+        return;
+
+    if (pPrinter->cRefs)
+        pPrinter->cRefs--;
+
+    if (pPrinter->cRefs == 0 && pPrinter->bPendingDeletion)
+        _FreeLocalPrinter(pPrinter);
+}
+
+/**
+ * @name _IsValidPrinterName
+ *
+ * Checks a Printer name against the restrictions the spooler puts on it.
+ * A comma or a backslash would make the name ambiguous in the many places
+ * where printers, drivers and ports are stored as comma separated lists.
+ */
+static BOOL
+_IsValidPrinterName(PCWSTR pwszPrinterName)
+{
+    if (!pwszPrinterName || !*pwszPrinterName)
+        return FALSE;
+
+    if (wcslen(pwszPrinterName) > MAX_PRINTER_NAME)
+        return FALSE;
+
+    if (wcschr(pwszPrinterName, L',') || wcschr(pwszPrinterName, L'\\'))
+        return FALSE;
+
+    return TRUE;
+}
+
+/**
+ * @name _RegSetSZ
+ *
+ * Writes a REG_SZ value, substituting an empty string for a missing one.
+ * Every value read back by InitializePrinterList has to be present, otherwise
+ * the Printer would be skipped the next time the spooler starts.
+ */
+static LONG
+_RegSetSZ(HKEY hKey, PCWSTR pwszValueName, PCWSTR pwszValue)
+{
+    if (!pwszValue)
+        pwszValue = L"";
+
+    return RegSetValueExW(hKey, pwszValueName, 0, REG_SZ, (const BYTE*)pwszValue, (wcslen(pwszValue) + 1) * sizeof(WCHAR));
+}
+
+static LONG
+_RegSetDWORD(HKEY hKey, PCWSTR pwszValueName, DWORD dwValue)
+{
+    return RegSetValueExW(hKey, pwszValueName, 0, REG_DWORD, (const BYTE*)&dwValue, sizeof(DWORD));
+}
+
+/**
+ * @name _CreateDefaultDevMode
+ *
+ * Builds a minimal DEVMODEW for a Printer that was added without one.
+ */
+static PDEVMODEW
+_CreateDefaultDevMode(PCWSTR pwszPrinterName)
+{
+    PDEVMODEW pDevMode;
+
+    pDevMode = DllAllocSplMem(sizeof(DEVMODEW));
+    if (!pDevMode)
+    {
+        ERR("DllAllocSplMem failed!\n");
+        return NULL;
+    }
+
+    ZeroMemory(pDevMode, sizeof(DEVMODEW));
+    StringCchCopyW(pDevMode->dmDeviceName, _countof(pDevMode->dmDeviceName), pwszPrinterName);
+    pDevMode->dmSpecVersion = DM_SPECVERSION;
+    pDevMode->dmSize = sizeof(DEVMODEW);
+    pDevMode->dmDriverExtra = 0;
+
+    return pDevMode;
+}
+
+/**
+ * @name _IsPrinterDriverInstalled
+ *
+ * Checks whether a Printer Driver of the given name is installed for the
+ * local print environment.
+ */
+static BOOL
+_IsPrinterDriverInstalled(PCWSTR pwszDriverName)
+{
+    HKEY hDriverKey;
+    HKEY hDriversKey;
+    LONG lStatus;
+
+    hDriversKey = open_driver_reg(NULL);
+    if (!hDriversKey)
+        return FALSE;
+
+    lStatus = RegOpenKeyExW(hDriversKey, pwszDriverName, 0, KEY_READ, &hDriverKey);
+    if (lStatus == ERROR_SUCCESS)
+        RegCloseKey(hDriverKey);
+
+    RegCloseKey(hDriversKey);
+    return (lStatus == ERROR_SUCCESS);
+}
+
+/**
+ * @name LocalAddPrinter
+ *
+ * Creates a new local Printer and returns an open handle to it.
+ * This is the fpAddPrinter entry of the local Print Provider.
+ */
+HANDLE WINAPI
+LocalAddPrinter(PWSTR pName, DWORD Level, PBYTE pPrinterInfo)
+{
+    BOOL bCreatedKey = FALSE;
+    DWORD dwDisposition;
+    DWORD dwErrorCode;
+    HANDLE hPrinter = NULL;
+    HKEY hPrinterKey = NULL;
+    PDEVMODEW pDevMode = NULL;
+    PLOCAL_PORT pPort;
+    PLOCAL_PRINTER pPrinter = NULL;
+    PLOCAL_PRINT_PROCESSOR pPrintProcessor;
+    PPRINTER_INFO_2W pInfo2 = (PPRINTER_INFO_2W)pPrinterInfo;
+    PWSTR pwszDatatype;
+    PWSTR pwszPrintProcessor;
+
+    TRACE("LocalAddPrinter(%S, %lu, %p)\n", pName, Level, pPrinterInfo);
+
+    // Only Level 2 carries enough information to create a Printer.
+    if (Level != 2)
+    {
+        ERR("Level = %lu, unsupported!\n", Level);
+        dwErrorCode = ERROR_INVALID_LEVEL;
+        goto Cleanup;
+    }
+
+    if (!pInfo2)
+    {
+        dwErrorCode = ERROR_INVALID_PARAMETER;
+        goto Cleanup;
+    }
+
+    if (!_IsValidPrinterName(pInfo2->pPrinterName))
+    {
+        ERR("Invalid Printer name!\n");
+        dwErrorCode = ERROR_INVALID_PRINTER_NAME;
+        goto Cleanup;
+    }
+
+    // A Printer of this name must not exist yet.
+    if (LookupElementSkiplist(&PrinterList, &pInfo2->pPrinterName, NULL))
+    {
+        dwErrorCode = ERROR_PRINTER_ALREADY_EXISTS;
+        goto Cleanup;
+    }
+
+    // Find the Print Processor, defaulting to "WinPrint" like Windows does.
+    pwszPrintProcessor = pInfo2->pPrintProcessor;
+    if (!pwszPrintProcessor || !*pwszPrintProcessor)
+        pwszPrintProcessor = L"WinPrint";
+
+    pPrintProcessor = FindPrintProcessor(pwszPrintProcessor);
+    if (!pPrintProcessor)
+    {
+        ERR("Invalid Print Processor \"%S\"!\n", pwszPrintProcessor);
+        dwErrorCode = ERROR_UNKNOWN_PRINTPROCESSOR;
+        goto Cleanup;
+    }
+
+    // Find the datatype, defaulting to "RAW".
+    pwszDatatype = pInfo2->pDatatype;
+    if (!pwszDatatype || !*pwszDatatype)
+        pwszDatatype = L"RAW";
+
+    if (!FindDatatype(pPrintProcessor, pwszDatatype))
+    {
+        ERR("Invalid datatype \"%S\"!\n", pwszDatatype);
+        dwErrorCode = ERROR_INVALID_DATATYPE;
+        goto Cleanup;
+    }
+
+    // Find the port.
+    pPort = FindPort(pInfo2->pPortName);
+    if (!pPort)
+    {
+        // The Port List is only built while the spooler starts up. Installers
+        // routinely create their port first (through XcvData or a Print Monitor
+        // of their own) and add the Printer right afterwards, so re-read the
+        // ports from the monitors before giving up.
+        RefreshPortList();
+        pPort = FindPort(pInfo2->pPortName);
+    }
+
+    if (!pPort)
+    {
+        ERR("Invalid Port \"%S\"!\n", pInfo2->pPortName);
+        dwErrorCode = ERROR_UNKNOWN_PORT;
+        goto Cleanup;
+    }
+
+    // The driver has to be installed already.
+    if (!pInfo2->pDriverName || !_IsPrinterDriverInstalled(pInfo2->pDriverName))
+    {
+        ERR("Invalid Printer Driver \"%S\"!\n", pInfo2->pDriverName);
+        dwErrorCode = ERROR_UNKNOWN_PRINTER_DRIVER;
+        goto Cleanup;
+    }
+
+    // Take the supplied DevMode or synthesize a default one.
+    if (pInfo2->pDevMode)
+        pDevMode = DuplicateDevMode(pInfo2->pDevMode);
+    else
+        pDevMode = _CreateDefaultDevMode(pInfo2->pPrinterName);
+
+    if (!pDevMode)
+    {
+        dwErrorCode = ERROR_NOT_ENOUGH_MEMORY;
+        goto Cleanup;
+    }
+
+    // Create the Printer's registry key.
+    dwErrorCode = (DWORD)RegCreateKeyExW(hPrintersKey, pInfo2->pPrinterName, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hPrinterKey, &dwDisposition);
+    if (dwErrorCode != ERROR_SUCCESS)
+    {
+        ERR("RegCreateKeyExW failed for Printer \"%S\" with status %lu!\n", pInfo2->pPrinterName, dwErrorCode);
+        goto Cleanup;
+    }
+
+    if (dwDisposition != REG_CREATED_NEW_KEY)
+    {
+        // A key of that name was already there, so it is not ours to remove again.
+        dwErrorCode = ERROR_PRINTER_ALREADY_EXISTS;
+        goto Cleanup;
+    }
+
+    bCreatedKey = TRUE;
+
+    // Write everything InitializePrinterList reads back on the next startup.
+    _RegSetSZ(hPrinterKey, L"Name", pInfo2->pPrinterName);
+    _RegSetSZ(hPrinterKey, L"Share Name", pInfo2->pShareName);
+    _RegSetSZ(hPrinterKey, L"Port", pPort->pwszName);
+    _RegSetSZ(hPrinterKey, L"Printer Driver", pInfo2->pDriverName);
+    _RegSetSZ(hPrinterKey, L"Description", pInfo2->pComment);
+    _RegSetSZ(hPrinterKey, L"Location", pInfo2->pLocation);
+    _RegSetSZ(hPrinterKey, L"Print Processor", pwszPrintProcessor);
+    _RegSetSZ(hPrinterKey, L"Datatype", pwszDatatype);
+    _RegSetSZ(hPrinterKey, L"Parameters", pInfo2->pParameters);
+    _RegSetSZ(hPrinterKey, L"Separator File", pInfo2->pSepFile);
+    _RegSetDWORD(hPrinterKey, L"Attributes", pInfo2->Attributes);
+    _RegSetDWORD(hPrinterKey, L"Priority", pInfo2->Priority);
+    _RegSetDWORD(hPrinterKey, L"Default Priority", pInfo2->DefaultPriority);
+    _RegSetDWORD(hPrinterKey, L"StartTime", pInfo2->StartTime);
+    _RegSetDWORD(hPrinterKey, L"UntilTime", pInfo2->UntilTime);
+    _RegSetDWORD(hPrinterKey, L"Status", 0);
+    RegSetValueExW(hPrinterKey, L"Default DevMode", 0, REG_BINARY, (const BYTE*)pDevMode, pDevMode->dmSize + pDevMode->dmDriverExtra);
+
+    // Create the in-memory Printer.
+    pPrinter = DllAllocSplMem(sizeof(LOCAL_PRINTER));
+    if (!pPrinter)
+    {
+        dwErrorCode = ERROR_NOT_ENOUGH_MEMORY;
+        ERR("DllAllocSplMem failed!\n");
+        goto Cleanup;
+    }
+
+    ZeroMemory(pPrinter, sizeof(LOCAL_PRINTER));
+    pPrinter->pwszPrinterName = AllocSplStr(pInfo2->pPrinterName);
+    pPrinter->pwszPrinterDriver = AllocSplStr(pInfo2->pDriverName);
+    pPrinter->pwszDescription = AllocSplStr(pInfo2->pComment ? pInfo2->pComment : L"");
+    pPrinter->pwszLocation = AllocSplStr(pInfo2->pLocation ? pInfo2->pLocation : L"");
+    pPrinter->pwszDefaultDatatype = AllocSplStr(pwszDatatype);
+    pPrinter->pDefaultDevMode = pDevMode;
+    pPrinter->pPrintProcessor = pPrintProcessor;
+
+    // The Printer owns the DevMode from here on.
+    pDevMode = NULL;
+    pPrinter->pPort = pPort;
+    pPrinter->dwAttributes = pInfo2->Attributes;
+    pPrinter->dwStatus = 0;
+
+    if (!pPrinter->pwszPrinterName || !pPrinter->pwszPrinterDriver || !pPrinter->pwszDescription ||
+        !pPrinter->pwszLocation || !pPrinter->pwszDefaultDatatype)
+    {
+        dwErrorCode = ERROR_NOT_ENOUGH_MEMORY;
+        goto Cleanup;
+    }
+
+    InitializePrinterJobList(pPrinter);
+
+    if (!InsertElementSkiplist(&PrinterList, pPrinter))
+    {
+        ERR("InsertElementSkiplist failed for Printer \"%S\"!\n", pPrinter->pwszPrinterName);
+        dwErrorCode = ERROR_NOT_ENOUGH_MEMORY;
+        goto Cleanup;
+    }
+
+    // Hand back an open handle to the new Printer, just like Windows does.
+    dwErrorCode = _LocalOpenPrinterHandle(pPrinter->pwszPrinterName, NULL, &hPrinter, NULL);
+    if (dwErrorCode != ERROR_SUCCESS)
+    {
+        ERR("_LocalOpenPrinterHandle failed for Printer \"%S\" with error %lu!\n", pPrinter->pwszPrinterName, dwErrorCode);
+        DeleteElementSkiplist(&PrinterList, pPrinter);
+        goto Cleanup;
+    }
+
+    // The Printer is now owned by the Printer List.
+    pPrinter = NULL;
+    dwErrorCode = ROUTER_SUCCESS;
+
+Cleanup:
+    if (hPrinterKey)
+        RegCloseKey(hPrinterKey);
+
+    // Roll back the registry key, but only when this call is the one that created it.
+    if (dwErrorCode != ROUTER_SUCCESS && bCreatedKey)
+        RegDeleteKeyW(hPrintersKey, pInfo2->pPrinterName);
+
+    if (pPrinter)
+        _FreeLocalPrinter(pPrinter);
+
+    if (pDevMode)
+        DllFreeSplMem(pDevMode);
+
+    SetLastError(dwErrorCode);
+    return hPrinter;
+}
+
+/**
+ * @name LocalDeletePrinter
+ *
+ * Deletes the Printer a handle refers to.
+ * This is the fpDeletePrinter entry of the local Print Provider.
+ */
+BOOL WINAPI
+LocalDeletePrinter(HANDLE hPrinter)
+{
+    DWORD dwErrorCode;
+    PLOCAL_HANDLE pHandle = (PLOCAL_HANDLE)hPrinter;
+    PLOCAL_PRINTER pPrinter;
+    PLOCAL_PRINTER_HANDLE pPrinterHandle;
+
+    TRACE("LocalDeletePrinter(%p)\n", hPrinter);
+
+    if (!pHandle)
+    {
+        dwErrorCode = ERROR_INVALID_HANDLE;
+        goto Cleanup;
+    }
+
+    if (pHandle->HandleType != HandleType_Printer)
+    {
+        dwErrorCode = ERROR_INVALID_HANDLE;
+        goto Cleanup;
+    }
+
+    pPrinterHandle = (PLOCAL_PRINTER_HANDLE)pHandle->pSpecificHandle;
+    pPrinter = pPrinterHandle->pPrinter;
+
+    if (pPrinter->bPendingDeletion)
+    {
+        dwErrorCode = ERROR_SUCCESS;
+        goto Cleanup;
+    }
+
+    // Windows refuses to delete a Printer that still has queued jobs.
+    if (pPrinter->JobList.NodeCount)
+    {
+        ERR("Printer \"%S\" still has %lu job(s)!\n", pPrinter->pwszPrinterName, pPrinter->JobList.NodeCount);
+        dwErrorCode = ERROR_PRINTER_HAS_JOBS_QUEUED;
+        goto Cleanup;
+    }
+
+    // Delete the Printer's registry key.
+    RegDeleteKeyW(hPrintersKey, pPrinter->pwszPrinterName);
+
+    // Take it out of the Printer List so that it is neither enumerated nor
+    // opened anymore, and mark it so the structure itself is released once the
+    // last handle referring to it is closed.
+    DeleteElementSkiplist(&PrinterList, pPrinter);
+    pPrinter->bPendingDeletion = TRUE;
+    pPrinter->dwStatus |= PRINTER_STATUS_PENDING_DELETION;
+
+    dwErrorCode = ERROR_SUCCESS;
+
+Cleanup:
+    SetLastError(dwErrorCode);
+    return (dwErrorCode == ERROR_SUCCESS);
+}
+
+/**
+ * @name LocalSetPrinter
+ *
+ * Changes the configuration or the state of a Printer.
+ * This is the fpSetPrinter entry of the local Print Provider.
+ */
+BOOL WINAPI
+LocalSetPrinter(HANDLE hPrinter, DWORD Level, PBYTE pPrinterInfo, DWORD Command)
+{
+    DWORD dwErrorCode;
+    HKEY hPrinterKey = NULL;
+    PLOCAL_HANDLE pHandle = (PLOCAL_HANDLE)hPrinter;
+    PLOCAL_PRINTER pPrinter;
+    PLOCAL_PRINTER_HANDLE pPrinterHandle;
+
+    TRACE("LocalSetPrinter(%p, %lu, %p, %lu)\n", hPrinter, Level, pPrinterInfo, Command);
+
+    if (!pHandle || pHandle->HandleType != HandleType_Printer)
+    {
+        dwErrorCode = ERROR_INVALID_HANDLE;
+        goto Cleanup;
+    }
+
+    pPrinterHandle = (PLOCAL_PRINTER_HANDLE)pHandle->pSpecificHandle;
+    pPrinter = pPrinterHandle->pPrinter;
+
+    // A command always takes precedence over the supplied structure.
+    if (Command)
+    {
+        switch (Command)
+        {
+            case PRINTER_CONTROL_PAUSE:
+                pPrinter->dwStatus |= PRINTER_STATUS_PAUSED;
+                break;
+
+            case PRINTER_CONTROL_RESUME:
+                pPrinter->dwStatus &= ~PRINTER_STATUS_PAUSED;
+                break;
+
+            case PRINTER_CONTROL_PURGE:
+                // Nothing is queued that we could purge yet.
+                break;
+
+            case PRINTER_CONTROL_SET_STATUS:
+                if (!pPrinterInfo)
+                {
+                    dwErrorCode = ERROR_INVALID_PARAMETER;
+                    goto Cleanup;
+                }
+
+                pPrinter->dwStatus = ((PPRINTER_INFO_6)pPrinterInfo)->dwStatus;
+                break;
+
+            default:
+                dwErrorCode = ERROR_INVALID_PARAMETER;
+                goto Cleanup;
+        }
+
+        dwErrorCode = (DWORD)RegOpenKeyExW(hPrintersKey, pPrinter->pwszPrinterName, 0, KEY_SET_VALUE, &hPrinterKey);
+        if (dwErrorCode == ERROR_SUCCESS)
+            _RegSetDWORD(hPrinterKey, L"Status", pPrinter->dwStatus);
+
+        dwErrorCode = ERROR_SUCCESS;
+        goto Cleanup;
+    }
+
+    dwErrorCode = (DWORD)RegOpenKeyExW(hPrintersKey, pPrinter->pwszPrinterName, 0, KEY_SET_VALUE, &hPrinterKey);
+    if (dwErrorCode != ERROR_SUCCESS)
+    {
+        ERR("RegOpenKeyExW failed for Printer \"%S\" with status %lu!\n", pPrinter->pwszPrinterName, dwErrorCode);
+        goto Cleanup;
+    }
+
+    switch (Level)
+    {
+        case 2:
+        {
+            PLOCAL_PORT pPort;
+            PLOCAL_PRINT_PROCESSOR pPrintProcessor;
+            PPRINTER_INFO_2W pInfo2 = (PPRINTER_INFO_2W)pPrinterInfo;
+
+            if (!pInfo2)
+            {
+                dwErrorCode = ERROR_INVALID_PARAMETER;
+                goto Cleanup;
+            }
+
+            // Renaming a Printer is not supported yet, so the name is ignored here.
+            if (pInfo2->pPortName && *pInfo2->pPortName)
+            {
+                pPort = FindPort(pInfo2->pPortName);
+                if (!pPort)
+                {
+                    RefreshPortList();
+                    pPort = FindPort(pInfo2->pPortName);
+                }
+
+                if (!pPort)
+                {
+                    dwErrorCode = ERROR_UNKNOWN_PORT;
+                    goto Cleanup;
+                }
+
+                pPrinter->pPort = pPort;
+                _RegSetSZ(hPrinterKey, L"Port", pPort->pwszName);
+            }
+
+            if (pInfo2->pPrintProcessor && *pInfo2->pPrintProcessor)
+            {
+                pPrintProcessor = FindPrintProcessor(pInfo2->pPrintProcessor);
+                if (!pPrintProcessor)
+                {
+                    dwErrorCode = ERROR_UNKNOWN_PRINTPROCESSOR;
+                    goto Cleanup;
+                }
+
+                pPrinter->pPrintProcessor = pPrintProcessor;
+                _RegSetSZ(hPrinterKey, L"Print Processor", pInfo2->pPrintProcessor);
+            }
+
+            if (pInfo2->pDatatype && *pInfo2->pDatatype)
+            {
+                if (!FindDatatype(pPrinter->pPrintProcessor, pInfo2->pDatatype))
+                {
+                    dwErrorCode = ERROR_INVALID_DATATYPE;
+                    goto Cleanup;
+                }
+
+                DllFreeSplStr(pPrinter->pwszDefaultDatatype);
+                pPrinter->pwszDefaultDatatype = AllocSplStr(pInfo2->pDatatype);
+                _RegSetSZ(hPrinterKey, L"Datatype", pInfo2->pDatatype);
+            }
+
+            if (pInfo2->pDriverName && *pInfo2->pDriverName)
+            {
+                if (!_IsPrinterDriverInstalled(pInfo2->pDriverName))
+                {
+                    dwErrorCode = ERROR_UNKNOWN_PRINTER_DRIVER;
+                    goto Cleanup;
+                }
+
+                DllFreeSplStr(pPrinter->pwszPrinterDriver);
+                pPrinter->pwszPrinterDriver = AllocSplStr(pInfo2->pDriverName);
+                _RegSetSZ(hPrinterKey, L"Printer Driver", pInfo2->pDriverName);
+            }
+
+            if (pInfo2->pComment)
+            {
+                DllFreeSplStr(pPrinter->pwszDescription);
+                pPrinter->pwszDescription = AllocSplStr(pInfo2->pComment);
+                _RegSetSZ(hPrinterKey, L"Description", pInfo2->pComment);
+            }
+
+            if (pInfo2->pLocation)
+            {
+                DllFreeSplStr(pPrinter->pwszLocation);
+                pPrinter->pwszLocation = AllocSplStr(pInfo2->pLocation);
+                _RegSetSZ(hPrinterKey, L"Location", pInfo2->pLocation);
+            }
+
+            if (pInfo2->pShareName)
+                _RegSetSZ(hPrinterKey, L"Share Name", pInfo2->pShareName);
+
+            if (pInfo2->pSepFile)
+                _RegSetSZ(hPrinterKey, L"Separator File", pInfo2->pSepFile);
+
+            if (pInfo2->pParameters)
+                _RegSetSZ(hPrinterKey, L"Parameters", pInfo2->pParameters);
+
+            if (pInfo2->pDevMode)
+            {
+                PDEVMODEW pDevMode = DuplicateDevMode(pInfo2->pDevMode);
+
+                if (!pDevMode)
+                {
+                    dwErrorCode = ERROR_NOT_ENOUGH_MEMORY;
+                    goto Cleanup;
+                }
+
+                if (pPrinter->pDefaultDevMode)
+                    DllFreeSplMem(pPrinter->pDefaultDevMode);
+
+                pPrinter->pDefaultDevMode = pDevMode;
+                RegSetValueExW(hPrinterKey, L"Default DevMode", 0, REG_BINARY, (const BYTE*)pDevMode, pDevMode->dmSize + pDevMode->dmDriverExtra);
+            }
+
+            pPrinter->dwAttributes = pInfo2->Attributes;
+            _RegSetDWORD(hPrinterKey, L"Attributes", pInfo2->Attributes);
+            _RegSetDWORD(hPrinterKey, L"Priority", pInfo2->Priority);
+            _RegSetDWORD(hPrinterKey, L"Default Priority", pInfo2->DefaultPriority);
+            _RegSetDWORD(hPrinterKey, L"StartTime", pInfo2->StartTime);
+            _RegSetDWORD(hPrinterKey, L"UntilTime", pInfo2->UntilTime);
+
+            dwErrorCode = ERROR_SUCCESS;
+            break;
+        }
+
+        case 6:
+        {
+            PPRINTER_INFO_6 pInfo6 = (PPRINTER_INFO_6)pPrinterInfo;
+
+            if (!pInfo6)
+            {
+                dwErrorCode = ERROR_INVALID_PARAMETER;
+                goto Cleanup;
+            }
+
+            pPrinter->dwStatus = pInfo6->dwStatus;
+            _RegSetDWORD(hPrinterKey, L"Status", pPrinter->dwStatus);
+            dwErrorCode = ERROR_SUCCESS;
+            break;
+        }
+
+        case 8:
+        case 9:
+        {
+            PPRINTER_INFO_9W pInfo9 = (PPRINTER_INFO_9W)pPrinterInfo;
+            PDEVMODEW pDevMode;
+
+            if (!pInfo9 || !pInfo9->pDevMode)
+            {
+                dwErrorCode = ERROR_INVALID_PARAMETER;
+                goto Cleanup;
+            }
+
+            pDevMode = DuplicateDevMode(pInfo9->pDevMode);
+            if (!pDevMode)
+            {
+                dwErrorCode = ERROR_NOT_ENOUGH_MEMORY;
+                goto Cleanup;
+            }
+
+            if (pPrinter->pDefaultDevMode)
+                DllFreeSplMem(pPrinter->pDefaultDevMode);
+
+            pPrinter->pDefaultDevMode = pDevMode;
+            RegSetValueExW(hPrinterKey, L"Default DevMode", 0, REG_BINARY, (const BYTE*)pDevMode, pDevMode->dmSize + pDevMode->dmDriverExtra);
+            dwErrorCode = ERROR_SUCCESS;
+            break;
+        }
+
+        default:
+            FIXME("Unsupported level %lu!\n", Level);
+            dwErrorCode = ERROR_INVALID_LEVEL;
+            break;
+    }
+
+Cleanup:
+    if (hPrinterKey)
+        RegCloseKey(hPrinterKey);
+
+    SetLastError(dwErrorCode);
+    return (dwErrorCode == ERROR_SUCCESS);
+}
+
 static void
 _LocalClosePrinterHandle(PLOCAL_PRINTER_HANDLE pPrinterHandle)
 {
@@ -1944,6 +2655,9 @@ _LocalClosePrinterHandle(PLOCAL_PRINTER_HANDLE pPrinterHandle)
     // Free memory for the fields.
     DllFreeSplMem(pPrinterHandle->pDevMode);
     DllFreeSplStr(pPrinterHandle->pwszDatatype);
+
+    // This releases the Printer itself if it was deleted while we held a handle.
+    ReleaseLocalPrinter(pPrinterHandle->pPrinter);
 }
 
 static void


### PR DESCRIPTION
CORE-19134, CORE-20749, CORE-20750

A printer could not be created or deleted at all, and every layer had a bug hiding the one below it. localspl registered NULL for fpAddPrinter, fpDeletePrinter and fpSetPrinter, spoolsv left _RpcAddPrinter and _RpcSetPrinter as stubs, spoolss returned the Print Provider's own handle instead of the wrapper it had just built, and the winspool ANSI entries converted the caller's structure in place and then freed those pointers, which is the VB6 crash in CORE-19134.

Also fixes the Xcv handle access mask, so an installer's AddPort stops failing with ERROR_ACCESS_DENIED, and the driver UI DLL path in driver_load(). The freetype commit is an unrelated GCC 11+ build fix, drop it if you don't want it here.

Tested on i386 GCC 13.4 in QEMU/KVM with the new winspool:AddPrinter apitest, 28 tests, no failures.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: