### PR TITLE
[NTUSER] Implement APIs for enumeration of raw input devices

### DIFF
--- a/win32ss/CMakeLists.txt
+++ b/win32ss/CMakeLists.txt
@@ -148,6 +148,7 @@ list(APPEND SOURCE
     user/ntuser/painting.c
     user/ntuser/power.c
     user/ntuser/prop.c
+    user/ntuser/rawinput.c
     user/ntuser/scrollbar.c
     user/ntuser/scrollex.c
     user/ntuser/security.c

--- a/win32ss/user/ntuser/input.c
+++ b/win32ss/user/ntuser/input.c
@@ -24,6 +24,8 @@ PKTIMER MasterTimer = NULL;
 PATTACHINFO gpai = NULL;
 INT paiCount = 0;
 HANDLE ghKeyboardDevice = NULL;
+PINPUT_DEVICE_INFO gpInputDeviceInfo = NULL;
+PERESOURCE gpDeviceInfoListMutex = NULL;
 
 static DWORD LastInputTick = 0;
 static HANDLE ghMouseDevice;
@@ -180,6 +182,11 @@ RawInputThreadMain(VOID)
         ASSERT(FALSE);
         /* Failed to open the interactive winsta! What now? */
     }
+
+    gpDeviceInfoListMutex = ExAllocatePoolWithTag(NonPagedPool, sizeof(*gpDeviceInfoListMutex), USERTAG_SYSTEM);
+    ASSERT(gpDeviceInfoListMutex);
+    Status = ExInitializeResourceLite(gpDeviceInfoListMutex);
+    ASSERT(NT_SUCCESS(Status));
 
     UserEnterExclusive();
     StartTheTimers();
@@ -361,6 +368,8 @@ RawInputThreadMain(VOID)
         ObDereferenceObject(pKbdDevice);
         ghKeyboardDevice = NULL;
     }
+
+    ExFreePoolWithTag(gpDeviceInfoListMutex, USERTAG_SYSTEM);
 
     ERR("Raw Input Thread Exit!\n");
 }

--- a/win32ss/user/ntuser/input.c
+++ b/win32ss/user/ntuser/input.c
@@ -153,6 +153,17 @@ RawInputThreadMain(VOID)
     KEYBOARD_INPUT_DATA KeyInput;
     PVOID ShutdownEvent;
     HWINSTA hWinSta;
+    INPUT_DEVICE_INFO Mouse;
+    INPUT_DEVICE_INFO Keyboard;
+
+    RtlZeroMemory(&Mouse, sizeof(Mouse));
+    Mouse.DeviceType = RIM_TYPEMOUSE;
+    RtlInitUnicodeString(&Mouse.DeviceName, L"\\Device\\PointerClass0");
+    Mouse.Mouse.Attributes.NumberOfButtons = 2;
+
+    RtlZeroMemory(&Keyboard, sizeof(Keyboard));
+    Keyboard.DeviceType = RIM_TYPEKEYBOARD;
+    RtlInitUnicodeString(&Keyboard.DeviceName, L"\\Device\\KeyboardClass0");
 
     ByteOffset.QuadPart = (LONGLONG)0;
     //WaitTimeout.QuadPart = (LONGLONG)(-10000000);
@@ -201,23 +212,28 @@ RawInputThreadMain(VOID)
         if (!ghMouseDevice)
         {
             /* Check if mouse device already exists */
-            Status = OpenInputDevice(&ghMouseDevice, &pMouDevice, L"\\Device\\PointerClass0" );
+            Status = OpenInputDevice(&ghMouseDevice, &pMouDevice, Mouse.DeviceName.Buffer);
             if (NT_SUCCESS(Status))
             {
                 ++cMaxWaitObjects;
                 TRACE("Mouse connected!\n");
+                Mouse.pNextDeviceInfo = gpInputDeviceInfo;
+                gpInputDeviceInfo = &Mouse;
             }
         }
         if (!ghKeyboardDevice)
         {
             /* Check if keyboard device already exists */
-            Status = OpenInputDevice(&ghKeyboardDevice, &pKbdDevice, L"\\Device\\KeyboardClass0");
+            Status = OpenInputDevice(&ghKeyboardDevice, &pKbdDevice, Keyboard.DeviceName.Buffer);
             if (NT_SUCCESS(Status))
             {
                 ++cMaxWaitObjects;
                 TRACE("Keyboard connected!\n");
+                Keyboard.pNextDeviceInfo = gpInputDeviceInfo;
+                gpInputDeviceInfo = &Keyboard;
                 // Get and load keyboard attributes.
                 UserInitKeyboard(ghKeyboardDevice);
+                Keyboard.Keyboard.Attributes = gKeyboardInfo;
                 UserEnterExclusive();
                 // Register the Window hotkey.
                 UserRegisterHotKey(PWND_BOTTOM, IDHK_WINKEY, MOD_WIN, 0);

--- a/win32ss/user/ntuser/input.h
+++ b/win32ss/user/ntuser/input.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <ndk/kbd.h>
- 
+#include <hidclass.h>
+
 typedef struct tagKBDNLSLAYER
 {
     USHORT OEMIdentifier;
@@ -90,11 +91,65 @@ UINT FASTCALL IntImmProcessKey(
     _In_ LPARAM lParam);
 VOID FASTCALL IntFreeImeHotKeys(VOID);
 
+/* Input devices */
+typedef struct _MOUSE_DEVICE_INFO
+{
+    MOUSE_ATTRIBUTES Attributes;
+    MOUSE_INPUT_DATA Data;
+} MOUSE_DEVICE_INFO, *PMOUSE_DEVICE_INFO;
+
+typedef struct _KEYBOARD_DEVICE_INFO
+{
+    KEYBOARD_ATTRIBUTES Attributes;
+    KEYBOARD_INPUT_DATA Data;
+} KEYBOARD_DEVICE_INFO, *PKEYBOARD_DEVICE_INFO;
+
+typedef struct _HID_DEVICE_INFO
+{
+    PHIDP_PREPARSED_DATA PreparsedData;
+    HID_COLLECTION_INFORMATION CollectionInformation;
+    HIDP_CAPS Caps;
+} HID_DEVICE_INFO, *PHID_DEVICE_INFO;
+
+typedef struct _INPUT_DEVICE_INFO
+{
+    struct _INPUT_DEVICE_INFO *pNextDeviceInfo;
+    UNICODE_STRING DeviceName;
+    HANDLE Handle;
+    IO_STATUS_BLOCK Iosb;
+    NTSTATUS Status;
+    ULONG DeviceType;
+    union
+    {
+        MOUSE_DEVICE_INFO Mouse;
+        KEYBOARD_DEVICE_INFO Keyboard;
+        HID_DEVICE_INFO Hid;
+    };
+} INPUT_DEVICE_INFO, *PINPUT_DEVICE_INFO;
+
 extern DWORD gSystemFS;
 extern UINT gSystemCPCharSet; 
 extern HANDLE ghKeyboardDevice;
 extern PTHREADINFO ptiRawInput;
 extern BYTE gafAsyncKeyState[256 * 2 / 8]; // 2 bits per key
+extern PINPUT_DEVICE_INFO gpInputDeviceInfo;
+extern PERESOURCE gpDeviceInfoListMutex;
+
+FORCEINLINE
+VOID
+AcquireDeviceInfoListMutex(VOID)
+{
+    KeEnterCriticalRegion();
+    ExAcquireResourceExclusiveLite(gpDeviceInfoListMutex, TRUE);
+}
+
+FORCEINLINE
+VOID
+ReleaseDeviceInfoListMutex(VOID)
+{
+    ExReleaseResourceLite(gpDeviceInfoListMutex);
+    KeLeaveCriticalRegion();
+}
 
 #define GET_KS_BYTE(vk) ((vk) * 2 / 8)
 #define GET_KS_DOWN_BIT(vk) (1 << (((vk) % 4)*2))

--- a/win32ss/user/ntuser/ntstubs.c
+++ b/win32ss/user/ntuser/ntstubs.c
@@ -402,30 +402,6 @@ NtUserGetRawInputData(
 
 DWORD
 APIENTRY
-NtUserGetRawInputDeviceInfo(
-    HANDLE hDevice,
-    UINT uiCommand,
-    LPVOID pData,
-    PUINT pcbSize
-)
-{
-    STUB;
-    return 0;
-}
-
-DWORD
-APIENTRY
-NtUserGetRawInputDeviceList(
-    PRAWINPUTDEVICELIST pRawInputDeviceList,
-    PUINT puiNumDevices,
-    UINT cbSize)
-{
-    STUB;
-    return 0;
-}
-
-DWORD
-APIENTRY
 NtUserGetRegisteredRawInputDevices(
     PRAWINPUTDEVICE pRawInputDevices,
     PUINT puiNumDevices,

--- a/win32ss/user/ntuser/rawinput.c
+++ b/win32ss/user/ntuser/rawinput.c
@@ -1,0 +1,220 @@
+/*
+ * PROJECT:     ReactOS Win32k subsystem
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Functions related to Raw Input handling
+ * COPYRIGHT:   Copyright 2026 Hervé Poussineau
+ */
+
+#include <win32k.h>
+
+DWORD
+APIENTRY
+NtUserGetRawInputDeviceInfo(
+    _In_opt_ HANDLE hDevice,
+    _In_ UINT uiCommand,
+    _Inout_opt_ LPVOID pData,
+    _Inout_ PUINT pcbSize)
+{
+    PINPUT_DEVICE_INFO DeviceInfo;
+    UINT cbSize, cbRequiredSize;
+    UINT Ret = (UINT)-1;
+
+    _SEH2_TRY
+    {
+        ProbeForRead(pcbSize, sizeof(*pcbSize), sizeof(DWORD));
+        cbSize = *pcbSize;
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        SetLastNtError(_SEH2_GetExceptionCode());
+        _SEH2_YIELD(return Ret);
+    }
+    _SEH2_END;
+
+    AcquireDeviceInfoListMutex();
+    for (DeviceInfo = gpInputDeviceInfo; DeviceInfo && DeviceInfo != hDevice; DeviceInfo = DeviceInfo->pNextDeviceInfo)
+        ;
+    if (!DeviceInfo)
+    {
+        ReleaseDeviceInfoListMutex();
+        EngSetLastError(ERROR_INVALID_HANDLE);
+        return Ret;
+    }
+
+    UserEnterShared();
+
+    switch (uiCommand)
+    {
+        case RIDI_PREPARSEDDATA:
+            if (DeviceInfo->DeviceType == RIM_TYPEHID)
+                cbRequiredSize = DeviceInfo->Hid.CollectionInformation.DescriptorSize;
+            else
+                cbRequiredSize = 0;
+            break;
+        case RIDI_DEVICENAME:
+            cbRequiredSize = DeviceInfo->DeviceName.Length / sizeof(WCHAR) + sizeof(ANSI_NULL);
+            break;
+        case RIDI_DEVICEINFO:
+            cbRequiredSize = sizeof(RID_DEVICE_INFO);
+            break;
+        default:
+            EngSetLastError(ERROR_INVALID_PARAMETER);
+            goto cleanup;
+    }
+
+    _SEH2_TRY
+    {
+        if (!pData)
+        {
+            ProbeForWrite(pcbSize, sizeof(*pcbSize), sizeof(DWORD));
+            *pcbSize = cbRequiredSize;
+            Ret = 0;
+            _SEH2_LEAVE;
+        }
+
+        if (cbSize < cbRequiredSize)
+        {
+            ProbeForWrite(pcbSize, sizeof(*pcbSize), sizeof(DWORD));
+            *pcbSize = cbRequiredSize;
+            EngSetLastError(ERROR_INSUFFICIENT_BUFFER);
+            _SEH2_LEAVE;
+        }
+
+        ProbeForWrite(pData, cbRequiredSize, sizeof(DWORD));
+        switch (uiCommand)
+        {
+            case RIDI_PREPARSEDDATA:
+                if (DeviceInfo->DeviceType == RIM_TYPEHID)
+                    RtlCopyMemory(pData, DeviceInfo->Hid.PreparsedData, cbRequiredSize);
+                break;
+            case RIDI_DEVICENAME:
+                // As cbSize/cbRequiredSize are in chars, we didn't probe a big enough buffer
+                // Do it again
+                ProbeForWrite(pData, DeviceInfo->DeviceName.Length + sizeof(UNICODE_NULL), sizeof(DWORD));
+                RtlCopyMemory(pData, DeviceInfo->DeviceName.Buffer, DeviceInfo->DeviceName.Length);
+                ((WCHAR*)pData)[cbRequiredSize - 1] = UNICODE_NULL;
+                break;
+            case RIDI_DEVICEINFO:
+            {
+                PRID_DEVICE_INFO prdi = pData;
+                ProbeForRead(&prdi->cbSize, sizeof(prdi->cbSize), sizeof(DWORD));
+                if (prdi->cbSize != cbRequiredSize)
+                {
+                    EngSetLastError(ERROR_INVALID_PARAMETER);
+                    _SEH2_YIELD(break);
+                }
+
+                ProbeForWrite(prdi, sizeof(*prdi), sizeof(DWORD));
+                RtlZeroMemory(prdi, sizeof(*prdi));
+                prdi->cbSize = sizeof(*prdi);
+                prdi->dwType = DeviceInfo->DeviceType;
+
+                switch (DeviceInfo->DeviceType)
+                {
+                    case RIM_TYPEMOUSE:
+                        prdi->mouse.dwId = DeviceInfo->Mouse.Attributes.MouseIdentifier & ~HORIZONTAL_WHEEL_PRESENT;
+                        prdi->mouse.dwNumberOfButtons = DeviceInfo->Mouse.Attributes.NumberOfButtons;
+                        prdi->mouse.dwSampleRate = DeviceInfo->Mouse.Attributes.SampleRate;
+                        prdi->mouse.fHasHorizontalWheel = !!(DeviceInfo->Mouse.Attributes.MouseIdentifier & HORIZONTAL_WHEEL_PRESENT);
+                        break;
+
+                    case RIM_TYPEKEYBOARD:
+                        prdi->keyboard.dwType = DeviceInfo->Keyboard.Attributes.KeyboardIdentifier.Type;
+                        prdi->keyboard.dwSubType = DeviceInfo->Keyboard.Attributes.KeyboardIdentifier.Subtype;
+                        prdi->keyboard.dwKeyboardMode = DeviceInfo->Keyboard.Attributes.KeyboardMode;
+                        prdi->keyboard.dwNumberOfFunctionKeys = DeviceInfo->Keyboard.Attributes.NumberOfFunctionKeys;
+                        prdi->keyboard.dwNumberOfIndicators = DeviceInfo->Keyboard.Attributes.NumberOfIndicators;
+                        prdi->keyboard.dwNumberOfKeysTotal = DeviceInfo->Keyboard.Attributes.NumberOfKeysTotal;
+                        break;
+
+                    case RIM_TYPEHID:
+                        prdi->hid.dwVendorId = DeviceInfo->Hid.CollectionInformation.VendorID;
+                        prdi->hid.dwProductId = DeviceInfo->Hid.CollectionInformation.ProductID;
+                        prdi->hid.dwVersionNumber = DeviceInfo->Hid.CollectionInformation.VersionNumber;
+                        prdi->hid.usUsagePage = DeviceInfo->Hid.Caps.UsagePage;
+                        prdi->hid.usUsage = DeviceInfo->Hid.Caps.Usage;
+                        break;
+
+                    default:
+                        break;
+                }
+                break;
+            }
+            default:
+                ASSERT(FALSE);
+                break;
+        }
+        Ret = cbRequiredSize;
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        SetLastNtError(_SEH2_GetExceptionCode());
+    }
+    _SEH2_END;
+
+cleanup:
+    UserLeave();
+    ReleaseDeviceInfoListMutex();
+    return Ret;
+}
+
+DWORD
+APIENTRY
+NtUserGetRawInputDeviceList(
+    _Out_opt_ PRAWINPUTDEVICELIST pRawInputDeviceList,
+    _Inout_ PUINT puiNumDevices,
+    _In_ UINT cbSize)
+{
+    PINPUT_DEVICE_INFO DeviceInfo;
+    UINT cDevices = 0, i, Ret = (UINT)-1;
+
+    if (cbSize != sizeof(RAWINPUTDEVICELIST))
+    {
+        EngSetLastError(ERROR_INVALID_PARAMETER);
+        return Ret;
+    }
+
+    AcquireDeviceInfoListMutex();
+    for (DeviceInfo = gpInputDeviceInfo; DeviceInfo; DeviceInfo = DeviceInfo->pNextDeviceInfo)
+        cDevices++;
+
+    UserEnterShared();
+
+    _SEH2_TRY
+    {
+        if (!pRawInputDeviceList)
+        {
+            ProbeForWrite(puiNumDevices, sizeof(*puiNumDevices), sizeof(DWORD));
+            *puiNumDevices = cDevices;
+            Ret = 0;
+            _SEH2_LEAVE;
+        }
+
+        ProbeForRead(puiNumDevices, sizeof(*puiNumDevices), sizeof(DWORD));
+        if (*puiNumDevices < cDevices)
+        {
+            ProbeForWrite(puiNumDevices, sizeof(*puiNumDevices), sizeof(DWORD));
+            *puiNumDevices = cDevices;
+            EngSetLastError(ERROR_INSUFFICIENT_BUFFER);
+            _SEH2_LEAVE;
+        }
+
+        ProbeForWrite(pRawInputDeviceList, cDevices * sizeof(*pRawInputDeviceList), sizeof(PVOID));
+        for (DeviceInfo = gpInputDeviceInfo, i = 0; DeviceInfo && i < cDevices; DeviceInfo = DeviceInfo->pNextDeviceInfo, i++)
+        {
+            pRawInputDeviceList[i].hDevice = DeviceInfo;
+            pRawInputDeviceList[i].dwType = DeviceInfo->DeviceType;
+        }
+        Ret = cDevices;
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        SetLastNtError(_SEH2_GetExceptionCode());
+    }
+    _SEH2_END;
+
+    UserLeave();
+    ReleaseDeviceInfoListMutex();
+    return Ret;
+}
+


### PR DESCRIPTION
Implement kernel-part of enumeration of raw input devices (`NtUserGetRawInputDeviceList` and `NtUserGetRawInputDeviceInfo`)
This a continuation of PR #9481.

With this PR, user mode applications are now able to enumerate raw input devices.

- Note that raw input device list is still hardcoded to a keyboard and a mouse, but this will be changed in a later PR.
- Note that applications are still not able to register for raw input events.

`user32_winetest.exe input` before :
<img width="800" height="600" alt="before" src="https://github.com/user-attachments/assets/b117642a-56e1-40db-a852-2b06dace3181" />
`user32_winetest.exe input` after :
<img width="800" height="600" alt="after" src="https://github.com/user-attachments/assets/97221f3d-8807-48d5-8525-9177d3d7e6d0" />

JIRA issue: [CORE-9818](https://jira.reactos.org/browse/CORE-9818)