### PR TITLE
[RTL] LdrRelocateImageWithBias: reject undersized or truncated relocation blocks

### DIFF
--- a/sdk/lib/rtl/image.c
+++ b/sdk/lib/rtl/image.c
@@ -511,8 +511,16 @@ LdrRelocateImageWithBias(
     RelocationEnd = (PIMAGE_BASE_RELOCATION)((ULONG_PTR)RelocationDir + SWAPD(RelocationDDir->Size));
 
     while (RelocationDir < RelocationEnd &&
-            SWAPW(RelocationDir->SizeOfBlock) > 0)
+            SWAPW(RelocationDir->SizeOfBlock) >= sizeof(IMAGE_BASE_RELOCATION))
     {
+        /* A truncated block that would run past the end of the relocation
+           directory must not be processed either. */
+        if ((ULONG_PTR)RelocationDir + SWAPW(RelocationDir->SizeOfBlock) >
+            (ULONG_PTR)RelocationEnd)
+        {
+            break;
+        }
+
         Count = (SWAPW(RelocationDir->SizeOfBlock) - sizeof(IMAGE_BASE_RELOCATION)) / sizeof(USHORT);
         Address = (ULONG_PTR)RVA(BaseAddress, SWAPD(RelocationDir->VirtualAddress));
         TypeOffset = (PUSHORT)(RelocationDir + 1);


### PR DESCRIPTION
`LdrRelocateImageWithBias` accepted relocation blocks whose `SizeOfBlock` was smaller than `sizeof(IMAGE_BASE_RELOCATION)`, so `SizeOfBlock - sizeof(IMAGE_BASE_RELOCATION)` underflowed, the entry count became huge and relocations were applied far outside the block. A full header is now required, and blocks that run past the end of the relocation directory are rejected.

Testing: static code review only; CI build validates compilation.