### PR TITLE
[PCIX] Implement the PCIX Arbiters

### DIFF
--- a/drivers/bus/pcix/arb/ar_busno.c
+++ b/drivers/bus/pcix/arb/ar_busno.c
@@ -115,12 +115,10 @@ arbusno_Initializer(IN PVOID Instance)
 
     PAGED_CODE();
 
-    /* Start from a clean engine instance */
     RtlZeroMemory(&Arbiter->CommonInstance, sizeof(Arbiter->CommonInstance));
 
     FdoExtension = Arbiter->BusFdoExtension;
 
-    /* Teach the engine how to read and write bus number descriptors */
     Arbiter->CommonInstance.UnpackRequirement = arbusno_UnpackRequirement;
     Arbiter->CommonInstance.PackResource = arbusno_PackResource;
     Arbiter->CommonInstance.UnpackResource = arbusno_UnpackResource;

--- a/drivers/bus/pcix/arb/ar_busno.c
+++ b/drivers/bus/pcix/arb/ar_busno.c
@@ -32,6 +32,81 @@ PCI_INTERFACE ArbiterInterfaceBusNumber =
 
 NTSTATUS
 NTAPI
+arbusno_UnpackRequirement(_In_ PIO_RESOURCE_DESCRIPTOR Descriptor,
+                          _Out_ PULONGLONG Minimum,
+                          _Out_ PULONGLONG Maximum,
+                          _Out_ PULONGLONG Length,
+                          _Out_ PULONGLONG Alignment)
+{
+    /* This arbiter is only ever handed bus number descriptors */
+    if (Descriptor->Type != CmResourceTypeBusNumber) return STATUS_INVALID_PARAMETER;
+
+    /* Bus numbers are counted, not addressed, so they are always unit-aligned */
+    *Minimum = Descriptor->u.BusNumber.MinBusNumber;
+    *Maximum = Descriptor->u.BusNumber.MaxBusNumber;
+    *Length = Descriptor->u.BusNumber.Length;
+    *Alignment = 1;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+NTAPI
+arbusno_PackResource(_In_ PIO_RESOURCE_DESCRIPTOR Descriptor,
+                     _In_ ULONGLONG Start,
+                     _Out_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource)
+{
+    /* Turn the run of bus numbers the engine settled on into a resource */
+    if (Descriptor->Type != CmResourceTypeBusNumber) return STATUS_INVALID_PARAMETER;
+
+    Resource->Type = CmResourceTypeBusNumber;
+    Resource->Flags = Descriptor->Flags;
+    Resource->ShareDisposition = Descriptor->ShareDisposition;
+    Resource->u.BusNumber.Start = (ULONG)Start;
+    Resource->u.BusNumber.Length = Descriptor->u.BusNumber.Length;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+NTAPI
+arbusno_UnpackResource(_In_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource,
+                       _Out_ PULONGLONG Start,
+                       _Out_ PULONGLONG Length)
+{
+    /* Read a previously packed run of bus numbers back out */
+    if (Resource->Type != CmResourceTypeBusNumber) return STATUS_INVALID_PARAMETER;
+
+    *Start = Resource->u.BusNumber.Start;
+    *Length = Resource->u.BusNumber.Length;
+    return STATUS_SUCCESS;
+}
+
+INT32
+NTAPI
+arbusno_ScoreRequirement(_In_ PIO_RESOURCE_DESCRIPTOR Descriptor)
+{
+    ULONGLONG Minimum, Maximum, Length, Alignment;
+
+    /* A requirement this arbiter cannot read is treated as unsatisfiable */
+    if (!NT_SUCCESS(arbusno_UnpackRequirement(Descriptor,
+                                              &Minimum,
+                                              &Maximum,
+                                              &Length,
+                                              &Alignment)) ||
+        (Maximum < Minimum))
+    {
+        return -1;
+    }
+
+    /*
+     * The score is how many places the run could go, so that the engine places
+     * the most constrained requirements first.
+     */
+    if ((Maximum - Minimum) >= MAXLONG) return MAXLONG;
+    return (INT32)(Maximum - Minimum + 1);
+}
+
+NTSTATUS
+NTAPI
 arbusno_Initializer(IN PVOID Instance)
 {
     PPCI_ARBITER_INSTANCE Arbiter = Instance;
@@ -40,19 +115,16 @@ arbusno_Initializer(IN PVOID Instance)
 
     PAGED_CODE();
 
+    /* Start from a clean engine instance */
     RtlZeroMemory(&Arbiter->CommonInstance, sizeof(Arbiter->CommonInstance));
 
     FdoExtension = Arbiter->BusFdoExtension;
 
-    /* Not yet implemented */
-    UNIMPLEMENTED;
-
-#if 0
+    /* Teach the engine how to read and write bus number descriptors */
     Arbiter->CommonInstance.UnpackRequirement = arbusno_UnpackRequirement;
     Arbiter->CommonInstance.PackResource = arbusno_PackResource;
     Arbiter->CommonInstance.UnpackResource = arbusno_UnpackResource;
     Arbiter->CommonInstance.ScoreRequirement = arbusno_ScoreRequirement;
-#endif
 
     Status = ArbiterLibInitializeInstance(&Arbiter->CommonInstance,
                                           FdoExtension->FunctionalDeviceObject,
@@ -62,7 +134,7 @@ arbusno_Initializer(IN PVOID Instance)
                                           NULL);
     if (!NT_SUCCESS(Status))
     {
-        DPRINT1("arbusno_Initializer: init arbiter return %X", Status);
+        DPRINT1("arbusno_Initializer: init arbiter return %X\n", Status);
     }
 
     return Status;
@@ -78,38 +150,22 @@ arbusno_Constructor(IN PVOID DeviceExtension,
                     IN PINTERFACE Interface)
 {
     PPCI_FDO_EXTENSION FdoExtension = (PPCI_FDO_EXTENSION)DeviceExtension;
-    NTSTATUS Status;
     PAGED_CODE();
 
     UNREFERENCED_PARAMETER(PciInterface);
     UNREFERENCED_PARAMETER(Version);
     UNREFERENCED_PARAMETER(Size);
-    UNREFERENCED_PARAMETER(Interface);
 
-    /* Make sure it's the expected interface */
+    /* This one only arbitrates bus numbers */
     if ((ULONG_PTR)InterfaceData != CmResourceTypeBusNumber)
     {
-        /* Arbiter support must have been initialized first */
-        if (FdoExtension->ArbitersInitialized)
-        {
-            /* Not yet implemented */
-            UNIMPLEMENTED;
-            while (TRUE);
-        }
-        else
-        {
-            /* No arbiters for this FDO */
-            Status = STATUS_NOT_SUPPORTED;
-        }
-    }
-    else
-    {
-        /* Not the right interface */
-        Status = STATUS_INVALID_PARAMETER_5;
+        return STATUS_INVALID_PARAMETER_5;
     }
 
-    /* Return the status */
-    return Status;
+    /* Hand out the instance that was built for this bus */
+    return PciArbiterConstructor(FdoExtension,
+                                 PciArb_BusNumber,
+                                 (PARBITER_INTERFACE)Interface);
 }
 
 /* EOF */

--- a/drivers/bus/pcix/arb/ar_memio.c
+++ b/drivers/bus/pcix/arb/ar_memio.c
@@ -45,14 +45,107 @@ PCI_INTERFACE ArbiterInterfaceIo =
 
 NTSTATUS
 NTAPI
+ario_UnpackRequirement(_In_ PIO_RESOURCE_DESCRIPTOR Descriptor,
+                       _Out_ PULONGLONG Minimum,
+                       _Out_ PULONGLONG Maximum,
+                       _Out_ PULONGLONG Length,
+                       _Out_ PULONGLONG Alignment)
+{
+    /* This arbiter is only ever handed I/O port descriptors */
+    if (Descriptor->Type != CmResourceTypePort) return STATUS_INVALID_PARAMETER;
+
+    /* An alignment of zero would place the range nowhere, so make it one byte */
+    *Minimum = (ULONGLONG)Descriptor->u.Port.MinimumAddress.QuadPart;
+    *Maximum = (ULONGLONG)Descriptor->u.Port.MaximumAddress.QuadPart;
+    *Length = Descriptor->u.Port.Length;
+    *Alignment = Descriptor->u.Port.Alignment ? Descriptor->u.Port.Alignment : 1;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+NTAPI
+ario_PackResource(_In_ PIO_RESOURCE_DESCRIPTOR Descriptor,
+                  _In_ ULONGLONG Start,
+                  _Out_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource)
+{
+    /* Turn the placement the engine settled on back into an I/O port resource */
+    if (Descriptor->Type != CmResourceTypePort) return STATUS_INVALID_PARAMETER;
+
+    Resource->Type = CmResourceTypePort;
+    Resource->Flags = Descriptor->Flags;
+    Resource->ShareDisposition = Descriptor->ShareDisposition;
+    Resource->u.Port.Start.QuadPart = (LONGLONG)Start;
+    Resource->u.Port.Length = Descriptor->u.Port.Length;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+NTAPI
+ario_UnpackResource(_In_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource,
+                    _Out_ PULONGLONG Start,
+                    _Out_ PULONGLONG Length)
+{
+    /* Read a previously packed I/O port resource back out */
+    if (Resource->Type != CmResourceTypePort) return STATUS_INVALID_PARAMETER;
+
+    *Start = (ULONGLONG)Resource->u.Port.Start.QuadPart;
+    *Length = Resource->u.Port.Length;
+    return STATUS_SUCCESS;
+}
+
+INT32
+NTAPI
+ario_ScoreRequirement(_In_ PIO_RESOURCE_DESCRIPTOR Descriptor)
+{
+    ULONGLONG Minimum, Maximum, Length, Alignment;
+
+    /* A requirement this arbiter cannot read is treated as unsatisfiable */
+    if (!NT_SUCCESS(ario_UnpackRequirement(Descriptor,
+                                           &Minimum,
+                                           &Maximum,
+                                           &Length,
+                                           &Alignment)) ||
+        (Maximum < Minimum))
+    {
+        return -1;
+    }
+
+    if ((Maximum - Minimum) >= MAXLONG) return MAXLONG;
+    return (INT32)(Maximum - Minimum + 1);
+}
+
+NTSTATUS
+NTAPI
 ario_Initializer(IN PVOID Instance)
 {
-    UNREFERENCED_PARAMETER(Instance);
+    PPCI_ARBITER_INSTANCE Arbiter = Instance;
+    PPCI_FDO_EXTENSION FdoExtension;
+    NTSTATUS Status;
+    PAGED_CODE();
 
-    /* Not yet implemented */
-    UNIMPLEMENTED;
-    //while (TRUE);
-    return STATUS_SUCCESS;
+    /* Start from a clean engine instance */
+    RtlZeroMemory(&Arbiter->CommonInstance, sizeof(Arbiter->CommonInstance));
+    FdoExtension = Arbiter->BusFdoExtension;
+
+    /* Teach the engine how to read and write I/O port descriptors */
+    Arbiter->CommonInstance.UnpackRequirement = ario_UnpackRequirement;
+    Arbiter->CommonInstance.PackResource = ario_PackResource;
+    Arbiter->CommonInstance.UnpackResource = ario_UnpackResource;
+    Arbiter->CommonInstance.ScoreRequirement = ario_ScoreRequirement;
+
+    /* The rest of the engine, and the PCI assignment ordering, is generic */
+    Status = ArbiterLibInitializeInstance(&Arbiter->CommonInstance,
+                                          FdoExtension->FunctionalDeviceObject,
+                                          CmResourceTypePort,
+                                          Arbiter->InstanceName,
+                                          L"Pci",
+                                          NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ario_Initializer: init arbiter returned %X\n", Status);
+    }
+
+    return Status;
 }
 
 NTSTATUS
@@ -65,38 +158,22 @@ ario_Constructor(IN PVOID DeviceExtension,
                  IN PINTERFACE Interface)
 {
     PPCI_FDO_EXTENSION FdoExtension = (PPCI_FDO_EXTENSION)DeviceExtension;
-    NTSTATUS Status;
     PAGED_CODE();
 
     UNREFERENCED_PARAMETER(PciInterface);
     UNREFERENCED_PARAMETER(Version);
     UNREFERENCED_PARAMETER(Size);
-    UNREFERENCED_PARAMETER(Interface);
 
-    /* Make sure it's the expected interface */
+    /* This one only arbitrates I/O ports */
     if ((ULONG_PTR)InterfaceData != CmResourceTypePort)
     {
-        /* Arbiter support must have been initialized first */
-        if (FdoExtension->ArbitersInitialized)
-        {
-            /* Not yet implemented */
-            UNIMPLEMENTED;
-            while (TRUE);
-        }
-        else
-        {
-            /* No arbiters for this FDO */
-            Status = STATUS_NOT_SUPPORTED;
-        }
-    }
-    else
-    {
-        /* Not the right interface */
-        Status = STATUS_INVALID_PARAMETER_5;
+        return STATUS_INVALID_PARAMETER_5;
     }
 
-    /* Return the status */
-    return Status;
+    /* Hand out the instance that was built for this bus */
+    return PciArbiterConstructor(FdoExtension,
+                                 PciArb_Io,
+                                 (PARBITER_INTERFACE)Interface);
 }
 
 VOID
@@ -104,8 +181,8 @@ NTAPI
 ario_ApplyBrokenVideoHack(IN PPCI_FDO_EXTENSION FdoExtension)
 {
     PPCI_ARBITER_INSTANCE PciArbiter;
-    //PARBITER_INSTANCE CommonInstance;
-    //NTSTATUS Status;
+    PARBITER_INSTANCE CommonInstance;
+    NTSTATUS Status;
 
     /* Only valid for root FDOs who are being applied the hack for the first time */
     ASSERT(!FdoExtension->BrokenVideoHackApplied);
@@ -116,7 +193,8 @@ ario_ApplyBrokenVideoHack(IN PPCI_FDO_EXTENSION FdoExtension)
                                                       SecondaryExtension.Next,
                                                       PciArb_Io);
     ASSERT(PciArbiter);
-#if 0 // when arb exist
+    if (!PciArbiter) return;
+
     /* Get the Arb instance */
     CommonInstance = &PciArbiter->CommonInstance;
 
@@ -126,29 +204,122 @@ ario_ApplyBrokenVideoHack(IN PPCI_FDO_EXTENSION FdoExtension)
 
     /* Build the ordering for broken video PCI access */
     Status = ArbiterLibDefaultAssignmentOrdering(CommonInstance,
-                                        L"Pci",
-                                        L"BrokenVideo",
-                                        NULL);
+                                                 L"Pci",
+                                                 L"BrokenVideo",
+                                                 NULL);
     ASSERT(NT_SUCCESS(Status));
-#else
-    //Status = STATUS_SUCCESS;
-    UNIMPLEMENTED;
-    while (TRUE);
-#endif
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ario_ApplyBrokenVideoHack: ordering failed %X\n", Status);
+    }
+
     /* Now the hack has been applied */
     FdoExtension->BrokenVideoHackApplied = TRUE;
 }
 
 NTSTATUS
 NTAPI
+armem_UnpackRequirement(_In_ PIO_RESOURCE_DESCRIPTOR Descriptor,
+                        _Out_ PULONGLONG Minimum,
+                        _Out_ PULONGLONG Maximum,
+                        _Out_ PULONGLONG Length,
+                        _Out_ PULONGLONG Alignment)
+{
+    /* This arbiter is only ever handed device memory descriptors */
+    if (Descriptor->Type != CmResourceTypeMemory) return STATUS_INVALID_PARAMETER;
+
+    /* An alignment of zero would place the range nowhere, so make it one byte */
+    *Minimum = (ULONGLONG)Descriptor->u.Memory.MinimumAddress.QuadPart;
+    *Maximum = (ULONGLONG)Descriptor->u.Memory.MaximumAddress.QuadPart;
+    *Length = Descriptor->u.Memory.Length;
+    *Alignment = Descriptor->u.Memory.Alignment ? Descriptor->u.Memory.Alignment : 1;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+NTAPI
+armem_PackResource(_In_ PIO_RESOURCE_DESCRIPTOR Descriptor,
+                   _In_ ULONGLONG Start,
+                   _Out_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource)
+{
+    /* Turn the placement the engine settled on back into a memory resource */
+    if (Descriptor->Type != CmResourceTypeMemory) return STATUS_INVALID_PARAMETER;
+
+    Resource->Type = CmResourceTypeMemory;
+    Resource->Flags = Descriptor->Flags;
+    Resource->ShareDisposition = Descriptor->ShareDisposition;
+    Resource->u.Memory.Start.QuadPart = (LONGLONG)Start;
+    Resource->u.Memory.Length = Descriptor->u.Memory.Length;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+NTAPI
+armem_UnpackResource(_In_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource,
+                     _Out_ PULONGLONG Start,
+                     _Out_ PULONGLONG Length)
+{
+    /* Read a previously packed memory resource back out */
+    if (Resource->Type != CmResourceTypeMemory) return STATUS_INVALID_PARAMETER;
+
+    *Start = (ULONGLONG)Resource->u.Memory.Start.QuadPart;
+    *Length = Resource->u.Memory.Length;
+    return STATUS_SUCCESS;
+}
+
+INT32
+NTAPI
+armem_ScoreRequirement(_In_ PIO_RESOURCE_DESCRIPTOR Descriptor)
+{
+    ULONGLONG Minimum, Maximum, Length, Alignment;
+
+    /* A requirement this arbiter cannot read is treated as unsatisfiable */
+    if (!NT_SUCCESS(armem_UnpackRequirement(Descriptor,
+                                            &Minimum,
+                                            &Maximum,
+                                            &Length,
+                                            &Alignment)) ||
+        (Maximum < Minimum))
+    {
+        return -1;
+    }
+
+    if ((Maximum - Minimum) >= MAXLONG) return MAXLONG;
+    return (INT32)(Maximum - Minimum + 1);
+}
+
+NTSTATUS
+NTAPI
 armem_Initializer(IN PVOID Instance)
 {
-    UNREFERENCED_PARAMETER(Instance);
+    PPCI_ARBITER_INSTANCE Arbiter = Instance;
+    PPCI_FDO_EXTENSION FdoExtension;
+    NTSTATUS Status;
+    PAGED_CODE();
 
-    /* Not yet implemented */
-    UNIMPLEMENTED;
-    //while (TRUE);
-    return STATUS_SUCCESS;
+    /* Start from a clean engine instance */
+    RtlZeroMemory(&Arbiter->CommonInstance, sizeof(Arbiter->CommonInstance));
+    FdoExtension = Arbiter->BusFdoExtension;
+
+    /* Teach the engine how to read and write memory descriptors */
+    Arbiter->CommonInstance.UnpackRequirement = armem_UnpackRequirement;
+    Arbiter->CommonInstance.PackResource = armem_PackResource;
+    Arbiter->CommonInstance.UnpackResource = armem_UnpackResource;
+    Arbiter->CommonInstance.ScoreRequirement = armem_ScoreRequirement;
+
+    /* The rest of the engine, and the PCI assignment ordering, is generic */
+    Status = ArbiterLibInitializeInstance(&Arbiter->CommonInstance,
+                                          FdoExtension->FunctionalDeviceObject,
+                                          CmResourceTypeMemory,
+                                          Arbiter->InstanceName,
+                                          L"Pci",
+                                          NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("armem_Initializer: init arbiter returned %X\n", Status);
+    }
+
+    return Status;
 }
 
 NTSTATUS
@@ -161,38 +332,22 @@ armem_Constructor(IN PVOID DeviceExtension,
                   IN PINTERFACE Interface)
 {
     PPCI_FDO_EXTENSION FdoExtension = (PPCI_FDO_EXTENSION)DeviceExtension;
-    NTSTATUS Status;
     PAGED_CODE();
 
     UNREFERENCED_PARAMETER(PciInterface);
     UNREFERENCED_PARAMETER(Version);
     UNREFERENCED_PARAMETER(Size);
-    UNREFERENCED_PARAMETER(Interface);
 
-    /* Make sure it's the expected interface */
+    /* This one only arbitrates device memory */
     if ((ULONG_PTR)InterfaceData != CmResourceTypeMemory)
     {
-        /* Arbiter support must have been initialized first */
-        if (FdoExtension->ArbitersInitialized)
-        {
-            /* Not yet implemented */
-            UNIMPLEMENTED;
-            while (TRUE);
-        }
-        else
-        {
-            /* No arbiters for this FDO */
-            Status = STATUS_NOT_SUPPORTED;
-        }
-    }
-    else
-    {
-        /* Not the right interface */
-        Status = STATUS_INVALID_PARAMETER_5;
+        return STATUS_INVALID_PARAMETER_5;
     }
 
-    /* Return the status */
-    return Status;
+    /* Hand out the instance that was built for this bus */
+    return PciArbiterConstructor(FdoExtension,
+                                 PciArb_Memory,
+                                 (PARBITER_INTERFACE)Interface);
 }
 
 /* EOF */

--- a/drivers/bus/pcix/arb/arb_comn.c
+++ b/drivers/bus/pcix/arb/arb_comn.c
@@ -97,6 +97,9 @@ PciInitializeArbiters(IN PPCI_FDO_EXTENSION FdoExtension)
     PCI_SIGNATURE ArbiterType;
     ASSERT_FDO(FdoExtension);
 
+    /* A bus that ends up needing no arbiter at all is not a failure */
+    Status = STATUS_SUCCESS;
+
     /* Loop all the arbiters */
     for (ArbiterType = PciArb_Io; ArbiterType <= PciArb_BusNumber; ArbiterType++)
     {

--- a/drivers/bus/pcix/arb/arb_comn.c
+++ b/drivers/bus/pcix/arb/arb_comn.c
@@ -80,10 +80,9 @@ VOID
 NTAPI
 PciArbiterDestructor(IN PPCI_ARBITER_INSTANCE Arbiter)
 {
-    UNREFERENCED_PARAMETER(Arbiter);
-    /* This function is not yet implemented */
-    UNIMPLEMENTED;
-    while (TRUE);
+    PAGED_CODE();
+
+    ArbiterLibDeleteInstance(&Arbiter->CommonInstance);
 }
 
 NTSTATUS

--- a/drivers/bus/pcix/arb/arb_comn.c
+++ b/drivers/bus/pcix/arb/arb_comn.c
@@ -183,11 +183,9 @@ PciInitializeArbiterRanges(IN PPCI_FDO_EXTENSION DeviceExtension,
                            IN PCM_RESOURCE_LIST Resources)
 {
     PPCI_PDO_EXTENSION PdoExtension;
-    //CM_RESOURCE_TYPE DesiredType;
-    PVOID Instance;
+    PPCI_ARBITER_INSTANCE Instance;
     PCI_SIGNATURE ArbiterType;
-
-    UNREFERENCED_PARAMETER(Resources);
+    NTSTATUS Status;
 
     /* Arbiters should not already be initialized */
     if (DeviceExtension->ArbitersInitialized)
@@ -213,37 +211,30 @@ PciInitializeArbiterRanges(IN PPCI_FDO_EXTENSION DeviceExtension,
         }
     }
 
-    /* Loop all arbiters */
+    /* Loop the arbiters that hand out the ranges a bus decodes */
     for (ArbiterType = PciArb_Io; ArbiterType <= PciArb_Memory; ArbiterType++)
     {
-        /* Pick correct resource type for each arbiter */
-        if (ArbiterType == PciArb_Io)
-        {
-            /* I/O Port */
-            //DesiredType = CmResourceTypePort;
-        }
-        else if (ArbiterType == PciArb_Memory)
-        {
-            /* Device RAM */
-            //DesiredType = CmResourceTypeMemory;
-        }
-        else
-        {
-            /* Ignore anything else */
-            continue;
-        }
-
         /* Find an arbiter of this type */
-        Instance = PciFindNextSecondaryExtension(&DeviceExtension->SecondaryExtension,
-                                                 ArbiterType);
+        Instance = (PVOID)PciFindNextSecondaryExtension(DeviceExtension->
+                                                        SecondaryExtension.Next,
+                                                        ArbiterType);
         if (Instance)
         {
             /*
-             * Now we should initialize it, not yet implemented because Arb
-             * library isn't yet implemented, not even the headers.
+             * Hand it the resources this bus was started with. They describe
+             * the windows the bus actually decodes, which is what bounds the
+             * addresses it may hand out to the devices behind it.
              */
-            UNIMPLEMENTED;
-            //while (TRUE);
+            Status = Instance->CommonInstance.StartArbiter(&Instance->CommonInstance,
+                                                           Resources);
+            if (!NT_SUCCESS(Status))
+            {
+                DPRINT1("PCI - FDO ext 0x%p %s arbiter failed to start: %X\n",
+                        DeviceExtension,
+                        PciArbiterNames[ArbiterType - PciArb_Io],
+                        Status);
+                return Status;
+            }
         }
         else
         {

--- a/drivers/bus/pcix/arb/arb_comn.c
+++ b/drivers/bus/pcix/arb/arb_comn.c
@@ -27,6 +27,57 @@ PCHAR PciArbiterNames[] =
 
 VOID
 NTAPI
+PciArbiter_Reference(_In_ PVOID Context)
+{
+    PARBITER_INSTANCE Arbiter = (PARBITER_INSTANCE)Context;
+
+    InterlockedIncrement((PLONG)&Arbiter->ReferenceCount);
+}
+
+VOID
+NTAPI
+PciArbiter_Dereference(_In_ PVOID Context)
+{
+    PARBITER_INSTANCE Arbiter = (PARBITER_INSTANCE)Context;
+
+    InterlockedDecrement((PLONG)&Arbiter->ReferenceCount);
+}
+
+NTSTATUS
+NTAPI
+PciArbiterConstructor(_In_ PPCI_FDO_EXTENSION FdoExtension,
+                      _In_ PCI_SIGNATURE ArbiterType,
+                      _Out_ PARBITER_INTERFACE Interface)
+{
+    PPCI_ARBITER_INSTANCE Arbiter;
+    PAGED_CODE();
+
+    if (!FdoExtension->ArbitersInitialized) return STATUS_NOT_SUPPORTED;
+
+    /* Find the instance this bus built for the requested resource type */
+    Arbiter = (PVOID)PciFindNextSecondaryExtension(FdoExtension->
+                                                   SecondaryExtension.Next,
+                                                   ArbiterType);
+    if (!Arbiter)
+    {
+        DPRINT1("PCI - FDO ext 0x%p has no %s arbiter to hand out.\n",
+                FdoExtension,
+                PciArbiterNames[ArbiterType - PciArb_Io]);
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    Interface->Size = sizeof(ARBITER_INTERFACE);
+    Interface->Version = ARBITER_INTERFACE_VERSION;
+    Interface->Context = &Arbiter->CommonInstance;
+    Interface->InterfaceReference = PciArbiter_Reference;
+    Interface->InterfaceDereference = PciArbiter_Dereference;
+    Interface->ArbiterHandler = ArbiterLibHandler;
+    Interface->Flags = 0;
+    return STATUS_SUCCESS;
+}
+
+VOID
+NTAPI
 PciArbiterDestructor(IN PPCI_ARBITER_INSTANCE Arbiter)
 {
     UNREFERENCED_PARAMETER(Arbiter);

--- a/drivers/bus/pcix/pci.h
+++ b/drivers/bus/pcix/pci.h
@@ -72,6 +72,11 @@
 #define PCI_HACK_FIXUP_BEFORE_UPDATE        0x03
 
 //
+// PCI Arbiter Interface Version
+//
+#define ARBITER_INTERFACE_VERSION           0
+
+//
 // PCI Debugging Device Support
 //
 #define MAX_DEBUGGING_DEVICES_SUPPORTED     0x04
@@ -1462,6 +1467,90 @@ VOID
 NTAPI
 ario_ApplyBrokenVideoHack(
     IN PPCI_FDO_EXTENSION FdoExtension
+);
+
+NTSTATUS
+NTAPI
+ario_UnpackRequirement(
+    _In_ PIO_RESOURCE_DESCRIPTOR Descriptor,
+    _Out_ PULONGLONG Minimum,
+    _Out_ PULONGLONG Maximum,
+    _Out_ PULONGLONG Length,
+    _Out_ PULONGLONG Alignment
+);
+
+NTSTATUS
+NTAPI
+ario_PackResource(
+    _In_ PIO_RESOURCE_DESCRIPTOR Descriptor,
+    _In_ ULONGLONG Start,
+    _Out_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource
+);
+
+NTSTATUS
+NTAPI
+ario_UnpackResource(
+    _In_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource,
+    _Out_ PULONGLONG Start,
+    _Out_ PULONGLONG Length
+);
+
+INT32
+NTAPI
+ario_ScoreRequirement(
+    _In_ PIO_RESOURCE_DESCRIPTOR Descriptor
+);
+
+NTSTATUS
+NTAPI
+armem_UnpackRequirement(
+    _In_ PIO_RESOURCE_DESCRIPTOR Descriptor,
+    _Out_ PULONGLONG Minimum,
+    _Out_ PULONGLONG Maximum,
+    _Out_ PULONGLONG Length,
+    _Out_ PULONGLONG Alignment
+);
+
+NTSTATUS
+NTAPI
+armem_PackResource(
+    _In_ PIO_RESOURCE_DESCRIPTOR Descriptor,
+    _In_ ULONGLONG Start,
+    _Out_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource
+);
+
+NTSTATUS
+NTAPI
+armem_UnpackResource(
+    _In_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource,
+    _Out_ PULONGLONG Start,
+    _Out_ PULONGLONG Length
+);
+
+INT32
+NTAPI
+armem_ScoreRequirement(
+    _In_ PIO_RESOURCE_DESCRIPTOR Descriptor
+);
+
+VOID
+NTAPI
+PciArbiter_Reference(
+    _In_ PVOID Context
+);
+
+VOID
+NTAPI
+PciArbiter_Dereference(
+    _In_ PVOID Context
+);
+
+NTSTATUS
+NTAPI
+PciArbiterConstructor(
+    _In_ PPCI_FDO_EXTENSION FdoExtension,
+    _In_ PCI_SIGNATURE ArbiterType,
+    _Out_ PARBITER_INTERFACE Interface
 );
 
 NTSTATUS

--- a/drivers/bus/pcix/pci.h
+++ b/drivers/bus/pcix/pci.h
@@ -1345,6 +1345,38 @@ arbusno_Initializer(
 
 NTSTATUS
 NTAPI
+arbusno_UnpackRequirement(
+    _In_ PIO_RESOURCE_DESCRIPTOR Descriptor,
+    _Out_ PULONGLONG Minimum,
+    _Out_ PULONGLONG Maximum,
+    _Out_ PULONGLONG Length,
+    _Out_ PULONGLONG Alignment
+);
+
+NTSTATUS
+NTAPI
+arbusno_PackResource(
+    _In_ PIO_RESOURCE_DESCRIPTOR Descriptor,
+    _In_ ULONGLONG Start,
+    _Out_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource
+);
+
+NTSTATUS
+NTAPI
+arbusno_UnpackResource(
+    _In_ PCM_PARTIAL_RESOURCE_DESCRIPTOR Resource,
+    _Out_ PULONGLONG Start,
+    _Out_ PULONGLONG Length
+);
+
+INT32
+NTAPI
+arbusno_ScoreRequirement(
+    _In_ PIO_RESOURCE_DESCRIPTOR Descriptor
+);
+
+NTSTATUS
+NTAPI
 agpintrf_Initializer(
     IN PVOID Instance
 );


### PR DESCRIPTION
Implement the I/O port and device memory arbiters.
Implement the bus number arbiter.
Return success when a bus needs no arbiters at all.
Start the bus arbiters with the resources the bus decodes.
Tear down the arbiter engine instead of hanging.

Honestly this just fills in the arbiter logic following as close to what I saw in PCIX already as I can.

## Testbot runs (Filled in by Devs)

N/A Dead code