### PR TITLE
[SETUP:REACTOS][PAINT] Update Brazilian Portuguese (pt-BR) translation

### DIFF
--- a/base/setup/reactos/lang/pt-BR.rc
+++ b/base/setup/reactos/lang/pt-BR.rc
@@ -7,18 +7,18 @@ STYLE DS_SHELLFONT | WS_CHILD
 FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Bem-vindo(a) ao Assistente de Instalação do ReactOS", IDC_STARTTITLE, 115, 8, 195, 24
-    LTEXT "This wizard will install or upgrade ReactOS on your computer, \
-and prepare the second part of the setup.", IDC_STATIC, 115, 40, 195, 27
+    LTEXT "Este assistente irá instalar ou atualizar o ReactOS no seu computador, \
+e preparar a segunda parte da instalação.", IDC_STATIC, 115, 40, 195, 27
 ////
-    GROUPBOX " IMPORTANT INFORMATION ", IDC_WARNTEXT1, 115, 70, 200, 90, BS_CENTER
-    LTEXT "ReactOS is in Alpha stage: it is not feature- complete and is \
-under heavy development. It is recommended to use it only for \
-evaluation and testing and not as your daily-usage OS.\n\
-It may corrupt your data or damage your hardware.", IDC_WARNTEXT2, 120, 80, 190, 50, SS_CENTER
-    LTEXT "Backup your data or test on a secondary computer \
-if you attempt to run ReactOS on real hardware.", IDC_WARNTEXT3, 120, 130, 190, 27, SS_CENTER
+    GROUPBOX " INFORMAÇÃO IMPORTANTE ", IDC_WARNTEXT1, 115, 70, 200, 97, BS_CENTER
+    LTEXT "O ReactOS está na fase Alpha: não possui todos os recursos e está \
+em desenvolvimento intenso. É recomendado usá-lo apenas para \
+avaliação e testes, e não como sistema operacional do dia a dia. \n\
+Ele pode corromper seus dados ou danificar seu hardware.", IDC_WARNTEXT2, 120, 80, 190, 57, SS_CENTER
+    LTEXT "Faça backup dos seus dados ou teste em um computador \
+secundário se você for tentar rodar o ReactOS em hardware real.", IDC_WARNTEXT3, 120, 137, 190, 27, SS_CENTER
 ////
-    LTEXT "Clique Avançar para continuar a instalação.", IDC_STATIC, 115, 169, 195, 17
+    LTEXT "Clique Avançar para continuar a instalação.", IDC_STATIC, 115, 176, 195, 17
 END
 
 IDD_TYPEPAGE DIALOGEX 0, 0, 317, 143
@@ -27,18 +27,18 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     AUTORADIOBUTTON "&Instalar ReactOS", IDC_INSTALL, 7, 20, 277, 10, WS_GROUP
     AUTORADIOBUTTON "&Reparar ou atualizar ReactOS", IDC_UPDATE, 7, 80, 277, 10
-    LTEXT "Install a new copy of ReactOS. This option does not keep your files, settings and programs. You can make changes to disks and partitions.", IDC_INSTALLTEXT, 19, 36, 279, 27
-    LTEXT "Update or repair an installed copy of ReactOS. This option keeps your files, settings and programs. This option is only available if ReactOS is already installed on this computer.", IDC_UPDATETEXT, 19, 96, 279, 27
+    LTEXT "Instala uma nova cópia do ReactOS. Esta opção não mantém seus arquivos, configurações e programas. Você pode fazer alterações em discos e partições.", IDC_INSTALLTEXT, 19, 36, 279, 27
+    LTEXT "Atualiza ou repara uma cópia instalada do ReactOS. Esta opção mantém seus arquivos, configurações e programas. Esta opção só está disponível se o ReactOS já estiver instalado neste computador.", IDC_UPDATETEXT, 19, 96, 279, 27
 END
 
 IDD_UPDATEREPAIRPAGE DIALOGEX 0, 0, 317, 143
 STYLE DS_SHELLFONT | WS_CHILD
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT       "The Setup program can upgrade one of the available ReactOS installations listed below, or, if a ReactOS installation is damaged, the Setup program can attempt to repair it.", IDC_STATIC, 6, 6, 303, 18
+    LTEXT       "O programa de instalação pode atualizar uma das instalações do ReactOS disponíveis listadas abaixo ou, se uma instalação do ReactOS estiver danificada, o programa de instalação pode tentar repará-la.", IDC_STATIC, 6, 6, 303, 18
     CONTROL     "", IDC_NTOSLIST, "SysListView32", LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_ALIGNLEFT | WS_BORDER | WS_TABSTOP, 6, 30, 303, 90
-    PUSHBUTTON  "&Do not upgrade", IDC_SKIPUPGRADE, 230, 128, 80, 14
-    LTEXT       "Click Next to upgrade the selected OS installation, or on 'Do not upgrade' to perform a new installation.", IDC_STATIC, 7, 124, 222, 16
+    PUSHBUTTON  "&Não atualizar", IDC_SKIPUPGRADE, 230, 128, 80, 14
+    LTEXT       "Clique em Avançar para atualizar a instalação do sistema operacional selecionado, ou em 'Não atualizar' para fazer uma nova instalação.", IDC_STATIC, 7, 124, 222, 16
 END
 
 IDD_DEVICEPAGE DIALOGEX 0, 0, 317, 143
@@ -59,9 +59,9 @@ STYLE DS_SHELLFONT | WS_CHILD
 FONT 8, "MS Shell Dlg"
 BEGIN
     CONTROL "", IDC_PARTITION, "SysTreeList32", WS_BORDER | WS_VISIBLE | WS_TABSTOP | LVS_REPORT | LVS_SINGLESEL, 7, 7, 303, 112
-    PUSHBUTTON "&Initialize", IDC_INITDISK, 7, 122, 50, 14, WS_GROUP // NOTE: At same position as IDC_PARTCREATE
+    PUSHBUTTON "&Inicializar", IDC_INITDISK, 7, 122, 50, 14, WS_GROUP // NOTE: At same position as IDC_PARTCREATE
     PUSHBUTTON "&Criar", IDC_PARTCREATE, 7, 122, 50, 14
-    PUSHBUTTON "&Format", IDC_PARTFORMAT, 7, 122, 50, 14 // NOTE: At same position as IDC_PARTCREATE
+    PUSHBUTTON "&Formatar", IDC_PARTFORMAT, 7, 122, 50, 14 // NOTE: At same position as IDC_PARTCREATE
     PUSHBUTTON "&Apagar", IDC_PARTDELETE, 63, 122, 50, 14
     PUSHBUTTON "D&rivers", IDC_DEVICEDRIVER, 174, 122, 50, 14, WS_DISABLED
     PUSHBUTTON "&Opções Avançadas...", IDC_PARTMOREOPTS, 230, 122, 80, 14
@@ -78,10 +78,10 @@ BEGIN
     CONTROL "", IDC_UPDOWN_PARTSIZE, UPDOWN_CLASS, UDS_SETBUDDYINT | UDS_ALIGNRIGHT |
             UDS_AUTOBUDDY | UDS_ARROWKEYS | WS_GROUP, 120, 22, 9, 13
     LTEXT "MB", IDC_UNIT, 134, 9, 14, 9
-    AUTOCHECKBOX "&Extended partition", IDC_CHECK_MBREXTPART, 7, 22, 180, 14
+    AUTOCHECKBOX "&Partição extendida", IDC_CHECK_MBREXTPART, 7, 22, 180, 14
     LTEXT "&Sistema de arquivo:", IDC_FS_STATIC, 7, 46, 70, 9
     COMBOBOX IDC_FSTYPE, 82, 44, 100, 50, CBS_DROPDOWNLIST | WS_TABSTOP
-    AUTOCHECKBOX "&Quick format", IDC_CHECK_QUICKFMT, 7, 59, 180, 14
+    AUTOCHECKBOX "&Formatação rápida", IDC_CHECK_QUICKFMT, 7, 59, 180, 14
     PUSHBUTTON "OK", IDOK, 88, 98, 50, 14
     PUSHBUTTON "Cancelar", IDCANCEL, 143, 98, 50, 14
 END
@@ -93,7 +93,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "&Sistema de arquivo:", IDC_FS_STATIC, 7, 9, 70, 9
     COMBOBOX IDC_FSTYPE, 82, 7, 100, 50, CBS_DROPDOWNLIST | WS_TABSTOP
-    AUTOCHECKBOX "&Quick format", IDC_CHECK_QUICKFMT, 7, 22, 180, 14
+    AUTOCHECKBOX "&Formatação rápida", IDC_CHECK_QUICKFMT, 7, 22, 180, 14
     PUSHBUTTON "OK", IDOK, 88, 61, 50, 14
     PUSHBUTTON "Cancelar", IDCANCEL, 143, 61, 50, 14
 END
@@ -103,38 +103,38 @@ STYLE DS_SHELLFONT | DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSM
 CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    LTEXT "Escolha o &diretório onde deseja instalar o ReactOS:", IDC_STATIC, 7, 9, 291, 10
     EDITTEXT IDC_PATH, 7, 23, 291, 13
     GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
-    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    LTEXT "Selecione o local onde o carregador de inicialização\nFreeLoader deve ser instalado.\n\nPor padrão, ele é instalado na partição do sistema do disco de inicialização (e seja no Registro Mestre de Inicialização ou no Registro de Inicialização de Volume para computadores baseados em BIOS).", IDC_STATIC, 13, 57, 279, 44
     COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
     DEFPUSHBUTTON "OK", IDOK, 193, 113, 50, 14
     PUSHBUTTON "Cancelar", IDCANCEL, 248, 113, 50, 14
 END
 
-IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
+IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 150
 STYLE DS_SHELLFONT | WS_CHILD
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT "Installation type:", IDC_STATIC, 18, 5, 74, 11
+    LTEXT "Tipo de instalação:", IDC_STATIC, 18, 5, 74, 11
     EDITTEXT IDC_INSTALLTYPE, 95, 5, 210, 12, ES_READONLY | ES_AUTOHSCROLL | NOT WS_BORDER | NOT WS_TABSTOP
-    LTEXT "Installation source:", IDC_STATIC, 18, 17, 74, 11
+    LTEXT "Fonte de instalação:", IDC_STATIC, 18, 17, 74, 11
     EDITTEXT IDC_INSTALLSOURCE, 95, 17, 210, 12, ES_READONLY | ES_AUTOHSCROLL | NOT WS_BORDER | NOT WS_TABSTOP
-    LTEXT "Architecture:", IDC_STATIC, 18, 29, 74, 11
+    LTEXT "Arquitetura:", IDC_STATIC, 18, 29, 74, 11
     EDITTEXT IDC_ARCHITECTURE, 95, 29, 210, 12, ES_READONLY | ES_AUTOHSCROLL | NOT WS_BORDER | NOT WS_TABSTOP
-    LTEXT "Computer:", IDC_STATIC, 18, 41, 74, 11
+    LTEXT "Computador:", IDC_STATIC, 18, 41, 74, 11
     EDITTEXT IDC_COMPUTER, 95, 41, 210, 12, ES_READONLY | ES_AUTOHSCROLL | NOT WS_BORDER | NOT WS_TABSTOP
-    LTEXT "Display:", IDC_STATIC, 18, 53, 74, 11
+    LTEXT "Tela:", IDC_STATIC, 18, 53, 74, 11
     EDITTEXT IDC_DISPLAY, 95, 53, 210, 12, ES_READONLY | ES_AUTOHSCROLL | NOT WS_BORDER | NOT WS_TABSTOP
-    LTEXT "Keyboard:", IDC_STATIC, 18, 65, 74, 11
+    LTEXT "Teclado:", IDC_STATIC, 18, 65, 74, 11
     EDITTEXT IDC_KEYBOARD, 95, 65, 210, 12, ES_READONLY | ES_AUTOHSCROLL | NOT WS_BORDER | NOT WS_TABSTOP
-    LTEXT "Destination volume:", IDC_STATIC, 18, 77, 74, 11
+    LTEXT "Disco de destino:", IDC_STATIC, 18, 77, 74, 11
     EDITTEXT IDC_DESTDRIVE, 95, 77, 210, 12, ES_READONLY | ES_AUTOHSCROLL | NOT WS_BORDER | NOT WS_TABSTOP
-    LTEXT "Destination directory:", IDC_STATIC, 18, 89, 74, 11
+    LTEXT "Diretório de destino:", IDC_STATIC, 18, 89, 74, 11
     EDITTEXT IDC_PATH, 95, 89, 210, 12, ES_READONLY | ES_AUTOHSCROLL | NOT WS_BORDER | NOT WS_TABSTOP
-    AUTOCHECKBOX "I confirm that all the installation settings are correct. I also acknowledge that\nReactOS is alpha-quality software and may break on my computer or corrupt my data.",
-        IDC_CONFIRM_INSTALL, 7, 104, 309, 18, BS_MULTILINE | WS_GROUP | WS_TABSTOP
-    LTEXT "Please confirm that all the installation settings are correct,\nthen click on Install to start the installation process.", IDC_STATIC, 7, 124, 303, 18
+    AUTOCHECKBOX "Confirmo que todas as configurações de instalação estão corretas e reconheço que o ReactOS é um software em estágio alfa e pode apresentar falhas no meu computador ou corromper meus dados.",
+        IDC_CONFIRM_INSTALL, 7, 104, 309, 25, BS_MULTILINE | WS_GROUP | WS_TABSTOP
+    LTEXT "Por favor confirme se todas as configurações de instalação estão corretas, e em seguida clique em Instalar para iniciar o processo de instalação.", IDC_STATIC, 7, 131, 303, 18
 END
 
 IDD_PROCESSPAGE DIALOGEX 0, 0, 317, 143
@@ -150,11 +150,11 @@ IDD_FINISHPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | WS_CHILD
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT "Restarting your Computer", IDC_FINISHTITLE, 115, 8, 195, 24
+    LTEXT "Reiniciando seu computador...", IDC_FINISHTITLE, 115, 8, 195, 24
     LTEXT "A primeira etapa de Instalação do ReactOS foi efetuada com sucesso.", IDC_STATIC, 115, 40, 195, 24
     // The following text can be replaced by IDS_FINISH_NO_REBOOT at runtime;
     // please ensure it can hold in the text control!
-    LTEXT "Setup will now restart your computer to continue with the second installation step.\n\nYour computer will automatically restart in 15 seconds or when you click on Restart.", IDC_FINISHTEXT, 115, 78, 195, 56
+    LTEXT "A configuração agora reiniciará seu computador para continuar com a segunda etapa da instalação.\n\nSeu computador será reiniciado automaticamente em 15 segundos ou quando você clicar em Reiniciar.", IDC_FINISHTEXT, 115, 78, 195, 56
     CONTROL "", IDC_RESTART_PROGRESS, "msctls_progress32", PBS_SMOOTH | WS_CHILD | WS_VISIBLE | WS_BORDER, 115, 135, 188, 12
 END
 
@@ -162,11 +162,11 @@ IDD_ABORTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | WS_CHILD
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT "The ReactOS Setup Wizard ended prematurely", IDC_FINISHTITLE, 115, 8, 195, 24
-    LTEXT "The first ReactOS installation step prematurely ended because of an error or because you have canceled it.\n\nYou will be able to run the Setup Wizard at a later time to install or upgrade ReactOS.", IDC_STATIC, 115, 40, 195, 48
+    LTEXT "O Assistente de Instalação do ReactOS foi encerrado prematuramente", IDC_FINISHTITLE, 115, 8, 195, 24
+    LTEXT "A primeira etapa de instalação do ReactOS foi encerrada prematuramente devido a um erro ou porque você a cancelou.\n\nVocê poderá executar o Assistente de Configuração em um momento posterior para instalar ou atualizar o ReactOS.", IDC_STATIC, 115, 40, 195, 48
     // The following text can be replaced by IDS_ABORT_NO_REBOOT at runtime;
     // please ensure it can hold in the text control!
-    LTEXT "Your computer will automatically restart in 15 seconds or when you click on Restart.", IDC_FINISHTEXT, 115, 110, 195, 24
+    LTEXT "Seu computador será reiniciado automaticamente em 15 segundos ou quando você clicar em Reiniciar.", IDC_FINISHTEXT, 115, 110, 195, 24
     CONTROL "", IDC_RESTART_PROGRESS, "msctls_progress32", PBS_SMOOTH | WS_CHILD | WS_VISIBLE | WS_BORDER, 115, 135, 188, 12
 END
 
@@ -175,10 +175,10 @@ END
 STRINGTABLE
 BEGIN
     IDS_CAPTION "Instalação do ReactOS"
-    IDS_TYPETITLE "Installation Type"
-    IDS_TYPESUBTITLE "You can setup a new ReactOS installation, or update/repair an existing installation."
-    IDS_UPDATETITLE "Update or Repair ReactOS"
-    IDS_UPDATESUBTITLE "Choose which existing ReactOS installation you want to update or repair."
+    IDS_TYPETITLE "Tipo de Instalação"
+    IDS_TYPESUBTITLE "Você pode configurar uma nova instalação do ReactOS ou atualizar/reparar uma instalação existente."
+    IDS_UPDATETITLE "Atualizar ou Reparar o ReactOS"
+    IDS_UPDATESUBTITLE "Escolha qual instalação existente do ReactOS você deseja atualizar ou reparar."
     IDS_DEVICETITLE "Instalar dispositivos básicos"
     IDS_DEVICESUBTITLE "Definir as configurações de monitor e teclado."
     IDS_DRIVETITLE "Configurar a partição de instalação e pasta do sistema"
@@ -189,36 +189,36 @@ BEGIN
     IDS_PROCESSSUBTITLE "Criar e formatar partição, copiar arquivos, instalar e configurar bootloader."
     IDS_ABORTSETUP "ReactOS não está totalmente instalado em seu computador. Se você sair da Instalação agora, você precisará executar o Instalador novamente para instalar o ReactOS. Tem certeza que deseja sair?"
     IDS_ABORTSETUP2 "Abortar instalação?"
-    IDS_NO_TXTSETUP_SIF "Unable to find 'txtsetup.sif'.\nSetup is unable to continue."
-    IDS_FINISH_NO_REBOOT "Setup needs to restart your computer to continue with the second installation step.\n\nClick on Restart to immediately restart your computer.\nClick on Postpone to quit the installer and restart your computer at a later time."
-    IDS_ABORT_NO_REBOOT "Click on Restart to immediately restart your computer.\nClick on Close to quit the installer."
-    IDS_INSTALLBTN "&Install"
-    IDS_RESTARTBTN "&Restart"
-    IDS_POSTPONEBTN "&Postpone"
-    IDS_VOLUME_NOFORMAT "Not formatted"
+    IDS_NO_TXTSETUP_SIF "Não foi possível encontrar 'txtsetup.sif'.\nA configuração não pode continuar."
+    IDS_FINISH_NO_REBOOT "A instalação precisa reiniciar o seu computador para continuar com o segundo passo da instalação.\n\nClique em Reiniciar para reiniciar seu computador imediatamente.\nClique em Adiar para sair do instalador e reiniciar seu computador em outro momento."
+    IDS_ABORT_NO_REBOOT "Clique em Reiniciar para reiniciar seu computador imediatamente.\nClique em Fechar para sair do instalador."
+    IDS_INSTALLBTN "&Instalar"
+    IDS_RESTARTBTN "&Reiniciar"
+    IDS_POSTPONEBTN "&Adiar"
+    IDS_VOLUME_NOFORMAT "Não formatado"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_INSTALLATION_NAME "Name"
-    IDS_INSTALLATION_PATH "Installation Path"
-    IDS_INSTALLATION_VENDOR "Vendor Name"
+    IDS_INSTALLATION_NAME "Nome"
+    IDS_INSTALLATION_PATH "Caminho da Instalação"
+    IDS_INSTALLATION_VENDOR "Nome do Fornecedor"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_PARTITION_NAME "Name"
-    IDS_PARTITION_TYPE "Type"
-    IDS_PARTITION_SIZE "Size"
+    IDS_PARTITION_NAME "Nome"
+    IDS_PARTITION_TYPE "Tipo"
+    IDS_PARTITION_SIZE "Tamanho"
     IDS_PARTITION_STATUS "Status"
 END
 
 STRINGTABLE
 BEGIN
     IDS_BOOTLOADER_NOINST "Não instalar"
-    IDS_BOOTLOADER_REMOVABLE "Removable media"
-    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
-    IDS_BOOTLOADER_MBRVBR "MBR e VBR (Default)"
+    IDS_BOOTLOADER_REMOVABLE "Mídia Removível"
+    IDS_BOOTLOADER_SYSTEM "Partição do sistema (Padrão)"
+    IDS_BOOTLOADER_MBRVBR "MBR e VBR (Padrão)"
     IDS_BOOTLOADER_VBRONLY "Apenas VBR"
 END
 
@@ -226,27 +226,27 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_FORMATTING_PROGRESS1 "Formatting volume %c: (%s) in %s..."
-    IDS_FORMATTING_PROGRESS2 "Formatting volume %s in %s..."
+    IDS_FORMATTING_PROGRESS1 "Formatando disco %c: (%s) in %s..."
+    IDS_FORMATTING_PROGRESS2 "Formatando disco %s in %s..."
 
-    IDS_CHECKING_PROGRESS1 "Checking volume %c: (%s)..."
-    IDS_CHECKING_PROGRESS2 "Checking volume %s..."
+    IDS_CHECKING_PROGRESS1 "Verificando disco %c: (%s)..."
+    IDS_CHECKING_PROGRESS2 "Verificando disco %s..."
 
-    IDS_COPYING  "Copying %s"
-    IDS_MOVING   "Moving %s to %s"
-    IDS_RENAMING "Renaming %s to %s"
-    IDS_DELETING "Deleting %s"
+    IDS_COPYING  "Copiando %s"
+    IDS_MOVING   "Movendo %s para %s"
+    IDS_RENAMING "Renomeando %s para %s"
+    IDS_DELETING "Excluindo %s"
 
-    IDS_CONFIG_SYSTEM_PARTITION "Configuring the system partition..."
-    IDS_PREPARE_PARTITIONS "Preparing partitions..."
-    IDS_PREPARE_FILES "Preparing the list of files to be copied, please wait..."
-    IDS_COPYING_FILES "Copying files..."
+    IDS_CONFIG_SYSTEM_PARTITION "Configurando a partição de sistema..."
+    IDS_PREPARE_PARTITIONS "Preparando partições..."
+    IDS_PREPARE_FILES "Preparando a lista de arquivos a serem copiados, por favor, aguarde..."
+    IDS_COPYING_FILES "Copiando arquivos..."
 
-    IDS_CREATE_REGISTRY "Creating the registry..."
-    IDS_UPDATE_REGISTRY "Updating the registry..."
+    IDS_CREATE_REGISTRY "Criando registro..."
+    IDS_UPDATE_REGISTRY "Atualizando registro..."
 
-    // IDS_INSTALL_FINALIZE "Finalizing the installation..."
-    IDS_INSTALL_BOOTLOADER "Installing the bootloader..."
+    // IDS_INSTALL_FINALIZE "Finalizando a instalação..."
+    IDS_INSTALL_BOOTLOADER "Instalando o bootloader..."
 END
 
 // Note to translators: please refer to the corresponding usetup/lang/*.h translations.
@@ -267,47 +267,47 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
-    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
-alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
-Spaces are not allowed."
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Caractere inválido"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "Os únicos caracteres válidos são:\n\
+alfanuméricos (a-z, a-z, 0-9), e\n . \\ - _\n\ 
+Espaços não são permitidos."
 
-    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
-    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
-and only contain letters, digits, dashes and periods. Spaces are not allowed."
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Caminho de instalação inválido."
+    IDS_ERROR_DIRECTORY_NAME "O caminho de instalação do ReactOS deve seguir o esquema de nomenclatura DOS 8.3, \
+e conter apenas letras, dígitos, traços e pontos. Espaços não são permitidos."
 
-    IDS_ERROR_CREATE_PARTITION_TITLE "Create partition"
-    IDS_ERROR_CREATE_PARTITION "Failed to create a new partition."
+    IDS_ERROR_CREATE_PARTITION_TITLE "Criar partição"
+    IDS_ERROR_CREATE_PARTITION "Falha ao criar partição"
 
-    IDS_WARN_DELETE_PARTITION_TITLE "Delete partition?"
-    IDS_WARN_DELETE_PARTITION "Are you sure you want to delete the selected partition?"
-    IDS_WARN_DELETE_MBR_EXTENDED_PARTITION "Are you sure you want to delete the selected extended partition and ALL the logical partitions it contains?"
+    IDS_WARN_DELETE_PARTITION_TITLE "Excluir partição?"
+    IDS_WARN_DELETE_PARTITION "Tem certeza de que deseja excluir a partição selecionada?"
+    IDS_WARN_DELETE_MBR_EXTENDED_PARTITION "Tem certeza de que deseja excluir a partição estendida selecionada e TODAS as partições lógicas que ela contém?"
 
-    IDS_ERROR_WRITE_PTABLE "Setup failed to write partition tables."
+    IDS_ERROR_WRITE_PTABLE "O instalador falhou ao escrever as tabelas de partição."
 
-    IDS_ERROR_SYSTEM_PARTITION "The ReactOS Setup could not find a supported system partition\n\
-on your system or could not create a new one. Without such a partition\n\
-the Setup program cannot install ReactOS.\
-\nClick on OK to return to the partition selection list."
+    IDS_ERROR_SYSTEM_PARTITION "O Instalador do ReactOS não pôde encontrar uma partição do sistema compatível\n\
+no seu sistema ou não pôde criar uma nova. Sem tal partição,\n\
+o programa de instalação não pode instalar o ReactOS.\
+\nClique em OK para retornar à lista de seleção de partições."
 
-    IDS_ERROR_FORMAT_UNRECOGNIZED_VOLUME "Unrecognized volume while attempting to format the partition."
+    IDS_ERROR_FORMAT_UNRECOGNIZED_VOLUME "Volume não reconhecido ao tentar formatar a partição."
 
-    IDS_ERROR_COULD_NOT_FORMAT "Setup is currently unable to format a partition in %s.\n\
-\nClick on OK to continue Setup.\
-\nClick on CANCEL to quit Setup."
+    IDS_ERROR_COULD_NOT_FORMAT "O instalador atualmente não consegue formatar uma partição em %s.\n\
+\nClique em OK para continuar a instalação.\
+\nClique em CANCELAR para sair da instalação."
 
-    IDS_ERROR_FORMATTING_PARTITION "Setup is unable to format the partition:\n %s\n"
+    IDS_ERROR_FORMATTING_PARTITION "O instalador não consegue formatar a partição:\n%s\n"
 
-    IDS_ERROR_COULD_NOT_CHECK "Setup is currently unable to check a partition formatted in %s.\n\
-\nClick on OK to continue Setup.\
-\nClick on CANCEL to quit Setup."
+    IDS_ERROR_COULD_NOT_CHECK "O instalador não consegue verificar uma partição formatada em %s no momento.\n\
+\nClique em OK para continuar a instalação.\
+\nClique em CANCELAR para sair da instalação."
 
-    IDS_ERROR_CHECKING_PARTITION "ChkDsk detected some disk errors.\n(Status 0x%08lx)."
+    IDS_ERROR_CHECKING_PARTITION "ChkDsk detectou alguns erros no disco.\n(Status 0x%08lx)."
 
-    IDS_ERROR_WRITE_BOOT "Setup failed to install the %s bootcode on the system partition."
-    IDS_ERROR_INSTALL_BOOTCODE "Setup failed to install the %s bootcode on the boot disk."
-    IDS_ERROR_INSTALL_BOOTCODE_REMOVABLE "Setup failed to install the bootcode on the removable media."
-    IDS_ERROR_BOOTLDR_ARCH_UNSUPPORTED "Setup does not currently support installing the bootloader on the computer you are using.\
-\nClick on OK to continue anyway."
-    IDS_ERROR_BOOTLDR_FAILED "Setup could not install the bootloader (Status 0x%08lx)."
+    IDS_ERROR_WRITE_BOOT "O instalador não conseguiu instalar o bootcode %s na partição do sistema."
+    IDS_ERROR_INSTALL_BOOTCODE "A instalação do programa de inicialização %s no disco de inicialização falhou."
+    IDS_ERROR_INSTALL_BOOTCODE_REMOVABLE "A configuração não conseguiu instalar o bootcode na mídia removível."
+    IDS_ERROR_BOOTLDR_ARCH_UNSUPPORTED "O instalador atualmente não suporta instalar o bootloader no computador que você está usando.\
+\nClique em OK para continuar mesmo assim."
+    IDS_ERROR_BOOTLDR_FAILED "A configuração não pôde instalar o bootloader (Status 0x%08lx)."
 END


### PR DESCRIPTION
## PR Description:

This PR updates the **Portuguese (pt-BR)** language for the *ReactOS Setup Wizard* GUI, localizing and fixing some untranslated *English* string leaks, ensuring a smoother setup experience

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes:

- Fixes the English untranslated string leaks to ensure a smoother setup experience
- **"Important Information":** Translated the "ReactOS Alpha Stage Warning" text to Portuguese. (Screenshot 2)
- **Installation Types:** Translated strings related to the description of each option (Install or Update). (Screenshot 1)
- **Installation Summary:** Translated strings related to installation settings and devices (Screenshot 3)
- **Paint:** Translated all the English string leaks that hadn't been translated yet.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:

## Screenshots
<img width="800" height="600" alt="ReactOS 0 4 17 (2)" src="https://github.com/user-attachments/assets/638c7a5e-689b-4ac7-9e8e-fe0f0f00bc83" />
<img width="800" height="600" alt="ROS 0 4 17 (4)" src="https://github.com/user-attachments/assets/122db6ea-a863-41a4-9947-b8478faa5b96" />
<img width="800" height="600" alt="ROS 0 4 17 (5)" src="https://github.com/user-attachments/assets/fb85b2e3-848f-4b74-9cdf-9a0addf704ab" />
