### PR TITLE
[CHKDSK][VFATLIB] Enable chkdsk /V to output filenames

### DIFF
--- a/sdk/lib/fslib/vfatlib/vfatlib.c
+++ b/sdk/lib/fslib/vfatlib/vfatlib.c
@@ -448,7 +448,14 @@ VfatChkdsk(
     /* Set parameters */
     FsCheckFlags = 0;
     if (Verbose)
+#ifdef __REACTOS__
+    {
         FsCheckFlags |= FSCHECK_VERBOSE;
+        FsCheckFlags |= FSCHECK_LIST_FILES;
+    }
+#else
+        FsCheckFlags |= FSCHECK_VERBOSE;
+#endif
     if (FixErrors)
         FsCheckFlags |= FSCHECK_READ_WRITE;
 

--- a/sdk/lib/fslib/vfatlib/vfatlib.c
+++ b/sdk/lib/fslib/vfatlib/vfatlib.c
@@ -48,13 +48,13 @@ ULONG FsCheckTotalFiles;
 BOOLEAN
 NTAPI
 VfatFormat(
-    IN PUNICODE_STRING DriveRoot,
-    IN PFMIFSCALLBACK Callback,
-    IN BOOLEAN QuickFormat,
-    IN BOOLEAN BackwardCompatible,
-    IN MEDIA_TYPE MediaType,
-    IN PUNICODE_STRING Label,
-    IN ULONG ClusterSize)
+    _In_ PUNICODE_STRING DriveRoot,
+    _In_ PFMIFSCALLBACK Callback,
+    _In_ BOOLEAN QuickFormat,
+    _In_ BOOLEAN BackwardCompatible,
+    _In_ MEDIA_TYPE MediaType,
+    _In_ PUNICODE_STRING Label,
+    _In_ ULONG ClusterSize)
 {
     OBJECT_ATTRIBUTES ObjectAttributes;
     DISK_GEOMETRY DiskGeometry;
@@ -415,17 +415,17 @@ VfatPrint(PCHAR Format, ...)
 BOOLEAN
 NTAPI
 VfatChkdsk(
-    IN PUNICODE_STRING DriveRoot,
-    IN PFMIFSCALLBACK Callback,
-    IN BOOLEAN FixErrors,
-    IN BOOLEAN Verbose,
-    IN BOOLEAN CheckOnlyIfDirty,
-    IN BOOLEAN ScanDrive,
-    IN PVOID pUnknown1,
-    IN PVOID pUnknown2,
-    IN PVOID pUnknown3,
-    IN PVOID pUnknown4,
-    IN PULONG ExitStatus)
+    _In_ PUNICODE_STRING DriveRoot,
+    _In_ PFMIFSCALLBACK Callback,
+    _In_ BOOLEAN FixErrors,
+    _In_ BOOLEAN Verbose,
+    _In_ BOOLEAN CheckOnlyIfDirty,
+    _In_ BOOLEAN ScanDrive,
+    _In_opt_ PVOID pUnknown1,
+    _In_opt_ PVOID pUnknown2,
+    _In_opt_ PVOID pUnknown3,
+    _In_opt_ PVOID pUnknown4,
+    _Out_ PULONG ExitStatus)
 {
     BOOLEAN verify;
     BOOLEAN salvage_files;
@@ -448,11 +448,7 @@ VfatChkdsk(
     /* Set parameters */
     FsCheckFlags = 0;
     if (Verbose)
-#ifdef __REACTOS__
         FsCheckFlags |= FSCHECK_VERBOSE | FSCHECK_LIST_FILES;
-#else
-        FsCheckFlags |= FSCHECK_VERBOSE;
-#endif
     if (FixErrors)
         FsCheckFlags |= FSCHECK_READ_WRITE;
 
@@ -549,7 +545,6 @@ VfatChkdsk(
         }
     }
 
-#ifdef __REACTOS__
     if (DriveRoot->Buffer[0] == '\\' && DriveRoot->Buffer[1] == '?' &&
         DriveRoot->Buffer[2] == '?' && DriveRoot->Buffer[3] == '\\')
     {
@@ -563,10 +558,7 @@ VfatChkdsk(
     else
         VfatPrint("%wZ: %u files, %lu/%lu clusters\n", DriveRoot,
             FsCheckTotalFiles, fs.data_clusters - free_clusters, fs.data_clusters);
-#else
-    VfatPrint("%wZ: %u files, %lu/%lu clusters\n", DriveRoot,
-        FsCheckTotalFiles, fs.data_clusters - free_clusters, fs.data_clusters);
-#endif
+
     if (FsCheckFlags & FSCHECK_READ_WRITE)
     {
         /* Dismount the volume */

--- a/sdk/lib/fslib/vfatlib/vfatlib.c
+++ b/sdk/lib/fslib/vfatlib/vfatlib.c
@@ -449,10 +449,7 @@ VfatChkdsk(
     FsCheckFlags = 0;
     if (Verbose)
 #ifdef __REACTOS__
-    {
-        FsCheckFlags |= FSCHECK_VERBOSE;
-        FsCheckFlags |= FSCHECK_LIST_FILES;
-    }
+        FsCheckFlags |= FSCHECK_VERBOSE | FSCHECK_LIST_FILES;
 #else
         FsCheckFlags |= FSCHECK_VERBOSE;
 #endif


### PR DESCRIPTION
CORE-20771

## Purpose

_Fix chkdsk /v so that it outputs all filenames as it checks them._

JIRA issue: [CORE-20771](https://jira.reactos.org/browse/CORE-20771)

## Proposed changes

_Add FSCHECK_LIST_FILES to FsCheckFlags in vfatlib.c._

## Testbot runs (Filled in by Devs)

N/A - Only runs on request

Before:

<img width="1042" height="856" alt="chkdsk-slash-v-fail" src="https://github.com/user-attachments/assets/239402f3-c469-4eda-b6ca-da31aa86ee3e" />

. . .
After:

<img width="1042" height="856" alt="chkdsk-slash-v-OK" src="https://github.com/user-attachments/assets/8a742dee-f2f4-426e-aa5c-7b4541dd5282" />
