### PR TITLE
[USERINIT] NULL-terminate the Shell registry value before using it

### DIFF
--- a/base/system/userinit/userinit.c
+++ b/base/system/userinit/userinit.c
@@ -163,6 +163,13 @@ GetShell(
         return FALSE;
     }
 
+    /* RegQueryValueExW does not guarantee that REG_SZ data is NUL terminated
+       and it can fill the whole buffer, so make sure there is a terminator
+       before the value is treated as a string below. */
+    if (Size >= sizeof(Shell))
+        Size = sizeof(Shell) - sizeof(WCHAR);
+    Shell[Size / sizeof(WCHAR)] = L'\0';
+
     if ((Type == REG_SZ) || (Type == REG_EXPAND_SZ))
     {
         TRACE("Found command line %s\n", debugstr_w(Shell));


### PR DESCRIPTION
`GetShell` copied the `Shell` registry value as a string, but `RegQueryValueExW` does not guarantee that REG_SZ data is NUL terminated and it can fill the whole buffer. A terminator is now written before the value is treated as a string.

Testing: static code review only; CI build validates compilation.