### PR TITLE
[NTOS:MM] Fix defects in ARM3 section, pagfault and wslist handling

### DIFF
--- a/ntoskrnl/mm/ARM3/pagfault.c
+++ b/ntoskrnl/mm/ARM3/pagfault.c
@@ -870,7 +870,22 @@ MiCompleteProtoPteFault(IN BOOLEAN StoreInstruction,
     /* Remove special/caching bits */
     Protection &= ~MM_PROTECT_SPECIAL;
 
-    /* Setup caching */
+    /* Check if this is a kernel or user address */
+    if (Address < MmSystemRangeStart)
+    {
+        /* Build the user PTE */
+        MI_MAKE_HARDWARE_PTE_USER(&TempPte, PointerPte, Protection, PageFrameIndex);
+    }
+    else
+    {
+        /* Build the kernel PTE */
+        MI_MAKE_HARDWARE_PTE(&TempPte, PointerPte, Protection, PageFrameIndex);
+    }
+
+    /* Setup caching. This has to happen after the PTE is built: the MAKE
+       macros start from a fresh PTE, so doing it before meant the cache
+       attributes of video memory (write-combined / non-cached) mappings were
+       silently discarded. */
     if (Pfn1->u3.e1.CacheAttribute == MiWriteCombined)
     {
         /* Write combining, no caching */
@@ -882,18 +897,6 @@ MiCompleteProtoPteFault(IN BOOLEAN StoreInstruction,
         /* Write through, no caching */
         MI_PAGE_DISABLE_CACHE(&TempPte);
         MI_PAGE_WRITE_THROUGH(&TempPte);
-    }
-
-    /* Check if this is a kernel or user address */
-    if (Address < MmSystemRangeStart)
-    {
-        /* Build the user PTE */
-        MI_MAKE_HARDWARE_PTE_USER(&TempPte, PointerPte, Protection, PageFrameIndex);
-    }
-    else
-    {
-        /* Build the kernel PTE */
-        MI_MAKE_HARDWARE_PTE(&TempPte, PointerPte, Protection, PageFrameIndex);
     }
 
     /* Set the dirty flag if needed */
@@ -985,6 +988,29 @@ MiResolvePageFileFault(_In_ BOOLEAN StoreInstruction,
         ASSERT(FALSE);
         Pfn1->u4.InPageError = 1;
         Pfn1->u1.ReadStatus = Status;
+
+        /* The paging IO failed, so the page was never written by the pager and
+           still contains whatever its previous owner left in it. Zero it before
+           it is mapped below, otherwise the faulting thread is handed a page
+           full of stale (and possibly sensitive) kernel memory. Do this with
+           the PFN lock released, like the paging IO itself. */
+        MiReleasePfnLock(*OldIrql);
+        {
+            KIRQL HyperOldIrql;
+            PEPROCESS Process = PsGetCurrentProcess();
+            PVOID ZeroAddress = MiMapPageInHyperSpace(Process, Page, &HyperOldIrql);
+
+            if (ZeroAddress)
+            {
+                KeZeroPages(ZeroAddress, PAGE_SIZE);
+                MiUnmapPageInHyperSpace(Process, ZeroAddress, HyperOldIrql);
+            }
+        }
+        *OldIrql = MiAcquirePfnLock();
+
+        /* Nobody should have changed that while we were not looking */
+        ASSERT(Pfn1->u3.e1.ReadInProgress == 1);
+        ASSERT(Pfn1->u3.e1.WriteInProgress == 0);
     }
 
     /* And the PTE can finally be valid */

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -864,7 +864,7 @@ MiUnmapViewOfSection(IN PEPROCESS Process,
     /* We need the base address for the debugger message on image-backed VADs */
     if (Vad->u.VadFlags.VadType == VadImageMap)
     {
-        DbgBase = (PVOID)(Vad->StartingVpn >> PAGE_SHIFT);
+        DbgBase = (PVOID)(Vad->StartingVpn << PAGE_SHIFT);
     }
 
     /* Compute the size of the VAD region */
@@ -875,7 +875,7 @@ MiUnmapViewOfSection(IN PEPROCESS Process,
     {
         /* Are we allowed to mess with this VAD? */
         Status = MiCheckSecuredVad(Vad,
-                                   (PVOID)(Vad->StartingVpn >> PAGE_SHIFT),
+                                   (PVOID)(Vad->StartingVpn << PAGE_SHIFT),
                                    RegionSize,
                                    MM_DELETE_CHECK);
         if (!NT_SUCCESS(Status))
@@ -1393,7 +1393,7 @@ MiMapViewOfDataSection(
         Segment->NumberOfCommittedPages -= QuotaCharge;
         KeReleaseGuardedMutex(&MmSectionCommitMutex);
 
-        PsReturnProcessNonPagedPoolQuota(PsGetCurrentProcess(), sizeof(MMVAD_LONG));
+        PsReturnProcessNonPagedPoolQuota(Process, sizeof(MMVAD_LONG));
         return Status;
     }
 
@@ -1479,7 +1479,7 @@ MiCreatePagingFileMap(OUT PSEGMENT *Segment,
                                         'tCmM');
     if (!ControlArea)
     {
-        ExFreePoolWithTag(Segment, 'tSmM');
+        ExFreePoolWithTag(NewSegment, 'tSmM');
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
@@ -3588,7 +3588,7 @@ NtExtendSection(IN HANDLE SectionHandle,
     }
 
     /* Return the status */
-    return STATUS_NOT_IMPLEMENTED;
+    return Status;
 }
 
 /* EOF */

--- a/ntoskrnl/mm/ARM3/wslist.cpp
+++ b/ntoskrnl/mm/ARM3/wslist.cpp
@@ -44,36 +44,48 @@ static void FreeWsleIndex(PMMWSL WsList, ULONG Index)
     if (Index == (LastEntry - 1))
     {
         /* We're freeing the last index of our list. */
-        while (Wsle[Index].u1.e1.Valid == 0)
+        while ((Index != 0) && (Wsle[Index].u1.e1.Valid == 0))
             Index--;
 
-        /* Should we bother about the Free entries */
-        if (FirstFree < Index)
+        if (Wsle[Index].u1.e1.Valid == 0)
         {
-            /* Try getting the index of the last free entry */
-            ASSERT(Wsle[Index + 1].u1.Free.MustBeZero == 0);
-            ULONG PreviousFree = Wsle[Index + 1].u1.Free.PreviousFree;
-            ASSERT(PreviousFree < LastEntry);
-            ULONG LastFree = Index + 1 - PreviousFree;
-#ifdef MMWSLE_PREVIOUS_FREE_JUMP
-            while (Wsle[LastFree].u1.e1.Valid)
-            {
-                ASSERT(LastFree > MMWSLE_PREVIOUS_FREE_JUMP);
-                LastFree -= MMWSLE_PREVIOUS_FREE_JUMP;
-            }
-#endif
-            /* Update */
-            ASSERT(LastFree >= FirstFree);
-            Wsle[FirstFree].u1.Free.PreviousFree = (Index + 1 - LastFree) & MMWSLE_PREVIOUS_FREE_MASK;
-            Wsle[LastFree].u1.Free.NextFree = 0;
+            /* Every entry up to the old end is free: the used part of the list
+               is empty. Resetting is the only consistent answer - relying on an
+               invariant alone used to walk Index past the beginning of the
+               array here and read (then use) Wsle[ULONG_MAX]. */
+            FirstFree = ULONG_MAX;
+            LastEntry = 0;
         }
         else
         {
-            /* No more free entries in our array */
-            FirstFree = ULONG_MAX;
+            /* Should we bother about the Free entries */
+            if (FirstFree < Index)
+            {
+                /* Try getting the index of the last free entry */
+                ASSERT(Wsle[Index + 1].u1.Free.MustBeZero == 0);
+                ULONG PreviousFree = Wsle[Index + 1].u1.Free.PreviousFree;
+                ASSERT(PreviousFree < LastEntry);
+                ULONG LastFree = Index + 1 - PreviousFree;
+#ifdef MMWSLE_PREVIOUS_FREE_JUMP
+                while (Wsle[LastFree].u1.e1.Valid)
+                {
+                    ASSERT(LastFree > MMWSLE_PREVIOUS_FREE_JUMP);
+                    LastFree -= MMWSLE_PREVIOUS_FREE_JUMP;
+                }
+#endif
+                /* Update */
+                ASSERT(LastFree >= FirstFree);
+                Wsle[FirstFree].u1.Free.PreviousFree = (Index + 1 - LastFree) & MMWSLE_PREVIOUS_FREE_MASK;
+                Wsle[LastFree].u1.Free.NextFree = 0;
+            }
+            else
+            {
+                /* No more free entries in our array */
+                FirstFree = ULONG_MAX;
+            }
+            /* This is the new size of our array */
+            LastEntry = Index + 1;
         }
-        /* This is the new size of our array */
-        LastEntry = Index + 1;
         /* Should we shrink the alloc? */
         while ((LastInitializedWsle - LastEntry) > (PAGE_SIZE / sizeof(MMWSLE)))
         {


### PR DESCRIPTION
Fix several defects in the ARM3 memory manager.

**ntoskrnl/mm/ARM3/section.c**
- `MiCreatePagingFileMap`: on ControlArea allocation failure the error path freed `Segment` (the caller's stack variable holding the pointer) instead of `NewSegment`. The real allocation leaked and pool metadata was corrupted by freeing a stack address.
- `MiUnmapViewOfSection`: `StartingVpn` is a page number, so the base address is `StartingVpn << PAGE_SHIFT`; the shift went the wrong way, making the `MiCheckSecuredVad` SEC_NO_CHANGE check essentially never match.
- `NtExtendSection`: returned `STATUS_NOT_IMPLEMENTED` although the extension already succeeded.
- `MiMapViewOfSection`: the VAD quota was returned to the current process instead of `Process` (the one it was charged to).

**ntoskrnl/mm/ARM3/pagfault.c**
- `MiResolveProtoPteFault`: the video-memory cache attributes (write-combined / non-cached) were applied to the PTE before it was built; the `MI_MAKE_HARDWARE_PTE(_USER)` macros start from a fresh PTE and silently discarded them. They are applied after the PTE is built now.
- `MiResolvePageFileFault`: when the paging IO failed the page was still made valid and mapped although the pager never wrote it, handing the faulting thread a page full of stale (possibly sensitive) kernel memory. The page is zeroed before it is mapped.

**ntoskrnl/mm/ARM3/wslist.cpp**
- `FreeWsleIndex`: the backward walk over free tail entries relied on an invariant and ran past zero when the whole used part of the list was free, reading/using `Wsle[ULONG_MAX]`. A fully-free list is detected and reset instead.

Testing: static code review only; CI build validates compilation.