### PR TITLE
[NTUSER] Harden message/DDE/hook paths: UAF and unchecked user pointers

### DIFF
--- a/win32ss/user/ntuser/dde.c
+++ b/win32ss/user/ntuser/dde.c
@@ -92,7 +92,36 @@ IntDDEPostCallback(
       return 0;
    }
 
-   RtlCopyMemory(Common, ResultPointer, ArgumentLength);
+   /* What comes back from user mode is a user mode pointer plus a length, and
+      nothing checked either of them: a short answer made the copy below read
+      past the end of the returned buffer, and an invalid pointer bugchecked
+      the kernel. */
+   if (ResultLength < ArgumentLength)
+   {
+      ERR("DDE Post callback returned a short result: %lu < %lu\n",
+          ResultLength, ArgumentLength);
+      IntCbFreeMemory(Argument);
+      return 0;
+   }
+
+   Status = STATUS_SUCCESS;
+   _SEH2_TRY
+   {
+      ProbeForRead(ResultPointer, ArgumentLength, 1);
+      RtlCopyMemory(Common, ResultPointer, ArgumentLength);
+   }
+   _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+   {
+      ERR("DDE Post callback returned an invalid result pointer 0x%p\n", ResultPointer);
+      Status = _SEH2_GetExceptionCode();
+   }
+   _SEH2_END;
+
+   if (!NT_SUCCESS(Status))
+   {
+      IntCbFreeMemory(Argument);
+      return 0;
+   }
 
    size    = Common->size;
    *lParam = Common->lParam;
@@ -155,7 +184,34 @@ IntDDEGetCallback(
       return FALSE;
    }
 
-   RtlMoveMemory(Common, ResultPointer, ArgumentLength);
+   /* Same as in IntDDEPostCallback(): validate what user mode handed back
+      before reading from it. */
+   if (ResultLength < ArgumentLength)
+   {
+      ERR("DDE Get callback returned a short result: %lu < %lu\n",
+          ResultLength, ArgumentLength);
+      IntCbFreeMemory(Argument);
+      return FALSE;
+   }
+
+   Status = STATUS_SUCCESS;
+   _SEH2_TRY
+   {
+      ProbeForRead(ResultPointer, ArgumentLength, 1);
+      RtlMoveMemory(Common, ResultPointer, ArgumentLength);
+   }
+   _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+   {
+      ERR("DDE Get callback returned an invalid result pointer 0x%p\n", ResultPointer);
+      Status = _SEH2_GetExceptionCode();
+   }
+   _SEH2_END;
+
+   if (!NT_SUCCESS(Status))
+   {
+      IntCbFreeMemory(Argument);
+      return FALSE;
+   }
 
    pMsg->lParam = Common->lParam;
 
@@ -178,6 +234,7 @@ IntDdePostMessageHook(
 {
    PWND pWndClient;
    PDDE_DATA pddeData;
+   NTSTATUS Status;
    int size;
    HGDIOBJ Object = NULL;
    PVOID userBuf = NULL;
@@ -241,6 +298,18 @@ IntDdePostMessageHook(
       }
       else
       {
+         /* The size and the data pointer both come straight from the user mode
+            callback, so they cannot be trusted: an invalid pointer used to
+            bugcheck the kernel, and a kernel address got copied into a buffer
+            that is later handed to another process. */
+         if (size <= 0 ||
+             userBuf == NULL ||
+             (ULONG_PTR)userBuf > (ULONG_PTR)MmHighestUserAddress)
+         {
+             ERR("DDE Post callback returned bogus data: 0x%p, size %d\n", userBuf, size);
+             return FALSE;
+         }
+
          // Set buffer with users data size.
          Buffer = ExAllocatePoolWithTag(PagedPool, size, USERTAG_DDE);
          if (Buffer == NULL)
@@ -248,8 +317,26 @@ IntDdePostMessageHook(
              ERR("Failed to allocate %i bytes.\n", size);
              return FALSE;
          }
-         // No SEH? Yes, the user memory is freed after the Acknowledgment or at Termination.
-         RtlCopyMemory(Buffer, userBuf, size);
+         // The user memory is freed after the Acknowledgment or at Termination,
+         // but it can already be gone by the time we get here.
+         Status = STATUS_SUCCESS;
+         _SEH2_TRY
+         {
+             ProbeForRead(userBuf, size, 1);
+             RtlCopyMemory(Buffer, userBuf, size);
+         }
+         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+         {
+             ERR("DDE Post: invalid user buffer 0x%p, size %d\n", userBuf, size);
+             Status = _SEH2_GetExceptionCode();
+         }
+         _SEH2_END;
+
+         if (!NT_SUCCESS(Status))
+         {
+             ExFreePoolWithTag(Buffer, USERTAG_DDE);
+             return FALSE;
+         }
       }
 
       TRACE("DDE Post size %d 0x%x\n",size, Msg);
@@ -259,7 +346,16 @@ IntDdePostMessageHook(
           case WM_DDE_POKE:
           {
               DDEPOKE *pddePoke = Buffer;
-              NT_ASSERT(pddePoke != NULL);
+              /* When the callback returned -1 there is no buffer at all, and a
+                 buffer that is too small for the header must not be read either.
+                 NT_ASSERT is compiled out in release builds, so the old code
+                 dereferenced NULL here. */
+              if (pddePoke == NULL ||
+                  (ULONG)size < FIELD_OFFSET(DDEPOKE, Value) + sizeof(HGDIOBJ))
+              {
+                  ERR("DDE POKE: buffer too small or absent (%d)\n", size);
+                  break;
+              }
               switch(pddePoke->cfFormat)
               {
                  case CF_BITMAP:
@@ -275,7 +371,12 @@ IntDdePostMessageHook(
           case WM_DDE_DATA:
           {
               DDEDATA *pddeData2 = Buffer;
-              NT_ASSERT(pddeData2 != NULL);
+              if (pddeData2 == NULL ||
+                  (ULONG)size < FIELD_OFFSET(DDEDATA, Value) + sizeof(HGDIOBJ))
+              {
+                  ERR("DDE DATA: buffer too small or absent (%d)\n", size);
+                  break;
+              }
               switch(pddeData2->cfFormat)
               {
                  case CF_BITMAP:

--- a/win32ss/user/ntuser/hook.c
+++ b/win32ss/user/ntuser/hook.c
@@ -1625,7 +1625,22 @@ NtUserSetWindowsHookEx( HINSTANCE Mod,
        //gptiCurrent->pDeskInfo->fsHooks |= HOOKID_TO_FLAG(HookId);
        ptiHook->rpdesk->pDeskInfo->fsHooks |= HOOKID_TO_FLAG(HookId);
        ptiHook->sphkCurrent = NULL;
-       ptiHook->pClientInfo->phkCurrent = NULL;
+
+       /* pClientInfo is a user mode shared structure: it can be NULL and it is
+          not mapped into this process, so the write below needs the same
+          exception handling the per-thread branches above use. */
+       if (ptiHook->pClientInfo)
+       {
+          _SEH2_TRY
+          {
+             ptiHook->pClientInfo->phkCurrent = NULL;
+          }
+          _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+          {
+             ERR("Problem writing to ClientInfo!\n");
+          }
+          _SEH2_END;
+       }
     }
 
     RtlInitUnicodeString(&Hook->ModuleName, NULL);

--- a/win32ss/user/ntuser/message.c
+++ b/win32ss/user/ntuser/message.c
@@ -239,7 +239,19 @@ MsgMemorySize(PMSGMEMORY MsgMemoryEntry, WPARAM wParam, LPARAM lParam)
             case WM_COPYDATA:
                 {
                 COPYDATASTRUCT *cds = (COPYDATASTRUCT *)lParam;
-                Size = sizeof(COPYDATASTRUCT) + cds->cbData;
+                /* cbData is a DWORD supplied by the caller, so this addition
+                   can wrap around. It used to allocate (and copy) a couple of
+                   bytes while the structure still claimed to own cbData bytes,
+                   and the receiver trusted that length. */
+                if (cds->cbData > MAXULONG - sizeof(COPYDATASTRUCT))
+                {
+                    ERR("WM_COPYDATA with overflowing cbData: 0x%lx\n", cds->cbData);
+                    Size = 0;
+                }
+                else
+                {
+                    Size = sizeof(COPYDATASTRUCT) + cds->cbData;
+                }
                 }
                 break;
 
@@ -2377,8 +2389,11 @@ NtUserGetMessage(PMSG pMsg,
         _SEH2_END;
     }
 
+    /* Use the kernel copy here: pMsg is a user mode pointer, and reading it
+       again outside the protected block above means another thread can unmap it
+       in between and bugcheck us. */
     if ((INT)Ret != -1)
-       Ret = Ret ? (WM_QUIT != pMsg->message) : FALSE;
+       Ret = Ret ? (WM_QUIT != Msg.message) : FALSE;
 
     return Ret;
 }
@@ -2758,11 +2773,41 @@ NtUserMessageCall( HWND hWnd,
                         }
                         ExFreePoolWithTag(List, USERTAG_WINDOWLIST);
                      }
-                     if (lParam && !wParam && _wcsicmp((WCHAR*)lParam, L"Environment") == 0)
+                     if (lParam && !wParam)
                      {
-                         /* Handle Broadcast of WM_SETTINGCHAGE for Environment */
-                         co_IntDoSendMessage(HWND_BROADCAST, WM_SETTINGCHANGE,
-                                             0, (LPARAM)L"Environment", 0);
+                         /* lParam is a user mode pointer here. Copy it into a
+                            kernel buffer with exception handling before looking
+                            at it, exactly like the WM_WININICHANGE path above
+                            does: dereferencing it directly meant that a stale
+                            or unmapped pointer bugchecked the kernel, and a
+                            pointer sitting on a page boundary without a
+                            terminator read across the page. */
+                         WCHAR lParamMsg[_countof(StrUserKernel[0]) + 1] = { 0 };
+                         BOOLEAN Copied = FALSE;
+
+                         _SEH2_TRY
+                         {
+                             RtlCopyMemory(lParamMsg, (PVOID)lParam, sizeof(lParamMsg));
+                             Copied = TRUE;
+                         }
+                         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+                         {
+                             Copied = FALSE;
+                         }
+                         _SEH2_END;
+
+                         if (Copied)
+                         {
+                             /* Make sure that we have a UNICODE_NULL within lParamMsg */
+                             lParamMsg[ARRAYSIZE(lParamMsg) - 1] = UNICODE_NULL;
+
+                             if (_wcsicmp(lParamMsg, L"Environment") == 0)
+                             {
+                                 /* Handle Broadcast of WM_SETTINGCHAGE for Environment */
+                                 co_IntDoSendMessage(HWND_BROADCAST, WM_SETTINGCHANGE,
+                                                     0, (LPARAM)L"Environment", 0);
+                             }
+                         }
                      }
                      Ret = TRUE;
                   }

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -3894,6 +3894,16 @@ co_IntSetWindowLongPtr(HWND hWnd, DWORD Index, LONG_PTR NewValue, BOOL Ansi, ULO
 
             co_IntSendMessage(hWnd, WM_STYLECHANGING, GWL_EXSTYLE, (LPARAM) &Style);
 
+            /* The window procedure is allowed to destroy the window while it
+               handles WM_STYLECHANGING, so the object we looked up at the top
+               of the function may already be freed. Re-validate the handle and
+               re-fetch the object before writing to it again. */
+            if (!(Window = UserGetWindowObject(hWnd)))
+            {
+                EngSetLastError(ERROR_INVALID_WINDOW_HANDLE);
+                return 0;
+            }
+
             /*
              * Remove extended window style bit WS_EX_TOPMOST for shell windows.
              */
@@ -3926,6 +3936,13 @@ co_IntSetWindowLongPtr(HWND hWnd, DWORD Index, LONG_PTR NewValue, BOOL Ansi, ULO
 
             if (!bAlter)
                 co_IntSendMessage(hWnd, WM_STYLECHANGING, GWL_STYLE, (LPARAM) &Style);
+
+            /* Same as above: the callback may have destroyed the window. */
+            if (!(Window = UserGetWindowObject(hWnd)))
+            {
+                EngSetLastError(ERROR_INVALID_WINDOW_HANDLE);
+                return 0;
+            }
 
             /* WS_CLIPSIBLINGS can't be reset on top-level windows */
             if (UserIsDesktopWindow(Window->spwndParent)) Style.styleNew |= WS_CLIPSIBLINGS;


### PR DESCRIPTION
Harden several win32k paths (three commits):

**window.c** — `co_IntSetWindowLongPtr` sends `WM_STYLECHANGING` to the window and then keeps writing to the window object. The window procedure is allowed to destroy the window while handling that message, so the object could already be freed. The handle is re-validated and the object re-fetched after the callback (both `GWL_STYLE` and `GWL_EXSTYLE`).

**message.c**
- `NtUserMessageCall` compared the user-supplied `lParam` against `L"Environment"` by dereferencing it directly — a stale/unmapped pointer bugchecked the kernel, and a pointer at a page boundary without a terminator read across the page. The string is now copied into a kernel buffer under SEH (same pattern as the `WM_WININICHANGE` path).
- `NtUserGetMessage` read `pMsg->message` outside the protected block that wrote it; another thread can unmap the buffer in between. It now uses the kernel-side copy.
- `MsgMemorySize` (`WM_COPYDATA`): `sizeof(COPYDATASTRUCT) + cbData` could wrap around, so the message was packed with a couple of bytes while the structure still claimed `cbData` bytes.

**dde.c** — everything the user-mode callbacks hand back is validated: the returned buffer length is checked before copying out of it and the copies run under SEH; in `IntDdePostMessageHook` the returned size and data pointer are validated and must point below `MmHighestUserAddress`; the `WM_DDE_POKE`/`WM_DDE_DATA` paths no longer dereference a missing or too-small buffer (the old `NT_ASSERT` is compiled out in release builds).

**hook.c** — the system-wide hook path wrote `ptiHook->pClientInfo->phkCurrent` without checking that `pClientInfo` exists and without the exception handling the per-thread branches use.

Testing: static code review only; CI build validates compilation.