### PR TITLE
[SDK] Don't use empty string defaultvalue for BSTR arguments

### DIFF
--- a/sdk/include/psdk/msxml2.idl
+++ b/sdk/include/psdk/msxml2.idl
@@ -1265,7 +1265,7 @@ interface IXSLProcessor : IDispatch
     [id(DISPID_XMLDOM_PROCESSOR_SETSTARTMODE)]
     HRESULT setStartMode(
         [in] BSTR p, 
-        [in, defaultvalue("")] BSTR uri);
+        [in, defaultvalue(NULL)] BSTR uri);
 
     [propget, id(DISPID_XMLDOM_PROCESSOR_STARTMODE)]
     HRESULT startMode([retval, out] BSTR *p);
@@ -1293,7 +1293,7 @@ interface IXSLProcessor : IDispatch
     HRESULT addParameter(
         [in] BSTR p, 
         [in] VARIANT var, 
-        [in, defaultvalue("")] BSTR uri);
+        [in, defaultvalue(NULL)] BSTR uri);
 
     [id(DISPID_XMLDOM_PROCESSOR_ADDOBJECT)]
     HRESULT addObject(

--- a/sdk/include/psdk/msxml6.idl
+++ b/sdk/include/psdk/msxml6.idl
@@ -1193,7 +1193,7 @@ interface IXSLProcessor : IDispatch
     [id(DISPID_XMLDOM_PROCESSOR_SETSTARTMODE)]
     HRESULT setStartMode(
         [in] BSTR p,
-        [in, defaultvalue("")] BSTR uri);
+        [in, defaultvalue(NULL)] BSTR uri);
 
     [propget, id(DISPID_XMLDOM_PROCESSOR_STARTMODE)]
     HRESULT startMode([retval, out] BSTR *p);
@@ -1221,7 +1221,7 @@ interface IXSLProcessor : IDispatch
     HRESULT addParameter(
         [in] BSTR p,
         [in] VARIANT var,
-        [in, defaultvalue("")] BSTR uri);
+        [in, defaultvalue(NULL)] BSTR uri);
 
     [id(DISPID_XMLDOM_PROCESSOR_ADDOBJECT)]
     HRESULT addObject(


### PR DESCRIPTION
The MS SDK changed to NULL somewhere between 10.0.14393 and 10.0.16299. This is required to use msxml2.h in GCC C++ source files, otherwise you get a const string fatal warning when `L""` is converted to a BSTR in default arguments.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: