### PR TITLE
[HALX86] Fill in some legacy HAL Interface handlers

### DIFF
--- a/hal/halx86/include/bus.h
+++ b/hal/halx86/include/bus.h
@@ -361,6 +361,24 @@ HalpWritePCIConfig(
 
 ULONG
 NTAPI
+HaliPciInterfaceReadConfig(_In_ PBUS_HANDLER RootBusHandler,
+                           _In_ ULONG BusNumber,
+                           _In_ PCI_SLOT_NUMBER SlotNumber,
+                           _In_ PVOID Buffer,
+                           _In_ ULONG Offset,
+                           _In_ ULONG Length);
+
+ULONG
+NTAPI
+HaliPciInterfaceWriteConfig(_In_ PBUS_HANDLER RootBusHandler,
+                            _In_ ULONG BusNumber,
+                            _In_ PCI_SLOT_NUMBER SlotNumber,
+                            _In_ PVOID Buffer,
+                            _In_ ULONG Offset,
+                            _In_ ULONG Length);
+
+ULONG
+NTAPI
 HalpGetPCIData(
     IN PBUS_HANDLER BusHandler,
     IN PBUS_HANDLER RootBusHandler,

--- a/hal/halx86/include/bus.h
+++ b/hal/halx86/include/bus.h
@@ -361,21 +361,23 @@ HalpWritePCIConfig(
 
 ULONG
 NTAPI
-HaliPciInterfaceReadConfig(_In_ PBUS_HANDLER RootBusHandler,
-                           _In_ ULONG BusNumber,
-                           _In_ PCI_SLOT_NUMBER SlotNumber,
-                           _In_ PVOID Buffer,
-                           _In_ ULONG Offset,
-                           _In_ ULONG Length);
+HaliPciInterfaceReadConfig(
+    _In_ PBUS_HANDLER RootBusHandler,
+    _In_ ULONG BusNumber,
+    _In_ PCI_SLOT_NUMBER SlotNumber,
+    _Out_writes_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Offset,
+    _In_ ULONG Length);
 
 ULONG
 NTAPI
-HaliPciInterfaceWriteConfig(_In_ PBUS_HANDLER RootBusHandler,
-                            _In_ ULONG BusNumber,
-                            _In_ PCI_SLOT_NUMBER SlotNumber,
-                            _In_ PVOID Buffer,
-                            _In_ ULONG Offset,
-                            _In_ ULONG Length);
+HaliPciInterfaceWriteConfig(
+    _In_ PBUS_HANDLER RootBusHandler,
+    _In_ ULONG BusNumber,
+    _In_ PCI_SLOT_NUMBER SlotNumber,
+    _In_reads_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Offset,
+    _In_ ULONG Length);
 
 ULONG
 NTAPI

--- a/hal/halx86/legacy/bus/pcibus.c
+++ b/hal/halx86/legacy/bus/pcibus.c
@@ -931,12 +931,13 @@ HalpAssignPCISlotResources(IN PBUS_HANDLER BusHandler,
 
 ULONG
 NTAPI
-HaliPciInterfaceReadConfig(_In_ PBUS_HANDLER RootBusHandler,
-                           _In_ ULONG BusNumber,
-                           _In_ PCI_SLOT_NUMBER SlotNumber,
-                           _In_ PVOID Buffer,
-                           _In_ ULONG Offset,
-                           _In_ ULONG Length)
+HaliPciInterfaceReadConfig(
+    _In_ PBUS_HANDLER RootBusHandler,
+    _In_ ULONG BusNumber,
+    _In_ PCI_SLOT_NUMBER SlotNumber,
+    _Out_writes_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Offset,
+    _In_ ULONG Length)
 {
     BUS_HANDLER BusHandler;
 
@@ -953,12 +954,13 @@ HaliPciInterfaceReadConfig(_In_ PBUS_HANDLER RootBusHandler,
 
 ULONG
 NTAPI
-HaliPciInterfaceWriteConfig(_In_ PBUS_HANDLER RootBusHandler,
-                            _In_ ULONG BusNumber,
-                            _In_ PCI_SLOT_NUMBER SlotNumber,
-                            _In_ PVOID Buffer,
-                            _In_ ULONG Offset,
-                            _In_ ULONG Length)
+HaliPciInterfaceWriteConfig(
+    _In_ PBUS_HANDLER RootBusHandler,
+    _In_ ULONG BusNumber,
+    _In_ PCI_SLOT_NUMBER SlotNumber,
+    _In_reads_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Offset,
+    _In_ ULONG Length)
 {
     BUS_HANDLER BusHandler;
 

--- a/hal/halx86/legacy/bus/pcibus.c
+++ b/hal/halx86/legacy/bus/pcibus.c
@@ -931,12 +931,12 @@ HalpAssignPCISlotResources(IN PBUS_HANDLER BusHandler,
 
 ULONG
 NTAPI
-HaliPciInterfaceReadConfig(IN PBUS_HANDLER RootBusHandler,
-                           IN ULONG BusNumber,
-                           IN PCI_SLOT_NUMBER SlotNumber,
-                           IN PVOID Buffer,
-                           IN ULONG Offset,
-                           IN ULONG Length)
+HaliPciInterfaceReadConfig(_In_ PBUS_HANDLER RootBusHandler,
+                           _In_ ULONG BusNumber,
+                           _In_ PCI_SLOT_NUMBER SlotNumber,
+                           _In_ PVOID Buffer,
+                           _In_ ULONG Offset,
+                           _In_ ULONG Length)
 {
     BUS_HANDLER BusHandler;
 
@@ -948,6 +948,25 @@ HaliPciInterfaceReadConfig(IN PBUS_HANDLER RootBusHandler,
     HalpReadPCIConfig(&BusHandler, SlotNumber, Buffer, Offset, Length);
 
     /* Return length */
+    return Length;
+}
+
+ULONG
+NTAPI
+HaliPciInterfaceWriteConfig(_In_ PBUS_HANDLER RootBusHandler,
+                            _In_ ULONG BusNumber,
+                            _In_ PCI_SLOT_NUMBER SlotNumber,
+                            _In_ PVOID Buffer,
+                            _In_ ULONG Offset,
+                            _In_ ULONG Length)
+{
+    BUS_HANDLER BusHandler;
+
+    RtlCopyMemory(&BusHandler, &HalpFakePciBusHandler, sizeof(BUS_HANDLER));
+    BusHandler.BusNumber = BusNumber;
+
+    HalpWritePCIConfig(&BusHandler, SlotNumber, Buffer, Offset, Length);
+
     return Length;
 }
 

--- a/hal/halx86/legacy/halpnpdd.c
+++ b/hal/halx86/legacy/halpnpdd.c
@@ -12,6 +12,9 @@
 #define NDEBUG
 #include <debug.h>
 
+#include <initguid.h>
+#include <wdmguid.h>
+
 typedef enum _EXTENSION_TYPE
 {
     PdoExtensionType = 0xC0,
@@ -135,6 +138,32 @@ HalpAddDevice(IN PDRIVER_OBJECT DriverObject,
     return Status;
 }
 
+VOID
+NTAPI
+HalpBusInterfaceReference(PVOID Context)
+{
+    PPDO_EXTENSION HalPdoExtension = ((PDEVICE_OBJECT)Context)->DeviceExtension;
+    InterlockedIncrement(&HalPdoExtension->InterfaceReferenceCount);
+}
+
+VOID
+NTAPI
+HalpBusInterfaceDereference(PVOID Context)
+{
+    PPDO_EXTENSION HalPdoExtension = ((PDEVICE_OBJECT)Context)->DeviceExtension;
+    InterlockedDecrement(&HalPdoExtension->InterfaceReferenceCount);
+}
+
+PDMA_ADAPTER
+NTAPI
+HalpBusInterfaceGetDmaAdapter(_Inout_opt_ PVOID Context,
+                              _In_        PDEVICE_DESCRIPTION DeviceDescriptor,
+                              _Out_       PULONG NumberOfMapRegisters)
+{
+    DeviceDescriptor->BusNumber = 0;
+    return HalpGetDmaAdapter(Context, DeviceDescriptor, NumberOfMapRegisters);
+}
+
 NTSTATUS
 NTAPI
 HalpQueryInterface(IN PDEVICE_OBJECT DeviceObject,
@@ -145,12 +174,51 @@ HalpQueryInterface(IN PDEVICE_OBJECT DeviceObject,
                    IN PINTERFACE Interface,
                    OUT PULONG Length)
 {
-    DPRINT1("HalpQueryInterface({%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X}) is UNIMPLEMENTED\n",
+    if (IsEqualIID(InterfaceType, &GUID_BUS_INTERFACE_STANDARD))
+    {
+        PBUS_INTERFACE_STANDARD BusInterface = (PBUS_INTERFACE_STANDARD)Interface;
+
+        *Length = sizeof(*BusInterface);
+        if (InterfaceBufferSize < sizeof(*BusInterface))
+            return STATUS_BUFFER_TOO_SMALL;
+        
+        RtlZeroMemory(BusInterface, sizeof(*BusInterface));
+        BusInterface->Size = sizeof(*BusInterface);
+        BusInterface->Version = 1;
+        BusInterface->Context = DeviceObject;
+        BusInterface->InterfaceDereference = HalpBusInterfaceDereference;
+        BusInterface->InterfaceReference = HalpBusInterfaceDereference;
+        BusInterface->GetDmaAdapter = HalpBusInterfaceGetDmaAdapter;
+    }
+    else if (IsEqualIID(InterfaceType, &GUID_PCI_BUS_INTERFACE_STANDARD))
+    {
+        PPCI_BUS_INTERFACE_STANDARD PciBusInterface = (PPCI_BUS_INTERFACE_STANDARD)Interface;
+        *Length = sizeof(*PciBusInterface);
+        if (InterfaceBufferSize < sizeof(*PciBusInterface))
+        {
+            DPRINT1("HalpQueryInterface Buffer Given: %X", InterfaceBufferSize);
+            return STATUS_BUFFER_TOO_SMALL;
+        }
+        
+        RtlZeroMemory(PciBusInterface, sizeof(*PciBusInterface));
+        PciBusInterface->Size = sizeof(*PciBusInterface);
+        PciBusInterface->Version = 1;
+        PciBusInterface->Context = DeviceObject;
+        PciBusInterface->InterfaceDereference = HalpBusInterfaceDereference;
+        PciBusInterface->InterfaceReference = HalpBusInterfaceDereference;
+        PciBusInterface->WriteConfig = (PCI_READ_WRITE_CONFIG)HaliPciInterfaceWriteConfig;
+        PciBusInterface->ReadConfig = (PCI_READ_WRITE_CONFIG)HaliPciInterfaceReadConfig;
+    }
+    else
+    {
+        DPRINT1("HalpQueryInterface({%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X}) is UNIMPLEMENTED\n",
             InterfaceType->Data1, InterfaceType->Data2, InterfaceType->Data3,
             InterfaceType->Data4[0], InterfaceType->Data4[1],
             InterfaceType->Data4[2], InterfaceType->Data4[3],
             InterfaceType->Data4[4], InterfaceType->Data4[5],
             InterfaceType->Data4[6], InterfaceType->Data4[7]);
+    }
+
     return STATUS_NOT_SUPPORTED;
 }
 

--- a/hal/halx86/legacy/halpnpdd.c
+++ b/hal/halx86/legacy/halpnpdd.c
@@ -138,6 +138,7 @@ HalpAddDevice(IN PDRIVER_OBJECT DriverObject,
     return Status;
 }
 
+static
 VOID
 NTAPI
 HalpBusInterfaceReference(PVOID Context)
@@ -146,6 +147,7 @@ HalpBusInterfaceReference(PVOID Context)
     InterlockedIncrement(&HalPdoExtension->InterfaceReferenceCount);
 }
 
+static
 VOID
 NTAPI
 HalpBusInterfaceDereference(PVOID Context)
@@ -154,11 +156,13 @@ HalpBusInterfaceDereference(PVOID Context)
     InterlockedDecrement(&HalPdoExtension->InterfaceReferenceCount);
 }
 
+static
 PDMA_ADAPTER
 NTAPI
-HalpBusInterfaceGetDmaAdapter(_Inout_opt_ PVOID Context,
-                              _In_        PDEVICE_DESCRIPTION DeviceDescriptor,
-                              _Out_       PULONG NumberOfMapRegisters)
+HalpBusInterfaceGetDmaAdapter(
+    _Inout_opt_ PVOID Context,
+    _In_ PDEVICE_DESCRIPTION DeviceDescriptor,
+    _Out_ PULONG NumberOfMapRegisters)
 {
     DeviceDescriptor->BusNumber = 0;
     return HalpGetDmaAdapter(Context, DeviceDescriptor, NumberOfMapRegisters);
@@ -193,19 +197,17 @@ HalpQueryInterface(IN PDEVICE_OBJECT DeviceObject,
     else if (IsEqualIID(InterfaceType, &GUID_PCI_BUS_INTERFACE_STANDARD))
     {
         PPCI_BUS_INTERFACE_STANDARD PciBusInterface = (PPCI_BUS_INTERFACE_STANDARD)Interface;
+
         *Length = sizeof(*PciBusInterface);
         if (InterfaceBufferSize < sizeof(*PciBusInterface))
-        {
-            DPRINT1("HalpQueryInterface Buffer Given: %X", InterfaceBufferSize);
             return STATUS_BUFFER_TOO_SMALL;
-        }
         
         RtlZeroMemory(PciBusInterface, sizeof(*PciBusInterface));
         PciBusInterface->Size = sizeof(*PciBusInterface);
         PciBusInterface->Version = 1;
         PciBusInterface->Context = DeviceObject;
         PciBusInterface->InterfaceDereference = HalpBusInterfaceDereference;
-        PciBusInterface->InterfaceReference = HalpBusInterfaceDereference;
+        PciBusInterface->InterfaceReference = HalpBusInterfaceReference;
         PciBusInterface->WriteConfig = (PCI_READ_WRITE_CONFIG)HaliPciInterfaceWriteConfig;
         PciBusInterface->ReadConfig = (PCI_READ_WRITE_CONFIG)HaliPciInterfaceReadConfig;
     }


### PR DESCRIPTION
Fills in some legacy hal interfaces to prep switching to PCIX

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=110091,110094,110097
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=110093,110095