### PR TITLE
[NTOS:KE] Flush expired timer DPCs before the array overflows

### DIFF
--- a/ntoskrnl/ke/dpc.c
+++ b/ntoskrnl/ke/dpc.c
@@ -424,7 +424,30 @@ KiTimerListExpire(IN PLIST_ENTRY ExpiredListHead,
                 DpcEntry[DpcCalls].Routine = TimerDpc->DeferredRoutine;
                 DpcEntry[DpcCalls].Context = TimerDpc->DeferredContext;
                 DpcCalls++;
-                ASSERT(DpcCalls < MAX_TIMER_DPCS);
+
+                /* The DPC array only has MAX_TIMER_DPCS entries, and ASSERT
+                   disappears in release builds, so once the array is full the
+                   accumulated DPCs have to be flushed right away and the
+                   collection has to go on. Otherwise the 17th expired timer
+                   was written past the end of the array (KiTimerExpiration
+                   avoids this because its accounting budget forces a flush). */
+                if (DpcCalls == MAX_TIMER_DPCS)
+                {
+                    KiReleaseDispatcherLock(DISPATCH_LEVEL);
+                    for (i = 0; DpcCalls; DpcCalls--, i++)
+                    {
+#if DBG
+                        /* Clear DPC Time */
+                        Prcb->DebugDpcTime = 0;
+#endif
+                        /* Call the DPC */
+                        DpcEntry[i].Routine(DpcEntry[i].Dpc,
+                                            DpcEntry[i].Context,
+                                            UlongToPtr(SystemTime.LowPart),
+                                            UlongToPtr(SystemTime.HighPart));
+                    }
+                    KiAcquireDispatcherLock();
+                }
             }
         }
     }


### PR DESCRIPTION
`KiTimerListExpire` collected the DPCs of expired timers into a `MAX_TIMER_DPCS` (16) stack array and only flushed them at the end of the loop, guarded by an `ASSERT` that disappears in release builds. Once a 17th timer expired at the same time (e.g. after a large system time change) it was written past the end of the array. The array is now flushed as soon as it is full, like `KiTimerExpiration` effectively does through its accounting budget.

Testing: static code review only; CI build validates compilation.