### PR TITLE
[CONSRV] Harden console history and alias handling

### DIFF
--- a/win32ss/user/winsrv/consrv/alias.c
+++ b/win32ss/user/winsrv/consrv/alias.c
@@ -500,6 +500,16 @@ CON_API(SrvAddConsoleAlias,
     }
     else // Add the entry
     {
+        /* Adding an alias that already exists must replace it: otherwise every
+           call appends another entry and a program can grow the list (and the
+           memory behind it) without bound by re-adding the same source name. */
+        Entry = IntGetAliasEntry(Console, Header,
+                                 ConsoleAliasRequest->Source,
+                                 ConsoleAliasRequest->SourceLength,
+                                 ConsoleAliasRequest->Unicode);
+        if (Entry)
+            IntDeleteAliasEntry(Header, Entry);
+
         Entry = IntCreateAliasEntry(Console,
                                     ConsoleAliasRequest->Source,
                                     ConsoleAliasRequest->SourceLength,
@@ -571,6 +581,9 @@ CON_API(SrvGetConsoleAlias,
         }
 
         RtlCopyMemory(lpTarget, Entry->Target.Buffer, Entry->Target.Length);
+        /* The caller expects a NULL-terminated string, and Length reserved room
+           for the terminator, so write it explicitly. */
+        ((PWCHAR)lpTarget)[Entry->Target.Length / sizeof(WCHAR)] = UNICODE_NULL;
         ConsoleAliasRequest->TargetLength = Length;
     }
     else
@@ -584,6 +597,8 @@ CON_API(SrvGetConsoleAlias,
         ConvertInputUnicodeToAnsi(Console,
                                   Entry->Target.Buffer, Entry->Target.Length,
                                   lpTarget, Entry->Target.Length / sizeof(WCHAR));
+        /* ConvertInputUnicodeToAnsi does not terminate either */
+        ((PCHAR)lpTarget)[Entry->Target.Length / sizeof(WCHAR)] = '\0';
         ConsoleAliasRequest->TargetLength = Length;
     }
 

--- a/win32ss/user/winsrv/consrv/history.c
+++ b/win32ss/user/winsrv/consrv/history.c
@@ -24,6 +24,22 @@ typedef struct _HISTORY_BUFFER
     PUNICODE_STRING Entries;
 } HISTORY_BUFFER, *PHISTORY_BUFFER;
 
+/* Windows caps the command history at 999 entries per buffer (and 999 buffers).
+   Enforcing the same bound here also keeps the entry-count multiplication from
+   overflowing: a value like 0x20000000 made NumCommands * sizeof(UNICODE_STRING)
+   wrap around to 0 on 32-bit, so an empty buffer was allocated and then written
+   past its end with the real number of entries. */
+#define CONSOLE_MAX_HISTORY_ENTRIES 999
+
+static ULONG
+HistoryClampNumCommands(IN ULONG NumCommands)
+{
+    if (NumCommands > CONSOLE_MAX_HISTORY_ENTRIES)
+        return CONSOLE_MAX_HISTORY_ENTRIES;
+
+    return NumCommands;
+}
+
 
 BOOLEAN
 ConvertInputAnsiToUnicode(PCONSRV_CONSOLE Console,
@@ -66,7 +82,7 @@ HistoryCurrentBuffer(
     {
         Hist = ConsoleAllocHeap(0, sizeof(HISTORY_BUFFER) + ExeName->Length);
         if (!Hist) return NULL;
-        Hist->MaxEntries = Console->HistoryBufferSize;
+        Hist->MaxEntries = HistoryClampNumCommands(Console->HistoryBufferSize);
         Hist->NumEntries = 0;
         Hist->Entries = ConsoleAllocHeap(0, Hist->MaxEntries * sizeof(UNICODE_STRING));
         if (!Hist->Entries)
@@ -160,6 +176,10 @@ HistoryResizeBuffer(
 {
     PUNICODE_STRING OldEntryList = Hist->Entries;
     PUNICODE_STRING NewEntryList;
+
+    /* Never let the caller talk us into an entry count whose size computation
+       wraps around, see CONSOLE_MAX_HISTORY_ENTRIES. */
+    NumCommands = HistoryClampNumCommands(NumCommands);
 
     NewEntryList = ConsoleAllocHeap(0, NumCommands * sizeof(UNICODE_STRING));
     if (!NewEntryList)
@@ -413,7 +433,7 @@ HistoryReshapeAllBuffers(
                     Hist, HistoryBufferSize, Status);
         }
     }
-    Console->HistoryBufferSize = HistoryBufferSize;
+    Console->HistoryBufferSize = HistoryClampNumCommands(HistoryBufferSize);
 
     /* No duplicates */
     Console->HistoryNoDup = !!HistoryNoDup;


### PR DESCRIPTION
Harden the console history and alias handling in the CSRSS console server.

**history.c** — the number of history entries came from the client unchecked, so `NumCommands * sizeof(UNICODE_STRING)` wrapped around to 0 on 32-bit (e.g. `0x20000000`): a zero-sized buffer was allocated and then filled with the real number of entries, overflowing the csrss heap. Entry counts taken from a client value are now capped at 999 (the Windows limit) in every path.

**alias.c**
- Adding an alias that already exists now replaces the existing entry instead of appending another one, so a client can no longer grow the list without bound by re-adding the same source name.
- `SrvGetConsoleAlias` never wrote the NULL terminator it reserved room for (both the Unicode and the ANSI branch), so callers received an unterminated string.

Testing: static code review only; CI build validates compilation.