### PR TITLE
[FREELDR] Validate on-disk filesystem data before use

### DIFF
--- a/boot/freeldr/freeldr/lib/fs/fat.c
+++ b/boot/freeldr/freeldr/lib/fs/fat.c
@@ -35,6 +35,12 @@ BOOLEAN    FatReadVolumeSectors(PFAT_VOLUME_INFO Volume, ULONG SectorNumber, ULO
 
 #define FAT_MAX_CACHE_SIZE (256 * 1024) // 256 KiB, note: it should fit maximum FAT12 FAT size (6144 bytes)
 
+/* A long file name is spread over at most 20 directory entries (13 characters
+   each, 260 characters total). The sequence number of an entry is read straight
+   from the disk, so it has to be validated before it is used to index into the
+   name buffer, otherwise a crafted image makes us write far past the buffer. */
+#define FAT_MAX_LFN_ENTRIES 20
+
 typedef struct _FAT_VOLUME_INFO
 {
     PUCHAR FatCache; /* A part of 1st FAT cached in memory */
@@ -296,6 +302,24 @@ BOOLEAN FatOpenVolume(PFAT_VOLUME_INFO Volume, PFAT_BOOTSECTOR BootSector, ULONG
                  FIELD_OFFSET(FAT32_BOOTSECTOR, TotalSectorsBig));
         Volume->TotalSectors = (FatVolumeBootSector->TotalSectors ? FatVolumeBootSector->TotalSectors
                                                                   : FatVolumeBootSector->TotalSectorsBig);
+    }
+
+    /* The bytes-per-sector value is read from the disk and is used as a divisor
+       all over this driver (root directory size, FAT cache, ...). A damaged or
+       crafted image can hold 0 (division by zero) or a non power of two, so
+       validate it before anything else consumes it. */
+    if (!ISFATX(Volume->FatType))
+    {
+        ULONG BytesPerSector = (Volume->FatType == FAT32)
+                             ? (ULONG)Fat32VolumeBootSector->BytesPerSector
+                             : (ULONG)FatVolumeBootSector->BytesPerSector;
+
+        if (BytesPerSector == 0 || (BytesPerSector & (BytesPerSector - 1)) != 0)
+        {
+            sprintf(ErrMsg, "Invalid bytes per sector: %u", BytesPerSector);
+            FileSystemError(ErrMsg);
+            return FALSE;
+        }
     }
 
     /* Get the sectors per FAT, root directory sector start, and data sector start */
@@ -615,6 +639,17 @@ static BOOLEAN FatSearchDirectoryBufferForFile(PFAT_VOLUME_INFO Volume, PVOID Di
             // and make the sequence number zero-based
             //
             LfnDirEntry->SequenceNumber &= 0x3F;
+
+            /* Refuse anything outside 1..20: the masked value is used below as
+               a zero-based index into a 265 byte buffer (offset 19 * 13 + 12),
+               and a malformed image can otherwise ask for offset 255 * 13. */
+            if (LfnDirEntry->SequenceNumber == 0 ||
+                LfnDirEntry->SequenceNumber > FAT_MAX_LFN_ENTRIES)
+            {
+                continue;
+            }
+
+            /* Make the sequence number zero-based */
             LfnDirEntry->SequenceNumber--;
 
             //
@@ -1108,8 +1143,19 @@ static
 ULONG FatCountClustersInChain(PFAT_VOLUME_INFO Volume, UINT32 StartCluster)
 {
     ULONG    ClusterCount = 0;
+    ULONG    MaxClusters;
 
     TRACE("FatCountClustersInChain() StartCluster = %d\n", StartCluster);
+
+    /* A cluster chain can never be longer than the number of clusters the volume
+       holds. Use that as a bound so a cyclic chain (damaged or crafted FAT) is
+       reported as an error instead of hanging the boot loader forever. */
+    if (Volume->SectorsPerCluster == 0)
+    {
+        ERR("FatCountClustersInChain() SectorsPerCluster is zero\n");
+        return 0;
+    }
+    MaxClusters = FatNumberOfClusters(Volume) + 1;
 
     while (1)
     {
@@ -1125,6 +1171,15 @@ ULONG FatCountClustersInChain(PFAT_VOLUME_INFO Volume, UINT32 StartCluster)
         // Increment count
         //
         ClusterCount++;
+
+        //
+        // Bail out if the chain is longer than the volume: it must be looping
+        //
+        if (ClusterCount > MaxClusters)
+        {
+            ERR("FatCountClustersInChain() cyclic cluster chain detected\n");
+            return 0;
+        }
 
         //
         // Get next cluster
@@ -1192,6 +1247,7 @@ static
 BOOLEAN FatReadClusterChain(PFAT_VOLUME_INFO Volume, UINT32 StartClusterNumber, UINT32 NumberOfClusters, PVOID Buffer, PUINT32 LastClusterNumber)
 {
     UINT32 ClustersRead, NextClusterNumber, ClustersLeft = NumberOfClusters;
+    UINT32 TotalClustersRead = 0;
 
     TRACE("FatReadClusterChain() StartClusterNumber = %d NumberOfClusters = %d Buffer = 0x%x\n", StartClusterNumber, NumberOfClusters, Buffer);
 
@@ -1200,16 +1256,30 @@ BOOLEAN FatReadClusterChain(PFAT_VOLUME_INFO Volume, UINT32 StartClusterNumber, 
     while (FatReadAdjacentClusters(Volume, StartClusterNumber, ClustersLeft, Buffer, &ClustersRead, &NextClusterNumber))
     {
         ClustersLeft -= ClustersRead;
+        TotalClustersRead += ClustersRead;
         Buffer = (PVOID)((ULONG_PTR)Buffer + (ClustersRead * Volume->SectorsPerCluster * Volume->BytesPerSector));
         StartClusterNumber = NextClusterNumber;
     }
+    TotalClustersRead += ClustersRead;
 
     if (LastClusterNumber)
     {
         *LastClusterNumber = NextClusterNumber;
     }
 
-    return (ClustersRead > 0);
+    /* 0xFFFFFFFF means "read until the end of the chain". For any other count
+       the caller expects exactly that many clusters, so a chain which ends early
+       is a failure: otherwise the caller (the boot loader loading a kernel, say)
+       is told everything went fine and goes on to use the part of the buffer we
+       never filled in. */
+    if (NumberOfClusters != 0xFFFFFFFF && TotalClustersRead != NumberOfClusters)
+    {
+        ERR("FatReadClusterChain() read %u of %u clusters\n",
+            TotalClustersRead, NumberOfClusters);
+        return FALSE;
+    }
+
+    return (TotalClustersRead > 0);
 }
 
 /*

--- a/boot/freeldr/freeldr/lib/fs/ntfs.c
+++ b/boot/freeldr/freeldr/lib/fs/ntfs.c
@@ -105,13 +105,65 @@ static PUCHAR NtfsDecodeRun(PUCHAR DataRun, LONGLONG *DataRunOffset, ULONGLONG *
     return DataRun;
 }
 
-static PNTFS_ATTR_CONTEXT NtfsPrepareAttributeContext(PNTFS_ATTR_RECORD AttrRecord)
+static PNTFS_ATTR_CONTEXT NtfsPrepareAttributeContext(PNTFS_ATTR_RECORD AttrRecord,
+                                                      PNTFS_ATTR_RECORD AttrRecordEnd)
 {
     PNTFS_ATTR_CONTEXT Context;
+    ULONG RecordLength, MinLength;
 
-    Context = FrLdrTempAlloc(FIELD_OFFSET(NTFS_ATTR_CONTEXT, Record) + AttrRecord->Length,
+    /*
+     * The attribute record length, and for non-resident attributes the offset of
+     * the mapping pairs, are read straight from the disk and were used as a copy
+     * size and as a pointer into the freshly allocated record without any check.
+     * A damaged or crafted image could therefore make us copy arbitrary amounts
+     * of data, or walk off the end of the record while decoding the run list.
+     */
+    if ((ULONG_PTR)AttrRecordEnd <= (ULONG_PTR)AttrRecord)
+    {
+        return NULL;
+    }
+
+    MinLength = FIELD_OFFSET(NTFS_ATTR_RECORD, Resident);
+    if (AttrRecord->IsNonResident)
+    {
+        ULONG PairsMinLength;
+
+        MinLength = FIELD_OFFSET(NTFS_ATTR_RECORD, NonResident.AllocatedSize);
+
+        /* The mapping pairs live inside the record too, so it has to be long
+           enough to hold at least their first byte. */
+        PairsMinLength = (ULONG)AttrRecord->NonResident.MappingPairsOffset + sizeof(UCHAR);
+        if (PairsMinLength > MinLength)
+        {
+            MinLength = PairsMinLength;
+        }
+    }
+
+    RecordLength = AttrRecord->Length;
+    if (RecordLength < MinLength ||
+        RecordLength > (ULONG)((ULONG_PTR)AttrRecordEnd - (ULONG_PTR)AttrRecord))
+    {
+        ERR("NtfsPrepareAttributeContext() invalid attribute record length: %u\n", RecordLength);
+        return NULL;
+    }
+
+    if (AttrRecord->IsNonResident &&
+        AttrRecord->NonResident.MappingPairsOffset >= RecordLength)
+    {
+        ERR("NtfsPrepareAttributeContext() invalid mapping pairs offset: %u\n",
+            AttrRecord->NonResident.MappingPairsOffset);
+        return NULL;
+    }
+
+    Context = FrLdrTempAlloc(FIELD_OFFSET(NTFS_ATTR_CONTEXT, Record) + RecordLength,
                              TAG_NTFS_CONTEXT);
-    RtlCopyMemory(&Context->Record, AttrRecord, AttrRecord->Length);
+    if (!Context)
+    {
+        ERR("NtfsPrepareAttributeContext() out of memory\n");
+        return NULL;
+    }
+
+    RtlCopyMemory(&Context->Record, AttrRecord, RecordLength);
     if (AttrRecord->IsNonResident)
     {
         LONGLONG DataRunOffset;
@@ -505,7 +557,7 @@ static PNTFS_ATTR_CONTEXT NtfsFindAttributeHelper(
             PNTFS_ATTR_LIST_ATTR ListAttrRecord;
             PNTFS_ATTR_LIST_ATTR ListAttrRecordEnd;
 
-            ListContext = NtfsPrepareAttributeContext(AttrRecord);
+            ListContext = NtfsPrepareAttributeContext(AttrRecord, AttrRecordEnd);
 
             ListSize = NtfsGetAttributeSize(&ListContext->Record);
             if (ListSize <= 0xFFFFFFFF)
@@ -547,7 +599,7 @@ static PNTFS_ATTR_CONTEXT NtfsFindAttributeHelper(
             if (RtlEqualMemory(AttrName, Name, NameLength * sizeof(WCHAR)))
             {
                 /* Found it, fill up the context and return */
-                Context = NtfsPrepareAttributeContext(AttrRecord);
+                Context = NtfsPrepareAttributeContext(AttrRecord, AttrRecordEnd);
                 break;
             }
         }


### PR DESCRIPTION
Validate on-disk filesystem data before using it in the FreeLoader FAT and NTFS drivers.

**fat.c**
- LFN sequence numbers now have to be in 1..20: the masked value was used as a zero-based index into a 265-byte buffer and comes straight from the disk, so a crafted image could ask for offset 255*13 and write far past the buffer during boot.
- The bytes-per-sector field is validated (nonzero, power of two) before it is used as a divisor.
- `FatCountClustersInChain` is bounded by the number of clusters the volume holds, so a cyclic cluster chain is reported as an error instead of hanging the boot loader.
- `FatReadClusterChain` no longer reports success when the chain ended before the requested number of clusters was read: the caller (the boot loader loading a kernel) used the part of its buffer that was never filled in. `0xFFFFFFFF` still means "read to the end of the chain".

**ntfs.c** — `NtfsPrepareAttributeContext` now receives the end of the attribute record and validates the record length (and the mapping-pairs offset for non-resident attributes) against it, checks the allocation result, and refuses records too small for their own header.

Testing: static code review only; CI build validates compilation.