### PR TITLE
[NTDLL] Fix module list hang and uninitialized stack buffer in the loader

### DIFF
--- a/dll/ntdll/ldr/ldrapi.c
+++ b/dll/ntdll/ldr/ldrapi.c
@@ -467,6 +467,12 @@ LdrFindEntryForAddress(
     {
         /* Get the entry and NT Headers */
         LdrEntry = CONTAINING_RECORD(NextEntry, LDR_DATA_TABLE_ENTRY, InMemoryOrderLinks);
+
+        /* Advance unconditionally: the step used to sit inside the "NtHeader"
+           check below, so a module with a corrupt header never moved the list
+           forward and this loop hung forever. */
+        NextEntry = NextEntry->Flink;
+
         NtHeader = RtlImageNtHeader(LdrEntry->DllBase);
         if (NtHeader)
         {
@@ -482,9 +488,6 @@ LdrFindEntryForAddress(
                 *Module = LdrEntry;
                 return STATUS_SUCCESS;
             }
-
-            /* Next Entry */
-            NextEntry = NextEntry->Flink;
         }
     }
 

--- a/dll/ntdll/ldr/ldrutils.c
+++ b/dll/ntdll/ldr/ldrutils.c
@@ -2055,6 +2055,11 @@ lookinhash:
                         DPRINT1("LDR: LdrpCheckForLoadedDll - Unable To Locate %wZ: 0x%08x\n",
                             &DllName, Length);
                     }
+
+                    /* Fail instead of falling through with an uninitialized
+                       stack buffer as FullDllName: the code below compares and
+                       converts that buffer as if it held a real path. */
+                    return FALSE;
                 }
 
                 /* Full dll name is found */


### PR DESCRIPTION
Two loader fixes:

- `LdrFindEntryForAddress` only advanced to the next module inside the `NtHeader != NULL` check, so a module with a corrupt header hung the loop forever. The list is advanced unconditionally now.
- `LdrpCheckForLoadedDll` kept going when the path search failed and used an uninitialized stack buffer as `FullDllName`, comparing and converting it as if it held a real path. It now returns failure.

Testing: static code review only; CI build validates compilation.