### PR TITLE
[MC] Add DRIVER_POWER_STATE_FAILURE bugcheck code

### DIFF
--- a/sdk/include/reactos/mc/bugcodes.mc
+++ b/sdk/include/reactos/mc/bugcodes.mc
@@ -1225,6 +1225,14 @@ If this is the first time you have seen this error screen, read
 If problems continue, remove all nonfree software from your computer.
 .
 
+MessageId=0x9F
+Severity=Success
+Facility=System
+SymbolicName=DRIVER_POWER_STATE_FAILURE
+Language=English
+DRIVER_POWER_STATE_FAILURE
+.
+
 MessageId=0xA0
 Severity=Success
 Facility=System


### PR DESCRIPTION
This is used by the Power Manager kernel module to put down the system due to power failures of a driver.

**JIRA Issue:** [CORE-18969](https://jira.reactos.org/browse/CORE-18969)

This is a subsequent PR that is a split-up from #9466, in order to make the main PO PR less congested.