### PR TITLE
[FSRTL][FASTFAT][IO] Storage-stack fixes: lock-IRP drain, dismount remount, sector alignment, share access

### DIFF
--- a/drivers/filesystems/fastfat/cleanup.c
+++ b/drivers/filesystems/fastfat/cleanup.c
@@ -465,7 +465,15 @@ Return Value:
 
             if (FlagOn( Ccb->Flags, CCB_FLAG_COMPLETE_DISMOUNT )) {
 
-                FatCheckForDismount( IrpContext, Vcb, TRUE );
+                //
+                //  If the volume was remounted before this handle closed, the
+                //  VCB is good again and should not be torn down.
+                //
+
+                if (Vcb->VcbCondition == VcbBad) {
+
+                    FatCheckForDismount( IrpContext, Vcb, TRUE );
+                }
 
             //
             //  If this handle had write access, and actually wrote something,

--- a/drivers/filesystems/fastfat/fatprocs.h
+++ b/drivers/filesystems/fastfat/fatprocs.h
@@ -1971,6 +1971,11 @@ FatVerifyVcb (
     IN PVCB Vcb
     );
 
+BOOLEAN
+FatMarkDevForVerifyIfVcbMounted (
+    IN PVCB Vcb
+    );
+
 _Requires_lock_held_(_Global_critical_region_)
 VOID
 FatVerifyFcb (

--- a/drivers/filesystems/fastfat/fsctrl.c
+++ b/drivers/filesystems/fastfat/fsctrl.c
@@ -1557,6 +1557,7 @@ Return Value:
             FatSetVcbCondition( OldVcb, VcbGood);
             OldVpb->RealDevice = Vpb->RealDevice;
             ClearFlag( OldVcb->VcbState, VCB_STATE_VPB_NOT_ON_DEVICE);
+            ClearFlag( OldVcb->VcbState, VCB_STATE_FLAG_VOLUME_DISMOUNTED );
 
 #ifdef _MSC_VER
 #pragma prefast( suppress: 28175, "touching Vpb is ok for a filesystem" )
@@ -3815,17 +3816,32 @@ Return Value:
         //  correct error code when operations are attempted via open handles.
         //
 
-        FatSetVcbCondition( Vcb, VcbBad);
+        //
+        //  Mark the VCB as not-mounted-but-valid instead of bad, so the next
+        //  open can remount it cleanly.  Leave VCB_STATE_FLAG_VOLUME_DISMOUNTED
+        //  set so existing handles see STATUS_VOLUME_DISMOUNTED where expected.
+        //
+
+        FatSetVcbCondition( Vcb, VcbNotMounted);
 
         SetFlag( Vcb->VcbState, VCB_STATE_FLAG_VOLUME_DISMOUNTED );
 
         //
-        //  Set a flag in the VPB to let others know that direct volume access is allowed.
+        //  Set a flag in the VPB to let others know that direct volume access is allowed,
+        //  then clear VPB_MOUNTED so the I/O manager re-drives a fresh mount on the next open.
         //
 
         IoAcquireVpbSpinLock( &SavedIrql );
         SetFlag( Vcb->Vpb->Flags, VPB_DIRECT_WRITES_ALLOWED );
+        ClearFlag( Vcb->Vpb->Flags, VPB_MOUNTED );
         IoReleaseVpbSpinLock( SavedIrql );
+
+        //
+        //  Ask the I/O manager to verify this device on the next access, which
+        //  will remount the volume through the fastfat mount path.
+        //
+
+        FatMarkDevForVerifyIfVcbMounted( Vcb );
 
         Status = STATUS_SUCCESS;
 

--- a/drivers/filesystems/fastfat/write.c
+++ b/drivers/filesystems/fastfat/write.c
@@ -2103,6 +2103,27 @@ Return Value:
 
                 SectorSize = (ULONG)Vcb->Bpb.BytesPerSector;
 
+                //
+                //  Windows FILE_FLAG_NO_BUFFERING contract: the user buffer
+                //  must be aligned to the volume sector size.  The I/O
+                //  manager gates the buffer only against
+                //  DeviceObject->AlignmentRequirement, which on this storage
+                //  stack is typically 0 or FILE_WORD_ALIGNMENT, so an
+                //  unaligned buffer can reach us.  Reject it here rather than
+                //  hand a byte-unaligned MDL down to the disk driver, whose
+                //  scatter/gather list would then carry a non-sector-aligned
+                //  physical address and risk tearing the sector on disk.
+                //
+
+                if (Irp->RequestorMode != KernelMode &&
+                    ((ULONG_PTR)Irp->UserBuffer & (SectorSize - 1)) != 0)
+                {
+                    DebugTrace(0, Dbg,
+                               "FatCommonWrite -> STATUS_INVALID_PARAMETER "
+                               "(ungated unbuffered buffer misalignment)\n", 0);
+                    try_return( Status = STATUS_INVALID_PARAMETER );
+                }
+
                 BytesToWrite = (ByteCount + (SectorSize - 1))
                                          & ~(SectorSize - 1);
 

--- a/ntoskrnl/fsrtl/filelock.c
+++ b/ntoskrnl/fsrtl/filelock.c
@@ -504,6 +504,7 @@ FsRtlPrivateLock(IN PFILE_LOCK FileLock,
                             IoStatus->Status = STATUS_PENDING;
                             if (Irp)
                             {
+                                Irp->IoStatus.Information = LockInfo->Generation;
                                 IoMarkIrpPending(Irp);
                                 IoCsqInsertIrpEx
                                     (&LockInfo->Csq,
@@ -1190,8 +1191,11 @@ FsRtlProcessFileLock(IN PFILE_LOCK FileLock,
                                           Irp,
                                           Context,
                                           FALSE);
-        /* FsRtlPrivateLock has _Must_inspect_result_. Just check this is consistent on debug builds */
-        NT_ASSERT(Result == NT_SUCCESS(IoStatusBlock.Status));
+        /* FsRtlPrivateLock has _Must_inspect_result_. A blocking conflicting lock
+           legitimately returns FALSE with STATUS_PENDING after queueing the IRP,
+           which is then reprocessed/completed when the conflicting lock is released. */
+        NT_ASSERT(IoStatusBlock.Status == STATUS_PENDING ||
+                  Result == NT_SUCCESS(IoStatusBlock.Status));
         (void)Result;
         return IoStatusBlock.Status;
     }
@@ -1304,10 +1308,18 @@ FsRtlUninitializeFileLock(IN PFILE_LOCK FileLock)
         }
         while ((Irp = IoCsqRemoveNextIrp(&InternalInfo->Csq, NULL)) != NULL)
         {
-            NTSTATUS Status = FsRtlProcessFileLock(FileLock, Irp, NULL);
-            /* FsRtlProcessFileLock has _Must_inspect_result_ */
-            NT_ASSERT(NT_SUCCESS(Status));
-            (void)Status;
+            /* The FILE_LOCK is going away. Any locks still waiting can never be
+               granted, so complete them with STATUS_CANCELLED instead of trying to
+               reprocess them (which could re-grant locks and loop forever). */
+            NTSTATUS Status;
+            PIO_STACK_LOCATION Stack = IoGetCurrentIrpStackLocation(Irp);
+            PFILE_OBJECT FileObject = Stack ? Stack->FileObject : NULL;
+            FsRtlCompleteLockIrpReal(FileLock->CompleteLockIrpRoutine,
+                                     NULL,
+                                     Irp,
+                                     STATUS_CANCELLED,
+                                     &Status,
+                                     FileObject);
         }
         ExFreePoolWithTag(InternalInfo, TAG_FLOCK);
         FileLock->LockInformation = NULL;

--- a/ntoskrnl/io/iomgr/file.c
+++ b/ntoskrnl/io/iomgr/file.c
@@ -3352,17 +3352,6 @@ IoUpdateShareAccess(IN PFILE_OBJECT FileObject,
 {
     PAGED_CODE();
 
-    /* Check if the file has an extension */
-    if (FileObject->Flags & FO_FILE_OBJECT_HAS_EXTENSION)
-    {
-        /* Check if caller specified to ignore access checks */
-        //if (FileObject->FoExtFlags & IO_IGNORE_SHARE_ACCESS_CHECK)
-        {
-            /* Don't update share access */
-            return;
-        }
-    }
-
     /* Otherwise, check if there's any access present */
     if ((FileObject->ReadAccess) ||
         (FileObject->WriteAccess) ||
@@ -3409,17 +3398,6 @@ IoCheckShareAccess(IN ACCESS_MASK DesiredAccess,
     FileObject->ReadAccess = ReadAccess;
     FileObject->WriteAccess = WriteAccess;
     FileObject->DeleteAccess = DeleteAccess;
-
-    /* Check if the file has an extension */
-    if (FileObject->Flags & FO_FILE_OBJECT_HAS_EXTENSION)
-    {
-        /* Check if caller specified to ignore access checks */
-        //if (FileObject->FoExtFlags & IO_IGNORE_SHARE_ACCESS_CHECK)
-        {
-            /* Don't check share access */
-            return STATUS_SUCCESS;
-        }
-    }
 
     /* Check if we have any access */
     if ((ReadAccess) || (WriteAccess) || (DeleteAccess))
@@ -3479,17 +3457,6 @@ IoRemoveShareAccess(IN PFILE_OBJECT FileObject,
 {
     PAGED_CODE();
 
-    /* Check if the file has an extension */
-    if (FileObject->Flags & FO_FILE_OBJECT_HAS_EXTENSION)
-    {
-        /* Check if caller specified to ignore access checks */
-        //if (FileObject->FoExtFlags & IO_IGNORE_SHARE_ACCESS_CHECK)
-        {
-            /* Don't update share access */
-            return;
-        }
-    }
-
     /* Otherwise, check if there's any access present */
     if ((FileObject->ReadAccess) ||
         (FileObject->WriteAccess) ||
@@ -3531,21 +3498,21 @@ IoSetShareAccess(IN ACCESS_MASK DesiredAccess,
     WriteAccess = (DesiredAccess & (FILE_WRITE_DATA | FILE_APPEND_DATA)) != 0;
     DeleteAccess = (DesiredAccess & DELETE) != 0;
 
-    /* Check if the file has an extension */
-    if (FileObject->Flags & FO_FILE_OBJECT_HAS_EXTENSION)
-    {
-        /* Check if caller specified to ignore access checks */
-        //if (FileObject->FoExtFlags & IO_IGNORE_SHARE_ACCESS_CHECK)
-        {
-            /* Don't update share access */
-            Update = FALSE;
-        }
-    }
-
     /* Update basic access */
     FileObject->ReadAccess = ReadAccess;
     FileObject->WriteAccess = WriteAccess;
     FileObject->DeleteAccess = DeleteAccess;
+
+    /*
+     *  File objects that carry an extension but have no actual I/O access
+     *  are typically auxiliary objects (e.g. stream objects or hint opens).
+     *  Don't clear or reset the share counts for these.
+     */
+    if ((FileObject->Flags & FO_FILE_OBJECT_HAS_EXTENSION) &&
+        !(ReadAccess) && !(WriteAccess) && !(DeleteAccess))
+    {
+        return;
+    }
 
     /* Check if we have no access as all */
     if (!(ReadAccess) && !(WriteAccess) && !(DeleteAccess))


### PR DESCRIPTION
Draft — four independent correctness fixes in the storage/filesystem stack, found while stress-testing a virtio-blk driver. Split out from that work since none of them depend on it.

## Commits

1. **[FSRTL] Drain queued lock IRPs when a FILE_LOCK is uninitialized** — `FsRtlUninitializeFileLock()` reprocessed every IRP still queued on the lock's cancel-safe queue via `FsRtlProcessFileLock()`. A blocking `LockFileEx` request that lost a race against teardown could be re-granted or re-queued there, leaving `FileObject->LastLock` pointing at freed `FILE_LOCK` memory and hanging or bugchecking the caller (STOP 0x1E / 0x23 / BAD_POOL_CALLER observed under concurrent LockFileEx stress). Now completes each queued IRP with `STATUS_CANCELLED` through `FsRtlCompleteLockIrpReal()`, records the lock generation in `Irp->IoStatus.Information` when a blocking lock IRP is queued, and relaxes the `FsRtlProcessFileLock()` assertion.

2. **[FASTFAT] Let a dismounted volume be remounted on the next open** — `FSCTL_DISMOUNT_VOLUME` marked the VCB `VcbBad` and left `VPB_MOUNTED` set, so the I/O manager never re-drove a mount and every subsequent open failed with "the volume does not contain a recognized file system" until reboot. Now marks the VCB `VcbNotMounted`, clears `VPB_MOUNTED` under the VPB lock, and calls `FatMarkDevForVerifyIfVcbMounted()` so the next access verifies and remounts; `FatCommonCleanup()` only tears down for a complete-dismount handle if the VCB is still `VcbBad`.

3. **[FASTFAT] Reject non-sector-aligned buffers for non-cached writes** — the `FILE_FLAG_NO_BUFFERING` contract requires the user buffer aligned to the volume sector size, but the I/O manager only checks `DeviceObject->AlignmentRequirement` (typically 0/word here), so a byte-misaligned buffer could reach the disk driver as a non-sector-aligned MDL and risk a torn sector. Now fails user-mode non-cached writes whose `UserBuffer` isn't a multiple of `Bpb.BytesPerSector` with `STATUS_INVALID_PARAMETER`.

4. **[IO] Stop skipping share-access checks for file objects with extensions** — `IoCheckShareAccess`/`IoUpdateShareAccess`/`IoRemoveShareAccess`/`IoSetShareAccess` all bailed early on `FO_FILE_OBJECT_HAS_EXTENSION`, disabling share-access bookkeeping for every extended file object (e.g. `DeleteFile()` on a file opened without `FILE_SHARE_DELETE` could succeed while still open). Removes the blanket early-outs; keeps a narrowed guard in `IoSetShareAccess()` only for extension objects opened with no read/write/delete access.

## Testing

Each was reproduced under a `stress.exe` battery (concurrent LockFileEx, dismount-under-open-handles, unbuffered misaligned writes, share-delete) on ReactOS before the fix and confirmed resolved after. Compile-verified on i386 Release.

Marked draft pending a final clean re-run on this exact branch. No JIRA ticket; found by inspection + stress reproduction — happy to file if a reviewer wants the reference.