### PR TITLE
[NDK] Add KAFFINITY_EX

### DIFF
--- a/sdk/include/asm/ksx.template.h
+++ b/sdk/include/asm/ksx.template.h
@@ -350,13 +350,12 @@ CONSTANT(MODE_MASK),
 
 /* STRUCTURE OFFSETS *********************************************************/
 
-//HEADER("KAFFINITY_EX"),
-//OFFSET(AfCount, KAFFINITY_EX, Count),
-//OFFSET(AfBitmap, KAFFINITY_EX, Bitmap),
-//SIZE(AffinityExLength, KAFFINITY_EX),
-
-//HEADER("Aligned Affinity"),
-//OFFSET(AfsCpuSet, ???, CpuSet), // FIXME: obsolete
+#if (NTDDI_VERSION >= NTDDI_WIN7) || defined(__REACTOS__)
+HEADER("KAFFINITY_EX"),
+OFFSET(AfCount, KAFFINITY_EX, Count),
+OFFSET(AfBitmap, KAFFINITY_EX, Bitmap),
+SIZE(AffinityExLength, KAFFINITY_EX),
+#endif
 
 HEADER("KAPC"),
 OFFSET(ApType, KAPC, Type),

--- a/sdk/include/ndk/ketypes.h
+++ b/sdk/include/ndk/ketypes.h
@@ -2301,6 +2301,27 @@ typedef struct _KSERVICE_TABLE_DESCRIPTOR
     PUCHAR Number;
 } KSERVICE_TABLE_DESCRIPTOR, *PKSERVICE_TABLE_DESCRIPTOR;
 
+//
+// Processor affinity (Extended Version)
+//
+#ifdef _M_IX86
+#define MAX_PROC_GROUPS 1
+#elif (NTDDI_VERSION < NTDDI_WIN8)
+#define MAX_PROC_GROUPS 4
+#else
+#define MAX_PROC_GROUPS 20
+#endif
+
+#if (NTDDI_VERSION >= NTDDI_WIN7) || defined(__REACTOS__)
+typedef struct _KAFFINITY_EX
+{
+    USHORT Count;
+    USHORT Size;
+    ULONG Reserved;
+    KAFFINITY Bitmap[MAX_PROC_GROUPS];
+} KAFFINITY_EX, *PKAFFINITY_EX;
+#endif
+
 #if (NTDDI_VERSION >= NTDDI_WIN8)
 //
 // Entropy Timing State


### PR DESCRIPTION
Introduce **KAFFINITY_EX**, which it gonna be used by power related structures (like PPM). 
More info https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ke/affinity/kaffinity_ex.htm.

**JIRA Issue:** [CORE-18969](https://jira.reactos.org/browse/CORE-18969)

This is a subsequent PR that is a split-up from #9466, in order to make the main PO PR less congested.