### PR TITLE
[WINHTTP_WINETEST] Skip hanging tests after sync to Wine-10.0

### DIFF
--- a/modules/rostests/winetests/winhttp/winhttp.c
+++ b/modules/rostests/winetests/winhttp/winhttp.c
@@ -6296,7 +6296,20 @@ START_TEST (winhttp)
         return;
     }
 
+#ifdef __REACTOS__
+    if (!winetest_interactive)
+    {
+        skip("Skipping tests due to hang. See ROSTESTS-422\n");
+    }
+    else
+    {
+        test_IWinHttpRequest(si.port);
+        test_bad_header(si.port);
+    }
+#else
     test_IWinHttpRequest(si.port);
+    test_bad_header(si.port);
+#endif
     test_connection_info(si.port);
     test_basic_request(si.port, NULL, L"/basic");
     test_basic_request(si.port, L"PUT", L"/test");
@@ -6308,7 +6321,9 @@ START_TEST (winhttp)
     test_basic_authentication(si.port);
     test_multi_authentication(si.port);
     test_large_data_authentication(si.port);
-    test_bad_header(si.port);
+#ifndef __REACTOS__ // See ROSTESTS-422
+    test_bad_header(si.port); // Moved up into the REACTOS skip section */
+#endif
 #ifdef __REACTOS__
     if (!winetest_interactive)
     {

--- a/modules/rostests/winetests/winhttp/winhttp.c
+++ b/modules/rostests/winetests/winhttp/winhttp.c
@@ -6308,7 +6308,6 @@ START_TEST (winhttp)
     }
 #else
     test_IWinHttpRequest(si.port);
-    test_bad_header(si.port);
 #endif
     test_connection_info(si.port);
     test_basic_request(si.port, NULL, L"/basic");
@@ -6321,8 +6320,8 @@ START_TEST (winhttp)
     test_basic_authentication(si.port);
     test_multi_authentication(si.port);
     test_large_data_authentication(si.port);
-#ifndef __REACTOS__ // See ROSTESTS-422
-    test_bad_header(si.port); // Moved up into the REACTOS skip section */
+#ifndef __REACTOS__ // Moved up into the REACTOS skip section. See ROSTESTS-422.
+    test_bad_header(si.port);
 #endif
 #ifdef __REACTOS__
     if (!winetest_interactive)

--- a/modules/rostests/winetests/winhttp/winhttp.c
+++ b/modules/rostests/winetests/winhttp/winhttp.c
@@ -6297,7 +6297,7 @@ START_TEST (winhttp)
     }
 
 #ifdef __REACTOS__
-    if (!winetest_interactive)
+    if (!winetest_interactive && is_reactos())
     {
         skip("Skipping tests due to hang. See ROSTESTS-422\n");
     }

--- a/modules/rostests/winetests/winhttp/winhttp.c
+++ b/modules/rostests/winetests/winhttp/winhttp.c
@@ -6297,7 +6297,7 @@ START_TEST (winhttp)
     }
 
 #ifdef __REACTOS__
-    if (!winetest_interactive && is_reactos())
+    if (is_reactos() && !winetest_interactive)
     {
         skip("Skipping tests due to hang. See ROSTESTS-422\n");
     }


### PR DESCRIPTION
ROSTESTS-422

## Purpose

_Add two more winhttp winetests to be skipped after sync to Wine-10.0.._

JIRA issue: [ROSTESTS-422](https://jira.reactos.org/browse/ROSTESTS-422)

## Proposed changes

_Skip these two hanging tests._
_* test_IWinHttpRequest_
_* test_bad_header_

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=110051,110054,110057 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=110052,110055,110058 LGTM