### PR TITLE
[NDK] Fix an annotation in NtGetDevicePowerState

### DIFF
--- a/sdk/include/ddk/ntpoapi.h
+++ b/sdk/include/ddk/ntpoapi.h
@@ -321,7 +321,7 @@ NTSTATUS
 NTAPI
 NtGetDevicePowerState(
   _In_ HANDLE Device,
-  _Out_ DEVICE_POWER_STATE *State);
+  _Out_ PDEVICE_POWER_STATE PowerState);
 
 NTSYSCALLAPI
 NTSTATUS

--- a/sdk/include/ndk/pofuncs.h
+++ b/sdk/include/ndk/pofuncs.h
@@ -63,7 +63,7 @@ NTSTATUS
 NTAPI
 NtGetDevicePowerState(
     _In_ HANDLE Device,
-    _In_ PDEVICE_POWER_STATE PowerState
+    _Out_ PDEVICE_POWER_STATE PowerState
 );
 
 NTSYSCALLAPI


### PR DESCRIPTION
`NtGetDevicePowerState` returns the power state of a device on its 2nd parameter, yet the annotation treats it like an input one. Fix that.

**Jira Issue:** [CORE-18969](https://jira.reactos.org/browse/CORE-18969)

This is a subsequent PR that is a split-up from https://github.com/reactos/reactos/pull/9466, in order to make the main PO PR less congested.